### PR TITLE
Setting AssemblyFileVersion to NugetVersion

### DIFF
--- a/GitFlowVersionTask/AssemblyInfoBuilder.cs
+++ b/GitFlowVersionTask/AssemblyInfoBuilder.cs
@@ -4,20 +4,18 @@
 
     public  class AssemblyInfoBuilder
     {
-
         public VersionAndBranch VersionAndBranch;
         public bool SignAssembly;
 
         public string GetAssemblyInfoText()
         {
             var assemblyVersion = GetAssemblyVersion();
-            var assemblyFileVersion = GetAssemblyFileVersion();
             var assemblyInfo = string.Format(@"
 using System.Reflection;
 [assembly: AssemblyVersion(""{0}"")]
 [assembly: AssemblyFileVersion(""{1}"")]
 [assembly: AssemblyInformationalVersion(""{2}"")]
-", assemblyVersion, assemblyFileVersion, VersionAndBranch.ToLongString());
+", assemblyVersion, NugetVersionBuilder.GenerateNugetVersion(VersionAndBranch), VersionAndBranch.ToLongString());
             return assemblyInfo;
         }
 


### PR DESCRIPTION
Setting the AssemblyFileVersion to the NugetVersion string allows for
using the AssemblyFileVersion to check against Nuget to verify that you
are runnig the latest version of the assembly. The use case for this is
self-updating applications like nuget.exe. If Microsoft where to provide
custom assembly attribute (key, values) we could have used that.
