### PR TITLE
Making UpdateAssemblyInfo to only consider files under the workingDirectory

### DIFF
--- a/GitVersionExe/AssemblyInfoFileUpdate.cs
+++ b/GitVersionExe/AssemblyInfoFileUpdate.cs
@@ -47,9 +47,11 @@ namespace GitVersion
         {
             if (args.UpdateAssemblyInfoFileName != null)
             {
-                if (File.Exists(args.UpdateAssemblyInfoFileName))
+                var fullPath = Path.Combine(workingDirectory, args.UpdateAssemblyInfoFileName);
+
+                if (File.Exists(fullPath))
                 {
-                    return new[] { Path.GetFullPath(args.UpdateAssemblyInfoFileName) };
+                    return new[] { fullPath };
                 }
             }
 


### PR DESCRIPTION
For some reason, when I did this, I assumed GitVersion is always located somewhere inside the working directory.
This pull request fixes a problem where File.Exist would return false if GitVersion was used from the outside (for example, when debugging!)

there are no tests for this :(
