### PR TITLE
Enable use of GitVersion variables in the VSO BuildNumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ ForSample/
 *NugetTaskBuild*
 *NugetRefBuild*
 *NugetExeBuild*
-*GitVersionVsoTaskBuild*
+*GitVersionTfsTaskBuild*
 *GemBuild*
 
 # Visual Studio profiler

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -38,7 +38,7 @@ GitVersion passes variables in the form of `GitVersion.*` (Eg: `GitVersion.Major
 See [Variables](/more-info/variables/) for an overview of available variables.
 
 
-#### Using GitVersion variables in build build name
+#### Using GitVersion variables in build name
 To use GitVersion's variables in the build name, just add them in the form `$(GITVERSION_FullSemVer)` into the Build definition's build number string. Then just ensure GitVersion is called with
 `/output buildserver` and it will replace those variables with the calculated version.
 

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -37,6 +37,12 @@ The VSO build step updates the build number automatically to the GitVersion numb
 GitVersion passes variables in the form of `GitVersion.*` (Eg: `GitVersion.Major`) to TFS Build and also writes `GITVERSION_*` (Eg: `GITVERSION_MAJOR`) environment variables that are available for any subsequent build step. 
 See [Variables](/more-info/variables/) for an overview of available variables.
 
+
+#### Using GitVersion variables in build build name
+To use GitVersion's variables in the build name, just add them in the form `$(GITVERSION_FullSemVer)` into the Build definition's build number string. Then just ensure GitVersion is called with
+`/output buildserver` and it will replace those variables with the calculated version.
+
+
 #### Known limitations
 * Due to [current limitations in TFS2015 On-Prem](https://github.com/Microsoft/vso-agent-tasks/issues/380) it's currently not possible to automatically set the build version in TFS2015 On-Prem. Instead a warning similar to `##[warning]Unable to process logging event:##vso[build.updatebuildnumber 1.0.0-unstable.1` is logged.
 * Due to a know limitation in TFS 2015 On-Prem it's currently not possible to use variables added during build in inputs of subsequent build tasks, since the variables are processed at the beginning of the build. 

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -30,7 +30,8 @@ From a TFS build definition, select "Add a Step" and then in the Build category,
 
 If you want the GitVersionTask to update AssemblyInfo files, check the box in the task configuration. For advanced usage, you can pass additional options to the GitVersion exe in the Additional arguments section.
 
-The VSO build step updates the build number automatically to the GitVersion number.
+The VSO build step can update your build number with GitVersion variables. See below for details.
+
 
 ## Running inside TFS
 ### Using the GitVersion Variables
@@ -42,6 +43,11 @@ See [Variables](/more-info/variables/) for an overview of available variables.
 To use GitVersion's variables in the build name, just add them in the form `$(GITVERSION_FullSemVer)` into the Build definition's build number string. Then just ensure GitVersion is called with
 `/output buildserver` and it will replace those variables with the calculated version.
 The TFS GitVersion Build Step (above) handles this too, so if you're already using that, there's nothing extra to configure.
+
+If you currently use `$(rev:.r)` in your build number, that won't work correctly if you 
+use GitVersion variables as well due to the delayed expansion of the GitVersion vars. Instead,
+You might be able to use `$(GitVersion_BuildMetaData)` to achieve a similar result.
+See [Variables](/more-info/variables/) for more info on the variables.
 
 
 #### Known limitations

--- a/docs/more-info/build-server-setup/tfs-build-vnext.md
+++ b/docs/more-info/build-server-setup/tfs-build-vnext.md
@@ -41,6 +41,7 @@ See [Variables](/more-info/variables/) for an overview of available variables.
 #### Using GitVersion variables in build name
 To use GitVersion's variables in the build name, just add them in the form `$(GITVERSION_FullSemVer)` into the Build definition's build number string. Then just ensure GitVersion is called with
 `/output buildserver` and it will replace those variables with the calculated version.
+The TFS GitVersion Build Step (above) handles this too, so if you're already using that, there's nothing extra to configure.
 
 
 #### Known limitations

--- a/src/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
@@ -39,9 +39,9 @@ public class BuildServerBaseTests
             throw new NotImplementedException();
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            return versionToUseForBuildNumber;
+            return variables.FullSemVer;
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/src/GitVersionCore.Tests/BuildServers/ContinuaCiTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/ContinuaCiTests.cs
@@ -1,4 +1,5 @@
 ﻿using GitVersion;
+using GitVersionCore.Tests;
 using NUnit.Framework;
 
 [TestFixture]
@@ -9,7 +10,8 @@ public class ContinuaCiTests
     public void GenerateBuildVersion()
     {
         var versionBuilder = new ContinuaCi();
-        var continuaCiVersion = versionBuilder.GenerateSetVersionMessage("0.0.0-Beta4.7");
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Beta4.7");
+        var continuaCiVersion = versionBuilder.GenerateSetVersionMessage(vars);
         Assert.AreEqual("@@continua[setBuildVersion value='0.0.0-Beta4.7']", continuaCiVersion);
     }
 

--- a/src/GitVersionCore.Tests/BuildServers/JenkinsMessageGenerationTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/JenkinsMessageGenerationTests.cs
@@ -13,7 +13,8 @@ public class JenkinsMessageGenerationTests
     public void GenerateSetVersionMessageReturnsVersionAsIs_AlthoughThisIsNotUsedByJenkins()
     {
         var j = new Jenkins();
-        j.GenerateSetVersionMessage("0.0.0-Beta4.7").ShouldBe("0.0.0-Beta4.7");
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Beta4.7");
+        j.GenerateSetVersionMessage(vars).ShouldBe("0.0.0-Beta4.7");
     }
 
     [Test]

--- a/src/GitVersionCore.Tests/BuildServers/MyGetTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/MyGetTests.cs
@@ -1,4 +1,5 @@
 ﻿using GitVersion;
+using GitVersionCore.Tests;
 using NUnit.Framework;
 
 [TestFixture]
@@ -8,7 +9,8 @@ public class MyGetTests
     public void Develop_branch()
     {
         var versionBuilder = new MyGet();
-        var message = versionBuilder.GenerateSetVersionMessage("0.0.0-Unstable4");
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
+        var message = versionBuilder.GenerateSetVersionMessage(vars);
         Assert.AreEqual(null, message);
     }
 

--- a/src/GitVersionCore.Tests/BuildServers/TeamCityTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/TeamCityTests.cs
@@ -1,4 +1,5 @@
 ﻿using GitVersion;
+using GitVersionCore.Tests;
 using NUnit.Framework;
 
 [TestFixture]
@@ -8,7 +9,8 @@ public class TeamCityTests
     public void Develop_branch()
     {
         var versionBuilder = new TeamCity();
-        var tcVersion = versionBuilder.GenerateSetVersionMessage("0.0.0-Unstable4");
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
+        var tcVersion = versionBuilder.GenerateSetVersionMessage(vars);
         Assert.AreEqual("##teamcity[buildNumber '0.0.0-Unstable4']", tcVersion);
     }
 

--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -1,4 +1,5 @@
 ﻿using GitVersion;
+using GitVersionCore.Tests;
 using NUnit.Framework;
 using Shouldly;
 
@@ -9,7 +10,8 @@ public class VsoAgentTests
     public void Develop_branch()
     {
         var versionBuilder = new VsoAgent();
-        var vsVersion = versionBuilder.GenerateSetVersionMessage("0.0.0-Unstable4");
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
+        var vsVersion = versionBuilder.GenerateSetVersionMessage(vars);
         vsVersion.ShouldBe("##vso[build.updatebuildnumber]0.0.0-Unstable4");
     }
 

--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -10,12 +10,15 @@ public class VsoAgentTests
 
     string key = "BUILD_BUILDNUMBER";
 
-    private void SetEnvironmentVariableForTest()
+
+    [SetUp]
+    public void SetEnvironmentVariableForTest()
     {
         Environment.SetEnvironmentVariable(key, "Some Build_Value $(GitVersion_FullSemVer)", EnvironmentVariableTarget.Process);
     }
 
-    private void ClearEnvironmentVariableForTest()
+    [TearDown]
+    public void ClearEnvironmentVariableForTest()
     {
         Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
     }
@@ -23,11 +26,9 @@ public class VsoAgentTests
     [Test]
     public void Develop_branch()
     {
-        SetEnvironmentVariableForTest();
         var versionBuilder = new VsoAgent();
         var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
         var vsVersion = versionBuilder.GenerateSetVersionMessage(vars);
-        ClearEnvironmentVariableForTest();
 
         vsVersion.ShouldBe("##vso[build.updatebuildnumber]Some Build_Value 0.0.0-Unstable4");
     }

--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -14,7 +14,7 @@ public class VsoAgentTests
     [SetUp]
     public void SetEnvironmentVariableForTest()
     {
-        Environment.SetEnvironmentVariable(key, "Some Build_Value $(GitVersion_FullSemVer)", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable(key, "Some Build_Value $(GitVersion_FullSemVer) 20151310.3 $(UnknownVar) Release", EnvironmentVariableTarget.Process);
     }
 
     [TearDown]
@@ -30,7 +30,7 @@ public class VsoAgentTests
         var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
         var vsVersion = versionBuilder.GenerateSetVersionMessage(vars);
 
-        vsVersion.ShouldBe("##vso[build.updatebuildnumber]Some Build_Value 0.0.0-Unstable4");
+        vsVersion.ShouldBe("##vso[build.updatebuildnumber]Some Build_Value 0.0.0-Unstable4 20151310.3 $(UnknownVar) Release");
     }
 
     [Test]

--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -1,4 +1,5 @@
-﻿using GitVersion;
+﻿using System;
+using GitVersion;
 using GitVersionCore.Tests;
 using NUnit.Framework;
 using Shouldly;
@@ -6,13 +7,29 @@ using Shouldly;
 [TestFixture]
 public class VsoAgentTests
 {
+
+    string key = "BUILD_BUILDNUMBER";
+
+    private void SetEnvironmentVariableForTest()
+    {
+        Environment.SetEnvironmentVariable(key, "Some Build_Value $(GitVersion_FullSemVer)", EnvironmentVariableTarget.Process);
+    }
+
+    private void ClearEnvironmentVariableForTest()
+    {
+        Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
+    }
+
     [Test]
     public void Develop_branch()
     {
+        SetEnvironmentVariableForTest();
         var versionBuilder = new VsoAgent();
         var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Unstable4");
         var vsVersion = versionBuilder.GenerateSetVersionMessage(vars);
-        vsVersion.ShouldBe("##vso[build.updatebuildnumber]0.0.0-Unstable4");
+        ClearEnvironmentVariableForTest();
+
+        vsVersion.ShouldBe("##vso[build.updatebuildnumber]Some Build_Value 0.0.0-Unstable4");
     }
 
     [Test]

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -169,6 +169,7 @@
     <Compile Include="ApprovalTestsConfig.cs" />
     <Compile Include="Fixtures\RepositoryFixtureBase.cs" />
     <Compile Include="SemanticVersionTests.cs" />
+    <Compile Include="TestableVersionVariables.cs" />
     <Compile Include="TestEffectiveConfiguration.cs" />
     <Compile Include="TestFileSystem.cs" />
     <Compile Include="TestStream.cs" />

--- a/src/GitVersionCore.Tests/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/TestableVersionVariables.cs
@@ -9,7 +9,7 @@ namespace GitVersionCore.Tests
     using GitVersion;
     class TestableVersionVariables : VersionVariables
     {
-        public TestableVersionVariables(string major = null, string minor = null, string patch = null, string buildMetaData = null, string buildMetaDataPadded = null, string fullBuildMetaData = null, string branchName = null, string sha = null, string majorMinorPatch = null, string semVer = null, string legacySemVer = null, string legacySemVerPadded = null, string fullSemVer = null, string assemblySemVer = null, string preReleaseTag = null, string preReleaseTagWithDash = null, string informationalVersion = null, string commitDate = null) : base(major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, sha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer, assemblySemVer, preReleaseTag, preReleaseTagWithDash, informationalVersion, commitDate)
+        public TestableVersionVariables(string major = "", string minor = "", string patch = "", string buildMetaData = "", string buildMetaDataPadded = "", string fullBuildMetaData = "", string branchName = "", string sha = "", string majorMinorPatch = "", string semVer = "", string legacySemVer = "", string legacySemVerPadded = "", string fullSemVer = "", string assemblySemVer = "", string preReleaseTag = "", string preReleaseTagWithDash = "", string informationalVersion = "", string commitDate = "") : base(major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, sha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer, assemblySemVer, preReleaseTag, preReleaseTagWithDash, informationalVersion, commitDate)
         {
         }
     }

--- a/src/GitVersionCore.Tests/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/TestableVersionVariables.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitVersionCore.Tests
+{
+    using GitVersion;
+    class TestableVersionVariables : VersionVariables
+    {
+        public TestableVersionVariables(string major = null, string minor = null, string patch = null, string buildMetaData = null, string buildMetaDataPadded = null, string fullBuildMetaData = null, string branchName = null, string sha = null, string majorMinorPatch = null, string semVer = null, string legacySemVer = null, string legacySemVerPadded = null, string fullSemVer = null, string assemblySemVer = null, string preReleaseTag = null, string preReleaseTagWithDash = null, string informationalVersion = null, string commitDate = null) : base(major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, sha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer, assemblySemVer, preReleaseTag, preReleaseTagWithDash, informationalVersion, commitDate)
+        {
+        }
+    }
+}

--- a/src/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/src/GitVersionCore/BuildServers/AppVeyor.cs
@@ -11,7 +11,7 @@
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR"));
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
             var buildNumber = Environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
 
@@ -20,7 +20,7 @@
             var request = (HttpWebRequest)WebRequest.Create(restBase + "api/build");
             request.Method = "PUT";
 
-            var data = string.Format("{{ \"version\": \"{0} (Build {1})\" }}", versionToUseForBuildNumber, buildNumber);
+            var data = string.Format("{{ \"version\": \"{0} (Build {1})\" }}", variables.FullSemVer, buildNumber);
             var bytes = Encoding.UTF8.GetBytes(data);
             request.ContentLength = bytes.Length;
             request.ContentType = "application/json";
@@ -39,7 +39,7 @@
                 }
             }
 
