### PR TITLE
Fixed path too long problem.

### DIFF
--- a/src/GitVersionTask/DirectoryDateFinder.cs
+++ b/src/GitVersionTask/DirectoryDateFinder.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
+using System.Linq;
 
 public static class DirectoryDateFinder
 {
     public static long GetLastDirectoryWrite(string path)
     {
-        var lastHigh = DateTime.MinValue;
-        foreach (var file in Directory.EnumerateDirectories(path, "*.*", SearchOption.AllDirectories))
-        {
-            var lastWriteTime = File.GetLastWriteTime(file);
-            if (lastWriteTime > lastHigh)
-            {
-                lastHigh = lastWriteTime;
-            }
-        }
-        return lastHigh.Ticks;
+        return new DirectoryInfo(path)
+            .GetDirectories("*.*", SearchOption.AllDirectories)
+            .Select(d => d.LastWriteTimeUtc)
+            .DefaultIfEmpty()
+            .Max()
+            .Ticks;
     }
 }


### PR DESCRIPTION
In solutions containing a node_modules folder somewhere, there was a very good chance that you would get a PathTooLongException in DirectoryDateFinder.GetLastDirectoryWrite() since the fully qualified name in one of its sub directories would likely be larger than 260 chars. This change determines last write time in a way that doesn't throw this exception.

It was not possible to create a failing unit test without calling CreateDirectoryW in Windows API directly since .NET refuses to create directories with full path names longer than 260 characters.