### PR TITLE
Revert "Fix build server doc links"

### DIFF
--- a/docs/build-server-support/build-server-support.md
+++ b/docs/build-server-support/build-server-support.md
@@ -1,16 +1,16 @@
 # Build Server Support
 GitVersion has support for quite a few build servers out of the box. Currently we support:
 
- - [AppVeyor](build-server-support/build-server/appveyor.md)
- - [Bamboo](build-server-support/build-server/bamboo.md)
- - [Continua CI](build-server-support/build-server/continua.md)
- - [GitLab CI](build-server-support/build-server/gitlab.md)
- - [Jenkins](build-server-support/build-server/jenkins.md)
- - [MyGet](build-server-support/build-server/myget.md)
- - [Octopus Deploy](build-server-support/build-server/octopus-deploy.md)
- - [TeamCity](build-server-support/build-server/teamcity.md)
- - [Team Build (TFS)](build-server-support/build-server/teambuild.md)
- - [TFS Build vNext](build-server-support/build-server/tfs-build-vnext.md)
+ - [AppVeyor](build-server/appveyor.md)
+ - [Bamboo](build-server/bamboo.md)
+ - [Continua CI](build-server/continua.md)
+ - [GitLab CI](build-server/gitlab.md)
+ - [Jenkins](build-server/jenkins.md)
+ - [MyGet](build-server/myget.md)
+ - [Octopus Deploy](build-server/octopus-deploy.md)
+ - [TeamCity](build-server/teamcity.md)
+ - [Team Build (TFS)](build-server/teambuild.md)
+ - [TFS Build vNext](build-server/tfs-build-vnext.md)
  
 When GitVersion.exe is run with the `/output buildserver` flag instead of outputting Json it will export variables to the current build server.
 For instance if you are running in TeamCity after you run `GitVersion /output buildserver` you will have the `%system.GitVersion.SemVer%` available for you to use


### PR DESCRIPTION
Reverts GitTools/GitVersion#957

Unfortunately this broke all links. Still no clue why the gitlab link in the original way didn't work...