### PR TITLE
Exclude base commit when getting intermediate commits.

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -43,4 +43,24 @@ public class VersionBumpingScenarios
         }
 
     }
+
+    [Test]
+    public void CanUseCommitMessagesToBumpVersionBaseVersionTagIsAppliedToSameCommit()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeACommit();
+            fixture.MakeATaggedCommit("1.0.0");
+            fixture.Repository.MakeACommit("+semver:minor");
+            fixture.AssertFullSemver("1.1.0+1");
+
+            fixture.ApplyTag("2.0.0");
+
+            fixture.Repository.MakeACommit("Hello");
+
+            // Default bump is patch
+
+            fixture.AssertFullSemver("2.0.1+1");
+        }
+    }
 }

--- a/src/GitVersionCore/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/IncrementStrategyFinder.cs
@@ -104,11 +104,11 @@
             var found = false;
             foreach (var commit in intermediateCommitCache)
             {
-                if (commit.Sha == baseCommit.Sha)
-                    found = true;
-
                 if (found)
                     yield return commit;
+
+                if (commit.Sha == baseCommit.Sha)
+                    found = true;
             }
         }
 


### PR DESCRIPTION
Fix for #974 (if #972 is rejected)