### PR TITLE
Add GitVersionInformationAttribute to make reflection easier

### DIFF
--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.0.0.0")]
@@ -40,7 +39,4 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
-
 }
-
-

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
@@ -8,6 +8,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {
     public string Date { get; private set; }
@@ -43,6 +44,7 @@ static class GitVersionInformation
 }
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {
     public string Major { get { return "2"; } }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
@@ -5,6 +5,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("2.3.4.0")]
 [assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -39,4 +40,28 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
+}
+
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{
+    public string Major { get { return "2"; } }
+    public string Minor { get { return "3"; } }
+    public string Patch { get { return "4"; } }
+    public string PreReleaseTag { get { return "beta.5"; } }
+    public string PreReleaseTagWithDash { get { return "-beta.5"; } }
+    public string BuildMetaData { get { return "6"; } }
+    public string FullBuildMetaData { get { return "6.Branch.master.Sha.commitSha"; } }
+    public string MajorMinorPatch { get { return "2.3.4"; } }
+    public string SemVer { get { return "2.3.4-beta.5"; } }
+    public string LegacySemVer { get { return "2.3.4-beta5"; } }
+    public string LegacySemVerPadded { get { return "2.3.4-beta0005"; } }
+    public string AssemblySemVer { get { return "2.0.0.0"; } }
+    public string FullSemVer { get { return "2.3.4-beta.5+6"; } }
+    public string InformationalVersion { get { return "2.3.4-beta.5+6.Branch.master.Sha.commitSha"; } }
+    public string BranchName { get { return "master"; } }
+    public string Sha { get { return "commitSha"; } }
+    public string NuGetVersionV2 { get { return "2.3.4-beta0005"; } }
+    public string NuGetVersion { get { return "2.3.4-beta0005"; } }
+    public string CommitDate { get { return "2014-03-06"; } }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
@@ -5,6 +5,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("2.3.4.0")]
 [assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -39,4 +40,28 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
+}
+
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{
+    public string Major { get { return "2"; } }
+    public string Minor { get { return "3"; } }
+    public string Patch { get { return "4"; } }
+    public string PreReleaseTag { get { return "beta.5"; } }
+    public string PreReleaseTagWithDash { get { return "-beta.5"; } }
+    public string BuildMetaData { get { return "6"; } }
+    public string FullBuildMetaData { get { return "6.Branch.master.Sha.commitSha"; } }
+    public string MajorMinorPatch { get { return "2.3.4"; } }
+    public string SemVer { get { return "2.3.4-beta.5"; } }
+    public string LegacySemVer { get { return "2.3.4-beta5"; } }
+    public string LegacySemVerPadded { get { return "2.3.4-beta0005"; } }
+    public string AssemblySemVer { get { return "2.3.0.0"; } }
+    public string FullSemVer { get { return "2.3.4-beta.5+6"; } }
+    public string InformationalVersion { get { return "2.3.4-beta.5+6.Branch.master.Sha.commitSha"; } }
+    public string BranchName { get { return "master"; } }
+    public string Sha { get { return "commitSha"; } }
+    public string NuGetVersionV2 { get { return "2.3.4-beta0005"; } }
+    public string NuGetVersion { get { return "2.3.4-beta0005"; } }
+    public string CommitDate { get { return "2014-03-06"; } }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
@@ -8,6 +8,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {
     public string Date { get; private set; }
@@ -43,6 +44,7 @@ static class GitVersionInformation
 }
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {
     public string Major { get { return "2"; } }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.0.0")]
@@ -40,7 +39,4 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
-
 }
-
-

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.4.0")]
@@ -40,7 +39,4 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
-
 }
