### PR TITLE
Perf improve part1

### DIFF
--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -84,7 +84,11 @@ namespace GitVersion
                 List<Branch> possibleParents;
                 if (branchPoint == null)
                 {
-                    possibleParents = currentCommit.GetBranchesContainingCommit(repository, branchesToEvaluate, true).ToList();
+                    possibleParents = currentCommit.GetBranchesContainingCommit(repository, branchesToEvaluate, true)
+                        // It fails to inherit Increment branch configuration if more than 1 parent;
+                        // therefore no point to get more than 2 parents
+                        .Take(2)
+                        .ToList();
                 }
                 else
                 {

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -167,15 +167,22 @@ namespace GitVersion
             }
         }
 
+        private static Dictionary<string, GitObject> _cachedPeeledTarget = new Dictionary<string, GitObject>();
+
         public static GitObject PeeledTarget(this Tag tag)
         {
+            GitObject cachedTarget;
+            if(_cachedPeeledTarget.TryGetValue(tag.Target.Sha, out cachedTarget))
+            {
+                return cachedTarget;
+            }
             var target = tag.Target;
 
             while (target is TagAnnotation)
             {
                 target = ((TagAnnotation)(target)).Target;
             }
-
+            _cachedPeeledTarget.Add(tag.Target.Sha, target);
             return target;
         }
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -8,13 +8,6 @@
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)
         {
-            string currentBranchName = null;
-            var head = context.Repository.Head;
-            if (head != null)
-            {
-                currentBranchName = head.CanonicalName;
-            }
-
             var olderThan = context.CurrentCommit.When();
             var allTags = context.Repository.Tags
                 .Where(tag => ((Commit)tag.PeeledTarget()).When() <= olderThan)
@@ -23,7 +16,7 @@
                 .Commits
                 .SelectMany(commit =>
                 {
-                    return allTags.Where(t => IsValidTag(context, currentBranchName, t, commit));
+                    return allTags.Where(t => IsValidTag(t, commit));
                 })
                 .Select(t =>
                 {
@@ -66,7 +59,7 @@
             return string.Format("Git tag '{0}'", version.Tag);
         }
 
-        protected virtual bool IsValidTag(GitVersionContext context, string branchName, Tag tag, Commit commit)
+        protected virtual bool IsValidTag(Tag tag, Commit commit)
         {
             return tag.PeeledTarget() == commit;
         }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -32,19 +32,7 @@
                 .Where(a => a != null)
                 .ToList();
 
-            if (tagsOnBranch.Count == 0)
-            {
-                yield break;
-            }
-            if (tagsOnBranch.Count == 1)
-            {
-                yield return CreateBaseVersion(context, tagsOnBranch[0]);
-            }
-
-            foreach (var result in tagsOnBranch.Select(t => CreateBaseVersion(context, t)))
-            {
-                yield return result;
-            }
+            return tagsOnBranch.Select(t => CreateBaseVersion(context, t));
         }
 
         BaseVersion CreateBaseVersion(GitVersionContext context, VersionTaggedCommit version)


### PR DESCRIPTION
- Cache the PeeledTarget to gain better perf
- We don't have to do anything in `TrackMergeTargetBaseVersionStrategy` if `TrackMergeTarget` is disabled or the current branch name is null or empty
- We don't have to get more than 2 parents because the inherit increment branch configuration fails if there are more than 1 branch.

Part2 #734 is to use Git Command Line to get the branches that contain a commit.