### PR TITLE
Fixes #1053: exclude NCrunch ItemGroup when NCrunch not present

### DIFF
--- a/src/GitVersionTask/NugetAssets/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/GitVersionTask.targets
@@ -79,7 +79,7 @@
   </Target>
 
   <!--Support for ncrunch-->
-  <ItemGroup>
+  <ItemGroup Condition=" $(NCrunch) != '' ">
     <None Include="$(MSBuildThisFileDirectory)..\..\GitVersionTask.dll">
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
This adds a condition to the ItemGroup that is required for NCrunch so that it is excluded when NCrunch is not installed. This is similar to the conditions [here](https://github.com/GitTools/GitVersion/blob/v3.6.3/src/GitVersionTask/GitVersionTask.csproj#L110) and [here](https://github.com/GitTools/GitVersion/blob/v3.6.3/src/GitVersionExe/GitVersionExe.csproj#L83) which also affect a section depending on the presence of NCrunch