### PR TITLE
Added a new command line argument -assemblyVersionFormat 

### DIFF
--- a/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -199,6 +199,23 @@ public class ArgumentParserTests
     }
 
     [Test]
+    public void update_assembly_info_with_assembly_version_format()
+    {
+        var arguments = ArgumentParser.ParseArguments("-updateAssemblyInfo true -assemblyVersionFormat MajorMinorPatch");
+        arguments.UpdateAssemblyInfo.ShouldBe(true);       
+        arguments.AssemblyVersionFormat.ShouldBe("MajorMinorPatch");
+    }
+
+    [Test]
+    public void update_assembly_info_with_filename_and_assembly_version_format()
+    {
+        var arguments = ArgumentParser.ParseArguments("-updateAssemblyInfo CommonAssemblyInfo.cs -assemblyVersionFormat MajorMinorPatch");
+        arguments.UpdateAssemblyInfo.ShouldBe(true);
+        arguments.AssemblyVersionFormat.ShouldBe("MajorMinorPatch");
+        arguments.UpdateAssemblyInfoFileName.ShouldBe("CommonAssemblyInfo.cs");
+    }
+
+    [Test]
     public void can_log_to_console()
     {
         var arguments = ArgumentParser.ParseArguments("-l console -proj foo.sln");

--- a/GitVersionExe/ArgumentParser.cs
+++ b/GitVersionExe/ArgumentParser.cs
@@ -141,6 +141,12 @@ namespace GitVersion
                     continue;
                 }
 
+                if (IsSwitch("assemblyversionformat", name))
+                {
+                    arguments.AssemblyVersionFormat = value;
+                    continue;
+                }
+
                 if ((IsSwitch("v", name)) && VersionParts.Contains(value.ToLower()))
                 {
                     arguments.VersionPart = value.ToLower();

--- a/GitVersionExe/Arguments.cs
+++ b/GitVersionExe/Arguments.cs
@@ -29,5 +29,6 @@ namespace GitVersion
 
         public bool UpdateAssemblyInfo;
         public string UpdateAssemblyInfoFileName;
+        public string AssemblyVersionFormat;      
     }
 }

--- a/GitVersionExe/AssemblyInfoFileUpdate.cs
+++ b/GitVersionExe/AssemblyInfoFileUpdate.cs
@@ -31,7 +31,16 @@ namespace GitVersion
                 });
                 cleanupBackupTasks.Add(() => fileSystem.Delete(backupAssemblyInfo));
 
-                var assemblyVersion = string.Format("{0}.{1}.0.0", variables[VariableProvider.Major], variables[VariableProvider.Minor]);
+                string assemblyVersion;
+                if (!string.IsNullOrWhiteSpace(args.AssemblyVersionFormat))
+                {
+                    assemblyVersion = variables[args.AssemblyVersionFormat];
+                }
+                else
+                {
+                    assemblyVersion = string.Format("{0}.{1}.0.0", variables[VariableProvider.Major], variables[VariableProvider.Minor]);
+                }
+
                 var assemblyInfoVersion = variables[VariableProvider.InformationalVersion];
                 var assemblyFileVersion = variables[VariableProvider.AssemblySemVer];
                 var fileContents = fileSystem.ReadAllText(assemblyInfoFile)

--- a/GitVersionExe/Program.cs
+++ b/GitVersionExe/Program.cs
@@ -25,8 +25,8 @@ namespace GitVersion
             {
                 // Dump log to console if we fail to complete successfully
                 Console.Write(log.ToString());
-            } 
-            
+            }
+
             Environment.Exit(exitCode);
         }
 
@@ -113,6 +113,14 @@ namespace GitVersion
                             break;
                     }
                 }
+
+                if (!string.IsNullOrWhiteSpace(arguments.AssemblyVersionFormat) && !variables.ContainsKey(arguments.AssemblyVersionFormat))
+                {
+                    Console.WriteLine("Unrecognised AssemblyVersionFormat argument. Valid values for this argument are: {0}", string.Join(" ", variables.Keys.OrderBy(a => a)));
+                    HelpWriter.Write();
+                    return 1;                   
+                }
+
 
                 using (var assemblyInfoUpdate = new AssemblyInfoFileUpdate(arguments, workingDirectory, variables, new FileSystem()))
                 {


### PR DESCRIPTION
Added a new command line argument -assemblyVersionFormat that can be used to specify which GitVersion variable is used when setting the AssemblyVersion attribute.
