### PR TITLE
re #611 - Ensures branch with dynamic repositories and buildserver

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
@@ -44,10 +44,5 @@ public class BuildServerBaseTests
         {
             return new string[0];
         }
-
-        public override string GetCurrentBranch()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/src/GitVersionCore/BuildServers/AppVeyor.cs
@@ -59,10 +59,5 @@
                 string.Format("Adding Environment Variable. name='GitVersion_{0}' value='{1}']", name, value)
             };
         }
-
-        public override string GetCurrentBranch()
-        {
-            return null;
-        }
     }
 }

--- a/src/GitVersionCore/BuildServers/BuildServerBase.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerBase.cs
@@ -7,7 +7,11 @@
         public abstract bool CanApplyToCurrentContext();
         public abstract string GenerateSetVersionMessage(string versionToUseForBuildNumber);
         public abstract string[] GenerateSetParameterMessage(string name, string value);
-        public abstract string GetCurrentBranch();
+
+        public virtual string GetCurrentBranch()
+        {
+            return null;
+        }
 
         public virtual void WriteIntegration(Action<string> writer, VersionVariables variables)
         {

--- a/src/GitVersionCore/BuildServers/ContinuaCi.cs
+++ b/src/GitVersionCore/BuildServers/ContinuaCi.cs
@@ -29,8 +29,6 @@
             };
         }
 
-        public override string GetCurrentBranch() { return string.Empty; }
-
         public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
         {
             return string.Format("@@continua[setBuildVersion value='{0}']", versionToUseForBuildNumber);

--- a/src/GitVersionCore/BuildServers/Jenkins.cs
+++ b/src/GitVersionCore/BuildServers/Jenkins.cs
@@ -26,8 +26,6 @@
             return versionToUseForBuildNumber;
         }
 
-        public override string GetCurrentBranch() { return string.Empty; }
-
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
             return new[]

--- a/src/GitVersionCore/BuildServers/MyGet.cs
+++ b/src/GitVersionCore/BuildServers/MyGet.cs
@@ -13,8 +13,6 @@
                 && buildRunner.Equals("MyGet", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public override string GetCurrentBranch() { return string.Empty; }
-
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
             var messages = new List<string>

--- a/src/GitVersionCore/BuildServers/TeamCity.cs
+++ b/src/GitVersionCore/BuildServers/TeamCity.cs
@@ -9,8 +9,6 @@
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
         }
 
-        public override string GetCurrentBranch() { return string.Empty; }
-
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
             return new[]

--- a/src/GitVersionCore/ExecuteCore.cs
+++ b/src/GitVersionCore/ExecuteCore.cs
@@ -13,6 +13,8 @@ namespace GitVersion
             var applicableBuildServers = BuildServerList.GetApplicableBuildServers();
             var buildServer = applicableBuildServers.FirstOrDefault();
             var currentBranch = buildServer == null ? null : buildServer.GetCurrentBranch();
+
+            currentBranch = string.IsNullOrWhiteSpace(currentBranch) ? targetBranch : currentBranch;
             if (!string.IsNullOrEmpty(currentBranch))
             {
                 Logger.WriteInfo("Branch from build environment: " + currentBranch);

--- a/src/GitVersionCore/ExecuteCore.cs
+++ b/src/GitVersionCore/ExecuteCore.cs
@@ -12,14 +12,9 @@ namespace GitVersion
             var gitPreparer = new GitPreparer(targetUrl, dynamicRepositoryLocation, authentication, noFetch, workingDirectory);
             var applicableBuildServers = BuildServerList.GetApplicableBuildServers();
             var buildServer = applicableBuildServers.FirstOrDefault();
-            var currentBranch = buildServer == null ? null : buildServer.GetCurrentBranch();
 
-            currentBranch = string.IsNullOrWhiteSpace(currentBranch) ? targetBranch : currentBranch;
-            if (!string.IsNullOrEmpty(currentBranch))
-            {
-                Logger.WriteInfo("Branch from build environment: " + currentBranch);
-            }
-            gitPreparer.Initialise(buildServer != null, currentBranch ?? targetBranch);
+            gitPreparer.Initialise(buildServer != null, ResolveCurrentBranch(buildServer, targetBranch));
+
             var dotGitDirectory = gitPreparer.GetDotGitDirectory();
             var projectRoot = gitPreparer.GetProjectRootDirectory();
             Logger.WriteInfo(string.Format("Project root is: " + projectRoot));
@@ -41,6 +36,16 @@ namespace GitVersion
             }
 
             return variables;
+        }
+
+        private static string ResolveCurrentBranch(IBuildServer buildServer, string targetBranch)
+        {
+            if (buildServer == null) return targetBranch;
+
+            var currentBranch = buildServer.GetCurrentBranch() ?? targetBranch;
+            Logger.WriteInfo("Branch from build environment: " + currentBranch);
+
+            return currentBranch;
         }
     }
 }


### PR DESCRIPTION
When using a dynamic repository with a buildserver the current branch will for most buildserver types return null or empty, this causes no branch to be set, dynamic repositories require a branch.

The fix ensures that if we are using dynamic repositories with a buildserver that if the buildserver does not return a branch we use the targetBranch specified via /b