### PR TITLE
Updated IncrementStrategyFinder to support version bumping from tags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,14 @@ The global configuration options are:
 
  - **`no-bump-message:`** Used to tell GitVersion not to increment when in Mainline development mode. Default `\+semver:\s?(none|skip)`, which will match occurrences of `+semver: none` and `+semver: skip`
 
+ - **`major-version-bump-tag:`** The regex to match commit tags with to perform a major version increment. Default set to `'\+semver-(breaking|major)'`, which will match occurrences of `+semver-major` and `+semver-breaking` in a commit tag.
+
+ - **`minor-version-bump-tag:`** The regex to match commit tags with to perform a minor version increment. Default set to `'\+semver-(feature|minor)'`, which will match occurrences of `+semver-feature` and `+semver-minor` in a commit tag.
+
+ - **`patch-version-bump-tag:`** The regex to match commit tags with to perform a patch version increment. Default set to `'\+semver-(fix|patch)'`, which will match occurrences of `+semver-fix` and `+semver-patch` in a commit tag.
+
+ - **`no-bump-tag:`** Used to tell GitVersion not to increment when in Mainline development mode. Default `\+semver-(none|skip)`, which will match occurrences of `+semver-none` and `+semver-skip` in a commit tag.
+
  - **`legacy-semver-padding:`** The number of characters to pad `LegacySemVer` to  in the `LegacySemVerPadded` [variable](/more-info/variables). Is default set to `4`, which will pad the `LegacySemVer` value of `3.0.0-beta1` to `3.0.0-beta0001`.
 
  - **`build-metadata-padding:`** The number of characters to pad `BuildMetaData` to in the `BuildMetaDataPadded` [variable](/more-info/variables). Is default set to `4`, which will pad the `BuildMetaData` value of `1` to `0001`.

--- a/docs/more-info/version-increments.md
+++ b/docs/more-info/version-increments.md
@@ -22,8 +22,10 @@ See [Octopus deploy](../build-server-support/build-server/octopus-deploy.md)
 ## Manually incrementing the version
 With v3 there are multiple approaches.
 
-### Commit messages
-Adding `+semver: breaking` or `+semver: major` will cause the major version to be increased, `+semver: feature` or `+semver:minor` will bump minor and `+semver:patch` or `+semver:fix` will bump the patch.
+### Commit messages and tags
+Adding a commit message containing `+semver: breaking` or `+semver: major` will cause the major version to be increased, `+semver: feature` or `+semver:minor` will bump minor and `+semver:patch` or `+semver:fix` will bump the patch.
+
+Adding a tag to a commit containing `+semver-breaking` or `+semver-major` will cause the major version to be increased, `+semver-feature` or `+semver-minor` will bump minor and `+semver-patch` or `+semver-fix` will bump the patch.
 
 #### Configuration
 The feature is enabled by default but can be disabled via configuration, the regex we use can be changed:
@@ -32,10 +34,13 @@ The feature is enabled by default but can be disabled via configuration, the reg
 major-version-bump-message: '\+semver:\s?(breaking|major)'
 minor-version-bump-message: '\+semver:\s?(feature|minor)'
 patch-version-bump-message: '\+semver:\s?(fix|patch)'
