### PR TITLE
Namespace name cannot start with numbers

### DIFF
--- a/src/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Text.RegularExpressions;
     using GitVersion;
     using GitVersion.Helpers;
     using Microsoft.Build.Framework;
@@ -90,8 +91,15 @@
                 AssemblyInfoTempFilePath = Path.Combine(IntermediateOutputPath, "GitVersionTaskAssemblyInfo.g.cs");
             }
 
+            var assemblyName = Path.GetFileNameWithoutExtension(ProjectFile);
+            var startsWithNumbers = new Regex(@"^\d+");
+            if (startsWithNumbers.IsMatch(assemblyName))
+            {
+                assemblyName = startsWithNumbers.Replace(assemblyName, string.Empty);
+            }
+
             var assemblyInfoBuilder = new AssemblyInfoBuilder();
-            var assemblyInfo = assemblyInfoBuilder.GetAssemblyInfoText(versionVariables, Path.GetFileNameWithoutExtension(ProjectFile));
+            var assemblyInfo = assemblyInfoBuilder.GetAssemblyInfoText(versionVariables, assemblyName);
             File.WriteAllText(AssemblyInfoTempFilePath, assemblyInfo);
         }
     }


### PR DESCRIPTION
Updating the assembly info on a project which file name starts with numbers will fail or when building a WPF project because the GenerateTemporaryTargetAssembly task will create a temporary project with a random name which can occasionally start with a number (see https://msdn.microsoft.com/en-us/library/bb397861.aspx).

The fix removes numbers from the start of the assembly name