-            return string.Format("Set AppVeyor build number to '{0} (Build {1})'.", versionToUseForBuildNumber, buildNumber);
+            return string.Format("Set AppVeyor build number to '{0} (Build {1})'.", variables.FullSemVer, buildNumber);
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/src/GitVersionCore/BuildServers/BuildServerBase.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerBase.cs
@@ -5,7 +5,7 @@
     public abstract class BuildServerBase : IBuildServer
     {
         public abstract bool CanApplyToCurrentContext();
-        public abstract string GenerateSetVersionMessage(string versionToUseForBuildNumber);
+        public abstract string GenerateSetVersionMessage(VersionVariables variables);
         public abstract string[] GenerateSetParameterMessage(string name, string value);
 
         public virtual string GetCurrentBranch()
@@ -21,7 +21,7 @@
             }
 
             writer(string.Format("Executing GenerateSetVersionMessage for '{0}'.", GetType().Name));
-            writer(GenerateSetVersionMessage(variables.FullSemVer));
+            writer(GenerateSetVersionMessage(variables));
             writer(string.Format("Executing GenerateBuildLogOutput for '{0}'.", GetType().Name));
             foreach (var buildParameter in BuildOutputFormatter.GenerateBuildLogOutput(this, variables))
             {

--- a/src/GitVersionCore/BuildServers/ContinuaCi.cs
+++ b/src/GitVersionCore/BuildServers/ContinuaCi.cs
@@ -29,9 +29,9 @@
             };
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            return string.Format("@@continua[setBuildVersion value='{0}']", versionToUseForBuildNumber);
+            return string.Format("@@continua[setBuildVersion value='{0}']", variables.FullSemVer);
         }
 
         static bool RegistryKeyExists(string keyName, RegistryView registryView)

