### PR TITLE
Ignore the build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ NuGetExeBuild/
 NuGetRefBuild/
 Packages/
 NuGetTaskBuild/
+build/


### PR DESCRIPTION
I'm not sure I understand why the `build` folder shouldn't be ignored.