-
-

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
@@ -5,6 +5,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("2.3.4.0")]
 [assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -39,4 +40,28 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
+}
+
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{
+    public string Major { get { return "2"; } }
+    public string Minor { get { return "3"; } }
+    public string Patch { get { return "4"; } }
+    public string PreReleaseTag { get { return "beta.5"; } }
+    public string PreReleaseTagWithDash { get { return "-beta.5"; } }
+    public string BuildMetaData { get { return "6"; } }
+    public string FullBuildMetaData { get { return "6.Branch.master.Sha.commitSha"; } }
+    public string MajorMinorPatch { get { return "2.3.4"; } }
+    public string SemVer { get { return "2.3.4-beta.5"; } }
+    public string LegacySemVer { get { return "2.3.4-beta5"; } }
+    public string LegacySemVerPadded { get { return "2.3.4-beta0005"; } }
+    public string AssemblySemVer { get { return "2.3.4.0"; } }
+    public string FullSemVer { get { return "2.3.4-beta.5+6"; } }
+    public string InformationalVersion { get { return "2.3.4-beta.5+6.Branch.master.Sha.commitSha"; } }
+    public string BranchName { get { return "master"; } }
+    public string Sha { get { return "commitSha"; } }
+    public string NuGetVersionV2 { get { return "2.3.4-beta0005"; } }
+    public string NuGetVersion { get { return "2.3.4-beta0005"; } }
+    public string CommitDate { get { return "2014-03-06"; } }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
@@ -8,6 +8,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {
     public string Date { get; private set; }
@@ -43,6 +44,7 @@ static class GitVersionInformation
 }
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {
     public string Major { get { return "2"; } }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
@@ -8,6 +8,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {
     public string Date { get; private set; }
@@ -43,6 +44,7 @@ static class GitVersionInformation
 }
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {
     public string Major { get { return "2"; } }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.4.5")]
@@ -40,7 +39,4 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
-
 }
-
-

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
@@ -5,6 +5,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("2.3.4.0")]
 [assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -39,4 +40,28 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "2.3.4-beta0005";
     public static string NuGetVersion = "2.3.4-beta0005";
     public static string CommitDate = "2014-03-06";
+}
+
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{
+    public string Major { get { return "2"; } }
+    public string Minor { get { return "3"; } }
+    public string Patch { get { return "4"; } }
+    public string PreReleaseTag { get { return "beta.5"; } }
+    public string PreReleaseTagWithDash { get { return "-beta.5"; } }
+    public string BuildMetaData { get { return "6"; } }
+    public string FullBuildMetaData { get { return "6.Branch.master.Sha.commitSha"; } }
+    public string MajorMinorPatch { get { return "2.3.4"; } }
+    public string SemVer { get { return "2.3.4-beta.5"; } }
+    public string LegacySemVer { get { return "2.3.4-beta5"; } }
+    public string LegacySemVerPadded { get { return "2.3.4-beta0005"; } }
+    public string AssemblySemVer { get { return "2.3.4.5"; } }
+    public string FullSemVer { get { return "2.3.4-beta.5+6"; } }
+    public string InformationalVersion { get { return "2.3.4-beta.5+6.Branch.master.Sha.commitSha"; } }
+    public string BranchName { get { return "master"; } }
+    public string Sha { get { return "commitSha"; } }
+    public string NuGetVersionV2 { get { return "2.3.4-beta0005"; } }
+    public string NuGetVersion { get { return "2.3.4-beta0005"; } }
+    public string CommitDate { get { return "2014-03-06"; } }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
@@ -5,6 +5,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("1.2.3.0")]
 [assembly: AssemblyInformationalVersion("1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -39,4 +40,28 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "1.2.3-unstable0004";
     public static string NuGetVersion = "1.2.3-unstable0004";
     public static string CommitDate = "2014-03-06";
+}
+
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{
+    public string Major { get { return "1"; } }
+    public string Minor { get { return "2"; } }
+    public string Patch { get { return "3"; } }
+    public string PreReleaseTag { get { return "unstable.4"; } }
+    public string PreReleaseTagWithDash { get { return "-unstable.4"; } }
+    public string BuildMetaData { get { return "5"; } }
+    public string FullBuildMetaData { get { return "5.Branch.feature1.Sha.commitSha"; } }
+    public string MajorMinorPatch { get { return "1.2.3"; } }
+    public string SemVer { get { return "1.2.3-unstable.4"; } }
+    public string LegacySemVer { get { return "1.2.3-unstable4"; } }
+    public string LegacySemVerPadded { get { return "1.2.3-unstable0004"; } }
+    public string AssemblySemVer { get { return "1.2.3.0"; } }
+    public string FullSemVer { get { return "1.2.3-unstable.4+5"; } }
+    public string InformationalVersion { get { return "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha"; } }
+    public string BranchName { get { return "feature1"; } }
+    public string Sha { get { return "commitSha"; } }
+    public string NuGetVersionV2 { get { return "1.2.3-unstable0004"; } }
+    public string NuGetVersion { get { return "1.2.3-unstable0004"; } }
+    public string CommitDate { get { return "2014-03-06"; } }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("1.2.3.0")]
@@ -40,7 +39,4 @@ static class GitVersionInformation
     public static string NuGetVersionV2 = "1.2.3-unstable0004";
     public static string NuGetVersion = "1.2.3-unstable0004";
     public static string CommitDate = "2014-03-06";
-
 }
-
-

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt
@@ -8,6 +8,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {
     public string Date { get; private set; }
@@ -43,6 +44,7 @@ static class GitVersionInformation
 }
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {
     public string Major { get { return "1"; } }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using ApprovalTests;
 using GitVersion;
@@ -30,13 +31,21 @@ public class AssemblyInfoBuilderTests
         Approvals.Verify(assemblyInfoText);
 
         var compilation = CSharpCompilation.Create("Fake.dll")
-            .WithOptions(new CSharpCompilationOptions(OutputKind.NetModule))
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
             .AddSyntaxTrees(CSharpSyntaxTree.ParseText(assemblyInfoText));
-        
 
-        var emitResult = compilation.Emit(new MemoryStream());
-        Assert.IsTrue(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics.Select(x => x.Descriptor)));
+
+        using (var stream = new MemoryStream())
+        {
+            var emitResult = compilation.Emit(stream);
+            
+            Assert.IsTrue(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics.Select(x => x.Descriptor)));
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var assembly = Assembly.Load(stream.ToArray());
+            VerifyGitVersionInformationAttribute(assembly, versionVariables);
+        }
     }
 
     [Test]
