### PR TITLE
Version calculation should not use tags from not merged branch

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherBranchScenarios.cs
@@ -2,6 +2,7 @@
 using GitVersionCore.Tests;
 using LibGit2Sharp;
 using NUnit.Framework;
+using Shouldly;
 
 [TestFixture]
 public class OtherBranchScenarios
@@ -20,6 +21,7 @@ public class OtherBranchScenarios
             fixture.AssertFullSemver("2.0.0-alpha.1+0");
         }
     }
+
     [Test]
     public void BranchesWithIllegalCharsShouldNotBeUsedInVersionNames()
     {
@@ -32,6 +34,27 @@ public class OtherBranchScenarios
             fixture.Repository.Checkout("issue/m/github-569");
 
             fixture.AssertFullSemver("1.0.4-issue-m-github-569.1+5");
+        }
+    }
+
+    [Test]
+    public void ShouldNotGetVersionFromFeatureBranchIfNotMerged()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0-unstable.0"); // initial commit in master
+
+            fixture.Repository.CreateBranch("feature");
+            fixture.Repository.Checkout("feature");
+            fixture.Repository.MakeATaggedCommit("1.0.1-feature.1");
+
+            fixture.Repository.Checkout("master");
+            fixture.Repository.CreateBranch("develop");
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.MakeACommit();
+
+            var version = fixture.GetVersion();
+            version.SemVer.ShouldBe("1.0.0-unstable.1");
         }
     }
 }


### PR DESCRIPTION
Create unit test which cover scenario described in #862 issue. Short description:
Repositories consist from three branch - feature, develop and master. There is only fork (NO merge commits) in repository. Feature and Master branches grow up from the same commit. Tags in feature branch should not taking in count for version calculation for develop branch.