### PR TITLE
add a test to ensure cache key is same even if renormalized

### DIFF
--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -28,13 +28,13 @@ public class ExecuteCoreTests
             var targetUrl = "https://github.com/GitTools/GitVersion.git";
             var targetBranch = "refs/head/master";
             var gitPreparer = new GitPreparer(targetUrl, null, new Authentication(), false, fixture.RepositoryPath);
+            //var cacheKey0 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+            gitPreparer.Initialise(true, targetBranch);
             var cacheKey1 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
             gitPreparer.Initialise(true, targetBranch);
             var cacheKey2 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
-            gitPreparer.Initialise(true, targetBranch);
-            var cacheKey3 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
 
-            cacheKey3.Value.ShouldBe(cacheKey2.Value);
+            cacheKey2.Value.ShouldBe(cacheKey1.Value);
         });        
     }
 

--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -19,6 +19,26 @@ public class ExecuteCoreTests
     }
 
     [Test]
+    public void CacheKeySameAfterReNormalizing()
+    {
+        var versionAndBranchFinder = new ExecuteCore(fileSystem);
+
+        RepositoryScope(versionAndBranchFinder, (fixture, vv) =>
+        {
+            var targetUrl = "https://github.com/GitTools/GitVersion.git";
+            var targetBranch = "refs/head/master";
+            var gitPreparer = new GitPreparer(targetUrl, null, new Authentication(), false, fixture.RepositoryPath);
+            var cacheKey1 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+            gitPreparer.Initialise(true, targetBranch);
+            var cacheKey2 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+            gitPreparer.Initialise(true, targetBranch);
+            var cacheKey3 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+
+            cacheKey3.Value.ShouldBe(cacheKey2.Value);
+        });        
+    }
+
+    [Test]
     public void CacheFileExistsOnDisk()
     {
         const string versionCacheFileContent = @"

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -104,7 +104,11 @@
                         // Perform whatever action is required in your scenario.
                         System.IO.FileInfo fi = new System.IO.FileInfo(file);
                         result.Add(fi.Name);
-                        Logger.WriteInfo(string.Format("{0}: {1}, {2}", fi.Name, fi.Length, fi.CreationTime));
+
+                        var reader = fi.OpenText();
+                        result.Add(reader.ReadToEnd());
+
+                        //Logger.WriteInfo(string.Format("{0}: {1}, {2}", fi.Name, fi.Length, fi.CreationTime));
                     }
                     catch (System.IO.FileNotFoundException e)
                     {

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -104,17 +104,11 @@
                         // Perform whatever action is required in your scenario.
                         System.IO.FileInfo fi = new System.IO.FileInfo(file);
                         result.Add(fi.Name);
-
-                        var reader = fi.OpenText();
-                        result.Add(reader.ReadToEnd());
-
+                        result.Add(File.ReadAllText(file));
                         //Logger.WriteInfo(string.Format("{0}: {1}, {2}", fi.Name, fi.Length, fi.CreationTime));
                     }
-                    catch (System.IO.FileNotFoundException e)
+                    catch (IOException e)
                     {
-                        // If file was deleted by a separate application
-                        //  or thread since the call to TraverseTree()
-                        // then just continue.
                         Logger.WriteError(e.Message);
                         continue;
                     }

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -6,6 +6,7 @@
     using System.IO;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Linq;
 
     public class GitVersionCacheKeyFactory
     {
@@ -33,20 +34,20 @@
         // lifted from https://msdn.microsoft.com/en-us/library/bb513869.aspx
         public static List<string> TraverseTree(string root)
         {
-            var result = new List<string>();
-            result.Add(root);
+            var result = new List<string> { root };
+
             // Data structure to hold names of subfolders to be
             // examined for files.
-            Stack<string> dirs = new Stack<string>(20);
+            var dirs = new Stack<string>(20);
 
-            if (!System.IO.Directory.Exists(root))
+            if (!Directory.Exists(root))
             {
                 throw new ArgumentException();
             }
 
             dirs.Push(root);
 
-            while (dirs.Count > 0)
+            while (dirs.Any())
             {
                 string currentDir = dirs.Pop();
 
@@ -56,7 +57,7 @@
                 string[] subDirs;
                 try
                 {
-                    subDirs = System.IO.Directory.GetDirectories(currentDir);
+                    subDirs = Directory.GetDirectories(currentDir);
                 }
                 // An UnauthorizedAccessException exception will be thrown if we do not have
                 // discovery permission on a folder or file. It may or may not be acceptable 
@@ -72,7 +73,7 @@
                     Logger.WriteError(e.Message);
                     continue;
                 }
-                catch (System.IO.DirectoryNotFoundException e)
+                catch (DirectoryNotFoundException e)
                 {
                     Logger.WriteError(e.Message);
                     continue;
@@ -81,7 +82,7 @@
                 string[] files = null;
                 try
                 {
-                    files = System.IO.Directory.GetFiles(currentDir);
+                    files = Directory.GetFiles(currentDir);
                 }
 
                 catch (UnauthorizedAccessException e)
@@ -90,19 +91,17 @@
                     continue;
                 }
 
-                catch (System.IO.DirectoryNotFoundException e)
+                catch (DirectoryNotFoundException e)
                 {
                     Logger.WriteError(e.Message);
                     continue;
                 }
-                // Perform the required action on each file here.
-                // Modify this block to perform your required task.
+
                 foreach (string file in files)
                 {
                     try
                     {
-                        // Perform whatever action is required in your scenario.
-                        System.IO.FileInfo fi = new System.IO.FileInfo(file);
+                        var fi = new FileInfo(file);
                         result.Add(fi.Name);
                         result.Add(File.ReadAllText(file));
                         //Logger.WriteInfo(string.Format("{0}: {1}, {2}", fi.Name, fi.Length, fi.CreationTime));


### PR DESCRIPTION
Re: https://github.com/GitTools/GitVersion/issues/942

If the gitPreparer normalize (in Initialize) is called multiple times, the cachekey will change each time, even though .git/refs has exactly the same content. This is because the cachekey is based on the timestamp rather than the contents. This PR changes the cachekey calculation so that it computes a hash based on the filenames and directory names in .git/refs.