@@ -90,5 +99,31 @@ public class AssemblyInfoBuilderTests
 
         var emitResult = compilation.Emit(new MemoryStream());
         Assert.IsTrue(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics.Select(x => x.Descriptor)));
+    }
+
+    static void VerifyGitVersionInformationAttribute(Assembly assembly, VersionVariables versionVariables)
+    {
+        var gitVersionInformationAttributeData = assembly.CustomAttributes
+            .FirstOrDefault(a => a.AttributeType.Name == "GitVersionInformationAttribute");
+
+        Assert.IsNotNull(gitVersionInformationAttributeData);
+
+        var gitVersionInformationAttributeType = gitVersionInformationAttributeData.AttributeType;
+        var gitVersionInformationAttribute = assembly
+            .GetCustomAttributes(gitVersionInformationAttributeType)
+            .FirstOrDefault();
+
+        Assert.IsNotNull(gitVersionInformationAttribute);
+
+        var properties = gitVersionInformationAttributeType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+        foreach (var variable in versionVariables)
+        {
+            var property = properties.FirstOrDefault(p => p.Name == variable.Key);
+            Assert.IsNotNull(property);
+
+            var propertyValue = property.GetValue(gitVersionInformationAttribute, null);
+            Assert.AreEqual(variable.Value, propertyValue, "{0} had an invalid value.", property.Name);
+        }
     }
 }

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
@@ -119,6 +119,8 @@ public class AssemblyInfoBuilderTests
 
         foreach (var variable in versionVariables)
         {
+            Assert.IsNotNull(variable.Value);
+
             var property = properties.FirstOrDefault(p => p.Name == variable.Key);
             Assert.IsNotNull(property);
 

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 [assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class ReleaseDateAttribute : System.Attribute
 {{
     public string Date {{ get; private set; }}
@@ -38,6 +39,7 @@ static class GitVersionInformation
 }}
 
 [System.Runtime.CompilerServices.CompilerGenerated]
+[AttributeUsage(AttributeTargets.Assembly)]
 sealed class GitVersionInformationAttribute : System.Attribute
 {{
 {5}

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 using GitVersion;
@@ -7,6 +8,8 @@ public class AssemblyInfoBuilder
 {
     public string GetAssemblyInfoText(VersionVariables vars)
     {
+        var v = vars.ToArray();
+
         var assemblyInfo = string.Format(@"
 using System;
 using System.Reflection;
@@ -39,18 +42,25 @@ static class GitVersionInformation
                                          vars.MajorMinorPatch + ".0",
                                          vars.InformationalVersion,
                                          vars.CommitDate,
-                                         GenerateVariableMembers(vars));
+                                         GenerateVariableMembers(v))
+            .Trim();
 
         return assemblyInfo;
     }
 
 
-    string GenerateVariableMembers(IEnumerable<KeyValuePair<string, string>> vars)
+    static string GenerateVariableMembers(IList<KeyValuePair<string, string>> vars)
     {
         var members = new StringBuilder();
-        foreach (var variable in vars)
+        for (var i = 0; i < vars.Count; i++)
         {
-            members.AppendLine(string.Format("    public static string {0} = \"{1}\";", variable.Key, variable.Value));
+            var variable = vars[i];
+            members.AppendFormat("    public static string {0} = \"{1}\";", variable.Key, variable.Value);
+
+            if (i < vars.Count - 1)
+            {
+                members.AppendLine();
+            }
         }
 
         return members.ToString();

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -18,6 +18,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion(""{1}"")]
 [assembly: AssemblyInformationalVersion(""{2}"")]
 [assembly: ReleaseDate(""{3}"")]
+[assembly: GitVersionInformation()]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
 sealed class ReleaseDateAttribute : System.Attribute
@@ -36,26 +37,48 @@ static class GitVersionInformation
 {4}
 }}
 
-
-",
+[System.Runtime.CompilerServices.CompilerGenerated]
+sealed class GitVersionInformationAttribute : System.Attribute
+{{
+{5}
+}}",
                                          vars.AssemblySemVer,
                                          vars.MajorMinorPatch + ".0",
                                          vars.InformationalVersion,
                                          vars.CommitDate,
-                                         GenerateVariableMembers(v))
+                                         GenerateStaticVariableMembers(v),
+                                         GenerateAttributeVariableMembers(v))
             .Trim();
 
         return assemblyInfo;
     }
 
 
