### PR TITLE
Fix problem in sorting pre-release-tags

### DIFF
--- a/GitVersionCore.Tests/SemanticVersionTests.cs
+++ b/GitVersionCore.Tests/SemanticVersionTests.cs
@@ -65,6 +65,8 @@ public class SemanticVersionTests
     public void VersionSorting()
     {
         SemanticVersion.Parse("1.0.0").ShouldBeGreaterThan(SemanticVersion.Parse("1.0.0-beta"));
+        SemanticVersion.Parse("1.0.0-beta.2").ShouldBeGreaterThan(SemanticVersion.Parse("1.0.0-beta.1"));
+        SemanticVersion.Parse("1.0.0-beta.1").ShouldBeLessThan(SemanticVersion.Parse("1.0.0-beta.2"));
     }
 
     [Test]

--- a/GitVersionCore/SemanticVersionPreReleaseTag.cs
+++ b/GitVersionCore/SemanticVersionPreReleaseTag.cs
@@ -106,7 +106,7 @@ namespace GitVersion
                 return -1;
             }
 
-            var nameComparison = StringComparer.InvariantCultureIgnoreCase.Compare(Name, other);
+            var nameComparison = StringComparer.InvariantCultureIgnoreCase.Compare(Name, other.Name);
             if (nameComparison != 0)
                 return nameComparison;
 


### PR DESCRIPTION
This fixes https://github.com/ParticularLabs/GitVersion/issues/294 which causes wrong ordering of pre-release tags. 
