### PR TITLE
Ability to merge release back to develop

### DIFF
--- a/GitVersionCore.Tests/GitFlow/WikiScenarios.cs
+++ b/GitVersionCore.Tests/GitFlow/WikiScenarios.cs
@@ -76,7 +76,7 @@ note over develop: 1.4.0.2-unstable
 
             // Make a commit after a tag should bump up the beta
             fixture.Repository.MakeACommit();
-            fixture.AssertFullSemver("1.3.0-beta.2+2");
+            fixture.AssertFullSemver("1.3.0-beta.2+0");
 
             // Merge release branch to master
             fixture.Repository.Checkout("master");

--- a/GitVersionCore/GitFlow/BranchFinders/HotfixVersionFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/HotfixVersionFinder.cs
@@ -1,6 +1,5 @@
 namespace GitVersion
 {
-    using System.Linq;
     using LibGit2Sharp;
 
     class HotfixVersionFinder 
@@ -28,7 +27,7 @@ namespace GitVersion
         static string GetSemanticVersionPreReleaseTag(GitVersionContext context, ShortVersion shortVersion, int nbHotfixCommits)
         {
             var semanticVersionPreReleaseTag = "beta.1";
-            var tagVersion = RecentTagVersionExtractor.RetrieveMostRecentOptionalTagVersion(context.Repository, shortVersion, context.CurrentBranch.Commits.Take(nbHotfixCommits + 1));
+            var tagVersion = RecentTagVersionExtractor.RetrieveMostRecentOptionalTagVersion(context, shortVersion);
             if (tagVersion != null)
             {
                 semanticVersionPreReleaseTag = tagVersion;

--- a/GitVersionCore/LibGitExtensions.cs
+++ b/GitVersionCore/LibGitExtensions.cs
@@ -39,6 +39,23 @@ namespace GitVersion
                 });
         }
 
+        public static IEnumerable<Tag> SemVerTagsRelatedToVersion(this IRepository repository, ShortVersion version)
+        {
+            foreach (var tag in repository.Tags)
+            {
+                SemanticVersion tagVersion;
+                if (SemanticVersion.TryParse(tag.Name, out tagVersion))
+                {
+                    if (version.Major == tagVersion.Major &&
+                        version.Minor == tagVersion.Minor &&
+                        version.Patch == tagVersion.Patch)
+                    {
+                        yield return tag;
+                    }
+                }
+            }
+        }
+
         public static GitObject PeeledTarget(this Tag tag)
         {
             var target = tag.Target;


### PR DESCRIPTION
This preserves the correct version when merging a release back into develop.

There are some behavioral changes as shown in the edited tests:

The behavior of the +n CommitsSinceTag metadata is changed to actually represent the commits since last tag. This means that this number gets reset to zero on change of PreReleaseTag. For instance, version 1.0.0-beta.1+5 gets reset to 1.0.0-beta.2+0 for the next commit after the 1.0.0-beta.1 tag). When only one tag is present, (i.e. the first tag in the release branch) it reverts to the previous behavior which is to indicate the number of commits since the creation of the release branch.