-    static string GenerateVariableMembers(IList<KeyValuePair<string, string>> vars)
+    static string GenerateStaticVariableMembers(IList<KeyValuePair<string, string>> vars)
     {
         var members = new StringBuilder();
         for (var i = 0; i < vars.Count; i++)
         {
             var variable = vars[i];
             members.AppendFormat("    public static string {0} = \"{1}\";", variable.Key, variable.Value);
+
+            if (i < vars.Count - 1)
+            {
+                members.AppendLine();
+            }
+        }
+
+        return members.ToString();
+    }
+
+
+    static string GenerateAttributeVariableMembers(IList<KeyValuePair<string, string>> vars)
+    {
+        var members = new StringBuilder();
+        for (var i = 0; i < vars.Count; i++)
+        {
+            var variable = vars[i];
+            members.AppendFormat("    public string {0} {{ get {{ return \"{1}\"; }} }}", variable.Key, variable.Value);
 
             if (i < vars.Count - 1)
             {

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text;
+
 using GitVersion;
 
 public class AssemblyInfoBuilder
@@ -33,15 +34,16 @@ static class GitVersionInformation
 }}
 
 
-", 
-vars.AssemblySemVer,
- vars.MajorMinorPatch + ".0", 
- vars.InformationalVersion,
-            vars.CommitDate,
-            GenerateVariableMembers(vars));
+",
+                                         vars.AssemblySemVer,
+                                         vars.MajorMinorPatch + ".0",
+                                         vars.InformationalVersion,
+                                         vars.CommitDate,
+                                         GenerateVariableMembers(vars));
 
         return assemblyInfo;
     }
+
 
     string GenerateVariableMembers(IEnumerable<KeyValuePair<string, string>> vars)
     {
@@ -53,5 +55,4 @@ vars.AssemblySemVer,
 
         return members.ToString();
     }
-
 }


### PR DESCRIPTION
Right now, it's a bit hard to do reflection on an assembly to dig out all of the juicy GitVersion data, since the data is embedded within the static class `GitVersionInformation`. To get to this class, you'd have to do `Assembly.GetTypes()`, which is prone to throwing exceptions. It would be more reflection-friendly to have the information inside an `[assembly: Attribute]`.

So I've created a `GitVersionInformationAttribute` that should remedy this. I've not removed any of the previously generated data, but I've taken the liberty of removing extraneous whitespace in the generated `.cs` file. I've also expanded on the `AssemblyInfoBuilderTests.VerifyCreatedCode()` test to verify the contents of the generated assembly and assert whether or not the `GitVersionInformationAttribute` actually contains the information we want to or not.