### PR TITLE
Added development dependency to nuspec file

### DIFF
--- a/GitFlowVersionTask/NugetAssets/GitFlowVersionTask.nuspec
+++ b/GitFlowVersionTask/NugetAssets/GitFlowVersionTask.nuspec
@@ -13,5 +13,6 @@
     <description>Stamps an assembly with git information based on SemVer.</description>
     <language>en-AU</language>
     <tags>Git, Versioning, GitFlowVersion, GitFlow, SemVer</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
 </package>


### PR DESCRIPTION
By adding the development dependency to the nuspec file, nuget marks the dependency in the packages.config as a development dependency and not as a dependency that should be included in the nuspec file of that project.
