### PR TITLE
Expose VariableProvider field names for /v cmd line argument

### DIFF
--- a/GitVersion/ArgumentParser.cs
+++ b/GitVersion/ArgumentParser.cs
@@ -3,9 +3,16 @@ namespace GitVersion
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
     class ArgumentParser
     {
+        static ArgumentParser()
+        {
+            var fields = typeof(VariableProvider).GetFields(BindingFlags.Public | BindingFlags.Static);
+            VersionParts = fields.Select(x => x.Name.ToLower()).ToArray();
+        }
+
         public static Arguments ParseArguments(string commandLineArguments)
         {
             return ParseArguments(commandLineArguments.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries).ToList());
@@ -167,6 +174,6 @@ namespace GitVersion
                 IsSwitch("?", singleArgument);
         }
 
-        static string[] VersionParts = {"major", "minor", "patch", "long", "short", "nuget"};
+        static string[] VersionParts;
     }
 }


### PR DESCRIPTION
Uses reflection in order to obtain public static field names, building up `ArgumentParser.VersionParts`.

This enables the user to obtain a specific version format when passing the `VersionPart` ( array of lower case `VariableProvider` field names) with the `/v` argument.

Prior, one could pass `/v nuget` in order to obtain a version name that is compatible with nuget versioning.
