### PR TITLE
Added skipIfNotDefined for upcoming Continua CI v1.5

### DIFF
--- a/GitVersionCore/BuildServers/ContinuaCi.cs
+++ b/GitVersionCore/BuildServers/ContinuaCi.cs
@@ -42,7 +42,7 @@
         {
             return new[]
             {
-                string.Format("@@continua[setVariable name='GitVersion_{0}' value='{1}']", name, value)
+                string.Format("@@continua[setVariable name='GitVersion_{0}' value='{1}' skipIfNotDefined='true']", name, value)
             };
         }
 


### PR DESCRIPTION
The upcoming Continua CI v1.5 will introduce a breaking change for variables that are not defined (but set). This pull request prepares for this (at the moment) unreleased version.
