### PR TITLE
Remove mentioning of GitHub since this is not specific.

### DIFF
--- a/docs/git-branching-strategies/converting-to-gitflow.md
+++ b/docs/git-branching-strategies/converting-to-gitflow.md
@@ -7,4 +7,4 @@ git checkout -b develop
 git push upstream develop
 ```
 
-Then in GitHub go to your repository settings then set develop to be your default branch. And now all development happens on the `develop` branch
+Afterwards you need to set `develop` to be your default branch. And now all development happens on the `develop` branch


### PR DESCRIPTION
Remove mentioning of GitHub in the documentation since the converting to GitFlow topic is not GitHub specific.