### PR TITLE
Update build version from VSO Agent task.

### DIFF
--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -14,6 +14,7 @@ See [MSBuild Task](/usage/#msbuild-task) for further instructions how to use the
 3. Set the Tool parameter to `<pathToGitVersion>\GitVersion.exe`.
 4. Set the Arguments parameter to `/output buildserver /nofetch`.
 5. If you want the GitVersionTask to update AssemblyInfo files add `updateAssemblyInfo true` to the Arguments parameter. 
+6. If you want to update the build number you need to send a [logging command](https://github.com/Microsoft/vso-agent-tasks/blob/master/docs/authoring/commands.md) to TFS.
 
 ### Using the custom GitVersion build step
 #### Installing/updating the custom build step
@@ -29,13 +30,15 @@ From a TFS build definition, select "Add a Step" and then in the Build category,
 
 If you want the GitVersionTask to update AssemblyInfo files, check the box in the task configuration. For advanced usage, you can pass additional options to the GitVersion exe in the Additional arguments section.
 
+The VSO build step updates the build number automatically to the GitVersion number.
+
 ## Running inside TFS
 ### Using the GitVersion Variables
 GitVersion passes variables in the form of `GitVersion.*` (Eg: `GitVersion.Major`) to TFS Build and also writes `GITVERSION_*` (Eg: `GITVERSION_MAJOR`) environment variables that are available for any subsequent build step. 
 See [Variables](/more-info/variables/) for an overview of available variables.
 
 #### Known limitations
-* Due to [current limitations in TFS](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to automatically set the TFS build name to the version detected by GitVersion.
+* Due to [current limitations in TFS2015 On-Prem](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to automatically set the build version in TFS2015 On-Prem.
 * Due to a know limitation in TFS 2015 On-Prem it's currently not possible to use variables added during build in inputs of subsequent build tasks, since the variables are processed at the beginning of the build. 
 As a workaround environment variables can be used in custom scripts.
 

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -38,7 +38,7 @@ GitVersion passes variables in the form of `GitVersion.*` (Eg: `GitVersion.Major
 See [Variables](/more-info/variables/) for an overview of available variables.
 
 #### Known limitations
-* Due to [current limitations in TFS2015 On-Prem](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to automatically set the build version in TFS2015 On-Prem.
+* Due to [current limitations in TFS2015 On-Prem](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to automatically set the build version in TFS2015 On-Prem. Instead a warning similar to `##[warning]Unable to process logging event:##vso[build.updatebuildnumber 1.0.0-unstable.1` is logged.
 * Due to a know limitation in TFS 2015 On-Prem it's currently not possible to use variables added during build in inputs of subsequent build tasks, since the variables are processed at the beginning of the build. 
 As a workaround environment variables can be used in custom scripts.
 

--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -10,9 +10,7 @@ public class VsoAgentTests
     {
         var versionBuilder = new VsoAgent();
         var vsVersion = versionBuilder.GenerateSetVersionMessage("0.0.0-Unstable4");
-        //  Assert.AreEqual("##vso[task.setvariable variable=GitBuildNumber;]0.0.0-Unstable4", vsVersion);
-
-        vsVersion.ShouldBe(null);
+        vsVersion.ShouldBe("##vso[build.updatebuildnumber]0.0.0-Unstable4");
     }
 
     [Test]

--- a/src/GitVersionCore/BuildServers/VsoAgent.cs
+++ b/src/GitVersionCore/BuildServers/VsoAgent.cs
@@ -24,8 +24,7 @@
 
         public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
         {
-            // Note: the VSO agent does not yet support updating the build display number from a variable
-            return null;
+            return string.Format("##vso[build.updatebuildnumber]{0}", ServiceMessageEscapeHelper.EscapeValue(versionToUseForBuildNumber));
         }
     }
 }


### PR DESCRIPTION
Fixes #663 

VSO task always updates the build version, as does GitVersion in TeamCity. Updated docs and testcases too.