### PR TITLE
Enable config based ignoring of commits/messages that incorrectly inc…

### DIFF
--- a/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -14,10 +14,12 @@ namespace GitVersionCore.Tests
             bool preventIncrementForMergedBranchVersion = false,
             string tagNumberPattern = null,
             string continuousDeploymentFallbackTag = "ci",
-            bool trackMergeTarget = false) : 
+            bool trackMergeTarget = false,
+            string[] commitsToIgnore = null,
+            string[] mergeMessagesToIgnore = null) : 
                 base(assemblyVersioningScheme, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch, 
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
-                    trackMergeTarget)
+                    trackMergeTarget, commitsToIgnore, mergeMessagesToIgnore)
         {
         }
     }

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -64,6 +64,12 @@
         [YamlMember(Alias = "next-version")]
         public string NextVersion { get; set; }
 
+        [YamlMember(Alias="commits-to-ignore")]
+        public string[] CommitsToIgnore { get; set; }
+
+        [YamlMember(Alias = "merge-messages-to-ignore")]
+        public string[] MergeMessagesToIgnore { get; set; }
+
         [YamlMember(Alias = "branches")]
         public Dictionary<string, BranchConfig> Branches
         {

--- a/GitVersionCore/EffectiveConfiguration.cs
+++ b/GitVersionCore/EffectiveConfiguration.cs
@@ -13,7 +13,9 @@
             bool preventIncrementForMergedBranchVersion, 
             string tagNumberPattern,
             string continuousDeploymentFallbackTag, 
-            bool trackMergeTarget)
+            bool trackMergeTarget,
+            string[] commitsToIgnore,
+            string[] mergeMessagesToIgnore)
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
             VersioningMode = versioningMode;
@@ -26,6 +28,8 @@
             TagNumberPattern = tagNumberPattern;
             ContinuousDeploymentFallbackTag = continuousDeploymentFallbackTag;
             TrackMergeTarget = trackMergeTarget;
+            CommitsToIgnore = commitsToIgnore;
+            MergeMessagesToIgnore = mergeMessagesToIgnore;
         }
 
         public VersioningMode VersioningMode { get; private set; }
@@ -54,5 +58,8 @@
 
         public string ContinuousDeploymentFallbackTag { get; private set; }
         public bool TrackMergeTarget { get; private set; }
+
+        public string[] CommitsToIgnore { get; private set; }
+        public string[] MergeMessagesToIgnore { get; set; }
     }
 }

--- a/GitVersionCore/EffectiveConfiguration.cs
+++ b/GitVersionCore/EffectiveConfiguration.cs
@@ -60,6 +60,6 @@
         public bool TrackMergeTarget { get; private set; }
 
         public string[] CommitsToIgnore { get; private set; }
-        public string[] MergeMessagesToIgnore { get; set; }
+        public string[] MergeMessagesToIgnore { get; private set; }
     }
 }

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -91,7 +91,9 @@
                 tag, nextVersion, incrementStrategy, currentBranchConfig.Key, 
                 preventIncrementForMergedBranchVersion, 
                 tagNumberPattern, configuration.ContinuousDeploymentFallbackTag,
-                currentBranchConfig.Value.TrackMergeTarget);
+                currentBranchConfig.Value.TrackMergeTarget,
+                configuration.CommitsToIgnore,
+                configuration.MergeMessagesToIgnore);
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,6 +1,7 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
     using System.Linq;
+    using System.Security.Cryptography.X509Certificates;
     using System.Text.RegularExpressions;
     using LibGit2Sharp;
 
@@ -38,6 +39,16 @@
         private static SemanticVersion Inner(Commit mergeCommit, EffectiveConfiguration configuration)
         {
             if (mergeCommit.Parents.Count() < 2)
+            {
+                return null;
+            }
+
+            if (configuration.CommitsToIgnore != null && configuration.CommitsToIgnore.Contains(mergeCommit.Sha))
+            {
+                return null;
+            }
+
+            if (configuration.MergeMessagesToIgnore != null && configuration.MergeMessagesToIgnore.Any(x => mergeCommit.Message.Contains(x)))
             {
                 return null;
             }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,7 +1,6 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
     using System.Linq;
-    using System.Security.Cryptography.X509Certificates;
     using System.Text.RegularExpressions;
     using LibGit2Sharp;
 


### PR DESCRIPTION
…rement version

The latest changes to the MergeMessage branching strategy, while very
helpful, have pulled in very old messages from our repo that are
formatted in a way that cause the version number to be unexpectedly
high.
This changes allows configuration of commit SHAs to ignore, or strings
to ignore inside merge messages, so you can "fix" old commits in your
repo that you don't want to effect the version generation.
This is related to #466 and a possible fix for #443