### PR TITLE
Make sure to convert the whole object back to the JSON file

### DIFF
--- a/build/Update-GitVersionTfsTaskVersion.ps1
+++ b/build/Update-GitVersionTfsTaskVersion.ps1
@@ -14,4 +14,4 @@ $task.version.Patch = $patch
 
 # get this as a string again
 
-ConvertTo-Json $task | Set-Content -Path $filePath
+ConvertTo-Json $task -Depth 999 | Set-Content -Path $filePath


### PR DESCRIPTION
This fixes a potential issue where part of the task.json file might be lost/altered on build while writing the changes back to the file.