### PR TITLE
Allow ignoring part of history when calculating version (issue #538)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,10 @@ The global configuration options are:
  - **`commits-since-version-source-padding:`** The number of characters to pad `CommitsSinceVersionSource` to in the `CommitsSinceVersionSourcePadded` [variable](/more-info/variables). Is default set to `4`, which will pad the `CommitsSinceVersionSource` value of `1` to `0001`.
 
  - **`commit-message-incrementing:`** Sets whether it should be possible to increment the version with special syntax in the commit message. See the `*-version-bump-message` options above for details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
+ 
+ - **`ignore:`** The header for ignore configuration
+   - **`sha:`** A sequence of SHAs to be excluded from the version calculations.  Useful when there is a rogue commit in history yielding a bad version.
+   - **`commits-before:`** Allows to setup an exclusion range.  Effectively any commit < `commits-before` will be ignored.
 
 ## Branch configuration
 

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -1,4 +1,4 @@
-﻿assembly-versioning-scheme: MajorMinorPatch
+assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
 continuous-delivery-fallback-tag: ci
@@ -53,3 +53,5 @@ branches:
     increment: Minor
     prevent-increment-of-merged-branch-version: false
     track-merge-target: true
+ignore:
+  sha: []

--- a/src/GitVersionCore.Tests/Configuration/IgnoreConfigTests.cs
+++ b/src/GitVersionCore.Tests/Configuration/IgnoreConfigTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using GitVersion;
+using NUnit.Framework;
+using Shouldly;
+using YamlDotNet.Core;
+
+namespace GitVersionCore.Tests.Configuration
+{
+    [TestFixture]
+    public class IgnoreConfigTests
+    {
+        [Test]
+        public void CanDeserialize()
+        {
+            var yaml = @"
+ignore:
+    sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98]
+    commits-before: 2015-10-23T12:23:15
+";
+
+            using (var reader = new StringReader(yaml))
+            {
+                var config = ConfigSerialiser.Read(reader);
+
+                config.Ignore.ShouldNotBeNull();
+                config.Ignore.SHAs.ShouldNotBeEmpty();
+                config.Ignore.SHAs.ShouldBe(new[] { "b6c0c9fda88830ebcd563e500a5a7da5a1658e98" });
+                config.Ignore.Before.ShouldBe(DateTimeOffset.Parse("2015-10-23T12:23:15"));
+            }
+        }
+
+        [Test]
+        public void ShouldSupportsOtherSequenceFormat()
+        {
+            var yaml = @"
+ignore:
+    sha: 
+        - b6c0c9fda88830ebcd563e500a5a7da5a1658e98
+        - 6c19c7c219ecf8dbc468042baefa73a1b213e8b1
+";
+
+            using (var reader = new StringReader(yaml))
+            {
+                var config = ConfigSerialiser.Read(reader);
+
+                config.Ignore.ShouldNotBeNull();
+                config.Ignore.SHAs.ShouldNotBeEmpty();
+                config.Ignore.SHAs.ShouldBe(new[] { "b6c0c9fda88830ebcd563e500a5a7da5a1658e98", "6c19c7c219ecf8dbc468042baefa73a1b213e8b1" });
+            }
+        }
+
+        [Test]
+        public void WhenNotInConfigShouldHaveDefaults()
+        {
+            var yaml = @"
+next-version: 1.0
+";
+
+            using (var reader = new StringReader(yaml))
+            {
+                var config = ConfigSerialiser.Read(reader);
+
+                config.Ignore.ShouldNotBeNull();
+                config.Ignore.SHAs.ShouldBeEmpty();
+                config.Ignore.Before.ShouldBeNull();
+            }
+        }
+
+        [Test]
+        public void WhenBadDateFormatShouldFail()
+        {
+            var yaml = @"
+ignore:
+    commits-before: bad format date
+";
+
+            using (var reader = new StringReader(yaml))
+            {
+                Should.Throw<YamlException>(() => ConfigSerialiser.Read(reader));
+            }
+        }
+    }
+}

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="BuildServers\MyGetTests.cs" />
     <Compile Include="BuildServers\VsoAgentTests.cs" />
     <Compile Include="BuildServers\TeamCityTests.cs" />
