### PR TITLE
Issue: #871 Fixing at least some occurences of error CS0579: Duplicate 'AssemblyVersion' attribute

### DIFF
--- a/src/GitVersionExe.Tests/AssemblyInfoFileUpdateTests.cs
+++ b/src/GitVersionExe.Tests/AssemblyInfoFileUpdateTests.cs
@@ -239,8 +239,6 @@ public class AssemblyInfoFileUpdateTests
     [TestCase("cs", "[assembly: AssemblyVersion ( \"1.0.0.0\") ]\r\n[assembly: AssemblyInformationalVersion\t(\t\"1.0.0.0\"\t)]\r\n[assembly: AssemblyFileVersion\r\n(\r\n\"1.0.0.0\"\r\n)]")]
     [TestCase("fs", "[<assembly: AssemblyVersion ( \"1.0.0.0\" )>]\r\n[<assembly: AssemblyInformationalVersion\t(\t\"1.0.0.0\"\t)>]\r\n[<assembly: AssemblyFileVersion\r\n(\r\n\"1.0.0.0\"\r\n)>]")]
     [TestCase("vb", "<Assembly: AssemblyVersion ( \"1.0.0.0\" )>\r\n<Assembly: AssemblyInformationalVersion\t(\t\"1.0.0.0\"\t)>\r\n<Assembly: AssemblyFileVersion\r\n(\r\n\"1.0.0.0\"\r\n)>")]
-    [Category("NoMono")]
-    [Description("Won't run on Mono due to source information not being available for ShouldMatchApproved.")]
     public void ShouldReplaceAssemblyVersionInRelativePathWithWhiteSpace(string fileExtension, string assemblyFileContent)
     {
         var workingDir = Path.GetTempPath();

--- a/src/GitVersionExe/AssemblyInfoFileUpdate.cs
+++ b/src/GitVersionExe/AssemblyInfoFileUpdate.cs
@@ -25,13 +25,13 @@ namespace GitVersion
             Logger.WriteInfo(string.Format("Found {0} files", assemblyInfoFiles.Count));
 
             var assemblyVersion = variables.AssemblySemVer;
-            var assemblyVersionRegex = new Regex(@"AssemblyVersion\(""[^""]*""\)");
+            var assemblyVersionRegex = new Regex(@"AssemblyVersion\s*\(\s*""[^""]*""\s*\)");
             var assemblyVersionString = string.Format("AssemblyVersion(\"{0}\")", assemblyVersion);
             var assemblyInfoVersion = variables.InformationalVersion;
-            var assemblyInfoVersionRegex = new Regex(@"AssemblyInformationalVersion\(""[^""]*""\)");
+            var assemblyInfoVersionRegex = new Regex(@"AssemblyInformationalVersion\s*\(\s*""[^""]*""\s*\)");
             var assemblyInfoVersionString = string.Format("AssemblyInformationalVersion(\"{0}\")", assemblyInfoVersion);
             var assemblyFileVersion = variables.MajorMinorPatch + ".0";
-            var assemblyFileVersionRegex = new Regex(@"AssemblyFileVersion\(""[^""]*""\)");
+            var assemblyFileVersionRegex = new Regex(@"AssemblyFileVersion\s*\(\s*""[^""]*""\s*\)");
             var assemblyFileVersionString = string.Format("AssemblyFileVersion(\"{0}\")", assemblyFileVersion);
 
             foreach (var assemblyInfoFile in assemblyInfoFiles)


### PR DESCRIPTION
Made regex finding attributes in files tolerate whitespacing.
Added unit test for whitespacing: ShouldReplaceAssemblyVersionInRelativePathWithWhiteSpace

Fixes #871.