### PR TITLE
Adding in new version of LibGit2Sharp, 0.19.0.

### DIFF
--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -42,9 +42,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\ApprovalUtilities.3.0.6\lib\net35\ApprovalUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="LibGit2Sharp, Version=0.19.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly">
       <HintPath>..\packages\Shouldly.2.1.1\lib\net40\Shouldly.dll</HintPath>
@@ -113,9 +113,9 @@
     <PostBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/AcceptanceTests/packages.config
+++ b/AcceptanceTests/packages.config
@@ -3,7 +3,7 @@
   <package id="ApprovalTests" version="3.0.6" targetFramework="net40" />
   <package id="ApprovalUtilities" version="3.0.6" targetFramework="net40" />
   <package id="Fody" version="1.24.0" targetFramework="net40" developmentDependency="true" />
-  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net45" />
   <package id="Shouldly" version="2.1.1" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net35" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net35" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -38,9 +38,9 @@
       <HintPath>..\packages\JetBrainsAnnotations.Fody.1.0.2\Lib\JetBrains.Annotations.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="LibGit2Sharp, Version=0.19.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -138,9 +138,9 @@
     <PostBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
   </PropertyGroup>
   <Target Name="Clean">
     <ItemGroup>

--- a/GitVersionCore/packages.config
+++ b/GitVersionCore/packages.config
@@ -3,7 +3,7 @@
   <package id="Caseless.Fody" version="1.3.3.0" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.24.0" targetFramework="net40" developmentDependency="true" />
   <package id="JetBrainsAnnotations.Fody" version="1.0.2" targetFramework="net40" developmentDependency="true" />
-  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net40" />
   <package id="PepitaPackage" version="1.20.1.0" targetFramework="net40" developmentDependency="true" />
   <package id="Visualize.Fody" version="0.4.0.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/GitVersionExe/GitVersionExe.csproj
+++ b/GitVersionExe/GitVersionExe.csproj
@@ -41,7 +41,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="LibGit2Sharp">
-      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -75,11 +75,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\git2-90befde.dll">
-      <Link>costura64\git2-90befde.dll</Link>
+    <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\git2-69db893.dll">
+      <Link>costura64\git2-69db893.dll</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\git2-90befde.dll">
-      <Link>costura32\git2-90befde.dll</Link>
+    <EmbeddedResource Include="..\Packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\git2-69db893.dll">
+      <Link>costura32\git2-69db893.dll</Link>
     </EmbeddedResource>
     <Content Include="FodyWeavers.xml">
       <SubType>Designer</SubType>
@@ -200,9 +200,9 @@ foreach (var item in filesToCleanup)
     <PostBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
   <Import Project="..\packages\PepitaPackage.1.20.1.0\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.20.1.0\build\PepitaPackage.targets')" />

--- a/GitVersionExe/packages.config
+++ b/GitVersionExe/packages.config
@@ -4,7 +4,7 @@
   <package id="Costura.Fody" version="1.1.0.0" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.24.0" targetFramework="net40" developmentDependency="true" />
   <package id="JetBrainsAnnotations.Fody" version="1.0.2" targetFramework="net40" developmentDependency="true" />
-  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net40" />
   <package id="PepitaPackage" version="1.20.1.0" targetFramework="net40" developmentDependency="true" />
   <package id="Visualize.Fody" version="0.4.0.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/GitVersionTask/GitVersionTask.csproj
+++ b/GitVersionTask/GitVersionTask.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="LibGit2Sharp, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />
@@ -123,9 +123,9 @@
     <PostBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
   <Target Name="ILMerge" BeforeTargets="AfterCompile">

--- a/GitVersionTask/packages.config
+++ b/GitVersionTask/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Caseless.Fody" version="1.3.3.0" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.24.0" targetFramework="net40" developmentDependency="true" />
-  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net40" />
   <package id="PepitaPackage" version="1.20.1.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/Tests/Mocks/MockRepository.cs
+++ b/Tests/Mocks/MockRepository.cs
@@ -35,6 +35,11 @@ public class MockRepository : IRepository
         throw new NotImplementedException();
     }
 
+    public CherryPickResult CherryPick(Commit commit, Signature committer, CherryPickOptions options = null)
+    {
+        throw new NotImplementedException();
+    }
+
     public GitObject Lookup(ObjectId id)
     {
         throw new NotImplementedException();

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -47,9 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\FluentDateTime.1.10.1.0\Lib\NET35\FluentDateTime.dll</HintPath>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="LibGit2Sharp, Version=0.19.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
@@ -172,9 +172,9 @@
     <PostBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="ApprovalUtilities" version="3.0.6" targetFramework="net45" />
   <package id="FluentDateTime" version="1.10.1.0" targetFramework="net45" />
   <package id="Fody" version="1.24.0" targetFramework="net45" developmentDependency="true" />
-  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net40" />
   <package id="ModuleInit.Fody" version="1.5.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />


### PR DESCRIPTION
As a result of some changes to the core LibGit2Sharp Library, in order to properly support Stash, I am suggesting that we pull in the latest version of LibGit2Sharp.

This was documented in https://github.com/Particular/GitVersion/issues/246 and then further documented in the equivalent issue in the LibGit2Sharp repository https://github.com/libgit2/libgit2sharp/issues/794.

Big thanks to @nulltoken and @carlosmn for getting the work completed!
