### PR TITLE
Add support for indicating change severity in commit messages

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -2,6 +2,10 @@
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
 continuous-delivery-fallback-tag: ci
+major-version-bump-message: '\+semver:\s?(breaking|major)'
+minor-version-bump-message: '\+semver:\s?(feature|minor)'
+patch-version-bump-message: '\+semver:\s?(fix|patch)'
+commit-message-incrementing: Enabled
 branches:
   master:
     mode: ContinuousDelivery

--- a/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -14,10 +14,16 @@ namespace GitVersionCore.Tests
             bool preventIncrementForMergedBranchVersion = false,
             string tagNumberPattern = null,
             string continuousDeploymentFallbackTag = "ci",
-            bool trackMergeTarget = false) : 
+            bool trackMergeTarget = false,
+            string majorMessage = null,
+            string minorMessage = null,
+            string patchMessage = null,
+            CommitMessageIncrementMode commitMessageMode = CommitMessageIncrementMode.Enabled) : 
                 base(assemblyVersioningScheme, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch, 
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
-                    trackMergeTarget)
+                    trackMergeTarget,
+                    majorMessage, minorMessage, patchMessage,
+                    commitMessageMode)
         {
         }
     }

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -16,6 +16,7 @@
             PreventIncrementOfMergedBranchVersion = branchConfiguration.PreventIncrementOfMergedBranchVersion;
             TagNumberPattern = branchConfiguration.TagNumberPattern;
             TrackMergeTarget = branchConfiguration.TrackMergeTarget;
+            CommitMessageIncrementing = branchConfiguration.CommitMessageIncrementing;
         }
 
         [YamlMember(Alias = "mode")]
@@ -38,5 +39,8 @@
 
         [YamlMember(Alias = "track-merge-target")]
         public bool? TrackMergeTarget { get; set; }
+        
+        [YamlMember(Alias = "commit-message-incrementing")]
+        public CommitMessageIncrementMode? CommitMessageIncrementing { get; set; }
     }
 }

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -23,6 +23,18 @@
         [YamlMember(Alias = "next-version")]
         public string NextVersion { get; set; }
 
+        [YamlMember(Alias = "major-version-bump-message")]
+        public string MajorVersionBumpMessage { get; set; }
+
+        [YamlMember(Alias = "minor-version-bump-message")]
+        public string MinorVersionBumpMessage { get; set; }
+
+        [YamlMember(Alias = "patch-version-bump-message")]
+        public string PatchVersionBumpMessage { get; set; }
+
+        [YamlMember(Alias = "commit-message-incrementing")]
+        public CommitMessageIncrementMode? CommitMessageIncrementing { get; set; }
+
         [YamlMember(Alias = "branches")]
         public Dictionary<string, BranchConfig> Branches
         {

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -24,6 +24,10 @@ namespace GitVersion
             config.TagPrefix = config.TagPrefix ?? DefaultTagPrefix;
             config.VersioningMode = config.VersioningMode ?? VersioningMode.ContinuousDelivery;
             config.ContinuousDeploymentFallbackTag = config.ContinuousDeploymentFallbackTag ?? "ci";
+            config.MajorVersionBumpMessage = config.MajorVersionBumpMessage ?? IncrementStrategyFinder.DefaultMajorPattern;
+            config.MinorVersionBumpMessage = config.MinorVersionBumpMessage ?? IncrementStrategyFinder.DefaultMinorPattern;
+            config.PatchVersionBumpMessage = config.PatchVersionBumpMessage ?? IncrementStrategyFinder.DefaultPatchPattern;
+            config.CommitMessageIncrementing = config.CommitMessageIncrementing ?? CommitMessageIncrementMode.Enabled;
             var configBranches = config.Branches.ToList();
 
             ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, "master"), defaultTag: string.Empty, defaultPreventIncrement: true);

--- a/src/GitVersionCore/Configuration/IncrementStrategy.cs
+++ b/src/GitVersionCore/Configuration/IncrementStrategy.cs
@@ -1,5 +1,7 @@
 ﻿namespace GitVersion
 {
+    using System;
+
     public enum IncrementStrategy
     {
         None,
@@ -9,6 +11,26 @@
         /// <summary>
         /// Uses the increment strategy from the branch the current branch was branched from
         /// </summary>
-        Inherit 
+        Inherit
+    }
+
+    public static class IncrementStrategyExtensions
+    {
+        public static VersionField ToVersionField(this IncrementStrategy strategy)
+        {
+            switch (strategy)
+            {
+                case IncrementStrategy.None:
+                    return VersionField.None;
+                case IncrementStrategy.Major:
+                    return VersionField.Major;
+                case IncrementStrategy.Minor:
+                    return VersionField.Minor;
+                case IncrementStrategy.Patch:
+                    return VersionField.Patch;
+                default:
+                    throw new ArgumentOutOfRangeException("strategy", strategy, null);
+            }
+        }
     }
 }

