### PR TITLE
Removing native pdbs as they are not handled by Costura. Saves size.

### DIFF
--- a/GitVersion/GitVersion.csproj
+++ b/GitVersion/GitVersion.csproj
@@ -140,14 +140,8 @@
     <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\amd64\git2-65e9dc6.dll">
       <Link>costura64\git2-65e9dc6.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\amd64\git2-65e9dc6.pdb">
-      <Link>costura64\git2-65e9dc6.pdb</Link>
-    </EmbeddedResource>
     <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\x86\git2-65e9dc6.dll">
       <Link>costura32\git2-65e9dc6.dll</Link>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\x86\git2-65e9dc6.pdb">
-      <Link>costura32\git2-65e9dc6.pdb</Link>
     </EmbeddedResource>
     <Content Include="FodyWeavers.xml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
This should save about 9.4MB on the final exe. 
