### PR TITLE
Added ProcessEnvironment BuildServer

### DIFF
--- a/GitFlowVersion/BuildServers/BuildServerList.cs
+++ b/GitFlowVersion/BuildServers/BuildServerList.cs
@@ -1,13 +1,15 @@
 ﻿namespace GitFlowVersion
 {
     using System.Collections.Generic;
+    using BuildServers;
 
     public static class BuildServerList
     {
         public static List<IBuildServer> BuildServers = new List<IBuildServer>
             {
                 new ContinuaCi(),
-                new TeamCity()
+                new TeamCity(),
+                new ProcessEnvironment()
             };
 
     }

--- a/GitFlowVersion/BuildServers/ProcessEnvironment.cs
+++ b/GitFlowVersion/BuildServers/ProcessEnvironment.cs
@@ -1,0 +1,35 @@
+﻿namespace GitFlowVersion.BuildServers
+{
+    using GitFlowVersion;
+
+    public class ProcessEnvironment : IBuildServer
+    {
+        public bool CanApplyToCurrentContext()
+        {
+            return true;
+        }
+
+        public void PerformPreProcessingSteps(string gitDirectory)
+        {
+            if (string.IsNullOrEmpty(gitDirectory))
+            {
+                throw new ErrorException("Failed to find .git directory");
+            }
+
+            GitHelper.NormalizeGitDirectory(gitDirectory);
+        }
+
+        public string GenerateSetParameterMessage(string name, string value)
+        {
+            var variableName = string.Format("GitFlowVersion.{0}", name);
+            System.Environment.SetEnvironmentVariable(variableName, value);
+            return string.Format("{0} = '{1}'", variableName, value);
+        }
+
+        public string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        {
+            System.Environment.SetEnvironmentVariable("GitFlowVersion", versionToUseForBuildNumber);
+            return string.Format("{0} = '{1}'", "GitFlowVersion", versionToUseForBuildNumber);
+        }
+    }
+}

--- a/GitFlowVersion/GitFlowVersion.csproj
+++ b/GitFlowVersion/GitFlowVersion.csproj
@@ -62,6 +62,7 @@
     <Compile Include="BuildServers\ContinuaCi.cs" />
     <Compile Include="BuildServers\GitHelper.cs" />
     <Compile Include="BuildServers\IBuildServer.cs" />
+    <Compile Include="BuildServers\ProcessEnvironment.cs" />
     <Compile Include="BuildServers\TeamCity.cs" />
     <Compile Include="GitFlowVersionContext.cs" />
     <Compile Include="HelpWriter.cs" />

--- a/Tests/BuildServers/ProcessEnvironmentTests.cs
+++ b/Tests/BuildServers/ProcessEnvironmentTests.cs
@@ -1,0 +1,22 @@
+﻿using GitFlowVersion.BuildServers;
+using NUnit.Framework;
+
+[TestFixture]
+public class ProcessEnvironmentTests
+{
+    [Test]
+    public void GenerateBuildVersion()
+    {
+        var versionBuilder = new ProcessEnvironment();
+        var environmentVersion = versionBuilder.GenerateSetVersionMessage("0.0.0-Beta4.7");
+        Assert.AreEqual("GitFlowVersion = '0.0.0-Beta4.7'", environmentVersion);
+    }
+
+    [Test]
+    public void GenerateVariable()
+    {
+        var versionBuilder = new ProcessEnvironment();
+        var environmentVersion = versionBuilder.GenerateSetParameterMessage("AnyName", "0.0.0-Beta4.7");
+        Assert.AreEqual("GitFlowVersion.AnyName = '0.0.0-Beta4.7'", environmentVersion);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="AssemblyLocation.cs" />
     <Compile Include="BranchClassifierTests.cs" />
     <Compile Include="BranchFinders\DevelopTests.cs" />
+    <Compile Include="BuildServers\ProcessEnvironmentTests.cs" />
     <Compile Include="BuildServers\TeamCityTests.cs" />
     <Compile Include="BuildServers\ContinuaCiTests.cs" />
     <Compile Include="GitHelperTests.cs" />


### PR DESCRIPTION
This pull is a discussion. I quickly spicked a build server implementation which sets environment variables in the executing process. The idea was that a build script which calls msbuild and compiles a solution which contains projects with the gitflowversiontask the environment variables could be read by the script. Unfortunately I couldn't read the environment variable in my scripts. 

Any ideas how this could be improved? Is this useful or not? Is there a better and working approach to feed information back into the build script without calling GitFlowVersion.exe manually?
