### PR TITLE
Issue when merging master to a branch and then back to master using Mainline

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -190,6 +190,88 @@ public class MainlineDevelopmentMode
             fixture.AssertFullSemver(config, "1.0.4-foo.2"); // TODO This probably should be 1.0.5
         }
     }
+
+    [Test]
+    public void VerifyMergingMasterToFeatureDoesNotCauseBranchCommitsToIncrementVersion()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeACommit("first in master");
+
+            fixture.BranchTo("feature/foo", "foo");
+            fixture.MakeACommit("first in foo");
+            
+            fixture.Checkout("master");
+            fixture.MakeACommit("second in master");
+
+            fixture.Checkout("feature/foo");
+            fixture.MergeNoFF("master");
+            fixture.MakeACommit("second in foo");
+
+            fixture.Checkout("master");
+            fixture.MakeATaggedCommit("1.0.0");
+
+            fixture.MergeNoFF("feature/foo");
+            fixture.AssertFullSemver(config, "1.0.1");
+        }
+    }
+
+    [Test]
+    public void VerifyMergingMasterToFeatureDoesNotStopMasterCommitsIncrementingVersion()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeACommit("first in master");
+
+            fixture.BranchTo("feature/foo", "foo");
+            fixture.MakeACommit("first in foo");
+
+            fixture.Checkout("master");
+            fixture.MakeATaggedCommit("1.0.0");
+            fixture.MakeACommit("third in master");
+
+            fixture.Checkout("feature/foo");
+            fixture.MergeNoFF("master");
+            fixture.MakeACommit("second in foo");
+
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo");
+            fixture.AssertFullSemver(config, "1.0.2");
+        }
+    }
+
+    [Test]
+    public void VerifyMergingMasterIntoAFeatureBranchWorksWithMultipleBranches()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeACommit("first in master");
+
+            fixture.BranchTo("feature/foo", "foo");
+            fixture.MakeACommit("first in foo");
+
+            fixture.BranchTo("feature/bar", "bar");
+            fixture.MakeACommit("first in bar");
+
+            fixture.Checkout("master");
+            fixture.MakeACommit("second in master");
+
+            fixture.Checkout("feature/foo");
+            fixture.MergeNoFF("master");
+            fixture.MakeACommit("second in foo");
+
+            fixture.Checkout("feature/bar");
+            fixture.MergeNoFF("master");
+            fixture.MakeACommit("second in bar");
+
+            fixture.Checkout("master");
+            fixture.MakeATaggedCommit("1.0.0");
+
+            fixture.MergeNoFF("feature/foo");
+            fixture.MergeNoFF("feature/bar");
+            fixture.AssertFullSemver(config, "1.0.2");
+        }
+    }
 }
 
 static class CommitExtensions

--- a/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -178,9 +178,9 @@ public class MainlineDevelopmentMode
             fixture.MakeACommit("+semver: minor");
             fixture.AssertFullSemver(config, "1.1.0");
             fixture.MergeNoFF("support/1.0");
-            fixture.AssertFullSemver(config, "1.1.2");
+            fixture.AssertFullSemver(config, "1.1.1");
             fixture.MakeACommit();
-            fixture.AssertFullSemver(config, "1.1.3");
+            fixture.AssertFullSemver(config, "1.1.2");
             fixture.Checkout("support/1.0");
             fixture.AssertFullSemver(config, "1.0.4");
 

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -99,8 +99,10 @@
                 {
                     IncludeReachableFrom = context.CurrentBranch,
                     ExcludeReachableFrom = baseVersion.BaseVersionSource,
-                    SortBy = CommitSortStrategies.Reverse
+                    SortBy = CommitSortStrategies.Reverse,
+                    FirstParentOnly = true
                 }).Where(c => c.Sha != baseVersion.BaseVersionSource.Sha).ToList();
+
                 var directCommits = new List<Commit>();
 
                 // Scans commit log in reverse, aggregating merge commits


### PR DESCRIPTION
When using Mainline after merging in a feature branch that has had master merged into it, GitVersion doesn't seem to correctly track the merge commits it should pay attention to.

See the snappily named `VerifyMergingMasterToFeatureDoesNotCauseBranchCommitsToIncrementVersion` test. When we create a feature branch, then merge master into it, then tag master and merge the feature branch in, we should only be at one merge commit past the tag, but `FindMainlineModeVersion` treats the merge from master to our branch as a merge into master, and commits before it as master commits.

I have a fix here that uses the `FirstParentOnly` flag on `CommitFilter` and make sure merges are to our target branch. I feel like I should be able to use that directly in the query for `commitLog` but that causes `VerifySupportForwardMerge` to fail, hence the dual queries shown.