### PR TITLE
Tag comparison was treating stable as higher than pre-release causing pa...

### DIFF
--- a/GitVersionCore/SemanticVersionPreReleaseTag.cs
+++ b/GitVersionCore/SemanticVersionPreReleaseTag.cs
@@ -97,6 +97,15 @@ namespace GitVersion
 
         public int CompareTo(SemanticVersionPreReleaseTag other)
         {
+            if (!HasTag() && other.HasTag())
+            {
+                return 1;
+            }
+            if (HasTag() && !other.HasTag())
+            {
+                return -1;
+            }
+
             var nameComparison = StringComparer.InvariantCultureIgnoreCase.Compare(Name, other);
             if (nameComparison != 0)
                 return nameComparison;

--- a/Tests/SemanticVersionTests.cs
+++ b/Tests/SemanticVersionTests.cs
@@ -62,6 +62,12 @@ public class SemanticVersionTests
     }
 
     [Test]
+    public void VersionSorting()
+    {
+        SemanticVersion.Parse("1.0.0").ShouldBeGreaterThan(SemanticVersion.Parse("1.0.0-beta"));
+    }
+
+    [Test]
     public void EmptyVersion()
     {
         Assert.IsTrue(SemanticVersion.Empty.IsEmpty());


### PR DESCRIPTION
...tch to bump when it shouldn't

Scenario which was broken was merging release branch into master, which was calculating v4.0.0, but the last tag was a beta tag on the release branch.

Because of the bug the pre-release was larger than the calculated version from the branch, and it bumped the patch
