### PR TITLE
FindCommitBranchWasBranchedFrom should not throw NullReferenceException

### DIFF
--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -118,18 +118,15 @@ namespace GitVersion
                 else
                     errorMessage = "Failed to inherit Increment branch configuration, ended up with: " + string.Join(", ", possibleParents.Select(p => p.Name));
 
-                var developBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.Name, "^develop", RegexOptions.IgnoreCase));
-                var branchName = developBranch != null ? developBranch.Name : "master";
+                var chosenBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.Name, "^develop", RegexOptions.IgnoreCase)
+                                                                           || Regex.IsMatch(b.Name, "master$", RegexOptions.IgnoreCase));
+                if (chosenBranch == null)
+                    throw new InvalidOperationException("Could not find a 'develop' or 'master' branch, neither locally nor remotely.");
 
+                var branchName = chosenBranch.Name;
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
-                currentBranch = repository.Branches[branchName];
 
-                if (currentBranch == null)
-                {
-                    throw new InvalidOperationException(String.Format("Could not find the branch '{0}'.", branchName));
-                }
-
-                var value = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, currentBranch).Value;
+                var value = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch).Value;
                 return new KeyValuePair<string, BranchConfig>(
                     keyValuePair.Key,
                     new BranchConfig(branchConfiguration)

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -4,6 +4,9 @@ namespace GitVersion
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.RegularExpressions;
+
+    using JetBrains.Annotations;
+
     using LibGit2Sharp;
 
     public class BranchConfigurationCalculator
@@ -35,10 +38,21 @@ namespace GitVersion
             throw new Exception(string.Format(format, currentBranch.Name, string.Join(", ", matchingBranches.Select(b => b.Key))));
         }
 
-        static KeyValuePair<string, BranchConfig>[] LookupBranchConfiguration(Config config, Branch currentBranch)
+        static KeyValuePair<string, BranchConfig>[] LookupBranchConfiguration([NotNull] Config config, [NotNull] Branch currentBranch)
         {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+            
+            if (currentBranch == null)
+            {
+                throw new ArgumentNullException("currentBranch");
+            }
+            
             return config.Branches.Where(b => Regex.IsMatch(currentBranch.Name, "^" + b.Key, RegexOptions.IgnoreCase)).ToArray();
         }
+
 
         static KeyValuePair<string, BranchConfig> InheritBranchConfiguration(bool onlyEvaluateTrackedBranches, IRepository repository, Commit currentCommit, Branch currentBranch, KeyValuePair<string, BranchConfig> keyValuePair, BranchConfig branchConfiguration, Config config, IList<Branch> excludedInheritBranches)
         {

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -122,7 +122,14 @@ namespace GitVersion
                 var branchName = developBranch != null ? developBranch.Name : "master";
 
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
-                var value = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, repository.Branches[branchName]).Value;
+                currentBranch = repository.Branches[branchName];
+
+                if (currentBranch == null)
+                {
+                    throw new InvalidOperationException(String.Format("Could not find the branch '{0}'.", branchName));
+                }
+
+                var value = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, currentBranch).Value;
                 return new KeyValuePair<string, BranchConfig>(
                     keyValuePair.Key,
                     new BranchConfig(branchConfiguration)

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -6,6 +6,9 @@ namespace GitVersion
     using System.Linq;
     using System.Text;
     using GitVersion.Helpers;
+
+    using JetBrains.Annotations;
+
     using LibGit2Sharp;
 
     static class LibGitExtensions
@@ -44,8 +47,14 @@ namespace GitVersion
             .FirstOrDefault();
         }
 
-        public static Commit FindCommitBranchWasBranchedFrom(this Branch branch, IRepository repository, params Branch[] excludedBranches)
+
+        public static Commit FindCommitBranchWasBranchedFrom([NotNull] this Branch branch, IRepository repository, params Branch[] excludedBranches)
         {
+            if (branch == null)
+            {
+                throw new ArgumentNullException("branch");
+            }
+
             using (Logger.IndentLog("Finding branch source"))
             {
                 var otherBranches = repository.Branches.Except(excludedBranches).Where(b => IsSameBranch(branch, b)).ToList();

--- a/src/GitVersionCore/Logger.cs
+++ b/src/GitVersionCore/Logger.cs
@@ -6,11 +6,13 @@ namespace GitVersion
 
     public static class Logger
     {
+        static readonly Regex ObscurePasswordRegex = new Regex("(https?://)(.+)(:.+@)", RegexOptions.Compiled);
         static string indent = string.Empty;
 
         public static Action<string> WriteInfo { get; private set; }
         public static Action<string> WriteWarning { get; private set; }
         public static Action<string> WriteError { get; private set; }
+
 
         static Logger()
         {
@@ -33,8 +35,7 @@ namespace GitVersion
         {
             Action<string> logAction = s =>
             {
-                var rgx = new Regex("(https?://)(.+)(:.+@)");
-                s = rgx.Replace(s, "$1$2:*******@");
+                s = ObscurePasswordRegex.Replace(s, "$1$2:*******@");
                 info(s);
             };
             return logAction;


### PR DESCRIPTION
This makes sure #618 and #674 are handled in a more graceful way, by throwing more intuitive exceptions than `NullReferenceException` when a branch has no tip. Before this is merged, it would be good to replace the `example.com` documentation URI with proper documentation explaining how to fix this problem in the repository.