### PR TITLE
Added global:: prefix in AssemblyInfoBuilder to avoid namespace conflicts.

### DIFF
--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag_NugetAssemblyInfo.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag_NugetAssemblyInfo.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch_NugetAssemblyInfo.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch_NugetAssemblyInfo.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfo.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfo.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfoWithMultipleVariables.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfoWithMultipleVariables.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major_NugetAssemblyInfo.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major_NugetAssemblyInfo.approved.txt
@@ -18,7 +18,7 @@ using System.Reflection;
 namespace Fake
 {
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {
         public static string Major = "2";

--- a/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode_NoNamespaceConflict.approved.txt
+++ b/src/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyCreatedCode_NoNamespaceConflict.approved.txt
@@ -15,7 +15,7 @@ using System.Reflection;
 [assembly: AssemblyFileVersion("1.2.3.0")]
 [assembly: AssemblyInformationalVersion("1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha")]
 
-namespace Fake
+namespace Fake.System
 {
 
     [global::System.Runtime.CompilerServices.CompilerGenerated]

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -143,6 +143,7 @@
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyCreatedCode_NoNamespaceConflict.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt" />
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -143,6 +143,11 @@
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag_NugetAssemblyInfo.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch_NugetAssemblyInfo.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfo.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor_NugetAssemblyInfoWithMultipleVariables.approved.txt" />
+    <Content Include="AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major_NugetAssemblyInfo.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyCreatedCode_NoNamespaceConflict.approved.txt" />
     <Content Include="AssemblyInfoBuilderTests.VerifyCreatedCode.approved.txt" />
     <Content Include="FodyWeavers.xml" />

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -30,7 +30,7 @@ using System.Reflection;
 namespace {4}
 {{
 
-    [System.Runtime.CompilerServices.CompilerGenerated]
+    [global::System.Runtime.CompilerServices.CompilerGenerated]
     static class GitVersionInformation
     {{
 {3}


### PR DESCRIPTION
Added global:: prefix to full namespace qualified [CompilerGenerated] attribute to avoid any possible conflicts with the namespace of the host project.