### PR TITLE
Use the first matched branch configuration

### DIFF
--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -20,6 +20,14 @@ namespace GitVersion
             if (matchingBranches.Length > 0)
             {
                 branchConfiguration = matchingBranches[0];
+
+                if (matchingBranches.Length > 1) {
+                    Logger.WriteInfo(string.Format(
+                        "Multiple branch configurations match the current branch branchName of '{0}'. Using the first matching configuration, '{1}'. Matching configurations include: '{2}'",
+                        currentBranch.FriendlyName,
+                        branchConfiguration.Name,
+                        string.Join("', '", matchingBranches.Select(b => b.Name))));
+                }
             }
             else
             {

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -21,8 +21,9 @@ namespace GitVersion
             {
                 branchConfiguration = matchingBranches[0];
 
-                if (matchingBranches.Length > 1) {
-                    Logger.WriteInfo(string.Format(
+                if (matchingBranches.Length > 1)
+                {
+                    Logger.WriteWarning(string.Format(
                         "Multiple branch configurations match the current branch branchName of '{0}'. Using the first matching configuration, '{1}'. Matching configurations include: '{2}'",
                         currentBranch.FriendlyName,
                         branchConfiguration.Name,

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -16,14 +16,8 @@ namespace GitVersion
         {
             var matchingBranches = LookupBranchConfiguration(config, currentBranch).ToArray();
 
-            if (matchingBranches.Length > 1)
-            {
-                const string format = "Multiple branch configurations match the current branch branchName of '{0}'. Matching configurations: '{1}'";
-                throw new Exception(string.Format(format, currentBranch.FriendlyName, string.Join(", ", matchingBranches.Select(b => b.Name))));
-            }
-
             BranchConfig branchConfiguration;
-            if (matchingBranches.Length == 1)
+            if (matchingBranches.Length > 0)
             {
                 branchConfiguration = matchingBranches[0];
             }


### PR DESCRIPTION
This change causes GitVersion to allow multiple branch configurations to match the current branch, and instead of throwing an exception it will use the first matching configuration that was found.

Fixes #881 
