### PR TITLE
Gitlab CI support

### DIFF
--- a/docs/build-server-support/build-server-support.md
+++ b/docs/build-server-support/build-server-support.md
@@ -4,6 +4,7 @@ GitVersion has support for quite a few build servers out of the box. Currently w
  - [AppVeyor](build-server/appveyor.md)
  - [Bamboo](build-server/bamboo.md)
  - [Continua CI](build-server/continua.md)
+ - [GitLab CI](build-server/gitlab.md)
  - [Jenkins](build-server/jenkins.md)
  - [MyGet](build-server/myget.md)
  - [Octopus Deploy](build-server/octopus-deploy.md)

--- a/docs/build-server-support/build-server/gitlab.md
+++ b/docs/build-server-support/build-server/gitlab.md
@@ -1,0 +1,3 @@
+# GitLab CI
+
+To use GitVersion with GitLab CI, either use the [MSBuild Task](/usage/msbuild-task) or put the GitVersion executable in your runner's `PATH`.

--- a/src/GitVersionCore.Tests/BuildServers/GitLabCiMessageGenerationTest.cs
+++ b/src/GitVersionCore.Tests/BuildServers/GitLabCiMessageGenerationTest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using GitVersion;
+using GitVersionCore.Tests;
+using NUnit.Framework;
+using Shouldly;
+
+[TestFixture]
+public class GitLabCiMessageGenerationTests
+{
+    [Test]
+    public void GenerateSetVersionMessageReturnsVersionAsIs_AlthoughThisIsNotUsedByJenkins()
+    {
+        var j = new GitLabCi();
+        var vars = new TestableVersionVariables(fullSemVer: "0.0.0-Beta4.7");
+        j.GenerateSetVersionMessage(vars).ShouldBe("0.0.0-Beta4.7");
+    }
+
+    [Test]
+    public void GenerateMessageTest()
+    {
+        var j = new GitLabCi();
+        var generatedParameterMessages = j.GenerateSetParameterMessage("name", "value");
+        generatedParameterMessages.Length.ShouldBe(1);
+        generatedParameterMessages[0].ShouldBe("GitVersion_name=value");
+    }
+
+    [Test, Explicit]
+    public void WriteAllVariablesToTheTextWriter()
+    {
+        // this test method writes to disc, hence marked explicit
+        var f = "this_file_should_be_deleted.properties";
+
+        try
+        {
+            AssertVariablesAreWrittenToFile(f);
+        }
+        finally
+        {
+            File.Delete(f);
+        }
+    }
+
+    static void AssertVariablesAreWrittenToFile(string f)
+    {
+        var writes = new List<string>();
+        var semanticVersion = new SemanticVersion
+        {
+            Major = 1,
+            Minor = 2,
+            Patch = 3,
+            PreReleaseTag = "beta1",
+            BuildMetaData = "5"
+        };
+
+        semanticVersion.BuildMetaData.CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z");
+        semanticVersion.BuildMetaData.Sha = "commitSha";
+
+        var config = new TestEffectiveConfiguration();
+
+        var variables = VariableProvider.GetVariablesFor(semanticVersion, config, false);
+
+        var j = new GitLabCi(f);
+
+        j.WriteIntegration(writes.Add, variables);
+
+        writes[1].ShouldBe("1.2.3-beta.1+5");
+
+        File.Exists(f).ShouldBe(true);
+
+        var props = File.ReadAllText(f);
+
+        props.ShouldContain("GitVersion_Major=1");
+        props.ShouldContain("GitVersion_Minor=2");
+    }
+}

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="BuildServers\BuildServerBaseTests.cs" />
     <Compile Include="BuildServers\ContinuaCiTests.cs" />
     <Compile Include="BuildServers\EnvironmentVariableJenkinsTests.cs" />
+    <Compile Include="BuildServers\GitLabCiMessageGenerationTest.cs" />
     <Compile Include="BuildServers\JenkinsMessageGenerationTests.cs" />
     <Compile Include="BuildServers\MyGetTests.cs" />
     <Compile Include="BuildServers\VsoAgentTests.cs" />

--- a/src/GitVersionCore/BuildServers/BuildServerList.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerList.cs
@@ -12,6 +12,7 @@
             new AppVeyor(),
             new MyGet(),
             new Jenkins(),
+            new GitLabCi(),
             new VsoAgent()
         };
 

--- a/src/GitVersionCore/BuildServers/GitLabCi.cs
+++ b/src/GitVersionCore/BuildServers/GitLabCi.cs
@@ -1,0 +1,60 @@
+﻿namespace GitVersion
+{
+    using System;
+    using System.IO;
+
+    public class GitLabCi : BuildServerBase
+    {
+        string _file;
+
+        public GitLabCi()
+            : this("gitversion.properties")
+        {
+        }
+
+        public GitLabCi(string propertiesFileName)
+        {
+            _file = propertiesFileName;
+        }
+
+        public override bool CanApplyToCurrentContext()
+        {
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITLAB_CI"));
+        }
+
+        public override string GenerateSetVersionMessage(VersionVariables variables)
+        {
+            return variables.FullSemVer;
+        }
+
+        public override string[] GenerateSetParameterMessage(string name, string value)
+        {
+            return new[]
+            {
+                string.Format("GitVersion_{0}={1}", name, value)
+            };
+        }
+
+        public override string GetCurrentBranch(bool usingDynamicRepos)
+        {
+            return Environment.GetEnvironmentVariable("CI_BUILD_REF_NAME");
+        }
+
+        public override bool PreventFetch()
+        {
+            return true;
+        }
+
+        public override void WriteIntegration(Action<string> writer, VersionVariables variables)
+        {
+            base.WriteIntegration(writer, variables);
+            writer(string.Format("Outputting variables to '{0}' ... ", _file));
+            WriteVariablesFile(variables);
+        }
+
+        void WriteVariablesFile(VersionVariables variables)
+        {
+            File.WriteAllLines(_file, BuildOutputFormatter.GenerateBuildLogOutput(this, variables));
+        }
+    }
+}

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -72,6 +72,7 @@
     <Compile Include="BuildServers\BuildServerList.cs" />
     <Compile Include="BuildServers\ContinuaCi.cs" />
     <Compile Include="BuildServers\GitHelper.cs" />
+    <Compile Include="BuildServers\GitLabCi.cs" />
     <Compile Include="BuildServers\IBuildServer.cs" />
     <Compile Include="BuildServers\Jenkins.cs" />
     <Compile Include="BuildServers\MyGet.cs" />


### PR DESCRIPTION
I've added build server support for [GitLab CI](https://about.gitlab.com/gitlab-ci/). The implementation is just copied from the code for Jenkins with a few small changes to use the correct environment variables.

We've been using this in production with an MSBuild Task for a few weeks and it works great with no further configuration required.