### PR TITLE
Exclude LibGit2Sharp from ILRepack in NuGet.CommandLine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
   - mono .nuget/nuget.exe install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
 script:
   - xbuild ./src/GitVersion.sln /property:Configuration="Debug" /verbosity:detailed
+  - mono ./build/NuGetCommandLineBuild/tools/GitVersion.exe -l -console -output buildserver -updateAssemblyInfo
+  - xbuild ./src/GitVersion.sln /property:Configuration="Debug" /verbosity:detailed
   - mono ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitVersionTask.Tests/bin/Debug/GitVersionTask.Tests.dll ./src/GitVersionCore.Tests/bin/Debug/GitVersionCore.Tests.dll ./src/GitVersionTask.Tests/bin/Debug/GitVersionTask.Tests.dll ./src/GitVersionExe.Tests/bin/Debug/GitVersionExe.Tests.dll --where "cat != NoMono" --noresult
 
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - linux
   - osx
 before_install: # We need to download nuget.exe due to: https://github.com/travis-ci/travis-ci/issues/5932
-  - git fetch --unshallow
+  - git fetch --unshallow # Travis always does a shallow clone, but GitVersion needs the full history including branches and tags
   - mkdir -p .nuget
   - wget -O .nuget/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - mono .nuget/nuget.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ os:
   - linux
   - osx
 before_install: # We need to download nuget.exe due to: https://github.com/travis-ci/travis-ci/issues/5932
+  - git fetch --unshallow
   - mkdir -p .nuget
   - wget -O .nuget/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - mono .nuget/nuget.exe
@@ -15,7 +16,7 @@ install:
   - mono .nuget/nuget.exe install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
 script:
   - xbuild ./src/GitVersion.sln /property:Configuration="Debug" /verbosity:detailed
-  - mono ./build/NuGetCommandLineBuild/tools/GitVersion.exe -l -console -output buildserver -updateAssemblyInfo
+  - mono ./build/NuGetCommandLineBuild/tools/GitVersion.exe -l console -output buildserver -updateAssemblyInfo
   - xbuild ./src/GitVersion.sln /property:Configuration="Debug" /verbosity:detailed
   - mono ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitVersionTask.Tests/bin/Debug/GitVersionTask.Tests.dll ./src/GitVersionCore.Tests/bin/Debug/GitVersionCore.Tests.dll ./src/GitVersionTask.Tests/bin/Debug/GitVersionTask.Tests.dll ./src/GitVersionExe.Tests/bin/Debug/GitVersionExe.Tests.dll --where "cat != NoMono" --noresult
 

