### PR TITLE
Don't swallow exceptions from LibGit2Sharp

### DIFF
--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -191,7 +191,7 @@ namespace GitVersion
                     throw new Exception("Not found: The repository was not found");
                 }
 
-                throw new Exception("There was an unknown problem with the Git repository you provided");
+                throw new Exception("There was an unknown problem with the Git repository you provided", ex);
             }
         }
     }

--- a/src/GitVersionCore/GitVersionFinder.cs
+++ b/src/GitVersionCore/GitVersionFinder.cs
@@ -14,7 +14,7 @@ namespace GitVersion
             var filePath = Path.Combine(context.Repository.GetRepositoryDirectory(), "NextVersion.txt");
             if (File.Exists(filePath))
             {
-                throw new WarningException("NextVersion.txt has been depreciated. See http://gitversion.readthedocs.org/en/latest/configuration/ for replacement");
+                throw new WarningException("NextVersion.txt has been deprecated. See http://gitversion.readthedocs.org/en/latest/configuration/ for replacement");
             }
 
             return new NextVersionCalculator().FindVersion(context);


### PR DESCRIPTION
Don't swallow unexpected exceptions form LibGit2Sharp; they might be very valuable for debugging purposes such as to figure out #916.