### PR TITLE
Fixed bug in SemanticVersion.Compare

### DIFF
--- a/GitVersionCore/SemanticVersion.cs
+++ b/GitVersionCore/SemanticVersion.cs
@@ -163,7 +163,7 @@ namespace GitVersion
                 return -1;
             }
 
-            return -1;
+            return 0;
         }
 
         public override string ToString()


### PR DESCRIPTION
When SemanticVersion.CompareTo() function cannot decide if the other SemanticVersion from parameter should go before or after the current instance, it returns -1. This is wrong as the function should return 0 when both instances should be considered as equal. 
Before the bug fix, it is also impossible to use OrderBy on enumeration of SemanticVerions with two same versions because it get stuck on the comparision and never finishes. This is probably because the result collection never seems as ordered because on every pass, the equal versions seem to be in wrong order (the second should go before the first).
