### PR TITLE
Updated with missing release information

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,16 @@
+# v1.2.0
+Support updating a single common AssemblyInfo.cs [#227](https://github.com/Particular/GitVersion/pull/227) thanks @hmemcpy
+Note we do not have the assembly info switches in the command line help at the moment, see [#237](https://github.com/Particular/GitVersion/issues/237)
+
+Usage for updating assembly info is /updateAssemblyInfo if you want to specify the file it is 
+
+```
+/updateassemblyinfo ..\src\CommonAssemblyInfo.cs or /updateassemblyinfo "C:\src\CommonAssemblyInfo.cs"
+```
+
+# v1.1.0
+Bug fix with release branches in GitHubFlow
+
 # v1.1.0 
 
  - [#222](https://github.com/Particular/GitVersion/pull/222) - Log is printed to console on error
@@ -17,3 +30,6 @@
  - [#87](https://github.com/Particular/GitVersion/issues/87) - only perform PerformPreProcessingSteps once per solution instance
 
 Commits: [493a204e81...232ef26ca3](https://github.com/Particular/GitVersion/compare/493a204e81...232ef26ca3)
+
+# v1.0.0
+Initial Release


### PR DESCRIPTION
Happened to notice that the ReleaseNotes.md didn't have all the information about the various releases, so thought I would add them in.  The information was taken from here:
https://github.com/Particular/GitVersion/releases
