### PR TITLE
Skip creation of HEAD branch when creating local branches

### DIFF
--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -172,10 +172,12 @@ namespace GitVersion
         static void CreateMissingLocalBranchesFromRemoteTrackingOnes(Repository repo, string remoteName)
         {
             var prefix = string.Format("refs/remotes/{0}/", remoteName);
+            var remoteHeadCanonicalName = string.Format("{0}{1}", prefix, "HEAD");
 
-            foreach (var remoteTrackingReference in repo.Refs.FromGlob(prefix + "*"))
+            foreach (var remoteTrackingReference in repo.Refs.FromGlob(prefix + "*").Where(r => r.CanonicalName != remoteHeadCanonicalName))
             {
                 var localCanonicalName = "refs/heads/" + remoteTrackingReference.CanonicalName.Substring(prefix.Length);
+
                 if (repo.Refs.Any(x => x.CanonicalName == localCanonicalName))
                 {
                     Logger.WriteInfo(string.Format("Skipping local branch creation since it already exists '{0}'.", remoteTrackingReference.CanonicalName));


### PR DESCRIPTION
- Based on a suggestion from @nulltoken, skipping the creation of the HEAD branch, if it exists in the list of branches to create.
- This was causing an issue when running on AppVeyor
- This can be seen working here:
  https://ci.appveyor.com/project/GaryEwanPark/webapisample/build/0.2.0-unstable.23+23%20(Build%2034)
