### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -113,7 +113,7 @@ namespace GitVersion
                         mergeBaseCommit = findMergeBase,
                         branch = otherBranch
                     };
-                }).Where(b => b != null).OrderByDescending(b => b.mergeBaseCommit.Committer.When).ToList();
+                }).Where(b => b.mergeBaseCommit != null).OrderByDescending(b => b.mergeBaseCommit.Committer.When).ToList();
 
                 var firstOrDefault = mergeBases.FirstOrDefault();
                 if (firstOrDefault != null)

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -113,7 +113,7 @@ namespace GitVersion
                         mergeBaseCommit = findMergeBase,
                         branch = otherBranch
                     };
-                }).Where(b => b.mergeBaseCommit != null).OrderByDescending(b => b.mergeBaseCommit.Committer.When).ToList();
+                }).Where(b => b != null && b.mergeBaseCommit != null).OrderByDescending(b => b.mergeBaseCommit.Committer.When).ToList();
 
                 var firstOrDefault = mergeBases.FirstOrDefault();
                 if (firstOrDefault != null)


### PR DESCRIPTION
Fixes

```
1>MSBUILD : warning : WARN [04/07/16 20:54:31:12] Could not determine assembly version: System.NullReferenceException: Object reference not set to an instance of an object.
1>MSBUILD : warning :    at GitVersion.LibGitExtensions.<>c.<FindCommitBranchWasBranchedFrom>b__3_6(<>f__AnonymousType2`2 b)
1>MSBUILD : warning :    at System.Linq.EnumerableSorter`2.ComputeKeys(TElement[] elements, Int32 count)
1>MSBUILD : warning :    at System.Linq.EnumerableSorter`1.Sort(TElement[] elements, Int32 count)
1>MSBUILD : warning :    at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
1>MSBUILD : warning :    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
1>MSBUILD : warning :    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
1>MSBUILD : warning :    at GitVersion.LibGitExtensions.FindCommitBranchWasBranchedFrom(Branch branch, IRepository repository, Branch[] excludedBranches)
1>MSBUILD : warning :    at GitVersion.VersionCalculation.BaseVersionCalculators.VersionInBranchBaseVersionStrategy.<GetVersions>d__0.MoveNext()
1>MSBUILD : warning :    at System.Linq.Enumerable.<SelectManyIterator>d__16`2.MoveNext()
1>MSBUILD : warning :    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
1>MSBUILD : warning :    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
1>MSBUILD : warning :    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
1>MSBUILD : warning :    at GitVersion.VersionCalculation.BaseVersionCalculator.GetBaseVersion(GitVersionContext context)
1>MSBUILD : warning :    at GitVersion.VersionCalculation.NextVersionCalculator.FindVersion(GitVersionContext context)
1>MSBUILD : warning :    at GitVersion.GitVersionFinder.FindVersion(GitVersionContext context)
1>MSBUILD : warning :    at GitVersion.ExecuteCore.ExecuteInternal(String targetBranch, String commitId, IRepository repo, GitPreparer gitPreparer, String projectRoot, IBuildServer buildServer)
1>MSBUILD : warning :    at GitVersion.ExecuteCore.ExecuteGitVersion(String targetUrl, String dynamicRepositoryLocation, Authentication authentication, String targetBranch, Boolean noFetch, String workingDirectory, String commitId)
1>MSBUILD : warning :    at GitVersion.ExecuteCore.TryGetVersion(String directory, VersionVariables& versionVariables, Boolean noFetch, Authentication authentication)
```

I guess that the `b => b != null` check was OK but then the result type of the `Select` was changed from `Commit` to an anonymous type and the check stopped to prevent null commits to come to downstream operators.