--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -141,8 +141,8 @@ CommitDate: 2015-11-10
     string RepositoryScope(ExecuteCore executeCore = null, Action<EmptyRepositoryFixture, VersionVariables> fixtureAction = null)
     {
         // Make sure GitVersion doesn't trigger build server mode when we are running the tests
-        Environment.SetEnvironmentVariable("APPVEYOR", null);
-		Environment.SetEnvironmentVariable("TRAVIS", null);
+        Environment.SetEnvironmentVariable(AppVeyor.EnvironmentVariableName, null);
+        Environment.SetEnvironmentVariable(TravisCI.EnvironmentVariableName, null);
         var infoBuilder = new StringBuilder();
         Action<string> infoLogger = s =>
         {

--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -142,6 +142,7 @@ CommitDate: 2015-11-10
     {
         // Make sure GitVersion doesn't trigger build server mode when we are running the tests
         Environment.SetEnvironmentVariable("APPVEYOR", null);
+		Environment.SetEnvironmentVariable("TRAVIS", null);
         var infoBuilder = new StringBuilder();
         Action<string> infoLogger = s =>
         {

--- a/src/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/src/GitVersionCore/BuildServers/AppVeyor.cs
@@ -6,9 +6,11 @@
 
     public class AppVeyor : BuildServerBase
     {
-        public override bool CanApplyToCurrentContext()
+		public const string EnvironmentVariableName = "APPVEYOR";
+
+		public override bool CanApplyToCurrentContext()
         {
-            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR"));
+			return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableName));
         }
 
         public override string GenerateSetVersionMessage(VersionVariables variables)

--- a/src/GitVersionCore/BuildServers/BuildServerList.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerList.cs
@@ -13,7 +13,8 @@
             new MyGet(),
             new Jenkins(),
             new GitLabCi(),
-            new VsoAgent()
+            new VsoAgent(),
+			new TravisCI(),
         };
 
         public static IEnumerable<IBuildServer> GetApplicableBuildServers()

--- a/src/GitVersionCore/BuildServers/TeamCity.cs
+++ b/src/GitVersionCore/BuildServers/TeamCity.cs
@@ -4,9 +4,11 @@
 
     public class TeamCity : BuildServerBase
     {
-        public override bool CanApplyToCurrentContext()
+		public const string EnvironmentVariableName = "TEAMCITY_VERSION";
+
+		public override bool CanApplyToCurrentContext()
         {
-            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
+			return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableName));
         }
 
         public override string GetCurrentBranch(bool usingDynamicRepos)

--- a/src/GitVersionCore/BuildServers/TravisCI.cs
+++ b/src/GitVersionCore/BuildServers/TravisCI.cs
@@ -3,9 +3,11 @@ namespace GitVersion
 {
 	public class TravisCI : BuildServerBase
 	{
+		public const string EnvironmentVariableName = "TRAVIS";
+
 		public override bool CanApplyToCurrentContext ()
 		{
-			return "true".Equals(Environment.GetEnvironmentVariable ("TRAVIS")) && "true".Equals(Environment.GetEnvironmentVariable("CI"));
+			return "true".Equals(Environment.GetEnvironmentVariable(EnvironmentVariableName)) && "true".Equals(Environment.GetEnvironmentVariable("CI"));
 		}
 
 		public override string GenerateSetVersionMessage(VersionVariables variables)

--- a/src/GitVersionCore/BuildServers/TravisCI.cs
+++ b/src/GitVersionCore/BuildServers/TravisCI.cs
@@ -1,0 +1,30 @@
+﻿using System;
+namespace GitVersion
+{
+	public class TravisCI : BuildServerBase
+	{
+		public override bool CanApplyToCurrentContext ()
+		{
+			return "true".Equals(Environment.GetEnvironmentVariable ("TRAVIS")) && "true".Equals(Environment.GetEnvironmentVariable("CI"));
+		}
+
+		public override string GenerateSetVersionMessage(VersionVariables variables)
+		{
+			return variables.FullSemVer;
+		}
+
+		public override string[] GenerateSetParameterMessage(string name, string value)
+		{
+			return new[]
+			{
+				string.Format("GitVersion_{0}={1}", name, value)
+			};
+		}
+
+		public override bool PreventFetch ()
+		{
+			return true;
+		}
+	}
+}
+

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -165,6 +165,7 @@
     <Compile Include="SemanticVersion.cs" />
     <Compile Include="SemanticVersionBuildMetaData.cs" />
     <Compile Include="SemanticVersionPreReleaseTag.cs" />
+    <Compile Include="BuildServers\TravisCI.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml">

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Caseless.Fody" version="1.4.1" targetFramework="net40" developmentDependency="true" />
+  <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net4" developmentDependency="true" />

--- a/src/GitVersionExe.Tests/GitVersionHelper.cs
+++ b/src/GitVersionExe.Tests/GitVersionHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using GitTools;
+using GitVersion;
 
 public static class GitVersionHelper
 {
@@ -36,10 +37,10 @@ public static class GitVersionHelper
         var environmentalVariables =
             new[]
             {
-                new KeyValuePair<string, string>("TEAMCITY_VERSION", arguments.IsTeamCity ? "8.0.0" : null),
-                new KeyValuePair<string, string>("APPVEYOR", null),
-				new KeyValuePair<string, string>("TRAVIS", null),
-			};
+                new KeyValuePair<string, string>(TeamCity.EnvironmentVariableName, arguments.IsTeamCity ? "8.0.0" : null),
+                new KeyValuePair<string, string>(AppVeyor.EnvironmentVariableName, null),
+                new KeyValuePair<string, string>(TravisCI.EnvironmentVariableName, null),
+            };
 
         var exitCode = -1;
 

--- a/src/GitVersionExe.Tests/GitVersionHelper.cs
+++ b/src/GitVersionExe.Tests/GitVersionHelper.cs
@@ -37,8 +37,9 @@ public static class GitVersionHelper
             new[]
             {
                 new KeyValuePair<string, string>("TEAMCITY_VERSION", arguments.IsTeamCity ? "8.0.0" : null),
-                new KeyValuePair<string, string>("APPVEYOR", null)
-            };
+                new KeyValuePair<string, string>("APPVEYOR", null),
+				new KeyValuePair<string, string>("TRAVIS", null),
+			};
 
         var exitCode = -1;
 

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -135,7 +135,7 @@
           ]]></Code>
     </Task>
   </UsingTask>