+    <Compile Include="Configuration\IgnoreConfigTests.cs" />
     <Compile Include="GitToolsTestingExtensions.cs" />
     <Compile Include="DocumentationTests.cs" />
     <Compile Include="ConfigProviderTests.cs" />
@@ -160,6 +161,8 @@
     <Compile Include="VersionCalculation\Strategies\VersionInBranchBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\TestBaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\TestMetaDataCalculator.cs" />
+    <Compile Include="VersionFilters\MinDateVersionFilterTests.cs" />
+    <Compile Include="VersionFilters\ShaVersionFilterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/GitVersionCore.Tests/Init/InitScenarios.CanSetNextVersion.approved.txt
+++ b/src/GitVersionCore.Tests/Init/InitScenarios.CanSetNextVersion.approved.txt
@@ -1,2 +1,4 @@
-﻿next-version: 2.0.0
+next-version: 2.0.0
 branches: {}
+ignore:
+  sha: []

--- a/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -1,14 +1,17 @@
 namespace GitVersionCore.Tests
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using GitVersion;
+    using GitVersion.VersionFilters;
 
     public class TestEffectiveConfiguration : EffectiveConfiguration
     {
         public TestEffectiveConfiguration(
-            AssemblyVersioningScheme assemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch, 
+            AssemblyVersioningScheme assemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch,
             string assemblyInformationalFormat = null,
-            VersioningMode versioningMode = VersioningMode.ContinuousDelivery, 
-            string gitTagPrefix = "v", 
+            VersioningMode versioningMode = VersioningMode.ContinuousDelivery,
+            string gitTagPrefix = "v",
             string tag = "",
             string nextVersion = null,
             string branchPrefixToTrim = "",
@@ -22,12 +25,15 @@ namespace GitVersionCore.Tests
             CommitMessageIncrementMode commitMessageMode = CommitMessageIncrementMode.Enabled,
             int legacySemVerPadding = 4,
             int buildMetaDataPadding = 4,
-            int commitsSinceVersionSourcePadding = 4) : 
-                base(assemblyVersioningScheme, assemblyInformationalFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch, 
+            int commitsSinceVersionSourcePadding = 4,
+            IEnumerable<IVersionFilter> versionFilters = null
+            ) :
+            base(assemblyVersioningScheme, assemblyInformationalFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage,
-                    commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding)
+                    commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
+                    versionFilters ?? Enumerable.Empty<IVersionFilter>())
         {
         }
     }

--- a/src/GitVersionCore.Tests/VersionFilters/ShaVersionFilterTests.cs
+++ b/src/GitVersionCore.Tests/VersionFilters/ShaVersionFilterTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using GitVersion;
+using GitVersion.VersionCalculation.BaseVersionCalculators;
+using GitVersion.VersionFilters;
+using LibGit2Sharp;
+using NUnit.Framework;
+using Shouldly;
+
+namespace GitVersionCore.Tests.VersionFilters
+{
+    [TestFixture]
+    public class ShaVersionFilterTests
+    {
+        [Test]
+        public void VerifyNullGuard()
+        {
+            Should.Throw<ArgumentNullException>(() => new ShaVersionFilter(null));
+        }
+
+        [Test]
+        public void VerifyNullGuard2()
+        {
+            var commit = new MockCommit();
+            var sut = new ShaVersionFilter(new[] { commit.Sha });
+
+            string reason;
+            Should.Throw<ArgumentNullException>(() => sut.Exclude(null, out reason));
+        }
+
+        [Test]
+        public void WhenShaMatchShouldExcludeWithReason()
+        {
+            var commit = new MockCommit();
+            var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
+            var sut = new ShaVersionFilter(new[] { commit.Sha });
+
+            string reason;
+            sut.Exclude(version, out reason).ShouldBeTrue();
+            reason.ShouldNotBeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void WhenShaMismatchShouldNotExclude()
+        {
+            var commit = new MockCommit();
+            var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
+            var sut = new ShaVersionFilter(new[] { "mismatched" });
+
+            string reason;
+            sut.Exclude(version, out reason).ShouldBeFalse();
+            reason.ShouldBeNull();
+        }
+
+        [Test]
+        public void ExcludeShouldAcceptVersionWithNullCommit()
+        {
+            Commit nullCommit = null;
+            var version = new BaseVersion("dummy", false, new SemanticVersion(1), nullCommit, string.Empty);
+            var sut = new ShaVersionFilter(new[] { "mismatched" });
+
+            string reason;
+            sut.Exclude(version, out reason).ShouldBeFalse();
+            reason.ShouldBeNull();
+        }
+    }
+}

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -10,6 +10,11 @@
         Dictionary<string, BranchConfig> branches = new Dictionary<string, BranchConfig>();
         string nextVersion;
 
+        public Config()
+        {
+            Ignore = new IgnoreConfig();
+        }
+
         [YamlMember(Alias = "assembly-versioning-scheme")]
         public AssemblyVersioningScheme? AssemblyVersioningScheme { get; set; }
 
@@ -82,11 +87,14 @@
         {
             typeof(T).GetProperties()
                 .Where(prop => prop.CanRead && prop.CanWrite)
-                .Select(_ => new {prop = _, value =_.GetValue(source, null) } )
+                .Select(_ => new { prop = _, value = _.GetValue(source, null) })
                 .Where(_ => _.value != null)
                 .ToList()
                 .ForEach(_ => _.prop.SetValue(target, _.value, null));
             return target;
         }
+
+        [YamlMember(Alias = "ignore")]
+        public IgnoreConfig Ignore { get; set; }
     }
 }

