### PR TITLE
NullReferenceException on missing .git folder

### DIFF
--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -116,6 +116,19 @@ CommitDate: 2015-11-10
         });
     }
 
+
+    [Test]
+    public void WorkingDirectoryWithoutGit()
+    {
+        var versionAndBranchFinder = new ExecuteCore(fileSystem);
+
+        RepositoryScope(versionAndBranchFinder, (fixture, vv) =>
+        {
+            var exception = Assert.Throws<DirectoryNotFoundException>(() => versionAndBranchFinder.ExecuteGitVersion(null, null, null, null, false, Environment.SystemDirectory, null));
+            exception.Message.ShouldContain("Can't find the .git directory in");
+        });
+    }
+
     string RepositoryScope(ExecuteCore executeCore = null, Action<EmptyRepositoryFixture, VersionVariables> fixtureAction = null)
     {
         // Make sure GitVersion doesn't trigger build server mode when we are running the tests

--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -97,7 +97,12 @@ namespace GitVersion
             if (IsDynamicGitRepository)
                 return DynamicGitRepositoryPath;
 
-            var dotGitDirectory = Repository.Discover(targetPath).TrimEnd('/', '\\');
+            var dotGitDirectory = Repository.Discover(targetPath);
+
+            if (String.IsNullOrEmpty(dotGitDirectory))
+                throw new DirectoryNotFoundException("Can't find the .git directory in " + targetPath);
+
+            dotGitDirectory = dotGitDirectory.TrimEnd('/', '\\');
             if (string.IsNullOrEmpty(dotGitDirectory))
                 throw new DirectoryNotFoundException("Can't find the .git directory in " + targetPath);
 

--- a/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using GitTools.Testing;
 using NUnit.Framework;
 
@@ -64,5 +65,12 @@ public class ExecCmdLineArgumentTest
     {
         var results = GitVersionHelper.ExecuteIn("InvalidDirectory", null, isTeamCity : false, logToFile : false);
         results.Output.ShouldContain("InvalidDirectory");
+    }
+
+    [Test]
+    public void WorkingDirectoryWithoutGitFolderCrashesWithInformativeMessage()
+    {
+        var results = GitVersionHelper.ExecuteIn(Environment.SystemDirectory, null, isTeamCity: false, logToFile: false);
+        results.Output.ShouldContain("Can't find the .git directory in");
     }
 }


### PR DESCRIPTION
Throw a more meaningful exception when the working directory does not contain the `.git` folder. Fixes #853.