### PR TITLE
FindCommitBranchWasBranchedFrom and GetBranchesContainingCommit ignore branches with no Tip

### DIFF
--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -71,7 +71,7 @@ namespace GitVersion
         public static IEnumerable<Branch> GetBranchesContainingCommit(this Commit commit, IRepository repository, bool onlyTrackedBranches)
         {
             var directBranchHasBeenFound = false;
-            foreach (var branch in repository.Branches)
+            foreach (var branch in repository.Branches.Where(b => b.Tip != null))
             {
                 if (branch.Tip.Sha != commit.Sha || (onlyTrackedBranches && !branch.IsTracking))
                 {

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -48,7 +48,7 @@ namespace GitVersion
         {
             using (Logger.IndentLog("Finding branch source"))
             {
-                var otherBranches = repository.Branches.Except(excludedBranches).Where(b => IsSameBranch(branch, b)).ToList();
+                var otherBranches = repository.Branches.Except(excludedBranches).Where(b => b.Tip != null).Where(b => IsSameBranch(branch, b)).ToList();
                 var mergeBases = otherBranches.Select(b =>
                 {
                     var otherCommit = b.Tip;


### PR DESCRIPTION
A change to ignore branches with no `Tip` from `FindCommitBranchWasBranchedFrom()`. Whilst this change works on the problem branch in my repo, I'm concerned if it has unintended side-effects.

Writing a test for this proved difficult - do you have any suggestions?

Fixes GitTools/GitVersion#618