--- a/src/GitVersionCore/Configuration/IgnoreConfig.cs
+++ b/src/GitVersionCore/Configuration/IgnoreConfig.cs
@@ -1,0 +1,28 @@
+﻿namespace GitVersion
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using GitVersion.VersionFilters;
+    using YamlDotNet.Serialization;
+
+    public class IgnoreConfig
+    {
+        public IgnoreConfig()
+        {
+            SHAs = Enumerable.Empty<string>();
+        }
+
+        [YamlMember(Alias = "commits-before")]
+        public DateTimeOffset? Before { get; set; }
+
+        [YamlMember(Alias = "sha")]
+        public IEnumerable<string> SHAs { get; set; }
+
+        public virtual IEnumerable<IVersionFilter> ToFilters()
+        {
+            if (SHAs.Any()) yield return new ShaVersionFilter(SHAs);
+            if (Before.HasValue) yield return new MinDateVersionFilter(Before.Value);
+        }
+    }
+}

--- a/src/GitVersionCore/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/EffectiveConfiguration.cs
@@ -1,4 +1,7 @@
-﻿namespace GitVersion
+﻿using System.Collections.Generic;
+using GitVersion.VersionFilters;
+
+namespace GitVersion
 {
     /// <summary>
     /// Configuration can be applied to different things, effective configuration is the result after applying the appropriate configuration
@@ -6,14 +9,14 @@
     public class EffectiveConfiguration
     {
         public EffectiveConfiguration(
-            AssemblyVersioningScheme assemblyVersioningScheme, 
+            AssemblyVersioningScheme assemblyVersioningScheme,
             string assemblyInformationalFormat,
-            VersioningMode versioningMode, string gitTagPrefix, 
-            string tag, string nextVersion, IncrementStrategy increment, 
-            string branchPrefixToTrim, 
-            bool preventIncrementForMergedBranchVersion, 
+            VersioningMode versioningMode, string gitTagPrefix,
+            string tag, string nextVersion, IncrementStrategy increment,
+            string branchPrefixToTrim,
+            bool preventIncrementForMergedBranchVersion,
             string tagNumberPattern,
-            string continuousDeploymentFallbackTag, 
+            string continuousDeploymentFallbackTag,
             bool trackMergeTarget,
             string majorVersionBumpMessage,
             string minorVersionBumpMessage,
@@ -21,7 +24,8 @@
             CommitMessageIncrementMode commitMessageIncrementing,
             int legacySemVerPaddding,
             int buildMetaDataPadding,
-            int commitsSinceVersionSourcePadding
+            int commitsSinceVersionSourcePadding,
+            IEnumerable<IVersionFilter> versionFilters
             )
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
@@ -43,6 +47,7 @@
             LegacySemVerPadding = legacySemVerPaddding;
             BuildMetaDataPadding = buildMetaDataPadding;
             CommitsSinceVersionSourcePadding = commitsSinceVersionSourcePadding;
+            VersionFilters = versionFilters;
         }
 
         public VersioningMode VersioningMode { get; private set; }
@@ -75,16 +80,18 @@
         public bool TrackMergeTarget { get; private set; }
 
         public string MajorVersionBumpMessage { get; private set; }
-        
+
         public string MinorVersionBumpMessage { get; private set; }
 
         public string PatchVersionBumpMessage { get; private set; }
 
         public int LegacySemVerPadding { get; private set; }
-        public  int BuildMetaDataPadding { get; private set; }
+        public int BuildMetaDataPadding { get; private set; }
 
         public int CommitsSinceVersionSourcePadding { get; private set; }
 
         public CommitMessageIncrementMode CommitMessageIncrementing { get; private set; }
+
+        public IEnumerable<IVersionFilter> VersionFilters { get; private set; }
     }
 }

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -100,7 +100,7 @@
             var incrementStrategy = currentBranchConfig.Value.Increment.Value;
             var preventIncrementForMergedBranchVersion = currentBranchConfig.Value.PreventIncrementOfMergedBranchVersion.Value;
             var trackMergeTarget = currentBranchConfig.Value.TrackMergeTarget.Value;
