### PR TITLE
Allow next-version to be an integer

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -117,6 +117,36 @@ branches:
     }
 
     [Test]
+    public void NextVersionCanBeInteger()
+    {
+        const string text = "next-version: 2";
+        SetupConfigFileContent(text);
+        var config = ConfigurationProvider.Provide(repoPath, fileSystem);
+
+        config.NextVersion.ShouldBe("2.0");
+    }
+
+    [Test]
+    public void NextVersionCanHaveEnormousMinorVersion()
+    {
+        const string text = "next-version: 2.118998723";
+        SetupConfigFileContent(text);
+        var config = ConfigurationProvider.Provide(repoPath, fileSystem);
+
+        config.NextVersion.ShouldBe("2.118998723");
+    }
+
+    [Test]
+    public void NextVersionCanHavePatch()
+    {
+        const string text = "next-version: 2.12.654651698";
+        SetupConfigFileContent(text);
+        var config = ConfigurationProvider.Provide(repoPath, fileSystem);
+
+        config.NextVersion.ShouldBe("2.12.654651698");
+    }
+    
+    [Test]
     [MethodImpl(MethodImplOptions.NoInlining)]
     public void CanWriteOutEffectiveConfiguration()
     {

--- a/src/GitVersionCore.Tests/VersionCalculation/Strategies/ConfigNextVersionBaseVersionStrategyTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/Strategies/ConfigNextVersionBaseVersionStrategyTests.cs
@@ -35,5 +35,50 @@
 
             baseVersion.ShouldBe(null);
         }
+
+        [Test]
+        public void NextVersionCanBeInteger()
+        {
+            var contextBuilder = new GitVersionContextBuilder()
+                .WithConfig(new Config
+                {
+                    NextVersion = "2"
+                });
+            var sut = new ConfigNextVersionBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersions(contextBuilder.Build()).Single();
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
+        }
+
+        [Test]
+        public void NextVersionCanHaveEnormousMinorVersion()
+        {
+            var contextBuilder = new GitVersionContextBuilder()
+                .WithConfig(new Config
+                {
+                    NextVersion = "2.118998723"
+                });
+            var sut = new ConfigNextVersionBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersions(contextBuilder.Build()).Single();
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.118998723.0");
+        }
+
+        [Test]
+        public void NextVersionCanHavePatch()
+        {
+            var contextBuilder = new GitVersionContextBuilder()
+                .WithConfig(new Config
+                {
+                    NextVersion = "2.12.654651698"
+                });
+            var sut = new ConfigNextVersionBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersions(contextBuilder.Build()).Single();
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.12.654651698");
+        }
     }
 }

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -1,12 +1,15 @@
 ﻿namespace GitVersion
 {
+    using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using YamlDotNet.Serialization;
 
     public class Config
     {
         Dictionary<string, BranchConfig> branches = new Dictionary<string, BranchConfig>();
+        string nextVersion;
 
         [YamlMember(Alias = "assembly-versioning-scheme")]
         public AssemblyVersioningScheme? AssemblyVersioningScheme { get; set; }
@@ -24,7 +27,17 @@
         public string ContinuousDeploymentFallbackTag { get; set; }
 
         [YamlMember(Alias = "next-version")]
-        public string NextVersion { get; set; }
+        public string NextVersion
+        {
+            get { return this.nextVersion; }
+            set
+            {
+                int major;
+                this.nextVersion = int.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out major)
+                    ? string.Format("{0}.0", major)
+                    : value;
+            }
+        }
 
         [YamlMember(Alias = "major-version-bump-message")]
         public string MajorVersionBumpMessage { get; set; }


### PR DESCRIPTION
Try to parse the `next-version` configuration value as a `System.Int32` and treat the parsed value as the major version number.