### PR TITLE
Restructure headlines & fix some typos in the TFS documentation

### DIFF
--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -2,25 +2,25 @@
 ## Basic Usage
 In [Visual Studio Online](https://www.visualstudio.com/) build vNext (the web based build system) you can call GitVersion either using the Command Line build step or install a custom build step. This requires a one-time setup to import the GitVersion task into your VSO instance.
 
-## Using GiVersion with the MSBuild Task NuGet Package
+## Using GitVersion with the MSBuild Task NuGet Package
 1. Add the [GitVersionTask](https://www.nuget.org/packages/GitVersionTask/) NuGet Package to your projects.
 
 See [MSBuild Task](http://gitversion.readthedocs.org/en/latest/usage/#msbuild-task) for further instructions how to use the MS Build Task.
 
-## Using the GitVersion with the Command Line build step
+## Using GitVersion with the Command Line build step
 1. Make sure to have GitVersion.exe under version control. There exists also a [Chocolatey package](https://chocolatey.org/packages/GitVersion.Portable) for installing GitVersion.exe on build agents.
 2. Add a Command Line build step to your build definition. You'll probably want to drag the task to be at or near the top to ensure it executes before your other build steps.
-3. Set the Tool parameter to `<pathToGitVersion>\GitVersion.exe`
-4. Set the Arguments parameter to `/output buildserver /nofetch`
+3. Set the Tool parameter to `<pathToGitVersion>\GitVersion.exe`.
+4. Set the Arguments parameter to `/output buildserver /nofetch`.
 5. If you want the GitVersionTask to update AssemblyInfo files add `updateAssemblyInfo true` to the Arguments parameter. 
 
-## Using the GitVersion with the custom build step
+## Using the custom GitVersion build step
 ### Installing/updating the VSO Build Step
-1. Install the `tfx` command line tool as shown [here](https://github.com/Microsoft/tfs-cli/blob/master/docs/buildtasks.md)
+1. Install the `tfx` command line tool as shown [here](https://github.com/Microsoft/tfs-cli/blob/master/docs/buildtasks.md).
 2. Download the GitVersion VSO build task from the latest release on the [GitVersion releases page](https://github.com/GitTools/GitVersion/releases) and unzip.
-3. Run `tfx login` if you haven't yet, make sure to use `https://<server>.visualstudio.com/DefaultCollection` as the URL and provide a personal access token
+3. Run `tfx login` if you haven't yet, make sure to use `https://<server>.visualstudio.com/DefaultCollection` as the URL and provide a personal access token.
 4. From the directory outside of where you unzipped the task, run `tfx build tasks upload .\GitVersionVsoTask` where GitVersionVsoTask is the directory containing the files.
-5. It should successfully install
+5. It should successfully install.
 
 ### Using the GitVersion VSO Build Step
 From a VSO vNext build definition, select "Add a Step" and then in the Build category, choose GitVersion and click Add. You'll probably want to drag the task to be at or near the top to ensure it executes before your other build steps.

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -6,7 +6,7 @@ In [Visual Studio Online](https://www.visualstudio.com/) build vNext (the web ba
 ### Using GitVersion with the MSBuild Task NuGet Package
 1. Add the [GitVersionTask](https://www.nuget.org/packages/GitVersionTask/) NuGet Package to your projects.
 
-See [MSBuild Task](http://gitversion.readthedocs.org/en/latest/usage/#msbuild-task) for further instructions how to use the MS Build Task.
+See [MSBuild Task](/usage/#msbuild-task) for further instructions how to use the MS Build Task.
 
 ### Using GitVersion with the Command Line build step
 1. Make sure to have GitVersion.exe under version control. There exists also a [Chocolatey package](https://chocolatey.org/packages/GitVersion.Portable) for installing GitVersion.exe on build agents.
@@ -32,7 +32,7 @@ If you want the GitVersionTask to update AssemblyInfo files, check the box in th
 ### Using the GitVersion Variables
 GitVersion writes build parameters into VSO, so they will automatically be passed to your build scripts to use. It also writes GITVERSION_* environment variables that are available for any subsequent build step. 
 We output the individual values of the GitVersion version as the build parameter: `GitVersion.*` (Eg: `GitVersion.Major`) if you need access to them in your build script.
-See [Variables](http://gitversion.readthedocs.org/en/latest/more-info/variables/) for an overview of available variables.
+See [Variables](/more-info/variables/) for an overview of available variables.
 
 Note that due to [current limitations in VSO](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to set the build version inside of VSO to one of the GITVERSION_* variables.
 

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -2,38 +2,39 @@
 ## Basic Usage
 In [Visual Studio Online](https://www.visualstudio.com/) build vNext (the web based build system) you can call GitVersion either using the Command Line build step or install a custom build step. This requires a one-time setup to import the GitVersion task into your VSO instance.
 
-## Using GitVersion with the MSBuild Task NuGet Package
+## Executing GitVersion
+### Using GitVersion with the MSBuild Task NuGet Package
 1. Add the [GitVersionTask](https://www.nuget.org/packages/GitVersionTask/) NuGet Package to your projects.
 
 See [MSBuild Task](http://gitversion.readthedocs.org/en/latest/usage/#msbuild-task) for further instructions how to use the MS Build Task.
 
-## Using GitVersion with the Command Line build step
+### Using GitVersion with the Command Line build step
 1. Make sure to have GitVersion.exe under version control. There exists also a [Chocolatey package](https://chocolatey.org/packages/GitVersion.Portable) for installing GitVersion.exe on build agents.
 2. Add a Command Line build step to your build definition. You'll probably want to drag the task to be at or near the top to ensure it executes before your other build steps.
 3. Set the Tool parameter to `<pathToGitVersion>\GitVersion.exe`.
 4. Set the Arguments parameter to `/output buildserver /nofetch`.
 5. If you want the GitVersionTask to update AssemblyInfo files add `updateAssemblyInfo true` to the Arguments parameter. 
 
-## Using the custom GitVersion build step
-### Installing/updating the VSO Build Step
+### Using the custom GitVersion build step
+#### Installing/updating the VSO Build Step
 1. Install the `tfx` command line tool as shown [here](https://github.com/Microsoft/tfs-cli/blob/master/docs/buildtasks.md).
 2. Download the GitVersion VSO build task from the latest release on the [GitVersion releases page](https://github.com/GitTools/GitVersion/releases) and unzip.
 3. Run `tfx login` if you haven't yet, make sure to use `https://<server>.visualstudio.com/DefaultCollection` as the URL and provide a personal access token.
 4. From the directory outside of where you unzipped the task, run `tfx build tasks upload .\GitVersionVsoTask` where GitVersionVsoTask is the directory containing the files.
 5. It should successfully install.
 
-### Using the GitVersion VSO Build Step
+#### Using the GitVersion VSO Build Step
 From a VSO vNext build definition, select "Add a Step" and then in the Build category, choose GitVersion and click Add. You'll probably want to drag the task to be at or near the top to ensure it executes before your other build steps.
 
 If you want the GitVersionTask to update AssemblyInfo files, check the box in the task configuration. For advanced usage, you can pass additional options to the GitVersion exe in the Additional arguments section.
 
-## Using the GitVersion Variables
-GitVersion writes build parameters into VSO, so they will automatically be passed to your build scripts to use. It also writes GITVERSION_* environment variables that are available for any subsequent build step.
+## Running inside Visual Studio Online
+### Using the GitVersion Variables
+GitVersion writes build parameters into VSO, so they will automatically be passed to your build scripts to use. It also writes GITVERSION_* environment variables that are available for any subsequent build step. 
+We output the individual values of the GitVersion version as the build parameter: `GitVersion.*` (Eg: `GitVersion.Major`) if you need access to them in your build script.
+See [Variables](http://gitversion.readthedocs.org/en/latest/more-info/variables/) for an overview of available variables.
 
 Note that due to [current limitations in VSO](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to set the build version inside of VSO to one of the GITVERSION_* variables.
 
-## Running inside Visual Studio Online
-* We output the individual values of the GitVersion version as the build parameter: `GitVersion.*` (Eg: `GitVersion.Major`) if you need access to them in your build script
-
-### Create a NuGet package in VSO
-* If you use a command script to build your NuPkg, use `%GITVERSION_NUGETVERSION%` as the version parameter: `nuget.exe pack path\to\my.nuspec -version %GITVERSION_NUGETVERSION%`
+## Create a NuGet package in VSO
+If you use a Command Line task to build your NuPkg, use `%GITVERSION_NUGETVERSION%` as the version parameter: `nuget.exe pack path\to\my.nuspec -version %GITVERSION_NUGETVERSION%`


### PR DESCRIPTION
Restructure headlines to make stuff more clear and fix some typos in the TFS Build documentation.

Do you know if it is possible to make links relative? Currently they are linking to the latests version of the docs which is not ideal for the stable docs.