-  <Target Name="AfterBuild" DependsOnTargets="Clean" Condition="$(NCrunch)=='' And '$(OS)' != 'Unix'">
+  <Target Name="AfterBuild" DependsOnTargets="Clean" Condition="$(NCrunch)==''">
     <MakeDir Directories="$(TargetDir)ILMergeTemp\" />
     <PropertyGroup>
       <Runtime Condition="'$(OS)'=='Unix'">mono</Runtime>
@@ -178,7 +178,7 @@
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\builds.png" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\img" />
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\build-task.png" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\img" />
     <Copy SourceFiles="$(OutputPath)ILMergeTemp\GitVersion.exe" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" />
-    <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" />
+    <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" Condition="Exists('$(OutputPath)GitVersion.pdb')" />
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\icon.png" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" />
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\task.json" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" />
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\GitVersion.ps1" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask" />

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -142,12 +142,23 @@
     </PropertyGroup>
     <!-- Copy target file so that our temporary file gets the correct permissions -->
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(TargetDir)ILMergeTemp\" />
-    <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot; &quot;$(TargetDir)LibGit2Sharp.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
+    <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <ItemGroup>
       <TempFiles Include="$(TargetDir)ILMergeTemp\*.*" />
       <NativeBinaries Include="$(TargetDir)lib\**\*.*" />
       <WindowsBinaries Include="$(TargetDir)lib\**\*.dll" />
+	  <LibGit2SharpFiles Include="$(TargetDir)LibGit2Sharp.*" Exclude="$(TargetDir)LibGit2Sharp.xml" />
     </ItemGroup>
+    <!-- NugetCommandLineBuild -->
+    <MakeDir Directories="$(BuildDir)NuGetCommandLineBuild" />
+    <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetCommandLineBuild\tools\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
+	<Copy SourceFiles="@(LibGit2SharpFiles)" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
+    <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.pdb')" />
+    <Copy SourceFiles="$(OutputPath)GitVersion.exe.mdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.exe.mdb')" />
+    <Copy SourceFiles="$(OutputPath)ILMergeTemp\GitVersion.exe" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.CommandLine.nuspec" DestinationFolder="$(BuildDir)NuGetCommandLineBuild" />
+    <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetCommandLineBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
+    <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot; &quot;$(TargetDir)LibGit2Sharp.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <!-- NugetExeBuild -->
     <MakeDir Directories="$(BuildDir)NuGetExeBuild" />
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetExeBuild\tools\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -158,14 +169,6 @@
     <Copy SourceFiles="$(ProjectDir)NugetAssets\chocolateyUninstall.ps1" DestinationFolder="$(BuildDir)NuGetExeBuild\tools" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.Portable.nuspec" DestinationFolder="$(BuildDir)NuGetExeBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetExeBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
-    <!-- NugetCommandLineBuild -->
-    <MakeDir Directories="$(BuildDir)NuGetCommandLineBuild" />
-    <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetCommandLineBuild\tools\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.pdb')" />
-    <Copy SourceFiles="$(OutputPath)GitVersion.exe.mdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.exe.mdb')" />
-    <Copy SourceFiles="$(OutputPath)ILMergeTemp\GitVersion.exe" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.CommandLine.nuspec" DestinationFolder="$(BuildDir)NuGetCommandLineBuild" />
-    <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetCommandLineBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
     <!-- TfsBuildTask -->
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild" Condition="Exists('$(OutputPath)GitVersion.pdb')" />

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -142,13 +142,15 @@
     </PropertyGroup>
     <!-- Copy target file so that our temporary file gets the correct permissions -->
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(TargetDir)ILMergeTemp\" />
-    <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <ItemGroup>
       <TempFiles Include="$(TargetDir)ILMergeTemp\*.*" />
       <NativeBinaries Include="$(TargetDir)lib\**\*.*" />
       <WindowsBinaries Include="$(TargetDir)lib\**\*.dll" />
 	  <LibGit2SharpFiles Include="$(TargetDir)LibGit2Sharp.*" Exclude="$(TargetDir)LibGit2Sharp.xml" />
     </ItemGroup>
