### PR TITLE
Update ArgumentParser to use variables from VersionVariables

### DIFF
--- a/GitVersionCore/OutputVariables/VersionVariables.cs
+++ b/GitVersionCore/OutputVariables/VersionVariables.cs
@@ -50,7 +50,7 @@
         public string NuGetVersionV2 { get { return LegacySemVerPadded.ToLower(); } }
         public string NuGetVersion { get { return NuGetVersionV2; } }
 
-        public IEnumerable<string> AvailableVariables
+        public static IEnumerable<string> AvailableVariables
         {
             get { return typeof(VersionVariables).GetProperties().Select(p => p.Name).OrderBy(a => a); }
         }

--- a/GitVersionExe/Program.cs
+++ b/GitVersionExe/Program.cs
@@ -42,6 +42,19 @@ namespace GitVersion
                 {
                     arguments = ArgumentParser.ParseArguments(argumentsWithoutExeName);
                 }
+                catch (WarningException ex)
+                {
+                    Console.WriteLine("Failed to parse arguments: {0}", string.Join(" ", argumentsWithoutExeName));
+                    if (!string.IsNullOrWhiteSpace(ex.Message))
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine(ex.Message);
+                        Console.WriteLine();
+                    }
+
+                    HelpWriter.Write();
+                    return 1;
+                }
                 catch (Exception)
                 {
                     Console.WriteLine("Failed to parse arguments: {0}", string.Join(" ", argumentsWithoutExeName));


### PR DESCRIPTION
I wasn't seeing any new progress in #447.

This changes VersionVariables.AvailableVariables to static and bubbles up WarningException.Message to console output

I went ahead and kept /v for backwards compatibility and added the documented /showvariable