### PR TITLE
Fix label for updating AssemblyInfos

### DIFF
--- a/src/GitVersionVsoTask/task.json
+++ b/src/GitVersionVsoTask/task.json
@@ -29,7 +29,7 @@
     {
       "name": "updateAssemblyInfo",
       "type": "boolean",
-      "label": "Update AssemblyInfo's",
+      "label": "Update AssemblyInfo files",
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Whether to update versions in the AssemblyInfo files"


### PR DESCRIPTION
Fix the label for updating AssemblyInfos in the VSO task as reported in #584