### PR TITLE
(#173) Fix up merge message for Stash

### DIFF
--- a/AcceptanceTests/PullRequestInTeamCityTest.cs
+++ b/AcceptanceTests/PullRequestInTeamCityTest.cs
@@ -12,7 +12,7 @@
         const string TaggedVersion = "1.0.3";
 
         [Theory]
-        [InlineData("refs/pull-requests/5/merge-clean")]
+        [InlineData("refs/pull-requests/5/merge")]
         [InlineData("refs/pull/5/merge")]
         public void GivenARemoteWithATagOnMaster_AndAPullRequestWithTwoCommits_AndBuildIsRunningInTeamCity_VersionIsCalculatedProperly(string pullRequestRef)
         {

--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -7,7 +7,7 @@ namespace GitVersion
 
     public static class GitHelper
     {
-        private const string MergeMessageRegexPattern = "refs/heads/pull(-requests)?/(?<issuenumber>[0-9]*)/merge(-clean)?";
+        private const string MergeMessageRegexPattern = "refs/heads/pull(-requests)?/(?<issuenumber>[0-9]*)/merge";
 
         public static void NormalizeGitDirectory(string gitDirectory, Authentication authentication, string branch = null)
         {
@@ -59,7 +59,7 @@ namespace GitVersion
         public static string ExtractIssueNumber(string mergeMessage)
         {
             // Github Message: refs/heads/pull/5/merge
-            // Stash Message:  refs/heads/pull-requests/5/merge-clean
+            // Stash Message:  refs/heads/pull-requests/5/merge
 
             var regex = new Regex(MergeMessageRegexPattern);
             var match = regex.Match(mergeMessage);


### PR DESCRIPTION
Additional fix for (#173)

After actual testing on a live Stash server, it is clear that the message generated from Stash is of the format:

refs/heads/pull-requests/5/merge

and not as first thought:

refs/heads/pull-requests/5/merge-clean

Updated Acceptance Test, and also the Regex which identifies the messages, and tested on a Pull Request issued to server.  All seems to work as expected.
