### PR TITLE
Fixed libgit2 bug/deprecated

### DIFF
--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -101,7 +101,7 @@ namespace GitVersion
 
             if (!string.IsNullOrEmpty(username))
             {
-                fetchOptions.Credentials = new UsernamePasswordCredentials
+                fetchOptions.CredentialsProvider = (url, user, types) =>  new UsernamePasswordCredentials
                 {
                     Username = username,
                     Password = password

--- a/GitVersionExe/GitPreparer.cs
+++ b/GitVersionExe/GitPreparer.cs
@@ -57,7 +57,7 @@
             Logger.WriteInfo(string.Format("Retrieving git info from url '{0}'", arguments.TargetUrl));
 
             Repository.Clone(arguments.TargetUrl, gitDirectory, 
-                new CloneOptions { IsBare = true, Checkout = false, Credentials = credentials});
+                new CloneOptions { IsBare = true, Checkout = false, CredentialsProvider = (url, user, types) => credentials });
 
             if (!string.IsNullOrWhiteSpace(arguments.TargetBranch))
             {


### PR DESCRIPTION
In libgit2 the "Credentials" property is deprecated, instead
CredentialsHelper should be used. In 0.19 there is a bug with the
Credentials property when cloning, using the "correct" way
(CredentialsHelper) fixes the bug:
https://github.com/libgit2/libgit2sharp/issues/834

In order to be consistent I changed also the fetch method.

Sorry for the missing tests, but I really don't know how to write a test for this?
