### PR TITLE
New cmd argument for override pre-release tag

### DIFF
--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="GitFlow\BaseGitFlowRepositoryFixture.cs" />
     <Compile Include="GitFlow\DevelopScenarios.cs" />
     <Compile Include="GitFlow\MetaDataByCommitFixture.cs" />
+    <Compile Include="OverwritePrereleaseTagArgTest.cs" />
     <Compile Include="GitFlow\PatchScenarios.cs" />
     <Compile Include="GitFlow\WikiScenarios.cs" />
     <Compile Include="GitHubFlow\OtherBranchTests.cs" />

--- a/AcceptanceTests/Helpers/GitVersionHelper.cs
+++ b/AcceptanceTests/Helpers/GitVersionHelper.cs
@@ -10,7 +10,7 @@
     public static class GitVersionHelper
     {
         public static ExecutionResults ExecuteIn(string workingDirectory,
-            string exec = null, string execArgs = null, string projectFile = null, string projectArgs = null,
+            string exec = null, string execArgs = null, string projectFile = null, string projectArgs = null, string preReleaseTag = null,
             bool isTeamCity = false)
         {
             var logFile = Path.Combine(workingDirectory, "log.txt");
@@ -19,9 +19,10 @@
             var execArgsArg = execArgs == null ? null : string.Format(" /execArgs \"{0}\"", execArgs);
             var projectFileArg = projectFile == null ? null : string.Format(" /proj \"{0}\"", projectFile);
             var targetsArg = projectArgs == null ? null : string.Format(" /projargs \"{0}\"", projectArgs);
+            var prereleaseTagArg = preReleaseTag == null ? null : string.Format(" /preReleaseTag \"{0}\"", preReleaseTag);
             var logArg = string.Format(" /l \"{0}\"", logFile);
-            var arguments = string.Format("\"{0}\"{1}{2}{3}{4}{5}", workingDirectory, execArg, execArgsArg,
-                projectFileArg, targetsArg, logArg);
+            var arguments = string.Format("\"{0}\"{1}{2}{3}{4}{5}{6}", workingDirectory, execArg, execArgsArg,
+                projectFileArg, targetsArg, logArg, prereleaseTagArg);
 
             var output = new StringBuilder();
 

--- a/AcceptanceTests/OverwritePrereleaseTagArgTest.cs
+++ b/AcceptanceTests/OverwritePrereleaseTagArgTest.cs
@@ -1,0 +1,44 @@
+﻿namespace AcceptanceTests
+{
+    using GitVersion;
+    using Helpers;
+    using LibGit2Sharp;
+    using Shouldly;
+    using Xunit;
+
+    public class OverwritePrereleaseTagArgTest
+    {
+        [Fact]
+        public void NoPrereleaseTag()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.Repository.MakeATaggedCommit("1.2.0");
+
+                fixture.Repository.CreateBranch("develop").Checkout();
+                fixture.Repository.MakeACommit();
+                fixture.Repository.CreateBranch("release/1.3");
+                var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, preReleaseTag: "");
+                
+                result.OutputVariables[VariableProvider.NuGetVersionV2].ShouldBe("1.3.0");
+            }
+        }
+
+
+        [Fact]
+        public void CustomPrereleaseTag()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.Repository.MakeATaggedCommit("1.2.0");
+
+                fixture.Repository.CreateBranch("develop").Checkout();
+                fixture.Repository.MakeACommit();
+                fixture.Repository.CreateBranch("release/1.3");
+                var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, preReleaseTag: "myprerealese");
+
+                result.OutputVariables[VariableProvider.NuGetVersionV2].ShouldBe("1.3.0-myprerealese");
+            }
+        }
+    }
+}

--- a/GitVersionExe/ArgumentParser.cs
+++ b/GitVersionExe/ArgumentParser.cs
@@ -158,6 +158,11 @@ namespace GitVersion
                     arguments.Output = outputType;
                     continue;
                 }
+                if (IsSwitch("preReleaseTag", name))
+                {
+                    arguments.PreReleaseTag = value;
+                    continue;
+                }
 
                 throw new WarningException(string.Format("Could not parse command line parameter '{0}'.", name));
             }

--- a/GitVersionExe/Arguments.cs
+++ b/GitVersionExe/Arguments.cs
@@ -29,5 +29,6 @@ namespace GitVersion
 
         public bool UpdateAssemblyInfo;
         public string UpdateAssemblyInfoFileName;
+        public string PreReleaseTag;
     }
 }

--- a/GitVersionExe/Program.cs
+++ b/GitVersionExe/Program.cs
@@ -61,6 +61,10 @@ namespace GitVersion
                 }
 
                 var semanticVersion = VersionCache.GetVersion(gitDirectory);
+                if (arguments.PreReleaseTag != null)
+                {
+                    semanticVersion.PreReleaseTag = arguments.PreReleaseTag;
+                }
 
                 if (arguments.Output == OutputType.BuildServer)
                 {


### PR DESCRIPTION
This pull request adds a new command line parameter named
"/preReleaseTag". When this argument will be specified, the pre-release
tag will be forced to be the value passed to the parameter.
