### PR TITLE
Fix gitlink's broken link in the documentation

### DIFF
--- a/docs/who.md
+++ b/docs/who.md
@@ -3,10 +3,10 @@ Various people are actively using GitVersion, and taking advantage of the automa
 
  * [Catel](https://github.com/catel/catel)
  * [ChocolateyGUI](https://github.com/chocolatey/ChocolateyGUI)
- * [GitLink](github.com/CatenaLogic/GitLink)
+ * [GitLink](https://github.com/CatenaLogic/GitLink)
  * [Orc.* packages](https://github.com/wildgums?query=orc)
  * [Orchestra](https://github.com/wildgums/orchestra)
  * [Pomona](http://pomona.io/)
  * [Shouldly](https://github.com/shouldly/shouldly)
- 
+
 If you are using GitVersion in your projects, and you are not listed above, please feel free to add a link to your project.


### PR DESCRIPTION
Noticed that this link was broken when clicking through the documentation.