-            
+
             var nextVersion = configuration.NextVersion;
             var assemblyVersioningScheme = configuration.AssemblyVersioningScheme.Value;
             var assemblyInformationalFormat = configuration.AssemblyInformationalFormat;
@@ -111,17 +111,20 @@
 
             var commitMessageVersionBump = currentBranchConfig.Value.CommitMessageIncrementing ?? configuration.CommitMessageIncrementing.Value;
 
+            var versionFilter =
             Configuration = new EffectiveConfiguration(
-                assemblyVersioningScheme, assemblyInformationalFormat, versioningMode, gitTagPrefix, 
-                tag, nextVersion, incrementStrategy, currentBranchConfig.Key, 
-                preventIncrementForMergedBranchVersion, 
+                assemblyVersioningScheme, assemblyInformationalFormat, versioningMode, gitTagPrefix,
+                tag, nextVersion, incrementStrategy, currentBranchConfig.Key,
+                preventIncrementForMergedBranchVersion,
                 tagNumberPattern, configuration.ContinuousDeploymentFallbackTag,
                 trackMergeTarget,
                 majorMessage, minorMessage, patchMessage,
                 commitMessageVersionBump,
                 configuration.LegacySemVerPadding.Value,
                 configuration.BuildMetaDataPadding.Value,
-                configuration.CommitsSinceVersionSourcePadding.Value);
+                configuration.CommitsSinceVersionSourcePadding.Value,
+                configuration.Ignore.ToFilters()
+                );
         }
     }
 }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Configuration\ConsoleAdapter.cs" />
     <Compile Include="Configuration\IConsole.cs" />
+    <Compile Include="Configuration\IgnoreConfig.cs" />
     <Compile Include="Configuration\Init\BuildServer\AppVeyorSetup.cs" />
     <Compile Include="Configuration\Init\BuildServer\SetupBuildScripts.cs" />
     <Compile Include="Configuration\Init\SetConfig\AssemblyVersioningSchemeSetting.cs" />
@@ -125,6 +126,9 @@
     <Compile Include="OutputVariables\VersionVariables.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />
     <Compile Include="SemanticVersionFormatValues.cs" />
