### PR TITLE
Remove build number from AppVeyor

### DIFF
--- a/src/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/src/GitVersionCore/BuildServers/AppVeyor.cs
@@ -13,14 +13,12 @@
 
         public override string GenerateSetVersionMessage(VersionVariables variables)
         {
-            var buildNumber = Environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
-
             var restBase = Environment.GetEnvironmentVariable("APPVEYOR_API_URL");
 
             var request = (HttpWebRequest)WebRequest.Create(restBase + "api/build");
             request.Method = "PUT";
 
-            var data = string.Format("{{ \"version\": \"{0} (Build {1})\" }}", variables.FullSemVer, buildNumber);
+            var data = string.Format("{{ \"version\": \"{0}\" }}", variables.FullSemVer);
             var bytes = Encoding.UTF8.GetBytes(data);
             request.ContentLength = bytes.Length;
             request.ContentType = "application/json";
@@ -39,7 +37,7 @@
                 }
             }
 
-            return string.Format("Set AppVeyor build number to '{0} (Build {1})'.", variables.FullSemVer, buildNumber);
+            return string.Format("Set AppVeyor build number to '{0}'.", variables.FullSemVer);
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)


### PR DESCRIPTION
 - Build Variables are not available during deployment, so the build number is the only way to communicate the version to the release
 - At the moment, the build number is not SemVer. This breaks github release tagging
 - Fixes #723