### PR TITLE
Added test and fix for scenario when branch-name contains slashes. Fixes #569.

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
@@ -5,18 +5,32 @@ using NUnit.Framework;
 [TestFixture]
 public class OtherBranchScenarios
 {
-    [Test]
-    public void CanTakeVersionFromReleaseBranch()
-    {
-        using (var fixture = new EmptyRepositoryFixture(new Config()))
-        {
-            const string TaggedVersion = "1.0.3";
-            fixture.Repository.MakeATaggedCommit(TaggedVersion);
-            fixture.Repository.MakeCommits(5);
-            fixture.Repository.CreateBranch("alpha-2.0.0");
-            fixture.Repository.Checkout("alpha-2.0.0");
+	[Test]
+	public void CanTakeVersionFromReleaseBranch()
+	{
+		using (var fixture = new EmptyRepositoryFixture(new Config()))
+		{
+			const string TaggedVersion = "1.0.3";
+			fixture.Repository.MakeATaggedCommit(TaggedVersion);
+			fixture.Repository.MakeCommits(5);
+			fixture.Repository.CreateBranch("alpha-2.0.0");
+			fixture.Repository.Checkout("alpha-2.0.0");
 
-            fixture.AssertFullSemver("2.0.0-alpha.1+0");
-        }
-    }
+			fixture.AssertFullSemver("2.0.0-alpha.1+0");
+		}
+	}
+	[Test]
+	public void BranchesWithIllegalCharsShouldNotBeUsedInVersionNames()
+	{
+		using (var fixture = new EmptyRepositoryFixture(new Config()))
+		{
+			const string TaggedVersion = "1.0.3";
+			fixture.Repository.MakeATaggedCommit(TaggedVersion);
+			fixture.Repository.MakeCommits(5);
+			fixture.Repository.CreateBranch("issue/m/github-569");
+			fixture.Repository.Checkout("issue/m/github-569");
+
+			fixture.AssertFullSemver("1.0.4-issue-m-github-569.1+5");
+		}
+	}
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
@@ -5,32 +5,32 @@ using NUnit.Framework;
 [TestFixture]
 public class OtherBranchScenarios
 {
-	[Test]
-	public void CanTakeVersionFromReleaseBranch()
-	{
-		using (var fixture = new EmptyRepositoryFixture(new Config()))
-		{
-			const string TaggedVersion = "1.0.3";
-			fixture.Repository.MakeATaggedCommit(TaggedVersion);
-			fixture.Repository.MakeCommits(5);
-			fixture.Repository.CreateBranch("alpha-2.0.0");
-			fixture.Repository.Checkout("alpha-2.0.0");
+    [Test]
+    public void CanTakeVersionFromReleaseBranch()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            const string TaggedVersion = "1.0.3";
+            fixture.Repository.MakeATaggedCommit(TaggedVersion);
+            fixture.Repository.MakeCommits(5);
+            fixture.Repository.CreateBranch("alpha-2.0.0");
+            fixture.Repository.Checkout("alpha-2.0.0");
 
-			fixture.AssertFullSemver("2.0.0-alpha.1+0");
-		}
-	}
-	[Test]
-	public void BranchesWithIllegalCharsShouldNotBeUsedInVersionNames()
-	{
-		using (var fixture = new EmptyRepositoryFixture(new Config()))
-		{
-			const string TaggedVersion = "1.0.3";
-			fixture.Repository.MakeATaggedCommit(TaggedVersion);
-			fixture.Repository.MakeCommits(5);
-			fixture.Repository.CreateBranch("issue/m/github-569");
-			fixture.Repository.Checkout("issue/m/github-569");
+            fixture.AssertFullSemver("2.0.0-alpha.1+0");
+        }
+    }
+    [Test]
+    public void BranchesWithIllegalCharsShouldNotBeUsedInVersionNames()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            const string TaggedVersion = "1.0.3";
+            fixture.Repository.MakeATaggedCommit(TaggedVersion);
+            fixture.Repository.MakeCommits(5);
+            fixture.Repository.CreateBranch("issue/m/github-569");
+            fixture.Repository.Checkout("issue/m/github-569");
 
-			fixture.AssertFullSemver("1.0.4-issue-m-github-569.1+5");
-		}
-	}
+            fixture.AssertFullSemver("1.0.4-issue-m-github-569.1+5");
+        }
+    }
 }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -52,8 +52,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Visualize, Version=0.4.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Visualize.Fody.0.4.3.0\Lib\portable-net4+sl4+wp7+win8+MonoAndroid16+MonoTouch40\Visualize.dll</HintPath>
+    <Reference Include="Visualize, Version=0.4.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Visualize.Fody.0.4.4.0\lib\portable-net4+sl4+wp7+win8+MonoAndroid16+MonoTouch40\Visualize.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="YamlDotNet, Version=3.6.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -61,8 +61,12 @@
             if (tagToUse == "useBranchName")
             {
                 Logger.WriteInfo("Using branch name to calculate version tag");
-                var name = branchNameOverride ?? context.CurrentBranch.Name;
-                tagToUse = name.RegexReplace(context.Configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                tagToUse = branchNameOverride ?? context.CurrentBranch.Name;
+                if (!string.IsNullOrWhiteSpace(context.Configuration.BranchPrefixToTrim))
+                {
+                    tagToUse = tagToUse.RegexReplace(context.Configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                }
+                tagToUse = tagToUse.RegexReplace("[^a-zA-Z0-9-]", "-");
             }
             int? number = null;
             if (!string.IsNullOrEmpty(context.Configuration.TagNumberPattern))

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -5,6 +5,6 @@
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net40" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net40" developmentDependency="true" />
-  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net4" developmentDependency="true" />
   <package id="YamlDotNet" version="3.6.1" targetFramework="net40" />
 </packages>

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -51,8 +51,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Visualize, Version=0.4.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Visualize.Fody.0.4.3.0\Lib\portable-net4+sl4+wp7+win8+MonoAndroid16+MonoTouch40\Visualize.dll</HintPath>
+    <Reference Include="Visualize, Version=0.4.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Visualize.Fody.0.4.4.0\lib\portable-net4+sl4+wp7+win8+MonoAndroid16+MonoTouch40\Visualize.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -5,5 +5,5 @@
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net40" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net40" developmentDependency="true" />
-  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Visualize.Fody" version="0.4.4.0" targetFramework="net4" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This fixes the scenario for issue #569 where multiple slashes in the branch-name (which is perfectly legal for branch-names, but probably should be avoided in the version-name (see issue for discussion).
Note: Added a fix too for the project-references where the the Visualizer.Fody references were off.