### PR TITLE
Removed call to Write-ChocolateySuccess from chocolatey PS scripts.

### DIFF
--- a/src/GitVersionExe/NugetAssets/chocolateyInstall.ps1
+++ b/src/GitVersionExe/NugetAssets/chocolateyInstall.ps1
@@ -1,2 +1,1 @@
 Generate-BinFile "gfv" "$packageFolder\Tools\GitVersion.exe"
-Write-ChocolateySuccess "GitVersion"

--- a/src/GitVersionExe/NugetAssets/chocolateyUninstall.ps1
+++ b/src/GitVersionExe/NugetAssets/chocolateyUninstall.ps1
@@ -1,3 +1,2 @@
 Remove-BinFile "gfv" "$packageFolder\Tools\GitVersion.exe"
 Remove-BinFile "GitVersion" "$packageFolder\Tools\GitVersion.exe"
-Write-ChocolateySuccess "GitVersion"


### PR DESCRIPTION
This will resolve issue https://github.com/GitTools/GitVersion/issues/515 ("GitVersion.Portable uses deprecated Write-ChocolateySuccess")