### PR TITLE
Add support for relative logfile paths

### DIFF
--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -113,6 +113,7 @@ namespace GitVersion
             return 0;
         }
 
+
         static void ConfigureLogging(Arguments arguments)
         {
             var writeActions = new List<Action<string>>
@@ -132,11 +133,11 @@ namespace GitVersion
                     var logFileFullPath = Path.GetFullPath(arguments.LogFilePath);
                     var logFile = new FileInfo(logFileFullPath);
 
-                    if (logFile.Directory == null)
-                        throw new DirectoryNotFoundException(String.Format("The directory of {0} does not exist.", logFile));
-
-                    if (!logFile.Directory.Exists)
+                    // NOTE: logFile.Directory will be null if the path is i.e. C:\logfile.log. @asbjornu
+                    if (logFile.Directory != null)
+                    {
                         logFile.Directory.Create();
+                    }
 
                     if (!logFile.Exists)
                     {

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -160,7 +160,7 @@ namespace GitVersion
         static void WriteLogEntry(Arguments arguments, string s)
         {
             var contents = string.Format("{0}\t\t{1}\r\n", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), s);
-            File.WriteAllText(arguments.LogFilePath, contents);
+            File.AppendAllText(arguments.LogFilePath, contents);
         }
 
         static List<string> GetArgumentsWithoutExeName()

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -132,11 +132,11 @@ namespace GitVersion
                     var logFileFullPath = Path.GetFullPath(arguments.LogFilePath);
                     var logFile = new FileInfo(logFileFullPath);
 
-                    if (logFile.Directory != null && !logFile.Directory.Exists)
-                    {
-                        // TODO: This should probably be done recursively. @asbjornu
+                    if (logFile.Directory == null)
+                        throw new DirectoryNotFoundException(String.Format("The directory of {0} does not exist.", logFile));
+
+                    if (!logFile.Directory.Exists)
                         logFile.Directory.Create();
-                    }
 
                     if (!logFile.Exists)
                     {

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -133,8 +133,10 @@ namespace GitVersion
                     var logFile = new FileInfo(logFileFullPath);
 
                     if (logFile.Directory != null && !logFile.Directory.Exists)
+                    {
                         // TODO: This should probably be done recursively. @asbjornu
                         logFile.Directory.Create();
+                    }
 
                     if (!logFile.Exists)
                     {

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -149,7 +149,7 @@ namespace GitVersion
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Failed to configure logging for '{0}': {1}", arguments.LogFilePath, ex.Message);
+                    Logger.WriteError(String.Format("Failed to configure logging for '{0}': {1}", arguments.LogFilePath, ex.Message));
                 }
             }
 

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -129,17 +129,25 @@ namespace GitVersion
             {
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(arguments.LogFilePath));
-                    if (File.Exists(arguments.LogFilePath))
+                    var logFileFullPath = Path.GetFullPath(arguments.LogFilePath);
+                    var logFile = new FileInfo(logFileFullPath);
+
+                    if (logFile.Directory != null && !logFile.Directory.Exists)
+                        // TODO: This should probably be done recursively. @asbjornu
+                        logFile.Directory.Create();
+
+                    if (!logFile.Exists)
                     {
-                        using (File.CreateText(arguments.LogFilePath)) { }
+                        using (logFile.CreateText())
+                        {
+                        }
                     }
 
                     writeActions.Add(x => WriteLogEntry(arguments, x));
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Failed to configure logging: " + ex.Message);
+                    Console.WriteLine("Failed to configure logging for '{0}': {1}", arguments.LogFilePath, ex.Message);
                 }
             }
 

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -139,11 +139,8 @@ namespace GitVersion
                         logFile.Directory.Create();
                     }
 
-                    if (!logFile.Exists)
+                    using (logFile.CreateText())
                     {
-                        using (logFile.CreateText())
-                        {
-                        }
                     }
 
                     writeActions.Add(x => WriteLogEntry(arguments, x));
@@ -163,7 +160,7 @@ namespace GitVersion
         static void WriteLogEntry(Arguments arguments, string s)
         {
             var contents = string.Format("{0}\t\t{1}\r\n", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), s);
-            File.AppendAllText(arguments.LogFilePath, contents);
+            File.WriteAllText(arguments.LogFilePath, contents);
         }
 
         static List<string> GetArgumentsWithoutExeName()


### PR DESCRIPTION
This changes the handling of `Arguments.LogFilePath` such that it can be relative as well as absolute. It also improves what is logged to the console when the log file can't be created.