### PR TITLE
Add Environment Variable for each GV Variable

### DIFF
--- a/GitVersionCore/BuildServers/TeamCity.cs
+++ b/GitVersionCore/BuildServers/TeamCity.cs
@@ -28,6 +28,8 @@
 
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
+            Environment.SetEnvironmentVariable("GitVersion." + name, value);
+            
             return new[]
             {
                 string.Format("##teamcity[setParameter name='GitVersion.{0}' value='{1}']", name, EscapeValue(value)),


### PR DESCRIPTION
In a recent Pull Request (#262), the decision was taken to, in the absence of setParameter being available in AppVeyor, to create environment variables that could then be accessible in the remainder of Build Script.  I would like to suggest that this also makes sense for TeamCity.

In my scenario, I want to use:

`/output buildserver`

but use the generated variables later in my psake build script.  In order to do this, I have to call GitVersion twice.

Using this approach should mean that I can access the created Environment Variables later in my psake script when I need them.

Does that make sense?
