### PR TITLE
Setting env variables to process so version is accessable to rest of msb...

### DIFF
--- a/GitFlowVersionTask/UpdateAssemblyInfo.cs
+++ b/GitFlowVersionTask/UpdateAssemblyInfo.cs
@@ -57,6 +57,7 @@
                 var versionAndBranch = VersionCache.GetVersion(gitDirectory);
 
                 WriteTeamCityParameters(versionAndBranch);
+                WriteEnvironmentalVariables(versionAndBranch);
                 CreateTempAssemblyInfo(versionAndBranch);
 
                 return true;
@@ -75,6 +76,24 @@
             {
                 Logger.Reset();
             }
+        }
+
+        private void WriteEnvironmentalVariables(VersionAndBranch versionAndBranch)
+        {
+            var semanticVersion = versionAndBranch.Version;
+
+            WriteEnvVariable("GitFlowVersionMajor", semanticVersion.Major.ToString());
+            WriteEnvVariable("GitFlowVersionMinor", semanticVersion.Minor.ToString());
+            WriteEnvVariable("GitFlowVersionPatch", semanticVersion.Patch.ToString());
+            WriteEnvVariable("GitFlowVersionStability", semanticVersion.Stability.ToString());
+            WriteEnvVariable("GitFlowVersionPreReleaseNumber", semanticVersion.PreReleaseNumber.ToString());
+            WriteEnvVariable("GitFlowVersionVersion", TeamCity.GenerateBuildVersion(versionAndBranch));
+            WriteEnvVariable("GitFlowVersionNugetVersion", TeamCity.GenerateNugetVersion(versionAndBranch));
+        }
+
+        private void WriteEnvVariable(string variableName, string value)
+        {
+            Environment.SetEnvironmentVariable(variableName, value, EnvironmentVariableTarget.Process);
         }
 
         void WriteTeamCityParameters(VersionAndBranch versionAndBranch)


### PR DESCRIPTION
...uild scripts

I generate my NuGet packages from my build script, and teamcity variables are evaluated and the env variables set when it executes each process. 

For the moment i have two steps each executing a target in my msbuild file, but it would be cool to just be able to execute multiple targets

Just an idea (and I havent really tested this, just checking what you think)
