### PR TITLE
Upgraded to newer GitTools.Core which fixes normalisation issues

### DIFF
--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\packages\FluentDateTime.1.13.0\lib\NET35\FluentDateTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net45\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net45\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="GitTools.Testing, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/GitVersionCore.Tests/packages.config
+++ b/src/GitVersionCore.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FluentDateTime" version="1.13.0" targetFramework="net45" />
   <package id="Fody" version="1.29.4" targetFramework="net45" developmentDependency="true" />
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net45" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace GitVersion
 {
-    using GitVersion.Helpers;
+    using Helpers;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -12,7 +12,7 @@
     {
         public static GitVersionCacheKey Create(IFileSystem fileSystem, GitPreparer gitPreparer, Config overrideConfig)
         {
-            var gitSystemHash = GetGitSystemHash(gitPreparer, fileSystem);
+            var gitSystemHash = GetGitSystemHash(gitPreparer);
             var configFileHash = GetConfigFileHash(fileSystem, gitPreparer);
             var repositorySnapshotHash = GetRepositorySnapshotHash(gitPreparer);
             var overrideConfigHash = GetOverrideConfigHash(overrideConfig);
@@ -21,7 +21,7 @@
             return new GitVersionCacheKey(compositeHash);
         }
 
-        private static string GetGitSystemHash(GitPreparer gitPreparer, IFileSystem fileSystem)
+        static string GetGitSystemHash(GitPreparer gitPreparer)
         {
             var dotGitDirectory = gitPreparer.GetDotGitDirectory();
 
@@ -32,7 +32,7 @@
         }
 
         // based on https://msdn.microsoft.com/en-us/library/bb513869.aspx
-        private static List<string> CalculateDirectoryContents(string root)
+        static List<string> CalculateDirectoryContents(string root)
         {
             var result = new List<string>();
 
@@ -79,7 +79,7 @@
                     continue;
                 }
 
-                string[] files = null;
+                string[] files;
                 try
                 {
                     files = Directory.GetFiles(currentDir);
@@ -95,7 +95,7 @@
                     continue;
                 }
 
-                foreach (string file in files)
+                foreach (var file in files)
                 {
                     try
                     {
@@ -106,14 +106,13 @@
                     catch (IOException e)
                     {
                         Logger.WriteError(e.Message);
-                        continue;
                     }
                 }
 
                 // Push the subdirectories onto the stack for traversal.
                 // This could also be done before handing the files.
                 // push in reverse order
-                for (int i = subDirs.Length - 1; i >= 0; i--)
+                for (var i = subDirs.Length - 1; i >= 0; i--)
                 {
                     dirs.Push(subDirs[i]);
                 }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -39,8 +39,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net4\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=8.1.11.55, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net40" />
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net4" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net40" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net40" />

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -35,8 +35,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net45\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net45\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="GitTools.Testing, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/GitVersionExe.Tests/packages.config
+++ b/src/GitVersionExe.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net45" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -41,8 +41,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net4\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=8.1.11.55, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
@@ -147,21 +147,19 @@
       <TempFiles Include="$(TargetDir)ILMergeTemp\*.*" />
       <NativeBinaries Include="$(TargetDir)lib\**\*.*" />
       <WindowsBinaries Include="$(TargetDir)lib\**\*.dll" />
-	  <LibGit2SharpFiles Include="$(TargetDir)LibGit2Sharp.*" Exclude="$(TargetDir)LibGit2Sharp.xml" />
+      <LibGit2SharpFiles Include="$(TargetDir)LibGit2Sharp.*" Exclude="$(TargetDir)LibGit2Sharp.xml" />
     </ItemGroup>
-
     <!-- Repack without LibGit2Sharp for NugetCommandLineBuild -->
     <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <!-- NugetCommandLineBuild -->
     <MakeDir Directories="$(BuildDir)NuGetCommandLineBuild" />
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetCommandLineBuild\tools\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
-	<Copy SourceFiles="@(LibGit2SharpFiles)" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
+    <Copy SourceFiles="@(LibGit2SharpFiles)" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
     <Copy SourceFiles="$(OutputPath)GitVersion.pdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.pdb')" />
     <Copy SourceFiles="$(OutputPath)GitVersion.exe.mdb" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" Condition="Exists('$(OutputPath)GitVersion.exe.mdb')" />
     <Copy SourceFiles="$(OutputPath)ILMergeTemp\GitVersion.exe" DestinationFolder="$(BuildDir)NuGetCommandLineBuild\tools" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.CommandLine.nuspec" DestinationFolder="$(BuildDir)NuGetCommandLineBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetCommandLineBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
-
     <!-- Repack with LibGit2Sharp for NugetCommandLineBuild -->
     <Exec Command="$(Runtime) &quot;$(SolutionDir)packages\ILRepack.2.0.10\tools\ILRepack.exe&quot; /allowDup /keyfile:&quot;$(SolutionDir)key.snk&quot; /out:&quot;$(TargetDir)ILMergeTemp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)GitVersionCore.dll&quot;  &quot;$(TargetDir)GitTools.Core.dll&quot; &quot;$(TargetDir)LibGit2Sharp.dll&quot;  &quot;$(TargetDir)YamlDotNet.dll&quot; /target:exe /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot; /ndebug /internalize " />
     <!-- NugetExeBuild -->
@@ -174,7 +172,6 @@
     <Copy SourceFiles="$(ProjectDir)NugetAssets\chocolateyUninstall.ps1" DestinationFolder="$(BuildDir)NuGetExeBuild\tools" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersion.Portable.nuspec" DestinationFolder="$(BuildDir)NuGetExeBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetExeBuild" MetadataAssembly="$(OutputPath)ILMergeTemp\GitVersion.exe" Version="$(GitVersion_NuGetVersion)" />
-
     <!-- TfsBuildTask -->
     <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)GitVersionTfsTaskBuild\GitVersionTask\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="$(SolutionDir)GitVersionTfsTask\extension-icon.png" DestinationFolder="$(BuildDir)GitVersionTfsTaskBuild" />
@@ -190,7 +187,6 @@
     <ReplaceFileText InputFilename="$(BuildDir)GitVersionTfsTaskBuild\manifest.json" OutputFilename="$(BuildDir)GitVersionTfsTaskBuild\manifest.json" MatchExpression="\$version\$" ReplacementText="$(GitVersion_SemVer)" Condition="'$(GitVersion_SemVer)' != ''" />
     <Exec Command="powershell -ExecutionPolicy RemoteSigned -NoProfile &quot;$(SolutionDir)GitVersionTfsTask\Update-GitVersionTfsTaskVersion.ps1 $(BuildDir)GitVersionTfsTaskBuild\GitVersionTask\task.json $(GitVersion_MajorMinorPatch)&quot;" WorkingDirectory="$(BuildDir)" Condition="'$(GitVersion_MajorMinorPatch)' != ''" />
     <Exec Command="powershell -ExecutionPolicy RemoteSigned -NoProfile &quot;$(SolutionDir)GitVersionTfsTask\Create-Vsix.ps1 $(BuildDir)GitVersionTfsTaskBuild&quot;" Condition="'$(GitVersion_SemVer)' != ''" />
-
     <!-- Gem -->
     <MakeDir Directories="$(BuildDir)GemBuild" />
     <!-- Gem can only treat files it knows about, so it throws an error for .so and .dylib files when building on Windows -->
@@ -214,7 +210,6 @@
     </PropertyGroup>
     <ReplaceFileText InputFilename="$(BuildDir)GemBuild\gitversion.gemspec" OutputFilename="$(BuildDir)GemBuild\gitversion.gemspec" MatchExpression="\$version\$" ReplacementText="$(GemVersion)" Condition="'$(GitVersion_SemVer)' != ''" />
     <Exec Command="gem build gitversion.gemspec" ContinueOnError="True" WorkingDirectory="$(BuildDir)GemBuild" Condition="'$(GitVersion_SemVer)' != ''" />
-
     <!-- Cleanup -->
     <RemoveDir Directories="$(TargetDir)ILMergeTemp\" />
   </Target>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net40" />
   <package id="ILRepack" version="2.0.10" targetFramework="net40" />
   <package id="JetBrainsAnnotations.Fody" version="1.0.4.0" targetFramework="net4" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net40" />

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\FluentDateTime.1.13.0\lib\NET35\FluentDateTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net45\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net45\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">

--- a/src/GitVersionTask.Tests/packages.config
+++ b/src/GitVersionTask.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="ApprovalUtilities" version="3.0.11" targetFramework="net45" />
   <package id="FluentDateTime" version="1.13.0" targetFramework="net45" />
   <package id="Fody" version="1.29.4" targetFramework="net45" developmentDependency="true" />
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net45" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -39,8 +39,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GitTools.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GitTools.Core.1.1.0-beta0001\lib\net4\GitTools.Core.dll</HintPath>
+    <Reference Include="GitTools.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GitTools.Core.1.2.0\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">

--- a/src/GitVersionTask/packages.config
+++ b/src/GitVersionTask/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Caseless.Fody" version="1.4.2" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="1.29.4" targetFramework="net40" developmentDependency="true" />
-  <package id="GitTools.Core" version="1.1.0-beta0001" targetFramework="net40" />
+  <package id="GitTools.Core" version="1.2.0" targetFramework="net40" />
   <package id="ILRepack" version="2.0.10" targetFramework="net40" />
   <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net40" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net40" />


### PR DESCRIPTION
There is a race condition in branch normalisation which seems to have been in there for ages.

If the remote moves on then it will actually move the checked out commit.. Pretty bad bug actually.