--- a/src/GitVersionCore/BuildServers/IBuildServer.cs
+++ b/src/GitVersionCore/BuildServers/IBuildServer.cs
@@ -5,7 +5,7 @@
     public interface IBuildServer
     {
         bool CanApplyToCurrentContext();
-        string GenerateSetVersionMessage(string versionToUseForBuildNumber);
+        string GenerateSetVersionMessage(VersionVariables variables);
         string[] GenerateSetParameterMessage(string name, string value);
 
         void WriteIntegration(Action<string> writer, VersionVariables variables);

--- a/src/GitVersionCore/BuildServers/Jenkins.cs
+++ b/src/GitVersionCore/BuildServers/Jenkins.cs
@@ -21,9 +21,9 @@
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JENKINS_URL"));
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            return versionToUseForBuildNumber;
+            return variables.FullSemVer;
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/src/GitVersionCore/BuildServers/MyGet.cs
+++ b/src/GitVersionCore/BuildServers/MyGet.cs
@@ -28,7 +28,7 @@
             return messages.ToArray();
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
             return null;
         }

--- a/src/GitVersionCore/BuildServers/TeamCity.cs
+++ b/src/GitVersionCore/BuildServers/TeamCity.cs
@@ -18,9 +18,9 @@
             };
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            return string.Format("##teamcity[buildNumber '{0}']", ServiceMessageEscapeHelper.EscapeValue(versionToUseForBuildNumber));
+            return string.Format("##teamcity[buildNumber '{0}']", ServiceMessageEscapeHelper.EscapeValue(variables.FullSemVer));
         }
     }
 }

