### PR TITLE
Enable GitVersionTask to work with NuGet v3

### DIFF
--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -115,7 +115,7 @@
     <Copy SourceFiles="@(x86)" DestinationFolder="$(BuildDir)NuGetTaskBuild\NativeBinaries\x86" />
     <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.dll" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.pdb" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build\portable-win8+net4+wp8+wpa81" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build\portable-net+sl+win+wpa+wp" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build\dotnet" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.nuspec" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetTaskBuild" MetadataAssembly="$(ILMergeTemp)GitVersionTask.dll" Version="$(GitVersion_NuGetVersion)" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -115,7 +115,8 @@
     <Copy SourceFiles="@(x86)" DestinationFolder="$(BuildDir)NuGetTaskBuild\NativeBinaries\x86" />
     <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.dll" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.pdb" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build\portable-win8+net4+wp8+wpa81" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\Build\dotnet" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.nuspec" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetTaskBuild" MetadataAssembly="$(ILMergeTemp)GitVersionTask.dll" Version="$(GitVersion_NuGetVersion)" />
     <Delete Files="@(TempFiles)" />

--- a/src/GitVersionTask/NugetAssets/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/GitVersionTask.targets
@@ -8,13 +8,13 @@
 
   <UsingTask
       TaskName="GitVersionTask.UpdateAssemblyInfo"
-      AssemblyFile="$(MSBuildThisFileDirectory)..\GitVersionTask.dll" />
+      AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll" />
   <UsingTask 
     TaskName="GitVersionTask.GetVersion" 
-    AssemblyFile="$(MSBuildThisFileDirectory)..\GitVersionTask.dll"  />
+    AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll"  />
   <UsingTask
       TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
-      AssemblyFile="$(MSBuildThisFileDirectory)..\GitVersionTask.dll" />
+      AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll" />
 
   <Target Name="UpdateAssemblyInfo"
           BeforeTargets="CoreCompile">
@@ -61,9 +61,15 @@
 
   <!--Support for ncrunch-->
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\GitVersionTask.dll" />
-    <None Include="$(MSBuildThisFileDirectory)..\GitVersionTask.pdb" />
-    <None Include="$(MSBuildThisFileDirectory)..\NativeBinaries\**\*" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll">
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\GitVersionTask.pdb">
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\NativeBinaries\**\*">
+      <Visible>False</Visible>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet v3 does not allow .props/.targets files directly in the `\build` directory. They must be in a subdirectory.

This PR puts the targets file in `\Build\portable-net+sl+win+wpa+wp` and `\lib\dotnet` so it'll work with any NuGet v2 or v3 client. The relative paths in the .targets file has been adjusted to match the new location.

Without this, the targets are never included in UWP or other project.json based projects (like modern PCL, etc).