+    <Compile Include="VersionFilters\MinDateVersionFilter.cs" />
+    <Compile Include="VersionFilters\IVersionFilter.cs" />
+    <Compile Include="VersionFilters\ShaVersionFilter.cs" />
     <Compile Include="StringFormatWith.cs" />
     <Compile Include="VersionAssemblyInfoResources\AssemblyVersionInfoTemplates.cs" />
     <EmbeddedResource Include="VersionAssemblyInfoResources\VersionAssemblyInfo.cs" />

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -21,13 +21,21 @@
                     .SelectMany(s => s.GetVersions(context))
                     .Where(v =>
                     {
-                        if (v != null)
+                        if (v == null) return false;
+
+                        Logger.WriteInfo(v.ToString());
+
+                        foreach (var filter in context.Configuration.VersionFilters)
                         {
-                            Logger.WriteInfo(v.ToString());
-                            return true;
+                            string reason;
+                            if (filter.Exclude(v, out reason))
+                            {
+                                Logger.WriteInfo(reason);
+                                return false;
+                            }
                         }
 
-                        return false;
+                        return true;
                     })
                     .Select(v => new
                     {

--- a/src/GitVersionCore/VersionFilters/IVersionFilter.cs
+++ b/src/GitVersionCore/VersionFilters/IVersionFilter.cs
@@ -1,0 +1,9 @@
+﻿using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+namespace GitVersion.VersionFilters
+{
+    public interface IVersionFilter
+    {
+        bool Exclude(BaseVersion version, out string reason);
+    }
+}

--- a/src/GitVersionCore/VersionFilters/MinDateVersionFilter.cs
+++ b/src/GitVersionCore/VersionFilters/MinDateVersionFilter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+namespace GitVersion.VersionFilters
+{
+    public class MinDateVersionFilter : IVersionFilter
+    {
+        private readonly DateTimeOffset minimum;
+
+        public MinDateVersionFilter(DateTimeOffset minimum)
+        {
+            this.minimum = minimum;
+        }
+
+        public bool Exclude(BaseVersion version, out string reason)
+        {
+            if (version == null) throw new ArgumentNullException("version");
+
+            reason = null;
+
+            if (version.BaseVersionSource != null &&
+                version.BaseVersionSource.When() < minimum)
+            {
+                reason = "Source was ignored due to commit date being outside of configured range";
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/GitVersionCore/VersionFilters/ShaVersionFilter.cs
+++ b/src/GitVersionCore/VersionFilters/ShaVersionFilter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+namespace GitVersion.VersionFilters
+{
+    public class ShaVersionFilter : IVersionFilter
+    {
+        private readonly IEnumerable<string> shas;
+
+        public ShaVersionFilter(IEnumerable<string> shas)
+        {
+            if (shas == null) throw new ArgumentNullException("shas");
+            this.shas = shas;
+        }
+
+        public bool Exclude(BaseVersion version, out string reason)
+        {
+            if (version == null) throw new ArgumentNullException("version");
+
+            reason = null;
+
+            if (version.BaseVersionSource != null &&
+                shas.Any(sha => version.BaseVersionSource.Sha.StartsWith(sha, StringComparison.OrdinalIgnoreCase)))
+            {
+                reason = "Source was ignored due to commit having been excluded by configuration";
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Based on @asbjornu 's recommendations for the yaml:
```
ignore:
    sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98, 6c19c7c219ecf8dbc468042baefa73a1b213e8b1]
    commits-before: 2015-10-23T12:23:15
```

Sequence format follows YAML and can be alternatively formatted across lines:
```
ignore:
    sha: 
        - b6c0c9fda88830ebcd563e500a5a7da5a1658e98
        - 6c19c7c219ecf8dbc468042baefa73a1b213e8b1
```
 
Configuration will be translated to IVersionFilters of which there are 2:
- `MinDateVersionFilter`
- `ShaVersionFilter`

`BaseVersionCalculator` applies the version filtering and will exclude version candidates accordingly.

Log output is as follows:
```
2016-04-29 13:35:02		  INFO [04/29/16 13:35:02:87] Merge message 'Merge pull request #176 in PROJ from hotfix/4.03/Tasks/some-task to support/4.1.0 : 4.3.0 with commit count source 5a8c7e368552e5808b20cabad28ea022df52735f
2016-04-29 13:35:02		  INFO [04/29/16 13:35:02:87] Source was ignored due to commit having been excluded by configuration
```

Date Filter reason is: `Source was ignored due to commit date being outside of configured range`

Some possible future amendments:
- Use the date filter to limit the history scrubbed by the strategies in an effort to improve overall performance.