### PR TITLE
Support multiline merge commits

### DIFF
--- a/GitFlowVersion/ExtensionMethods.cs
+++ b/GitFlowVersion/ExtensionMethods.cs
@@ -1,13 +1,18 @@
 namespace GitFlowVersion
 {
+    using System;
     using System.Text;
     using JetBrains.Annotations;
 
     static class ExtensionMethods
     {
-        public static string TrimNewLines(this string s)
+        public static string TrimToFirstLine(this string s)
         {
-            return s.TrimEnd('\r', '\n');
+            return s.Split(new[]
+            {
+                "\r\n",
+                "\n"
+            }, StringSplitOptions.None)[0];
         }
         [StringFormatMethod("format")]
         public static void AppendLineFormat(this StringBuilder stringBuilder, string format, params object[] args)

--- a/GitFlowVersion/MergeMessageParser.cs
+++ b/GitFlowVersion/MergeMessageParser.cs
@@ -45,7 +45,7 @@ namespace GitFlowVersion
             {
                 return false;
             }
-            trimmed = trimmed.TrimNewLines();
+            trimmed = trimmed.TrimToFirstLine();
             if (!trimmed.EndsWith("'"))
             {
                 return false;

--- a/Tests/MergeMessageParserTests.cs
+++ b/Tests/MergeMessageParserTests.cs
@@ -62,6 +62,12 @@ public class MergeMessageParserTests
         Assert.IsFalse(MergeMessageParser.TryParse(c, out versionPart));
     }
 
+    [Test]
+    public void Supports_multiline_commit_message()
+    {
+        AssertMergeMessage("0.1.5", "Merge branch 'hotfix-0.1.5'\n\nRelates to: TicketId");
+    }
+
     void AssertMergeMessage(string expectedVersion, string message)
     {
         var c = new MockCommit


### PR DESCRIPTION
As a user that uses a `prepare-commit-msg` hook that automatically includes metadata from my environment I am not able to finish a branch into master.  This pull request plucks only the first line from the merge commit, ignoring any details that may follow on additional lines.
