### PR TITLE
Move GitVersionTask into build directory

### DIFF
--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -122,13 +122,12 @@
     <ItemGroup>
       <NativeBinaries Include="$(TargetDir)lib\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetTaskBuild\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="$(TargetDir)LibGit2Sharp.dll.config" DestinationFiles="$(BuildDir)NuGetTaskBuild\GitVersionTask.dll.config" />
-    <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.dll" DestinationFolder="$(BuildDir)NuGetTaskBuild" Condition="Exists('$(TargetDir)ILMergeTemp\GitVersionTask.dll')" />
-    <Copy SourceFiles="$(TargetDir)GitVersionTask.pdb" DestinationFolder="$(BuildDir)NuGetTaskBuild" Condition="Exists('$(TargetDir)GitVersionTask.pdb')" />
-    <Copy SourceFiles="$(TargetDir)GitVersionTask.dll.mdb" DestinationFolder="$(BuildDir)NuGetTaskBuild" Condition="Exists('$(TargetDir)GitVersionTask.dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build\portable-net+sl+win+wpa+wp" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build\dotnet" />
+    <Copy SourceFiles="@(NativeBinaries)" DestinationFiles="@(NativeBinaries->'$(BuildDir)NuGetTaskBuild\build\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="$(TargetDir)LibGit2Sharp.dll.config" DestinationFiles="$(BuildDir)NuGetTaskBuild\build\GitVersionTask.dll.config" />
+    <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.dll" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)ILMergeTemp\GitVersionTask.dll')" />
+    <Copy SourceFiles="$(TargetDir)GitVersionTask.pdb" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)GitVersionTask.pdb')" />
+    <Copy SourceFiles="$(TargetDir)GitVersionTask.dll.mdb" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)GitVersionTask.dll.mdb')" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.nuspec" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetTaskBuild" MetadataAssembly="$(ILMergeTemp)GitVersionTask.dll" Version="$(GitVersion_NuGetVersion)" />
     <Delete Files="@(TempFiles)" />

--- a/src/GitVersionTask/NugetAssets/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/GitVersionTask.targets
@@ -14,17 +14,18 @@
     <!-- Property that enables GetVersion -->
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
+    <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)</GitVersionTaskLibrary>
   </PropertyGroup>
 
   <UsingTask
       TaskName="GitVersionTask.UpdateAssemblyInfo"
-      AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll" />
+      AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
   <UsingTask
     TaskName="GitVersionTask.GetVersion"
-    AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll"  />
+    AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll"  />
   <UsingTask
       TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
-      AssemblyFile="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll" />
+      AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
 
   <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="CoreCompile" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
     <WriteVersionInfoToBuildLog SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
@@ -81,13 +82,13 @@
 
   <!--Support for ncrunch-->
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll">
+    <None Include="$(GitVersionTaskDir)GitVersionTask.dll">
       <Visible>False</Visible>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)..\..\GitVersionTask.pdb">
+    <None Include="$(GitVersionTaskDir)GitVersionTask.pdb">
       <Visible>False</Visible>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)..\..\NativeBinaries\**\*">
+    <None Include="$(GitVersionTaskDir)NativeBinaries\**\*">
       <Visible>False</Visible>
     </None>
   </ItemGroup>


### PR DESCRIPTION
The current layout of the nupkg the task comes in causes problems in some variations of project.json (see description in #1040). This moves all the related build tools into the `build/` folder and removes target specific folders (since they don't add anything special).

Fixes #1040 