+
+    <!-- Repack without LibGit2Sharp for NugetCommandLineBuild -->
+    <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <!-- NugetCommandLineBuild -->
     <MakeDir Directories="$(BuildDir)NuGetCommandLineBuild" />
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetCommandLineBuild\tools\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -158,6 +160,8 @@
     <Copy SourceFiles="$(OutputPath)ILMergeTemp\GitVersion.exe" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.CommandLine.nuspec" DestinationFolder="$(BuildDir)NuGetCommandLineBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetCommandLineBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
+
+    <!-- Repack with LibGit2Sharp for NugetCommandLineBuild -->
     <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot; &quot;$(TargetDir)LibGit2Sharp.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <!-- NugetExeBuild -->
     <MakeDir Directories="$(BuildDir)NuGetExeBuild" />
@@ -169,6 +173,7 @@
     <Copy SourceFiles="$(ProjectDir)NugetAssets\chocolateyUninstall.ps1" DestinationFolder="$(BuildDir)NuGetExeBuild\tools" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.Portable.nuspec" DestinationFolder="$(BuildDir)NuGetExeBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetExeBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
+
     <!-- TfsBuildTask -->
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild" Condition="Exists('$(OutputPath)GitVersion.pdb')" />
@@ -185,6 +190,7 @@
     <ReplaceFileText InputFilename="$(BuildDir)GitVersionTfsTaskBuild\manifest.json" OutputFilename="$(BuildDir)GitVersionTfsTaskBuild\manifest.json" MatchExpression="\$version\$" ReplacementText="$(GitVersion_SemVer)" Condition="'$(GitVersion_SemVer)' != ''" />
     <Exec Command="powershell -ExecutionPolicy RemoteSigned -NoProfile &quot;$(SolutionDir)GitVersionTfsTask\Update-GitVersionTfsTaskVersion.ps1 $(BuildDir)GitVersionTfsTaskBuild\GitVersionTask\task.json $(GitVersion_Major) $(GitVersion_Minor) $(GitVersion_Patch)&quot;" WorkingDirectory="$(BuildDir)" Condition="'$(GitVersion_SemVer)' != ''" />
     <Exec Command="powershell -ExecutionPolicy RemoteSigned -NoProfile &quot;$(SolutionDir)GitVersionTfsTask\Create-Vsix.ps1 $(BuildDir)GitVersionTfsTaskBuild&quot;" Condition="'$(GitVersion_SemVer)' != ''" />
+
     <!-- Gem -->
     <MakeDir Directories="$(BuildDir)GemBuild" />
     <!-- Gem can only treat files it knows about, so it throws an error for .so and .dylib files when building on Windows -->
@@ -208,6 +214,7 @@
     </PropertyGroup>
     <ReplaceFileText InputFilename="$(BuildDir)GemBuild\gitversion.gemspec" OutputFilename="$(BuildDir)GemBuild\gitversion.gemspec" MatchExpression="\$version\$" ReplacementText="$(GemVersion)" Condition="'$(GitVersion_SemVer)' != ''" />
     <Exec Command="gem build gitversion.gemspec" ContinueOnError="True" WorkingDirectory="$(BuildDir)GemBuild" Condition="'$(GitVersion_SemVer)' != ''" />
+
     <!-- Cleanup -->
     <RemoveDir Directories="$(TargetDir)ILMergeTemp\" />
   </Target>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Caseless.Fody" version="1.4.1" targetFramework="net40" developmentDependency="true" />
+  <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.10" targetFramework="net40" />

--- a/src/GitVersionTask/packages.config
+++ b/src/GitVersionTask/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Caseless.Fody" version="1.4.1" targetFramework="net40" developmentDependency="true" />
+  <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.10" targetFramework="net40" />


### PR DESCRIPTION
Fixes #854 

This is a short-term fix for NuGet.CommandLine on Mono. It excludes LibGit2Sharp from ILRepack, and copies LibGit2Sharp (and its config file) into the package instead. Only NuGet.CommandLine is affected; changing the other packages build by GitVersionExe might (or might not) make sense, but that decision is being deferred to get this change in, in order to unblock other work.