### PR TITLE
(#240) Added link to ReleaseNotes.md for Choco Package

### DIFF
--- a/GitVersionExe/NugetAssets/GitVersion.Portable.nuspec
+++ b/GitVersionExe/NugetAssets/GitVersion.Portable.nuspec
@@ -13,5 +13,8 @@
     <description>Derives SemVer information from a repository following GitFlow or GitHubFlow.</description>
     <language>en-AU</language>
     <tags>Git, Versioning, GitVersion, GitFlowVersion, GitFlow, GitHubFlow, SemVer</tags>
+    <releaseNotes>
+      Full release notes can be found here - https://github.com/Particular/GitVersion/blob/master/ReleaseNotes.md
+    </releaseNotes>
   </metadata>
 </package>


### PR DESCRIPTION
Since Chocolatey.org now supports markdown from nuspec file, adding in link to the full release notes stored in GitHub repo.  Decided not to add the full text for the release notes in the nuspec file, as this is just one more thing that needs to be remembered during the release.  Rather, point users to the one source of truth for release notes.

We might want to think about doing the same for the Nuget Package, but since this won't actually render a clickable link, not sure how useful this would actually be.
