### PR TITLE
Fixed assemblyinfo patching with stars

### DIFF
--- a/GitVersionExe.Tests/AssemblyInfoFileUpdateTests.cs
+++ b/GitVersionExe.Tests/AssemblyInfoFileUpdateTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace GitVersionExe.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using GitVersion;
@@ -17,6 +18,82 @@
             using (new AssemblyInfoFileUpdate(new Arguments{ UpdateAssemblyInfo = true }, workingDir, new Dictionary<string, string>(), fileSystem))
             {
                 fileSystem.Received().DirectoryGetFiles(Arg.Is(workingDir), Arg.Any<string>(), Arg.Any<SearchOption>());
+            }
+        }
+
+        [Test]
+        public void ShouldReplaceAssemblyVersion()
+        {
+            var fileSystem = Substitute.For<IFileSystem>();
+            var version = new SemanticVersion()
+                {
+                    BuildMetaData = new SemanticVersionBuildMetaData(3, "foo", "hash", DateTimeOffset.Now),
+                    Major = 2,
+                    Minor = 3,
+                    Patch = 1
+                };
+
+            const string workingDir = "C:\\Testing";
+            const string assemblyInfoFile = @"AssemblyVersion(""1.0.0.0"");
+AssemblyInformationalVersion(""1.0.0.0"");
+AssemblyFileVersion(""1.0.0.0"");";
+            
+            fileSystem.Exists("C:\\Testing\\AssemblyInfo.cs").Returns(true);
+            fileSystem.ReadAllText("C:\\Testing\\AssemblyInfo.cs").Returns(assemblyInfoFile);
+            var config = new Config()
+                             {
+                                 AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch
+                             };
+            var variable = VariableProvider.GetVariablesFor(version, config); 
+            var args = new Arguments
+                           {
+                               UpdateAssemblyInfo = true,
+                               UpdateAssemblyInfoFileName = "AssemblyInfo.cs"
+                           };
+            using (new AssemblyInfoFileUpdate(args, workingDir, variable, fileSystem))
+            {
+                const string expected = @"AssemblyVersion(""2.3.0.0"");
+AssemblyInformationalVersion(""2.3.1+3.Branch.foo.Sha.hash"");
+AssemblyFileVersion(""2.3.1.0"");";
+                fileSystem.Received().WriteAllText("C:\\Testing\\AssemblyInfo.cs", expected);
+            }
+        }
+
+        [Test]
+        public void ShouldReplaceAssemblyVersionWithStar()
+        {
+            var fileSystem = Substitute.For<IFileSystem>();
+            var version = new SemanticVersion()
+                              {
+                                  BuildMetaData = new SemanticVersionBuildMetaData(3, "foo", "hash", DateTimeOffset.Now),
+                                  Major = 2,
+                                  Minor = 3,
+                                  Patch = 1
+                              };
+
+            const string workingDir = "C:\\Testing";
+            const string assemblyInfoFile = @"AssemblyVersion(""1.0.0.*"");
+AssemblyInformationalVersion(""1.0.0.*"");
+AssemblyFileVersion(""1.0.0.*"");";
+
+            fileSystem.Exists("C:\\Testing\\AssemblyInfo.cs").Returns(true);
+            fileSystem.ReadAllText("C:\\Testing\\AssemblyInfo.cs").Returns(assemblyInfoFile);
+            var config = new Config()
+                             {
+                                 AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch
+                             };
+            var variable = VariableProvider.GetVariablesFor(version, config);
+            var args = new Arguments
+                           {
+                               UpdateAssemblyInfo = true,
+                               UpdateAssemblyInfoFileName = "AssemblyInfo.cs"
+                           };
+            using (new AssemblyInfoFileUpdate(args, workingDir, variable, fileSystem))
+            {
+                const string expected = @"AssemblyVersion(""2.3.0.0"");
+AssemblyInformationalVersion(""2.3.1+3.Branch.foo.Sha.hash"");
+AssemblyFileVersion(""2.3.1.0"");";
+                fileSystem.Received().WriteAllText("C:\\Testing\\AssemblyInfo.cs", expected);
             }
         }
     }

--- a/GitVersionExe/AssemblyInfoFileUpdate.cs
+++ b/GitVersionExe/AssemblyInfoFileUpdate.cs
@@ -35,9 +35,9 @@ namespace GitVersion
                 var assemblyInfoVersion = variables[VariableProvider.InformationalVersion];
                 var assemblyFileVersion = variables[VariableProvider.AssemblySemVer];
                 var fileContents = fileSystem.ReadAllText(assemblyInfoFile)
-                    .RegexReplace(@"AssemblyVersion\(""\d+.\d+.\d+(.\d+|\*)?""\)", string.Format("AssemblyVersion(\"{0}\")", assemblyVersion))
-                    .RegexReplace(@"AssemblyInformationalVersion\(""\d+.\d+.\d+(.\d+|\*)?""\)", string.Format("AssemblyInformationalVersion(\"{0}\")", assemblyInfoVersion))
-                    .RegexReplace(@"AssemblyFileVersion\(""\d+.\d+.\d+(.\d+|\*)?""\)", string.Format("AssemblyFileVersion(\"{0}\")", assemblyFileVersion));
+                    .RegexReplace(@"AssemblyVersion\(""\d+.\d+.\d+(.(\d+|\*))?""\)", string.Format("AssemblyVersion(\"{0}\")", assemblyVersion))
+                    .RegexReplace(@"AssemblyInformationalVersion\(""\d+.\d+.\d+(.(\d+|\*))?""\)", string.Format("AssemblyInformationalVersion(\"{0}\")", assemblyInfoVersion))
+                    .RegexReplace(@"AssemblyFileVersion\(""\d+.\d+.\d+(.(\d+|\*))?""\)", string.Format("AssemblyFileVersion(\"{0}\")", assemblyFileVersion));
 
                 fileSystem.WriteAllText(assemblyInfoFile, fileContents);
             }


### PR DESCRIPTION
When an AssemblyInfo.cs contained a version like 1.0.0.\* it wasn't recognized by GitVersion. Only 1.0.0.0 or 1.0.0\* worked.
