### PR TITLE
Improve the language discovery heuristics of AssemblyInfoBuilder

### DIFF
--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -87,6 +87,10 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
       <Private>True</Private>

--- a/src/GitVersionTask.Tests/packages.config
+++ b/src/GitVersionTask.Tests/packages.config
@@ -14,6 +14,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="ModuleInit.Fody" version="1.5.9.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
   <package id="ObjectApproval" version="1.3.0" targetFramework="net45" />

--- a/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
+++ b/src/GitVersionTask/AssemblyInfoBuilder/AssemblyInfoBuilder.cs
@@ -1,37 +1,44 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using GitTools;
 using GitVersion;
 using Microsoft.Build.Framework;
-using System.IO;
-using GitTools;
 
 public abstract class AssemblyInfoBuilder
 {
-    private static readonly Dictionary<string, Type> assemblyInfoBuilders = new Dictionary<string, Type>()
+    private static readonly Dictionary<string, Type> assemblyInfoBuilders = new Dictionary<string, Type>
     {
-        { ".cs", typeof(CSharpAssemblyInfoBuilder) },
-        { ".vb", typeof(VisualBasicAssemblyInfoBuilder) }
+        {".cs", typeof(CSharpAssemblyInfoBuilder)},
+        {".vb", typeof(VisualBasicAssemblyInfoBuilder)}
         // TODO: Missing FSharpAssemblyInfoBuilder
     };
 
+    public abstract string AssemblyInfoExtension { get; }
+
     public static AssemblyInfoBuilder GetAssemblyInfoBuilder(IEnumerable<ITaskItem> compileFiles)
     {
+        if (compileFiles == null)
+        {
+            throw new ArgumentNullException("compileFiles");
+        }
+
         Type builderType;
 
-        var assemblyInfoExtension = compileFiles.Select(x => x.ItemSpec)
-            .Where(compileFile => compileFile.Contains("AssemblyInfo"))
-            .Select(Path.GetExtension).FirstOrDefault();
+        var assemblyInfoExtension = compileFiles
+            .Select(x => x.ItemSpec)
+            .Select(Path.GetExtension)
+            // TODO: While it works, this seems like a bad way to discover the language is being compiled. @asbjornu
+            .FirstOrDefault(extension => assemblyInfoBuilders.ContainsKey(extension.ToLowerInvariant()));
 
-        if (assemblyInfoBuilders.TryGetValue(assemblyInfoExtension, out builderType))
+        if (assemblyInfoExtension != null && assemblyInfoBuilders.TryGetValue(assemblyInfoExtension, out builderType))
         {
             return Activator.CreateInstance(builderType) as AssemblyInfoBuilder;
         }
 
         throw new WarningException("Unable to determine which AssemblyBuilder required to generate GitVersion assembly information");
     }
-
-    public abstract string AssemblyInfoExtension { get; }
 
     public abstract string GetAssemblyInfoText(VersionVariables vars, string rootNamespace);
 }


### PR DESCRIPTION
This PR improves how the `AssemblyInfoBuilder` discovers what language is being compiled by not looking for an `AssemblyInfo.*` file, but instead finding the first `*.vb` or `*.cs` file and deducing the langauge from there.

Also adds a few more guards and tests for `AssemblyInfoBuilder` to make it more robust and easier to understand if it breaks.

Fixes #885.