+major-version-bump-tag: '\+semver-(breaking|major)'
+minor-version-bump-tag: '\+semver-(feature|minor)'
+patch-version-bump-tag: '\+semver-(fix|patch)'
 commit-message-incrementing: Enabled
 ```
 
-The options for `commit-message-incrementing` are `Enabled`, `MergeMessageOnly` and `Disabled`
+The options for `commit-message-incrementing` are `Enabled`, `MergeMessageOnly`, and `Disabled`
 
 If the incrementing mode is set to `MergeMessageOnly` you can add this information in when merging a pull request. This prevents commits within a PR bumping the version.
 

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -6,6 +6,10 @@ major-version-bump-message: '\+semver:\s?(breaking|major)'
 minor-version-bump-message: '\+semver:\s?(feature|minor)'
 patch-version-bump-message: '\+semver:\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
+major-version-bump-tag: '\+semver-(breaking|major)'
+minor-version-bump-tag: '\+semver-(feature|minor)'
+patch-version-bump-tag: '\+semver-(fix|patch)'
+no-bump-tag: '\+semver-(none|skip)'
 legacy-semver-padding: 4
 build-metadata-padding: 4
 commits-since-version-source-padding: 4

--- a/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -43,4 +43,21 @@ public class VersionBumpingScenarios
         }
 
     }
+
+    [Test]
+    public void CanUseTaggedCommitsToBumpVersion()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeACommit();
+            fixture.MakeATaggedCommit("1.0.0");
+            fixture.Repository.MakeATaggedCommit("+semver-minor");
+
+            fixture.AssertFullSemver("1.1.0+1");
+
+            fixture.Repository.MakeATaggedCommit("+semver-major");
+
+            fixture.AssertFullSemver("2.0.0+2");
+        }
+    }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -45,6 +45,26 @@ public class VersionBumpingScenarios
     }
 
     [Test]
+    public void CanUseCommitMessagesToBumpVersionBaseVersionTagIsAppliedToSameCommit()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeACommit();
+            fixture.MakeATaggedCommit("1.0.0");
+            fixture.Repository.MakeACommit("+semver:minor");
+            fixture.AssertFullSemver("1.1.0+1");
+
+            fixture.ApplyTag("2.0.0");
+
+            fixture.Repository.MakeACommit("Hello");
+
+            // Default bump is patch
+
+            fixture.AssertFullSemver("2.0.1+1");
+        }
+    }
+
+    [Test]
     public void CanUseTaggedCommitsToBumpVersion()
     {
         using (var fixture = new EmptyRepositoryFixture())
@@ -58,6 +78,27 @@ public class VersionBumpingScenarios
             fixture.Repository.MakeATaggedCommit("+semver-major");
 
             fixture.AssertFullSemver("2.0.0+2");
+        }
+    }
+
+
+    [Test]
+    public void CanUseTaggedCommitsToBumpVersionBaseVersionTagIsAppliedToSameCommit()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeACommit();
+            fixture.MakeATaggedCommit("1.0.0");
+            fixture.Repository.MakeATaggedCommit("+semver-minor");
+            fixture.AssertFullSemver("1.1.0+1");
+
+            fixture.ApplyTag("2.0.0");
+
+            fixture.Repository.MakeACommit("hello");
+
+            // Default bump is patch
+
+            fixture.AssertFullSemver("2.0.1+1");
         }
     }
 }

--- a/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -23,6 +23,10 @@ namespace GitVersionCore.Tests
             string minorMessage = null,
             string patchMessage = null,
             string noBumpMessage = null,
+            string majorTag = null,
+            string minorTag = null,
+            string patchTag = null,
+            string noBumpTag = null,
             CommitMessageIncrementMode commitMessageMode = CommitMessageIncrementMode.Enabled,
             int legacySemVerPadding = 4,
             int buildMetaDataPadding = 4,
@@ -34,6 +38,7 @@ namespace GitVersionCore.Tests
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,
+                    majorTag, minorTag, patchTag, noBumpTag,
                     commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
                     versionFilters ?? Enumerable.Empty<IVersionFilter>(),
                     isDevelop, isRelease)

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -55,6 +55,19 @@
         [YamlMember(Alias = "no-bump-message")]
         public string NoBumpMessage { get; set; }
 
+        [YamlMember(Alias = "major-version-bump-tag")]
+        public string MajorVersionBumpTag { get; set; }
+
+        [YamlMember(Alias = "minor-version-bump-tag")]
+        public string MinorVersionBumpTag { get; set; }
+
+        [YamlMember(Alias = "patch-version-bump-tag")]
+        public string PatchVersionBumpTag { get; set; }
+
+        [YamlMember(Alias = "no-bump-tag")]
+        public string NoBumpTag { get; set; }
+
+
         [YamlMember(Alias = "legacy-semver-padding")]
         public int? LegacySemVerPadding { get; set; }
 

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -63,6 +63,10 @@ namespace GitVersion
             config.MinorVersionBumpMessage = config.MinorVersionBumpMessage ?? IncrementStrategyFinder.DefaultMinorPattern;
             config.PatchVersionBumpMessage = config.PatchVersionBumpMessage ?? IncrementStrategyFinder.DefaultPatchPattern;
             config.NoBumpMessage = config.NoBumpMessage ?? IncrementStrategyFinder.DefaultNoBumpPattern;
+            config.MajorVersionBumpTag = config.MajorVersionBumpTag ?? IncrementStrategyFinder.DefaultMajorTagPattern;
+            config.MinorVersionBumpTag = config.MinorVersionBumpTag ?? IncrementStrategyFinder.DefaultMinorTagPattern;
+            config.PatchVersionBumpTag = config.PatchVersionBumpTag ?? IncrementStrategyFinder.DefaultPatchTagPattern;
+            config.NoBumpTag = config.NoBumpTag ?? IncrementStrategyFinder.DefaultNoBumpTagPattern;
             config.CommitMessageIncrementing = config.CommitMessageIncrementing ?? CommitMessageIncrementMode.Enabled;
             config.LegacySemVerPadding = config.LegacySemVerPadding ?? 4;
             config.BuildMetaDataPadding = config.BuildMetaDataPadding ?? 4;

--- a/src/GitVersionCore/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/EffectiveConfiguration.cs
@@ -22,6 +22,10 @@ namespace GitVersion
             string minorVersionBumpMessage,
             string patchVersionBumpMessage,
             string noBumpMessage,
+            string majorVersionBumpTag,
+            string minorVersionBumpTag,
+            string patchVersionBumpTag,
+            string noBumpTag,
             CommitMessageIncrementMode commitMessageIncrementing,
             int legacySemVerPaddding,
             int buildMetaDataPadding,
@@ -46,6 +50,10 @@ namespace GitVersion
             MinorVersionBumpMessage = minorVersionBumpMessage;
             PatchVersionBumpMessage = patchVersionBumpMessage;
             NoBumpMessage = noBumpMessage;
+            MajorVersionBumpTag = majorVersionBumpTag;
+            MinorVersionBumpTag = minorVersionBumpTag;
+            PatchVersionBumpTag = patchVersionBumpTag;
+            NoBumpTag = noBumpTag;
             CommitMessageIncrementing = commitMessageIncrementing;
             LegacySemVerPadding = legacySemVerPaddding;
             BuildMetaDataPadding = buildMetaDataPadding;
@@ -94,6 +102,15 @@ namespace GitVersion
         public string PatchVersionBumpMessage { get; private set; }
 
         public string NoBumpMessage { get; private set; }
+
+        public string MajorVersionBumpTag { get; private set; }
+
+        public string MinorVersionBumpTag { get; private set; }
+
+        public string PatchVersionBumpTag { get; private set; }
+
+        public string NoBumpTag { get; private set; }
+
         public int LegacySemVerPadding { get; private set; }
         public int BuildMetaDataPadding { get; private set; }
 

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -124,6 +124,10 @@
             var minorMessage = FullConfiguration.MinorVersionBumpMessage;
             var patchMessage = FullConfiguration.PatchVersionBumpMessage;
             var noBumpMessage = FullConfiguration.NoBumpMessage;
+            var majorTag = FullConfiguration.MajorVersionBumpTag;
+            var minorTag = FullConfiguration.MinorVersionBumpTag;
+            var patchTag = FullConfiguration.PatchVersionBumpTag;
+            var noBumpTag = FullConfiguration.NoBumpTag;
 
             var commitMessageVersionBump = currentBranchConfig.Value.CommitMessageIncrementing ?? FullConfiguration.CommitMessageIncrementing.Value;
 
@@ -134,6 +138,7 @@
                 tagNumberPattern, FullConfiguration.ContinuousDeploymentFallbackTag,
                 trackMergeTarget,
                 majorMessage, minorMessage, patchMessage, noBumpMessage,
+                majorTag, minorTag, patchTag, noBumpTag,
                 commitMessageVersionBump,
                 FullConfiguration.LegacySemVerPadding.Value,
                 FullConfiguration.BuildMetaDataPadding.Value,

--- a/src/GitVersionCore/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/IncrementStrategyFinder.cs
@@ -117,11 +117,11 @@
             var found = false;
             foreach (var commit in intermediateCommitCache)
             {
-                if (commit.Sha == baseCommit.Sha)
-                    found = true;
-
                 if (found)
                     yield return commit;
+
+                if (commit.Sha == baseCommit.Sha)
+                    found = true;
             }
         }
 


### PR DESCRIPTION
Updated IncrementStrategyFinder to support version bumping from tagged commits.

Updated tests and docs.

#971 