### PR TITLE
UpdateAssemblyInfo: create local tmp file in \obj.

### DIFF
--- a/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
+++ b/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
@@ -24,6 +24,13 @@
 
         [Required]
         public string ProjectFile { get; set; }
+
+        [Required]
+        public string ProjectDir { get; set; }
+
+        [Required]
+        public string Configuration { get; set; }
+
         [Required]
         public ITaskItem[] CompileFiles { get; set; }
 
@@ -127,8 +134,20 @@
                                       };
             var assemblyInfo = assemblyInfoBuilder.GetAssemblyInfoText(configuration);
 
-            var tempFileName = string.Format("AssemblyInfo_{0}_{1}.g.cs", Path.GetFileNameWithoutExtension(ProjectFile), Path.GetRandomFileName());
-            AssemblyInfoTempFilePath = Path.Combine(TempFileTracker.TempPath, tempFileName);
+            string tempFileName, tempDir;
+            if (string.IsNullOrEmpty(ProjectDir) || string.IsNullOrWhiteSpace(ProjectDir))
+            {
+                tempDir = TempFileTracker.TempPath;
+                tempFileName = string.Format("AssemblyInfo_{0}_{1}.g.cs", Path.GetFileNameWithoutExtension(ProjectFile), Path.GetRandomFileName());
+            }
+            else
+            {
+                tempDir = Path.Combine(ProjectDir, "obj", Configuration);
+                Directory.CreateDirectory(tempDir);
+                tempFileName = string.Format("GitVersionTaskAssemblyInfo.g.cs");
+            }
+
+            AssemblyInfoTempFilePath = Path.Combine(tempDir, tempFileName);
             File.WriteAllText(AssemblyInfoTempFilePath, assemblyInfo);
         }
     }

--- a/GitVersionTask/NugetAssets/GitVersionTask.targets
+++ b/GitVersionTask/NugetAssets/GitVersionTask.targets
@@ -25,6 +25,8 @@
     <UpdateAssemblyInfo
       SolutionDirectory="$(SolutionDir)"
       ProjectFile="$(ProjectPath)"
+      ProjectDir="$(ProjectDir)"
+      Configuration="$(ConfigurationName)"
       AssemblyVersioningScheme="$(GitVersionAssemblyVersioningScheme)"
       CompileFiles ="@(Compile)">
       <Output


### PR DESCRIPTION
Now UpdateAssemblyInfo task creates temp assembly info file within
$(ProjectDir)\obj\$(ConfigurationName).

Fix #146.

To include generated temp assembly info file to a nuget symbols package you should write in nuspec a line like this one:

``` xml
<file src="BuildTest\**\*.cs" target="src\BuildTest\" />
```
