### PR TITLE
Remove no break space character that messes up header

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-﻿# Configuration
+# Configuration
 GitVersion 3.0 is mainly powered by configuration and no longer has branching
 strategies hard coded.
 


### PR DESCRIPTION
See http://gitversion.readthedocs.io/en/latest/configuration/ where header "Configuration" is not properly formatted.

Removing \ufeff (nbsp) fixes this.
