### PR TITLE
Should not checkout branch on update

### DIFF
--- a/src/GitVersionCore/BuildServers/GitHelper.cs
+++ b/src/GitVersionCore/BuildServers/GitHelper.cs
@@ -279,7 +279,6 @@ namespace GitVersion
                     var remoteRefTipId = remotedirectReference.Target.Id;
                     Logger.WriteInfo(string.Format("Updating local ref '{0}' to point at {1}.", localRef.CanonicalName, remoteRefTipId));
                     repo.Refs.UpdateTarget(localRef, remoteRefTipId);
-                    repo.Checkout(branchName);
                     continue;
                 }
 


### PR DESCRIPTION
An update on a local branch cannot checkout the updated branch, since that
will cause GV to calculate the version on the updated branch instead of
the intended.

Fixes #624