### PR TITLE
Add note that VSO build version cannot be set atm

### DIFF
--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -17,6 +17,7 @@ If you want the GitVersionTask to update AssemblyInfo files, check the box in th
 ## Using the GitVersion Variables
 GitVersion writes build parameters into VSO, so they will automatically be passed to your build scripts to use. It also writes GITVERSION_* environment variables that are available for any subsequent build step.
 
+Note that due to [current limitations in VSO](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to set the build version inside of VSO to one of the GITVERSION_* variables.
 
 ## Running inside Visual Studio Online
 * We output the individual values of the GitVersion version as the build parameter: `GitVersion.*` (Eg: `GitVersion.Major`) if you need access to them in your build script


### PR DESCRIPTION
Add note that it currently is not possible to set the VSO build version to the version determined by GitVersion