### PR TITLE
Add config wizard changes to support private repositories on Appveyor

### DIFF
--- a/src/GitVersionCore/Configuration/Init/BuildServer/AppveyorPublicPrivate.cs
+++ b/src/GitVersionCore/Configuration/Init/BuildServer/AppveyorPublicPrivate.cs
@@ -4,9 +4,9 @@
     using GitVersion.Configuration.Init.Wizard;
     using GitVersion.Helpers;
 
-    class SetupBuildScripts : ConfigInitWizardStep
+    class AppveyorPublicPrivate : ConfigInitWizardStep
     {
-        public SetupBuildScripts(IConsole console, IFileSystem fileSystem) : base(console, fileSystem)
+        public AppveyorPublicPrivate(IConsole console, IFileSystem fileSystem) : base(console, fileSystem)
         {
         }
 
@@ -18,7 +18,10 @@
                     steps.Enqueue(new EditConfigStep(Console, FileSystem));
                     return StepResult.Ok();
                 case "1":
-                    steps.Enqueue(new AppveyorPublicPrivate(Console, FileSystem));
+                    steps.Enqueue(new AppVeyorSetup(Console, FileSystem, ProjectVisibility.Public));
+                    return StepResult.Ok();
+                case "2":
+                    steps.Enqueue(new AppVeyorSetup(Console, FileSystem, ProjectVisibility.Private));
                     return StepResult.Ok();
             }
             return StepResult.Ok();
@@ -26,12 +29,13 @@
 
         protected override string GetPrompt(Config config, string workingDirectory)
         {
-            return @"What build server are you using?
+            return @"Is your project public or private?
 
-Want to see more? Contribute a pull request!
+That is ... does it require authentication to clone/pull?
 
 0) Go Back
-1) AppVeyor";
+1) Public
+2) Private";
         }
 
         protected override string DefaultResult

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Configuration\ConsoleAdapter.cs" />
     <Compile Include="Configuration\IConsole.cs" />
     <Compile Include="Configuration\IgnoreConfig.cs" />
+    <Compile Include="Configuration\Init\BuildServer\AppveyorPublicPrivate.cs" />
     <Compile Include="Configuration\Init\BuildServer\AppVeyorSetup.cs" />
     <Compile Include="Configuration\Init\BuildServer\SetupBuildScripts.cs" />
     <Compile Include="Configuration\Init\SetConfig\AssemblyVersioningSchemeSetting.cs" />


### PR DESCRIPTION
This is to resolve #869 
I checked [the docs](https://github.com/GitTools/GitVersion/blob/master/docs/build-server-support/build-server/appveyor.md) for this.  They look OK as-is for this change.

@Philo also expressed some interest in documenting this use case of `/nofetch` command-line option under this PR