--- a/src/GitVersionCore/BuildServers/VsoAgent.cs
+++ b/src/GitVersionCore/BuildServers/VsoAgent.cs
@@ -22,9 +22,9 @@
             return Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
         }
 
-        public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)
+        public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            return string.Format("##vso[build.updatebuildnumber]{0}", ServiceMessageEscapeHelper.EscapeValue(versionToUseForBuildNumber));
+            return string.Format("##vso[build.updatebuildnumber]{0}", ServiceMessageEscapeHelper.EscapeValue(variables.FullSemVer));
         }
     }
 }

--- a/src/GitVersionCore/BuildServers/VsoAgent.cs
+++ b/src/GitVersionCore/BuildServers/VsoAgent.cs
@@ -33,7 +33,7 @@
             var buildNum = Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER");
 
             buildNum = variables.Aggregate(buildNum, (current, kvp) => 
-                current.RegexReplace(string.Format(@"\$\(GITVERSION_{0}\)", kvp.Key ?? string.Empty), kvp.Value, RegexOptions.IgnoreCase));
+                current.RegexReplace(string.Format(@"\$\(GITVERSION_{0}\)", kvp.Key), kvp.Value ?? string.Empty, RegexOptions.IgnoreCase));
 
             return string.Format("##vso[build.updatebuildnumber]{0}", buildNum);
         }

