### PR TITLE
Fixes version calculation issue introduced when fixing #465

### DIFF
--- a/src/GitVersionCore.Tests/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersionCore.Tests/Fixtures/RepositoryFixtureBase.cs
@@ -122,7 +122,15 @@ noteText.Replace("\n", "\n  "));
         Trace.WriteLine("---------");
 
         var variables = GetVersion(repository, commitId);
-        variables.FullSemVer.ShouldBe(fullSemver);
+        try
+        {
+            variables.FullSemVer.ShouldBe(fullSemver);
+        }
+        catch (Exception)
+        {
+            if (repository != null)
+                repository.DumpGraph();
+        }
         if (commitId == null)
             diagramBuilder.AppendLineFormat("note over {0} #D3D3D3: {1}", GetParticipant(Repository.Head.Name), fullSemver);
     }

--- a/src/GitVersionCore.Tests/IntegrationTests/DocumentationSamples.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DocumentationSamples.cs
@@ -139,7 +139,7 @@ public class DocumentationSamples
 
             // Make a commit after a tag should bump up the beta
             fixture.MakeACommit();
-            fixture.AssertFullSemver("1.3.0-beta.2+2");
+            fixture.AssertFullSemver("1.3.0-beta.2+1");
 
             // Complete release
             fixture.Checkout("master");
@@ -195,7 +195,7 @@ public class DocumentationSamples
 
             // Make a commit after a tag should bump up the beta
             fixture.MakeACommit();
-            fixture.AssertFullSemver("2.0.0-beta.2+2");
+            fixture.AssertFullSemver("2.0.0-beta.2+1");
 
             // Complete release
             fixture.Checkout("master");

--- a/src/GitVersionCore.Tests/IntegrationTests/HotfixBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/HotfixBranchScenarios.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 public class HotfixBranchScenarios
 {
     [Test]
+    // This test actually validates #465 as well
     public void PatchLatestReleaseExample()
     {
         using (var fixture = new BaseGitFlowRepositoryFixture("1.2.0"))

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -160,6 +160,26 @@ public class ReleaseBranchScenarios
     }
 
     [Test]
+    public void MasterVersioningContinuousCorrectlyAfterMergingReleaseBranch()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.3");
+            fixture.Repository.MakeCommits(1);
+            fixture.Repository.CreateBranch("release-2.0.0");
+            fixture.Repository.Checkout("release-2.0.0");
+            fixture.Repository.MakeCommits(4);
+            fixture.Repository.Checkout("master");
+            fixture.Repository.MergeNoFF("release-2.0.0", Constants.SignatureNow());
+
+            fixture.AssertFullSemver("2.0.0+0");
+            fixture.Repository.ApplyTag("2.0.0");
+            fixture.Repository.MakeCommits(1);
+            fixture.AssertFullSemver("2.0.1+1");
+        }
+    }
+
+    [Test]
     public void WhenReleaseBranchIsMergedIntoDevelopHighestVersionIsTakenWithIt()
     {
         using (var fixture = new EmptyRepositoryFixture(new Config()))
@@ -180,7 +200,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.Checkout("develop");
             fixture.Repository.MergeNoFF("release-1.0.0", Constants.SignatureNow());
 
-            fixture.AssertFullSemver("2.1.0-unstable.5");
+            fixture.AssertFullSemver("2.1.0-unstable.0");
         }
     }
 
@@ -231,7 +251,7 @@ public class ReleaseBranchScenarios
 
             fixture.Repository.MakeCommits(1);
 
-            fixture.AssertFullSemver("2.0.0-beta.2+2");
+            fixture.AssertFullSemver("2.0.0-beta.2+1");
 
             //merge down to develop
             fixture.Repository.Checkout("develop");
@@ -239,7 +259,7 @@ public class ReleaseBranchScenarios
 
             //but keep working on the release
             fixture.Repository.Checkout("release-2.0.0");
-            fixture.AssertFullSemver("2.0.0-beta.2+2");
+            fixture.AssertFullSemver("2.0.0-beta.2+1");
         }
     }
 }


### PR DESCRIPTION
The logic for figuring out conflicting sources was wrong. It was close enough to look right in most scenarios but caused master to calculate with the wrong version after merging a release branch and tagging (did not increment to next patch release).