### PR TITLE
generated assembly file is now ignored by StyleCop

### DIFF
--- a/GitFlowVersionTask/UpdateAssemblyInfo.cs
+++ b/GitFlowVersionTask/UpdateAssemblyInfo.cs
@@ -128,7 +128,7 @@
                                       };
             var assemblyInfo = assemblyInfoBuilder.GetAssemblyInfoText();
 
-            var tempFileName = string.Format("AssemblyInfo_{0}_{1}.cs", Path.GetFileNameWithoutExtension(ProjectFile), Path.GetRandomFileName());
+            var tempFileName = string.Format("AssemblyInfo_{0}_{1}.g.cs", Path.GetFileNameWithoutExtension(ProjectFile), Path.GetRandomFileName());
             AssemblyInfoTempFilePath = Path.Combine(TempFileTracker.TempPath, tempFileName);
             File.WriteAllText(AssemblyInfoTempFilePath, assemblyInfo);
         }


### PR DESCRIPTION
I changed the name of the generated AssemblyInfo file to include ".g." so that StyleCop ignores the file.
Otherwise it is not possible (or at least I don't know how) to use StyleCop with GitFlowVersion task.