--- a/src/GitVersionCore/BuildServers/VsoAgent.cs
+++ b/src/GitVersionCore/BuildServers/VsoAgent.cs
@@ -33,7 +33,7 @@
             var buildNum = Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER");
 
             buildNum = variables.Aggregate(buildNum, (current, kvp) => 
-                current.RegexReplace(string.Format(@"\$\(GITVERSION_{0}\)", kvp.Key), kvp.Value, RegexOptions.IgnoreCase));
+                current.RegexReplace(string.Format(@"\$\(GITVERSION_{0}\)", kvp.Key ?? string.Empty), kvp.Value, RegexOptions.IgnoreCase));
 
             return string.Format("##vso[build.updatebuildnumber]{0}", buildNum);
         }

--- a/src/GitVersionTask/WriteVersionInfoToBuildLog.cs
+++ b/src/GitVersionTask/WriteVersionInfoToBuildLog.cs
@@ -67,7 +67,7 @@
             foreach (var buildServer in applicableBuildServers)
             {
                 logger.LogInfo(string.Format("Executing GenerateSetVersionMessage for '{0}'.", buildServer.GetType().Name));
-                logger.LogInfo(buildServer.GenerateSetVersionMessage(variables.FullSemVer));
+                logger.LogInfo(buildServer.GenerateSetVersionMessage(variables));
                 logger.LogInfo(string.Format("Executing GenerateBuildLogOutput for '{0}'.", buildServer.GetType().Name));
                 foreach (var buildParameter in BuildOutputFormatter.GenerateBuildLogOutput(buildServer, variables))
                 {


### PR DESCRIPTION
As discussed in #663, this lets the VSO BuildNumber control placement and use of the GitVersion variables in the build number.

Just put $(GitVersion_Foo) wherever you want in the VSO build number and the agent task will replace that with the actual version.