### PR TITLE
Support setting Verbosity of GitVersion

### DIFF
--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -133,6 +133,7 @@
     <Compile Include="OutputVariables\VersionVariables.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />
     <Compile Include="SemanticVersionFormatValues.cs" />
+    <Compile Include="VerbosityLevel.cs" />
     <Compile Include="VersionFilters\MinDateVersionFilter.cs" />
     <Compile Include="VersionFilters\IVersionFilter.cs" />
     <Compile Include="VersionFilters\ShaVersionFilter.cs" />

--- a/src/GitVersionCore/VerbosityLevel.cs
+++ b/src/GitVersionCore/VerbosityLevel.cs
@@ -1,0 +1,10 @@
+﻿namespace GitVersion
+{
+    public enum VerbosityLevel
+    {
+        None,
+        Error,
+        Warn,
+        Info
+    }
+}

--- a/src/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/src/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -338,4 +338,23 @@ public class ArgumentParserTests
         var arguments = ArgumentParser.ParseArguments("-nocache");
         arguments.NoCache.ShouldBe(true);
     }
+
+    [TestCase("-verbosity x", true, VerbosityLevel.None)]
+    [TestCase("-verbosity none", false, VerbosityLevel.None)]
+    [TestCase("-verbosity info", false, VerbosityLevel.Info)]
+    [TestCase("-verbosity INFO", false, VerbosityLevel.Info)]
+    [TestCase("-verbosity warn", false, VerbosityLevel.Warn)]
+    [TestCase("-verbosity error", false, VerbosityLevel.Error)]
+    public void check_verbosity_parsing(string command, bool shouldThrow, VerbosityLevel expectedVerbosity)
+    {
+        if (shouldThrow)
+        {
+            Assert.Throws<WarningException>(() => ArgumentParser.ParseArguments(command));
+        }
+        else
+        {
+            var arguments = ArgumentParser.ParseArguments(command);
+            arguments.Verbosity.ShouldBe(expectedVerbosity);
+        }
+    }
 }

--- a/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
@@ -62,6 +62,24 @@ public class ExecCmdLineArgumentTest
         }
     }
 
+    [Theory]
+    [TestCase("", "INFO [")]
+    [TestCase("-verbosity Info", "INFO [")]
+    [TestCase("-verbosity Error", "")]
+    public void CheckBuildServerVerbosityConsole(string verbosityArg, string expectedOutput)
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeATaggedCommit("1.2.3");
+            fixture.MakeACommit();
+
+            var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, arguments: String.Format( @" {0} -output buildserver /l ""/some/path""", verbosityArg), logToFile: false);
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldContain(expectedOutput);
+        }
+    }
+
     [Test]
     public void WorkingDirectoryWithoutGitFolderCrashesWithInformativeMessage()
     {

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -312,6 +312,15 @@ namespace GitVersion
                     continue;
                 }
 
+                if (name.IsSwitch("verbosity"))
+                {
+                    if (!Enum.TryParse(value, true, out arguments.Verbosity))
+                    {
+                        throw new WarningException(String.Format("Could not parse Verbosity value '{0}'", value));
+                    }
+                    continue;
+                }
+
                 var couldNotParseMessage = string.Format("Could not parse command line parameter '{0}'.", name);
 
                 // If we've reached through all argument switches without a match, we can relatively safely assume that the first argument isn't a switch, but the target path.

--- a/src/GitVersionExe/Arguments.cs
+++ b/src/GitVersionExe/Arguments.cs
@@ -10,6 +10,7 @@ namespace GitVersion
             OverrideConfig = new Config();
             Output = OutputType.Json;
             UpdateAssemblyInfoFileName = new HashSet<string>();
+            Verbosity = VerbosityLevel.Info;
         }
 
         public Authentication Authentication;
@@ -44,6 +45,8 @@ namespace GitVersion
         public bool ShowConfig;
         public bool NoFetch;
         public bool NoCache;
+
+        public VerbosityLevel Verbosity;
 
         public void AddAssemblyInfoFileName(string fileName)
         {

--- a/src/GitVersionExe/HelpWriter.cs
+++ b/src/GitVersionExe/HelpWriter.cs
@@ -54,6 +54,7 @@ GitVersion [path]
     /execargs       Arguments for the executable specified by /exec
     /proj           Build a msbuild file, GitVersion variables will be passed as msbuild properties
     /projargs       Additional arguments to pass to msbuild
+    /verbosity      Set Verbosity level (info, warn, error, none). Default is info
 
 
 gitversion init     Configuration utility for gitversion

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -169,9 +169,9 @@ namespace GitVersion
             }
 
             Logger.SetLoggers(
-                s => writeActions.ForEach(a => a(s)),
-                s => writeActions.ForEach(a => a(s)),
-                s => writeActions.ForEach(a => a(s)));
+                s => writeActions.ForEach(a => { if (arguments.Verbosity >= VerbosityLevel.Info) a(s); }),
+                s => writeActions.ForEach(a => { if (arguments.Verbosity >= VerbosityLevel.Warn) a(s); }),
+                s => writeActions.ForEach(a => { if (arguments.Verbosity >= VerbosityLevel.Error) a(s); }));
 
             if (exception != null)
                 Logger.WriteError(string.Format("Failed to configure logging for '{0}': {1}", arguments.LogFilePath, exception.Message));

--- a/src/GitVersionTfsTask/GitVersion.ps1
+++ b/src/GitVersionTfsTask/GitVersion.ps1
@@ -54,6 +54,13 @@ if($additionalArguments)
   $argsGitVersion = $argsGitVersion + " $additionalArguments"
 }
 
+if(!$additionalArguments -or !$additionalArguments.Contains("-debug"))
+{
+  if([string]::IsNullOrEmpty($env:SYSTEM_DEBUG) -or $env:SYSTEM_DEBUG -ne "true"){
+    $argsGitVersion = $argsGitVersion + " -verbosity Error"
+  }
+}
+
 Write-Host (Get-LocalizedString -Key "Invoking GitVersion with {0}" -ArgumentList $argsGitVersion)
 
 Invoke-Tool -Path $GitVersionPath -Arguments "$argsGitVersion"


### PR DESCRIPTION
Hi,

I added support to set verbosity of GitVersion when launching command line

GitVersion.exe -Verbosity Error allows to have less info/debug messages in your logs

fixes #955 

Thomas P.