--- a/src/GitVersionCore/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/EffectiveConfiguration.cs
@@ -13,7 +13,11 @@
             bool preventIncrementForMergedBranchVersion, 
             string tagNumberPattern,
             string continuousDeploymentFallbackTag, 
-            bool trackMergeTarget)
+            bool trackMergeTarget,
+            string majorVersionBumpMessage,
+            string minorVersionBumpMessage,
+            string patchVersionBumpMessage,
+            CommitMessageIncrementMode commitMessageIncrementing)
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
             VersioningMode = versioningMode;
@@ -26,6 +30,10 @@
             TagNumberPattern = tagNumberPattern;
             ContinuousDeploymentFallbackTag = continuousDeploymentFallbackTag;
             TrackMergeTarget = trackMergeTarget;
+            MajorVersionBumpMessage = majorVersionBumpMessage;
+            MinorVersionBumpMessage = minorVersionBumpMessage;
+            PatchVersionBumpMessage = patchVersionBumpMessage;
+            CommitMessageIncrementing = commitMessageIncrementing;
         }
 
         public VersioningMode VersioningMode { get; private set; }
@@ -55,5 +63,13 @@
         public string ContinuousDeploymentFallbackTag { get; private set; }
 
         public bool TrackMergeTarget { get; private set; }
+
+        public string MajorVersionBumpMessage { get; private set; }
+        
+        public string MinorVersionBumpMessage { get; private set; }
+
+        public string PatchVersionBumpMessage { get; private set; }
+
+        public CommitMessageIncrementMode CommitMessageIncrementing { get; private set; }
     }
 }

--- a/src/GitVersionCore/FodyWeavers.xml
+++ b/src/GitVersionCore/FodyWeavers.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Weavers VerifyAssembly="true">
   <Caseless/>
   <JetBrainsAnnotations/>

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -91,6 +91,8 @@
                 throw new Exception(string.Format("Configuration value for 'TrackMergeTarget' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
             if (!configuration.AssemblyVersioningScheme.HasValue)
                 throw new Exception("Configuration value for 'AssemblyVersioningScheme' has no value. (this should not happen, please report an issue)");
+            if (!configuration.CommitMessageIncrementing.HasValue)
+                throw new Exception("Configuration value for 'CommitMessageIncrementing' has no value. (this should not happen, please report an issue)");
 
             var versioningMode = currentBranchConfig.Value.VersioningMode.Value;
             var tag = currentBranchConfig.Value.Tag;
@@ -98,16 +100,24 @@
             var incrementStrategy = currentBranchConfig.Value.Increment.Value;
             var preventIncrementForMergedBranchVersion = currentBranchConfig.Value.PreventIncrementOfMergedBranchVersion.Value;
             var trackMergeTarget = currentBranchConfig.Value.TrackMergeTarget.Value;
-
+            
             var nextVersion = configuration.NextVersion;
             var assemblyVersioningScheme = configuration.AssemblyVersioningScheme.Value;
             var gitTagPrefix = configuration.TagPrefix;
+            var majorMessage = configuration.MajorVersionBumpMessage;
+            var minorMessage = configuration.MinorVersionBumpMessage;
+            var patchMessage = configuration.MinorVersionBumpMessage;
+
+            var commitMessageVersionBump = currentBranchConfig.Value.CommitMessageIncrementing ?? configuration.CommitMessageIncrementing.Value;
+
             Configuration = new EffectiveConfiguration(
                 assemblyVersioningScheme, versioningMode, gitTagPrefix, 
                 tag, nextVersion, incrementStrategy, currentBranchConfig.Key, 
                 preventIncrementForMergedBranchVersion, 
                 tagNumberPattern, configuration.ContinuousDeploymentFallbackTag,
-                trackMergeTarget);
+                trackMergeTarget,
+                majorMessage, minorMessage, patchMessage,
+                commitMessageVersionBump);
         }
     }
 }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Helpers\IFileSystem.cs" />
     <Compile Include="Helpers\ProcessHelper.cs" />
     <Compile Include="Helpers\ServiceMessageEscapeHelper.cs" />
