### PR TITLE
Removed libgit2sharp dep for nuget package

### DIFF
--- a/GitVersion/NugetRefAssets/GitVersion.nuspec
+++ b/GitVersion/NugetRefAssets/GitVersion.nuspec
@@ -13,8 +13,5 @@
     <description>Derives SemVer information from a repository following GitFlow or GitHubFlow.</description>
     <language>en-AU</language>
     <tags>Git, Versioning, GitVersion, GitFlowVersion, GitFlow, GitHubFlow, SemVer</tags>
-    <dependencies>
-      <dependency id="LibGit2Sharp"  version="0.14.1.0" />
-    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
As pointed out by @GeertvanHorrik in #125, this was left in by mistake.
