### PR TITLE
When using gitHub flow we don't need to Fetch other branches then master

### DIFF
--- a/GitFlowVersion/BuildServers/GitHelper.cs
+++ b/GitFlowVersion/BuildServers/GitHelper.cs
@@ -1,5 +1,6 @@
 namespace GitFlowVersion.GitFlowVersion
 {
+    using System;
     using System.Linq;
     using LibGit2Sharp;
 
@@ -14,7 +15,8 @@ namespace GitFlowVersion.GitFlowVersion
                 Logger.WriteInfo(string.Format("Fetching from remote '{0}' using the following refspecs: {1}.",
                     remote.Name, string.Join(", ", remote.FetchRefSpecs.Select(r => r.Specification))));
 
-                repo.Network.Fetch(remote);
+                var fetchOptions = BuildFetchOptions();
+                repo.Network.Fetch(remote, fetchOptions);
 
                 CreateMissingLocalBranchesFromRemoteTrackingOnes(repo, remote.Name);
 
@@ -28,6 +30,21 @@ namespace GitFlowVersion.GitFlowVersion
 
                 CreateFakeBranchPointingAtThePullRequestTip(repo);
             }
+        }
+
+        static FetchOptions BuildFetchOptions()
+        {
+            var username = Environment.GetEnvironmentVariable("GITVERSION_REMOTE_USERNAME");
+            var password = Environment.GetEnvironmentVariable("GITVERSION_REMOTE_PASSWORD");
+
+            var fetchOptions = new FetchOptions();
+
+            if (!string.IsNullOrEmpty(username))
+            {
+                fetchOptions.Credentials = new Credentials { Username = username, Password = password };
+            }
+
+            return fetchOptions;
         }
 
         static void CreateFakeBranchPointingAtThePullRequestTip(Repository repo)


### PR DESCRIPTION
Can we have an environment configuration switch or argument to stop this error... (?)

`[UpdateAssemblyInfo] GitFlowVersionTask.UpdateAssemblyInfo
[18:06:08][GitFlowVersionTask.UpdateAssemblyInfo] Applicable build agent found: 'TeamCity'.
[18:06:08][GitFlowVersionTask.UpdateAssemblyInfo] Executing PerformPreProcessingSteps for 'TeamCity'.
[18:06:08][GitFlowVersionTask.UpdateAssemblyInfo] One remote found (origin -> 'https://sfarmar@github.com/Particular/Website.Backend.git').
[18:06:08][GitFlowVersionTask.UpdateAssemblyInfo] Fetching from remote 'origin' using the following refspecs: +refs/heads/*:refs/remotes/origin/*.
[18:06:08]
[GitFlowVersionTask.UpdateAssemblyInfo] Error occurred: LibGit2Sharp.LibGit2SharpException: An error was raised by libgit2. Category = Net (Error).
Request failed with status code: 401
   at LibGit2Sharp.Core.Ensure.HandleError(Int32 result)
   at LibGit2Sharp.Core.Proxy.git_remote_connect(RemoteSafeHandle remote, GitDirection direction)
   at LibGit2Sharp.Network.DoFetch(RemoteSafeHandle remoteHandle, FetchOptions options)
   at LibGit2Sharp.Network.Fetch(Remote remote, FetchOptions options)
   at GitFlowVersion.GitFlowVersion.GitHelper.NormalizeGitDirectory(String gitDirectory) in c:\BuildAgent\work\5e0d79a4e3943b17\GitFlowVersion\BuildServers\GitHelper.cs:line 17
   at GitFlowVersion.TeamCity.PerformPreProcessingSteps(String gitDirectory) in c:\BuildAgent\work\5e0d79a4e3943b17\GitFlowVersion\BuildServers\TeamCity.cs:line 20
   at GitFlowVersionTask.UpdateAssemblyInfo.InnerExecute() in c:\BuildAgent\work\5e0d79a4e3943b17\GitFlowVersionTask\UpdateAssemblyInfo.cs:line 85
   at GitFlowVersionTask.UpdateAssemblyInfo.Execute() in c:\BuildAgent\work\5e0d79a4e3943b17\GitFlowVersionTask\UpdateAssemblyInfo.cs:line 43`