+    <Compile Include="IncrementStrategyFinder.cs" />
     <Compile Include="OutputVariables\VersionVariables.cs" />
     <Compile Include="Extensions\ExtensionMethods.git.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />

--- a/src/GitVersionCore/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/IncrementStrategyFinder.cs
@@ -1,0 +1,107 @@
+﻿namespace GitVersion
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using VersionCalculation.BaseVersionCalculators;
+    using LibGit2Sharp;
+
+    public enum CommitMessageIncrementMode
+    {
+        Enabled,
+        Disabled,
+        MergeMessageOnly
+    }
+
+    public static class IncrementStrategyFinder
+    {
+        public const string DefaultMajorPattern = @"\+semver:\s?(breaking|major)";
+        public const string DefaultMinorPattern = @"\+semver:\s?(feature|minor)";
+        public const string DefaultPatchPattern = @"\+semver:\s?(fix|patch)";
+
+        public static VersionField? DetermineIncrementedField(GitVersionContext context, BaseVersion baseVersion)
+        {
+            var commitMessageIncrement = FindCommitMessageIncrement(context, baseVersion);
+            var defaultIncrement = context.Configuration.Increment.ToVersionField();
+
+            // use the default branch config increment strategy if there are no commit message overrides
+            if (commitMessageIncrement == null)
+            {
+                return baseVersion.ShouldIncrement ? defaultIncrement : (VersionField?)null;
+            }
+
+            // cap the commit message severity to minor for alpha versions
+            if (baseVersion.SemanticVersion < new SemanticVersion(1) && commitMessageIncrement > VersionField.Minor)
+            {
+                commitMessageIncrement = VersionField.Minor;
+            }
+
+            // don't increment for less than the branch config increment, if the absense of commit messages would have
+            // still resulted in an increment of configuration.Increment
+            if (baseVersion.ShouldIncrement && commitMessageIncrement < defaultIncrement)
+            {
+                return defaultIncrement;
+            }
+
+            return commitMessageIncrement;
+        }
+
+        private static VersionField? FindCommitMessageIncrement(GitVersionContext context, BaseVersion baseVersion)
+        {
+            if (context.Configuration.CommitMessageIncrementing == CommitMessageIncrementMode.Disabled)
+            {
+                return null;
+            }
+            
+            var commits = GetIntermediateCommits(context.Repository, baseVersion.BaseVersionSource, context.CurrentCommit);
+
+            if (context.Configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
+            {
+                commits = commits.Where(c => c.Parents.Count() > 1);
+            }
+
+            var majorRegex = CreateRegex(context.Configuration.MajorVersionBumpMessage ?? DefaultMajorPattern);
+            var minorRegex = CreateRegex(context.Configuration.MinorVersionBumpMessage ?? DefaultMinorPattern);
+            var patchRegex = CreateRegex(context.Configuration.PatchVersionBumpMessage ?? DefaultPatchPattern);
+
+            var increments = commits
+                .Select(c => FindIncrementFromMessage(c.Message, majorRegex, minorRegex, patchRegex))
+                .Where(v => v != null)
+                .Select(v => v.Value)
+                .ToList();
+
+            if (increments.Any())
+            {
+                return increments.Max();
+            }
+
+            return null;
+        }
+        
+        private static IEnumerable<Commit> GetIntermediateCommits(IRepository repo, Commit baseCommit, Commit headCommit)
+        {
+            var filter = new CommitFilter
+            {
+                Since = headCommit,
+                Until = baseCommit,
+                SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse
+            };
+
+            return repo.Commits.QueryBy(filter);
+        }
+
+        private static VersionField? FindIncrementFromMessage(string message, Regex major, Regex minor, Regex patch)
+        {
+            if (major.IsMatch(message)) return VersionField.Major;
+            if (minor.IsMatch(message)) return VersionField.Minor;
+            if (patch.IsMatch(message)) return VersionField.Patch;
+
+            return null;
+        }
+
+        private static Regex CreateRegex(string pattern)
+        {
+            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        }
+    }
+}

--- a/src/GitVersionCore/SemanticVersion.cs
+++ b/src/GitVersionCore/SemanticVersion.cs
@@ -281,25 +281,25 @@ namespace GitVersion
             }
         }
 
