### PR TITLE
Fix to stop GitVersion from introducing the remote name into branch name

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
@@ -7,6 +7,8 @@ using Shouldly;
 public class EnvironmentVariableJenkinsTests
 {
     string key = "JENKINS_URL";
+    string branch = "GIT_BRANCH";
+    string localBranch = "GIT_LOCAL_BRANCH";
 
     private void SetEnvironmentVariableForDetection()
     {
@@ -32,5 +34,25 @@ public class EnvironmentVariableJenkinsTests
         ClearEnvironmentVariableForDetection();
         var j = new Jenkins();
         j.CanApplyToCurrentContext().ShouldBe(false);  
+    }
+
+    [Test]
+    public void JenkinsTakesLocalBranchNameNotRemoteName()
+    {
+        // Save original values so they can be restored
+        string branchOrig = Environment.GetEnvironmentVariable(branch);
+        string localBranchOrig = Environment.GetEnvironmentVariable(localBranch);
+
+        // Set new Environment variables for testing
+        Environment.SetEnvironmentVariable(branch, "origin/master");
+        Environment.SetEnvironmentVariable(localBranch, "master");
+
+        // Test Jenkins GetCurrentBranch method
+        var j = new Jenkins();
+        j.GetCurrentBranch(true).ShouldBe("master");
+
+        // Restore environment variables
+        Environment.SetEnvironmentVariable(branch, branchOrig);
+        Environment.SetEnvironmentVariable(localBranch, localBranchOrig);
     }
 }

--- a/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
@@ -43,12 +43,17 @@ public class EnvironmentVariableJenkinsTests
         string branchOrig = Environment.GetEnvironmentVariable(branch);
         string localBranchOrig = Environment.GetEnvironmentVariable(localBranch);
 
-        // Set new Environment variables for testing
+        // Set GIT_BRANCH for testing
         Environment.SetEnvironmentVariable(branch, "origin/master");
+
+        // Test Jenkins that GetCurrentBranch falls back to GIT_BRANCH if GIT_LOCAL_BRANCH undefined
+        var j = new Jenkins();
+        j.GetCurrentBranch(true).ShouldBe("origin/master");
+
+        // Set GIT_LOCAL_BRANCH
         Environment.SetEnvironmentVariable(localBranch, "master");
 
-        // Test Jenkins GetCurrentBranch method
-        var j = new Jenkins();
+        // Test Jenkins GetCurrentBranch method now returns GIT_LOCAL_BRANCH
         j.GetCurrentBranch(true).ShouldBe("master");
 
         // Restore environment variables

--- a/src/GitVersionCore/BuildServers/Jenkins.cs
+++ b/src/GitVersionCore/BuildServers/Jenkins.cs
@@ -36,7 +36,7 @@
 
         public override string GetCurrentBranch(bool usingDynamicRepos)
         {
-            return Environment.GetEnvironmentVariable("GIT_BRANCH");
+            return Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH");
         }
 
         public override bool PreventFetch()

--- a/src/GitVersionCore/BuildServers/Jenkins.cs
+++ b/src/GitVersionCore/BuildServers/Jenkins.cs
@@ -36,7 +36,7 @@
 
         public override string GetCurrentBranch(bool usingDynamicRepos)
         {
-            return Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH");
+            return Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH") ?? Environment.GetEnvironmentVariable("GIT_BRANCH");
         }
 
         public override bool PreventFetch()


### PR DESCRIPTION
When using GitVersion on a Jenkins build server, the remote name was getting introduced into the branch name when NormalizeGitDirectory was called. I found this to be happening because in the Jenkins GetCurrentBranch method, it was getting the environment variable "GIT_BRANCH" which would be something like "origin/master". There is now a variable available in Git called "GIT_LOCAL_BRANCH" that would just return "master" without the remote name, so I changed Jenkins.cs to use that variable instead unless it is not defined. I also added a simple test to EnvironmentVariableJenkinsTests.cs

Fixes #857 