### PR TITLE
[WIP] Should be possible to re-integrate develop into a long running feature

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -128,4 +128,32 @@ public class FeatureBranchScenarios
             fixture.AssertFullSemver("0.1.0-feature2.1+1");
         }
     }
+
+    [Test]
+    public void ShouldBePossibleToMergeDevelopForALongRunningBranchWhereDevelopAndMasterAreEqual()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config() { VersioningMode = VersioningMode.ContinuousDeployment }))
+        {
+            fixture.Repository.MakeATaggedCommit("v1.0.0");
+
+            fixture.Repository.CreateBranch("develop");
+            fixture.Repository.Checkout("develop");
+
+            fixture.Repository.CreateBranch("feature/longrunning");
+            fixture.Repository.Checkout("feature/longrunning");
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("master");
+            fixture.Repository.Merge(fixture.Repository.FindBranch("develop"), SignatureBuilder.SignatureNow());
+            fixture.Repository.ApplyTag("v1.1.0");
+
+            fixture.Repository.Checkout("feature/longrunning"); 
+            fixture.Repository.Merge(fixture.Repository.FindBranch("develop"), SignatureBuilder.SignatureNow());
+
+            fixture.AssertFullSemver("1.2.0-longrunning.2");
+        }
+    }
 }

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -50,14 +50,18 @@ namespace GitVersion
                 if (parentCount == 2)
                 {
                     var parents = currentCommit.Parents.ToArray();
-                    var branch = repository.Branches.SingleOrDefault(b => !b.IsRemote && b.Tip == parents[1]);
+
+                    // Treat multiple branches as null instead of letting SingleOrDefault() throw
+                    var branches = repository.Branches.Where(b => !b.IsRemote && b.Tip == parents[1]).Take(2).ToList();
+                    var branch = branches.Count() == 1 ? branches.Single() : null;
+
                     if (branch != null)
                     {
                         excludedBranches = new[]
                         {
-                        currentBranch,
-                        branch
-                    };
+                            currentBranch,
+                            branch
+                        };
                         currentBranch = branch;
                     }
                     else


### PR DESCRIPTION
I think my test case is correct but I don't like the implementation where I treat the branch even if there're two matches. This will however make the test pass.

NOTE: I've also seen some strange behavior when running (resharpers nunit) the whole test suit causing ShouldBePossibleToMergeDevelopForALongRunningBranchWhereDevelopAndMasterAreEqual() to fail, but I cannot find anything obvious, related to this implementation. I can see that it's failing at appveyor https://ci.appveyor.com/project/GitTools/gitversion/build/3.1.0-PullRequest.582+88%20(Build%20226)/tests

I'll have to admit that I'm struggling to fully understand *BranchConfigurationCalculator.InheritBranchConfiguration* so another pair of eyes on this issue would help!

This fixes the issue where the BranchConfigurationCalulator thrown an
exception if develop and master are equal and re-integrated into a long
running feature branch.

Fixes #568