-        public SemanticVersion IncrementVersion(IncrementStrategy incrementStrategy)
+        public SemanticVersion IncrementVersion(VersionField incrementStrategy)
         {
             var incremented = new SemanticVersion(this);
             if (!incremented.PreReleaseTag.HasTag())
             {
                 switch (incrementStrategy)
                 {
-                    case IncrementStrategy.None:
+                    case VersionField.None:
                         break;
-                    case IncrementStrategy.Major:
+                    case VersionField.Major:
                         incremented.Major++;
                         incremented.Minor = 0;
                         incremented.Patch = 0;
                         break;
-                    case IncrementStrategy.Minor:
+                    case VersionField.Minor:
                         incremented.Minor++;
                         incremented.Patch = 0;
                         break;
-                    case IncrementStrategy.Patch:
+                    case VersionField.Patch:
                         incremented.Patch++;
                         break;
                     default:
@@ -317,5 +317,13 @@ namespace GitVersion
 
             return incremented;
         }
+    }
+
+    public enum VersionField
+    {
+        None,
+        Patch,
+        Minor,
+        Major
     }
 }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -74,7 +74,13 @@
 
         static SemanticVersion MaybeIncrement(GitVersionContext context, BaseVersion version)
         {
-            return version.ShouldIncrement ? version.SemanticVersion.IncrementVersion(context.Configuration.Increment) : version.SemanticVersion;
+            var increment = IncrementStrategyFinder.DetermineIncrementedField(context, version);
+            if (increment != null)
+            {
+                return version.SemanticVersion.IncrementVersion(increment.Value);
+            }
+
+            return version.SemanticVersion;
         }
     }
 }

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -38,9 +38,10 @@
 
             var baseVersion = baseVersionFinder.GetBaseVersion(context);
             var semver = baseVersion.SemanticVersion;
-            if (baseVersion.ShouldIncrement)
+            var increment = IncrementStrategyFinder.DetermineIncrementedField(context, baseVersion);
+            if (increment != null)
             {
-                semver = semver.IncrementVersion(context.Configuration.Increment);
+                semver = semver.IncrementVersion(increment.Value);
             }
             else Logger.WriteInfo("Skipping version increment");
 

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -5,6 +5,6 @@
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net40" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net40" developmentDependency="true" />
-  <package id="Visualize.Fody" version="0.4.3.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net40" developmentDependency="true" />
   <package id="YamlDotNet" version="3.6.1" targetFramework="net40" />
 </packages>

--- a/src/GitVersionExe/FodyWeavers.xml
+++ b/src/GitVersionExe/FodyWeavers.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Weavers VerifyAssembly="true" VerifyIgnoreCodes="0x80131869">
   <Caseless/>
   <JetBrainsAnnotations/>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -5,5 +5,5 @@
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net40" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net40" developmentDependency="true" />
-  <package id="Visualize.Fody" version="0.4.3.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net40" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Adds two new increment strategies: `CommitMessage` and `MergeMessage`.

While active, the version increment is determined by reading commit/merge commit messages for markers describing the change severity. All new commits introduced since the base version are scanned.

For example, "+semver: breaking" will force a major version bump.

### New Branch Configuration Options

* `major-version-bump-message`: a regex used for parsing breaking changes in commit messages. Defaults to `\+semver:\s?(breaking|major)`.
* `minor-version-bump-message`: a regex used for parsing minor changes in commit messages. Defaults to `\+semver:\s?(feature|minor)`.
* `message-fallback`: the increment strategy to fall back into if no change severity indicators are found in commit messages, while using the `CommitMessage` or `MergeMessage` strategies. Defaults to `Patch`.

### Potential Issues
* I changed the default increment strategy for the `master` branch to `CommitMessage`. This will behave the same as it did prior to this change if the user does not have markers in this commit messages. However this could certainly be considered a breaking change.
* This change does not work for new repositories, as the base version of a new repository will be determined by the `FallbackBaseVersionStrategy`, which never increments versions. Certainly, If I am using GitHub Flow, this is not what I would expect. Changing the behaviour of `FallbackBaseVersionStrategy` when using commit message increments would be an option, but I do not know if this would make sense for other work flows.
* Breaking changes always increment the major version. This may not be desirable for < 1.0.0 builds. We could add an option to treat breaking changes as minor version bumps for 0.x.x builds.

Addresses #137.