### PR TITLE
Include the config hash in the cache key

### DIFF
--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text;
 
 using GitVersion;
@@ -66,6 +67,53 @@ CommitDate: 2015-11-10
     {
         var info = RepositoryScope();
         info.ShouldContain("yml not found", () => info);
+    }
+
+
+    [Test]
+    public void ConfigChangeInvalidatesCache()
+    {
+        const string versionCacheFileContent = @"
+Major: 4
+Minor: 10
+Patch: 3
+PreReleaseTag: test.19
+PreReleaseTagWithDash: -test.19
+PreReleaseLabel: test
+PreReleaseNumber: 19
+BuildMetaData: 
+BuildMetaDataPadded: 
+FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+MajorMinorPatch: 4.10.3
+SemVer: 4.10.3-test.19
+LegacySemVer: 4.10.3-test19
+LegacySemVerPadded: 4.10.3-test0019
+AssemblySemVer: 4.10.3.0
+FullSemVer: 4.10.3-test.19
+InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+BranchName: feature/test
+Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+NuGetVersionV2: 4.10.3-test0019
+NuGetVersion: 4.10.3-test0019
+CommitsSinceVersionSource: 19
+CommitsSinceVersionSourcePadded: 0019
+CommitDate: 2015-11-10
+";
+
+        var versionAndBranchFinder = new ExecuteCore(fileSystem);
+
+        RepositoryScope(versionAndBranchFinder, (fixture, vv) =>
+        {
+            fileSystem.WriteAllText(vv.FileName, versionCacheFileContent);
+            vv = versionAndBranchFinder.ExecuteGitVersion(null, null, null, null, false, fixture.RepositoryPath, null);
+            vv.AssemblySemVer.ShouldBe("4.10.3.0");
+            
+            var configPath = Path.Combine(fixture.RepositoryPath, "GitVersionConfig.yaml");
+            fileSystem.WriteAllText(configPath, "next-version: 5.0");
+
+            vv = versionAndBranchFinder.ExecuteGitVersion(null, null, null, null, false, fixture.RepositoryPath, null);
+            vv.AssemblySemVer.ShouldBe("5.0.0.0");
+        });
     }
 
     string RepositoryScope(ExecuteCore executeCore = null, Action<EmptyRepositoryFixture, VersionVariables> fixtureAction = null)


### PR DESCRIPTION
Include the hash of `GitVersionConfig.yaml` in the key of the disk cache file so the file is invalidated when the configuration changes. Fixes #798.