### PR TITLE
[WIP] Feature branches should track the develop branch

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using GitVersion;
 using LibGit2Sharp;
 using NUnit.Framework;
@@ -174,7 +175,15 @@ public class FeatureBranchScenarios
     [Test]
     public void FeatureBranchShouldTrackDevelopBranchIfPossible()
     {
-        using (var fixture = new EmptyRepositoryFixture(new Config() { VersioningMode = VersioningMode.ContinuousDeployment }))
+        using (var fixture = new EmptyRepositoryFixture(
+            new Config
+            {
+                VersioningMode = VersioningMode.ContinuousDeployment,
+                Branches =
+                {
+                    { "feature[/-]", new BranchConfig() { TrackMergeTarget = true } }
+                }            
+            }))
         {
             fixture.Repository.MakeATaggedCommit("v1.0.0");
 


### PR DESCRIPTION
This is just a failing test case and I'm not sure if it's possible or even desirable to solve this issue.

We're using a derived version of git flow where feature branches is merged into develop via pull requests. Develop is then merged to master via a merge commit that's tagged with the actual version.

Doing like this a new feature branch will then loose tracking to develop branch, this is not the case if develop is integrated to master via a fast forward commit.

I would like to know what you think, does this test make sense and should I investigate it further?