### PR TITLE
Support 3rd party test framework in VS2013

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -158,6 +158,9 @@
       <Name>GitFlowVersion</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>


### PR DESCRIPTION
This adds the `<Service/>` item tag that will be automatically added by any user of VS2013, with 3rd party test frameworks, that do not use a "Unit Test Project" template for the test project.

http://connect.microsoft.com/VisualStudio/feedback/details/800245/vs2013rc-adds-to-vs2012-c-project-section-itemgroup

> Posted by Microsoft on 10/24/2013 at 7:38 AM
> This behavior is intentional. 
> 
> To support third-party test frameworks, like NUnit and XUnit, Visual Studio 2012 loaded Test Explorer on solution open, regardless of whether it contained test projects. This added seconds of delay to startup and solution open scenarios for all users, majority of whom don't use tests.
> 
> In Visual Studio 2013, we changed it so that Test Explorer package is loaded only when the solution contains one or more test projects. Test projects are identified in two different ways. Projects created from one of the built-in unit test project templates are identified using project type GUIDs. Other types of projects, such as Class Library project with XUnit or NUnit tests, are identified by Test Explorer during first test discovery and “tagged” with the <Service/> item. 
> 
> You can avoid Visual Studio automatically adding the <Service/> item to your test projects by creating them from any of the built-in unit test project templates. In other words, select the "Unit Test Project" template instead of the "Class Library" template in the New Project dialog.
> 
> Oleg Sych

This request was split from #62.
