### PR TITLE
Make GitFlowVersionFinder.FindVersion() throw when the branch type can't be detected

### DIFF
--- a/GitFlowVersion/GitFlowVersionFinder.cs
+++ b/GitFlowVersion/GitFlowVersionFinder.cs
@@ -69,12 +69,8 @@ namespace GitFlowVersion
                            FeatureBranch = Branch
                        }.FindVersion();
             }
-            return new FeatureVersionFinder
-                   {
-                       Commit = Commit,
-                       Repository = Repository,
-                       FeatureBranch = Branch
-                   }.FindVersion();
+
+            throw new ErrorException("Branch '{0}' doesn't respect the GitFlowVersion naming convention.");
         }
 
         private void EnsureMainTopologyConstraints()

--- a/Tests/GitFlowVersionFinderTests.cs
+++ b/Tests/GitFlowVersionFinderTests.cs
@@ -311,4 +311,23 @@ public class GitFlowVersionFinderTests : Lg2sHelperBase
             Assert.Throws<ErrorException>(() => gfvf.FindVersion());
         }
     }
+
+    [Test]
+    public void CannotBuildAVersionFromAnBranchWithAnInvalidPrefix()
+    {
+        string repoPath = Clone(ASBMTestRepoWorkingDirPath);
+        using (var repo = new Repository(repoPath))
+        {
+            repo.Branches.Add("members-only", repo.Head.Tip).ForceCheckout();
+
+            var gfvf = new GitFlowVersionFinder
+            {
+                Repository = repo,
+                Branch = repo.Head,
+                Commit = repo.Head.Tip
+            };
+
+            Assert.Throws<ErrorException>(() => gfvf.FindVersion());
+        }
+    }
 }


### PR DESCRIPTION
Fix #43
