### PR TITLE
FxCop compliance for generated NugetVersionAttribute and GitFlowVersionI...

### DIFF
--- a/GitFlowVersionTask/AssemblyInfoBuilder.cs
+++ b/GitFlowVersionTask/AssemblyInfoBuilder.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 
 namespace {4}
 {{
+    [System.Runtime.CompilerServices.CompilerGenerated]
     class NugetVersionAttribute : Attribute
     {{
         public NugetVersionAttribute(string version)
@@ -35,6 +36,7 @@ namespace {4}
 }}
 namespace {4}
 {{
+    [System.Runtime.CompilerServices.CompilerGenerated]
     static class GitFlowVersionInformation
     {{
         public static string AssemblyVersion = ""{0}"";

--- a/Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
+++ b/Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
@@ -9,6 +9,7 @@ using System.Reflection;
 
 namespace MyAssembly
 {
+    [System.Runtime.CompilerServices.CompilerGenerated]
     class NugetVersionAttribute : Attribute
     {
         public NugetVersionAttribute(string version)
@@ -21,6 +22,7 @@ namespace MyAssembly
 }
 namespace MyAssembly
 {
+    [System.Runtime.CompilerServices.CompilerGenerated]
     static class GitFlowVersionInformation
     {
         public static string AssemblyVersion = "1.2.3";


### PR DESCRIPTION
Without the CompilerGenerated Attribute a solution being analyzed with FxCop engine will always fail to build. The following violations will be shown:

```
CA1823  Avoid unused private fields It appears that field 'GitFlowVersionInformation.SemVer' is never used or is only ever assigned to. Use this field or remove it.    ClassLibrary2   AssemblyInfo.cs 44
CA2243  Attribute string literals should parse correctly    In the constructor of 'NugetVersionAttribute', change the value of argument 'version', which is currently "0.2.0-Unstable0001", to something that can be correctly parsed as 'Version'. ClassLibrary2   (Global)    
CA1016  Mark assemblies with AssemblyVersionAttribute   Add an AssemblyVersion attribute to 'ClassLibrary2.dll'.    ClassLibrary2   (Global)    
CA2243  Attribute string literals should parse correctly    In the constructor of 'AssemblyInformationalVersionAttribute', change the value of argument 'informationalVersion', which is currently "0.2.0-unstable1 Branch:'develop' Sha:'bb4d4a2d0a69f9dc119310f3dc0051c8d5b019f5", to something that can be correctly parsed as 'Version'.    ClassLibrary2   (Global)    
CA2210  Assemblies should have valid strong names   Sign 'ClassLibrary2.dll' with a strong name key.    ClassLibrary2   (Global)    
CA1813  Avoid unsealed attributes   Seal 'NugetVersionAttribute', if possible.  ClassLibrary2   AssemblyInfo.cs 28
CA1823  Avoid unused private fields It appears that field 'GitFlowVersionInformation.AssemblyVersion' is never used or is only ever assigned to. Use this field or remove it.   ClassLibrary2   AssemblyInfo.cs 40
CA1810  Initialize reference type static fields inline  Initialize all static fields in 'GitFlowVersionInformation' when those fields are declared and remove the explicit static constructor.  ClassLibrary2   AssemblyInfo.cs 40
CA1823  Avoid unused private fields It appears that field 'GitFlowVersionInformation.AssemblyFileVersion' is never used or is only ever assigned to. Use this field or remove it.   ClassLibrary2   AssemblyInfo.cs 41
CA1823  Avoid unused private fields It appears that field 'GitFlowVersionInformation.AssemblyInformationalVersion' is never used or is only ever assigned to. Use this field or remove it.  ClassLibrary2   AssemblyInfo.cs 42
CA1823  Avoid unused private fields It appears that field 'GitFlowVersionInformation.NugetVersion' is never used or is only ever assigned to. Use this field or remove it.  ClassLibrary2   AssemblyInfo.cs 43
```

With this pull almost all warning will dissapear. One remains though and I have currently no idea how to fix it.

http://msdn.microsoft.com/query/dev12.query?appId=Dev12IDEF1&l=EN-US&k=k(CA2243);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv4.5)&rd=true

The problem is declarations like the following:

```
[assembly: AssemblyInformationalVersion("0.2.0-unstable1 Branch:'develop' Sha:'bb4d4a2d0a69f9dc119310f3dc0051c8d5b019f5")]
[assembly: NugetVersionAttribute("0.2.0-Unstable0001")]
```

are not valid according to FxCop. One way would be to emit also a suppression like this:

```
[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly")]
```

BUT this would remove it globally which might not be intended.
