### PR TITLE
TagPrefix cleanup

### DIFF
--- a/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDelivery
-tag-prefix: '[vV]|'
+tag-prefix: '[vV]'
 continuous-delivery-fallback-tag: ci
 branches:
   master:

--- a/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -120,7 +120,7 @@ branches:
         config.AssemblyVersioningScheme.ShouldBe(AssemblyVersioningScheme.MajorMinorPatch);
         config.Branches["develop"].Tag.ShouldBe("unstable");
         config.Branches["release[/-]"].Tag.ShouldBe("beta");
-        config.TagPrefix.ShouldBe("[vV]|");
+        config.TagPrefix.ShouldBe(Config.DefaultTagPrefix);
         config.NextVersion.ShouldBe(null);
     }
 

--- a/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
@@ -167,25 +167,6 @@ public class MasterScenarios
     }
 
     [Test]
-    public void CanTagPrefixStillBeOptional()
-    {
-        using (var fixture = new EmptyRepositoryFixture(new Config { TagPrefix = "[vV]|" }))  //we use tag prefix to denote whether optional
-        {
-            string TaggedVersion = "v1.0.3";
-            fixture.Repository.MakeATaggedCommit(TaggedVersion);
-            fixture.Repository.MakeCommits(5);
-
-            fixture.AssertFullSemver("1.0.4+5");
-
-            TaggedVersion = "1.0.5";
-            fixture.Repository.MakeATaggedCommit(TaggedVersion);
-            fixture.Repository.MakeCommits(1);
-
-            fixture.AssertFullSemver("1.0.6+1");
-        }
-    }
-
-    [Test]
     public void AreTagsNotAdheringToTagPrefixIgnored()
     {
         using (var fixture = new EmptyRepositoryFixture(new Config { TagPrefix = "" }))

--- a/GitVersionCore.Tests/SemanticVersionTests.cs
+++ b/GitVersionCore.Tests/SemanticVersionTests.cs
@@ -26,7 +26,10 @@ public class SemanticVersionTests
     [TestCase("1.2.3+4.Branch.Foo", 1, 2, 3, null, null, 4, "Foo", null, null, null, null)]
     [TestCase("1.2.3+randomMetaData", 1, 2, 3, null, null, null, null, null, "randomMetaData", null, null)]
     [TestCase("1.2.3-beta.1+4.Sha.12234.Othershiz", 1, 2, 3, "beta", 1, 4, null, "12234", "Othershiz", null, null)]
-    [TestCase("1.2.3", 1, 2, 3, null, null, null, null, null, null, null, "v")]
+    [TestCase("1.2.3", 1, 2, 3, null, null, null, null, null, null, null, Config.DefaultTagPrefix)]
+    [TestCase("v1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", Config.DefaultTagPrefix)]
+    [TestCase("V1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", Config.DefaultTagPrefix)]
+    [TestCase("version-1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", "version-")]
     public void ValidateVersionParsing(
         string versionString, int major, int minor, int patch, string tag, int? tagNumber, int? numberOfBuilds,
         string branchName, string sha, string otherMetaData, string fullFormattedVersionString, string tagPrefixRegex)

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -1,12 +1,13 @@
 ﻿namespace GitVersion
 {
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using YamlDotNet.Serialization;
 
     public class Config
     {
-        public const string DefaultTagPrefix = "[vV]";
+        internal const string DefaultTagPrefix = "[vV]";
 
         Dictionary<string, BranchConfig> branches = new Dictionary<string, BranchConfig>();
 

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -6,12 +6,14 @@
 
     public class Config
     {
+        public const string DefaultTagPrefix = "[vV]";
+
         Dictionary<string, BranchConfig> branches = new Dictionary<string, BranchConfig>();
 
         public Config()
         {
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
-            TagPrefix = "[vV]|";
+            TagPrefix = DefaultTagPrefix;
             VersioningMode = GitVersion.VersioningMode.ContinuousDelivery;
             ContinuousDeploymentFallbackTag = "ci";
 

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -1,7 +1,6 @@
 ﻿namespace GitVersion
 {
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using YamlDotNet.Serialization;
 


### PR DESCRIPTION
Cleaning up a few leftovers that resulted from a partial merge of pull request #496.  As before, TagPrefix is always considered optional.