### PR TITLE
Use the Inherit strategy by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ next-version: 1.0
 assembly-versioning-scheme: MajorMinorPatch
 assembly-informational-format: '{InformationalVersion}'
 mode: ContinuousDelivery
+increment: Inherit
 continuous-delivery-fallback-tag: ci
 tag-prefix: '[vV]'
 major-version-bump-message: '\+semver:\s?(breaking|major)'
@@ -69,6 +70,11 @@ value of the `AssemblyInformationalVersion` attribute. Default set to
 ### mode
 Sets the `mode` of how GitVersion should create a new version. Read more at
 [versioning mode](/reference/versioning-mode.md).
+
+### increment
+The part of the SemVer to increment when GitVersion detects it needs to be increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
+
+The special value `Inherit` means that GitVersion should find the parent branch (i.e. the branch where the current branch was branched from), and use its values for [increment](#increment), [prevent-increment-of-merged-branch-version](#prevent-increment-of-merged-branch-version) and [is-develop](#is-develop).
 
 ### continuous-delivery-fallback-tag
 When using `mode: ContinuousDeployment`, the value specified in
@@ -246,8 +252,7 @@ of `alpha.foo` with the value of `alpha.{BranchName}`.
 **Note:** To clear a default use an empty string: `tag: ''`
 
 ### increment
-The part of the SemVer to increment when GitVersion detects it needs to be (i.e
-commit after a tag)
+Same as for the [global configuration, explained above](#increment).
 
 ### prevent-increment-of-merged-branch-version
 When `release-2.0.0` is merged into master, we want master to build `2.0.0`. If

--- a/docs/more-info/version-sources.md
+++ b/docs/more-info/version-sources.md
@@ -1,5 +1,5 @@
 # Version Sources
-GitVersion has a two step process for calculating the version number, the first is to calculate the base version which is used to then calculate what the next version should be.
+GitVersion has a two step process for calculating the version number. First it calculates the base version, which is then used to calculate what the next version should be.
 
 The logic of GitVersion is something like this:
 
@@ -8,26 +8,38 @@ The logic of GitVersion is something like this:
    - No: continue
  - Calculate the base version (highest version from all the sources)
  - Increment version if needed based on branch config
- - Calculate the build metadata (everything after the +) and append to the calcuated version
+ - Calculate the build metadata (everything after the +) and append to the calculated version
 
 ## Version Sources
-### Highest Accessible Tag
-GitVersion will find all tags on the current branch and return the highest one.
+### Tag name
+Returns the version numbers extracted from the current branch's tags.
 
 Will increment: true
 
 ### Version in branch name
-If the branch has a version in it, then that version will be returned.
+Returns the version number from the branch's name.
 
 Will increment: false
 
 ### Merge message
-If a branch with a version number in it is merged into the current branch, that version number will be used.
+Returns the version number of any branch (with a version number in its name) merged into the current branch.
+
+Will increment: depends on the value of `prevent-increment-of-merged-branch-version`
+
+### GitVersion.yml
+Returns the value of the `next-version` property in the config file.
 
 Will increment: false
 
-### GitVersion.yml
-If the `next-version` property is specified in the config file, it will be used as a version source.
+### Develop branch
+For the develop branch, i.e. marked with `is-develop: true`
+- Returns the version number extracted from any child release-branches, i.e. those marked with `is-release-branch: true`
+- Returns the version number of any tags on the master branch
+
+Will increment: true 
+
+### Fallback
+Returns the version number `0.1.0`.
 
 Will increment: false
 

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -173,7 +173,7 @@
     <Compile Include="VersionCalculation\Strategies\ConfigNextVersionBaseVersionStrategyTests.cs" />
     <Compile Include="GitVersionContextBuilder.cs" />
     <Compile Include="VersionCalculation\Strategies\MergeMessageBaseVersionStrategyTests.cs" />
-    <Compile Include="VersionCalculation\Strategies\VersionInBranchBaseVersionStrategyTests.cs" />
+    <Compile Include="VersionCalculation\Strategies\VersionInBranchNameBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\TestBaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\TestMetaDataCalculator.cs" />
     <Compile Include="VersionFilters\MinDateVersionFilterTests.cs" />

--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using GitTools.Testing;
 using GitVersion;
 using GitVersionCore.Tests;
@@ -223,7 +224,7 @@ public class FeatureBranchScenarios
             fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release/0.2.0");
             fixture.Repository.Branches.Remove("release/2.0.0");
-                
+
             fixture.Repository.MakeACommit();
 
             //validate develop branch version after merging release 0.2.0 to master and develop (finish release)
@@ -235,6 +236,240 @@ public class FeatureBranchScenarios
 
             //I'm not entirely sure what the + value should be but I know the semvar major/minor/patch should be 0.3.0
             fixture.AssertFullSemver("0.3.0-TEST-1.1+2");
+        }
+    }
+
+    [Test]
+    public void ShouldPickUpVersionFromDevelopAfterReleaseBranchCreated()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            // Create develop and release branches
+            fixture.MakeACommit();
+            fixture.BranchTo("develop");
+            fixture.MakeACommit();
+            fixture.BranchTo("release/1.0");
+            fixture.MakeACommit();
+            fixture.Checkout("develop");
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.1.0-alpha.1");
+
+            // create a feature branch from develop and verify the version
+            fixture.BranchTo("feature/test");
+            fixture.AssertFullSemver("1.1.0-test.1+1");
+        }
+    }
+
+    [Test]
+    public void ShouldPickUpVersionFromDevelopAfterReleaseBranchMergedBack()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            // Create develop and release branches
+            fixture.MakeACommit();
+            fixture.BranchTo("develop");
+            fixture.MakeACommit();
+            fixture.BranchTo("release/1.0");
+            fixture.MakeACommit();
+
+            // merge release into develop
+            fixture.Checkout("develop");
+            fixture.MergeNoFF("release/1.0");
+            fixture.AssertFullSemver("1.1.0-alpha.2");
+
+            // create a feature branch from develop and verify the version
+            fixture.BranchTo("feature/test");
+            fixture.AssertFullSemver("1.1.0-test.1+2");
+        }
+    }
+
+    public class WhenMasterMarkedAsIsDevelop
+    {
+        [Test]
+        public void ShouldPickUpVersionFromMasterAfterReleaseBranchCreated()
+        {
+            var config = new Config
+            {
+                Branches = new Dictionary<string, BranchConfig>
+                {
+                    {
+                        "master", new BranchConfig()
+                        {
+                            IsDevelop = true,
+                            Regex = "master"
+                        }
+                    }
+                }
+            };
+
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                // Create release branch
+                fixture.MakeACommit();
+                fixture.BranchTo("release/1.0");
+                fixture.MakeACommit();
+                fixture.Checkout("master");
+                fixture.MakeACommit();
+                fixture.AssertFullSemver(config, "1.0.1+1");
+
+                // create a feature branch from master and verify the version
+                fixture.BranchTo("feature/test");
+                fixture.AssertFullSemver(config, "1.0.1-test.1+1");
+            }
+        }
+
+        [Test]
+        public void ShouldPickUpVersionFromMasterAfterReleaseBranchMergedBack()
+        {
+            var config = new Config
+            {
+                Branches = new Dictionary<string, BranchConfig>
+                {
+                    {
+                        "master", new BranchConfig()
+                        {
+                            IsDevelop = true,
+                            Regex = "master"
+                        }
+                    }
+                }
+            };
+
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                // Create release branch
+                fixture.MakeACommit();
+                fixture.BranchTo("release/1.0");
+                fixture.MakeACommit();
+
+                // merge release into master
+                fixture.Checkout("master");
+                fixture.MergeNoFF("release/1.0");
+                fixture.AssertFullSemver(config, "1.0.1+2");
+
+                // create a feature branch from master and verify the version
+                fixture.BranchTo("feature/test");
+                fixture.AssertFullSemver(config, "1.0.1-test.1+2");
+            }
+        }
+    }
+
+    public class WhenFeatureBranchHasNoConfig
+    {
+        [Test]
+        public void ShouldPickUpVersionFromMasterAfterReleaseBranchCreated()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                // Create develop and release branches
+                fixture.MakeACommit();
+                fixture.BranchTo("develop");
+                fixture.MakeACommit();
+                fixture.BranchTo("release/1.0");
+                fixture.MakeACommit();
+                fixture.Checkout("develop");
+                fixture.MakeACommit();
+                fixture.AssertFullSemver("1.1.0-alpha.1");
+
+                // create a misnamed feature branch (i.e. it uses the default config) from develop and verify the version
+                fixture.BranchTo("misnamed");
+                fixture.AssertFullSemver("1.1.0-misnamed.1+1");
+            }
+        }
+
+        [Test]
+        public void ShouldPickUpVersionFromDevelopAfterReleaseBranchMergedBack()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                // Create develop and release branches
+                fixture.MakeACommit();
+                fixture.BranchTo("develop");
+                fixture.MakeACommit();
+                fixture.BranchTo("release/1.0");
+                fixture.MakeACommit();
+
+                // merge release into develop
+                fixture.Checkout("develop");
+                fixture.MergeNoFF("release/1.0");
+                fixture.AssertFullSemver("1.1.0-alpha.2");
+
+                // create a misnamed feature branch (i.e. it uses the default config) from develop and verify the version
+                fixture.BranchTo("misnamed");
+                fixture.AssertFullSemver("1.1.0-misnamed.1+2");
+            }
+        }
+
+        // ReSharper disable once MemberHidesStaticFromOuterClass
+        public class WhenMasterMarkedAsIsDevelop
+        {
+            [Test]
+            public void ShouldPickUpVersionFromMasterAfterReleaseBranchCreated()
+            {
+                var config = new Config
+                {
+                    Branches = new Dictionary<string, BranchConfig>
+                    {
+                        {
+                            "master", new BranchConfig()
+                            {
+                                IsDevelop = true,
+                                Regex = "master"
+                            }
+                        }
+                    }
+                };
+
+                using (var fixture = new EmptyRepositoryFixture())
+                {
+                    // Create release branch
+                    fixture.MakeACommit();
+                    fixture.BranchTo("release/1.0");
+                    fixture.MakeACommit();
+                    fixture.Checkout("master");
+                    fixture.MakeACommit();
+                    fixture.AssertFullSemver(config, "1.0.1+1");
+
+                    // create a misnamed feature branch (i.e. it uses the default config) from master and verify the version
+                    fixture.BranchTo("misnamed");
+                    fixture.AssertFullSemver(config, "1.0.1-misnamed.1+1");
+                }
+            }
+
+            [Test]
+            public void ShouldPickUpVersionFromMasterAfterReleaseBranchMergedBack()
+            {
+                var config = new Config
+                {
+                    Branches = new Dictionary<string, BranchConfig>
+                    {
+                        {
+                            "master", new BranchConfig()
+                            {
+                                IsDevelop = true,
+                                Regex = "master"
+                            }
+                        }
+                    }
+                };
+
+                using (var fixture = new EmptyRepositoryFixture())
+                {
+                    // Create release branch
+                    fixture.MakeACommit();
+                    fixture.BranchTo("release/1.0");
+                    fixture.MakeACommit();
+
+                    // merge release into master
+                    fixture.Checkout("master");
+                    fixture.MergeNoFF("release/1.0");
+                    fixture.AssertFullSemver(config, "1.0.1+2");
+
+                    // create a misnamed feature branch (i.e. it uses the default config) from master and verify the version
+                    fixture.BranchTo("misnamed");
+                    fixture.AssertFullSemver(config, "1.0.1-misnamed.1+2");
+                }
+            }
         }
     }
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -58,47 +58,61 @@
         [Test]
         public void PreReleaseTagCanUseBranchName()
         {
-            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), new MockCommit());
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(2, "develop", "b1a34e", DateTimeOffset.Now);
-            var sut = new NextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
-            var config = new Config();
-            config.Branches.Add("custom", new BranchConfig
+            var config = new Config
             {
-                Regex = "custom/",
-                Tag = "useBranchName"
-            });
-            var context = new GitVersionContextBuilder()
-                .WithConfig(config)
-                .WithDevelopBranch()
-                .AddBranch("custom/foo")
-                .Build();
+                NextVersion = "1.0.0",
+                Branches = new Dictionary<string, BranchConfig>
+                {
+                    {
+                        "custom", new BranchConfig
+                        {
+                            Regex = "custom/",
+                            Tag = "useBranchName"
+                        }
+                    }
+                }
+            };
 
-            var version = sut.FindVersion(context);
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.MakeACommit();
+                fixture.BranchTo("develop");
+                fixture.MakeACommit();
+                fixture.BranchTo("custom/foo");
+                fixture.MakeACommit();
 
-            version.ToString("f").ShouldBe("1.0.0-foo.1+2");
+                fixture.AssertFullSemver(config, "1.0.0-foo.1+2");
+            }
         }
 
         [Test]
         public void PreReleaseTagCanUseBranchNameVariable()
         {
-            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), new MockCommit());
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(2, "develop", "b1a34e", DateTimeOffset.Now);
-            var sut = new NextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
-            var config = new Config();
-            config.Branches.Add("custom", new BranchConfig
+            var config = new Config
             {
-                Regex = "custom/",
-                Tag = "alpha.{BranchName}"
-            });
-            var context = new GitVersionContextBuilder()
-                .WithConfig(config)
-                .WithDevelopBranch()
-                .AddBranch("custom/foo")
-                .Build();
+                NextVersion = "1.0.0",
+                Branches = new Dictionary<string, BranchConfig>
+                {
+                    {
+                        "custom", new BranchConfig
+                        {
+                            Regex = "custom/",
+                            Tag = "alpha.{BranchName}"
+                        }
+                    }
+                }
+            };
 
-            var version = sut.FindVersion(context);
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.MakeACommit();
+                fixture.BranchTo("develop");
+                fixture.MakeACommit();
+                fixture.BranchTo("custom/foo");
+                fixture.MakeACommit();
 
-            version.ToString("f").ShouldBe("1.0.0-alpha.foo.1+2");
+                fixture.AssertFullSemver(config, "1.0.0-alpha.foo.1+2");
+            }
         }
 
         [Test]

--- a/src/GitVersionCore.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
@@ -9,7 +9,7 @@
     using Shouldly;
 
     [TestFixture]
-    public class VersionInBranchBaseVersionStrategyTests
+    public class VersionInBranchNameBaseVersionStrategyTests
     {
         [Test]
         [TestCase("release-2.0.0", "2.0.0")]
@@ -23,7 +23,7 @@
             {
                 fixture.Repository.MakeACommit();
                 var branch = fixture.Repository.CreateBranch(branchName);
-                var sut = new VersionInBranchBaseVersionStrategy();
+                var sut = new VersionInBranchNameBaseVersionStrategy();
 
                 var gitVersionContext = new GitVersionContext(fixture.Repository, branch, new Config().ApplyDefaults());
                 var baseVersion = sut.GetVersions(gitVersionContext).SingleOrDefault();

--- a/src/GitVersionCore/BranchCommit.cs
+++ b/src/GitVersionCore/BranchCommit.cs
@@ -1,0 +1,51 @@
+﻿namespace GitVersion
+{
+    using LibGit2Sharp;
+
+    /// <summary>
+    /// A commit, together with the branch to which the commit belongs.
+    /// </summary>
+    public struct BranchCommit
+    {
+        public static readonly BranchCommit Empty = new BranchCommit();
+
+        public BranchCommit(Commit commit, Branch branch) : this()
+        {
+            Branch = branch;
+            Commit = commit;
+        }
+
+        public Branch Branch { get; private set; }
+        public Commit Commit { get; private set; }
+
+        public bool Equals(BranchCommit other)
+        {
+            return Equals(Branch, other.Branch) && Equals(Commit, other.Commit);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            return obj is BranchCommit && Equals((BranchCommit)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Branch != null ? Branch.GetHashCode() : 0) * 397) ^ (Commit != null ? Commit.GetHashCode() : 0);
+            }
+        }
+
+        public static bool operator ==(BranchCommit left, BranchCommit right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(BranchCommit left, BranchCommit right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -89,7 +89,7 @@ namespace GitVersion
 
                 var branchPoint = currentBranch.FindCommitBranchWasBranchedFrom(repository, excludedInheritBranches.ToArray());
                 List<Branch> possibleParents;
-                if (branchPoint == null)
+                if (branchPoint == BranchCommit.Empty)
                 {
                     possibleParents = currentCommit.GetBranchesContainingCommit(repository, branchesToEvaluate, true)
                         // It fails to inherit Increment branch configuration if more than 1 parent;
@@ -99,7 +99,7 @@ namespace GitVersion
                 }
                 else
                 {
-                    var branches = branchPoint.GetBranchesContainingCommit(repository, branchesToEvaluate, true).ToList();
+                    var branches = branchPoint.Commit.GetBranchesContainingCommit(repository, branchesToEvaluate, true).ToList();
                     if (branches.Count > 1)
                     {
                         var currentTipBranches = currentCommit.GetBranchesContainingCommit(repository, branchesToEvaluate, true).ToList();

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -11,9 +11,12 @@ namespace GitVersion
 
     public class BranchConfigurationCalculator
     {
-        public static KeyValuePair<string, BranchConfig> GetBranchConfiguration(Commit currentCommit, IRepository repository, bool onlyEvaluateTrackedBranches, Config config, Branch currentBranch, IList<Branch> excludedInheritBranches = null)
+        /// <summary>
+        /// Gets the <see cref="BranchConfig"/> for the current commit.
+        /// </summary>
+        public static BranchConfig GetBranchConfiguration(Commit currentCommit, IRepository repository, bool onlyEvaluateTrackedBranches, Config config, Branch currentBranch, IList<Branch> excludedInheritBranches = null)
         {
-            var matchingBranches = LookupBranchConfiguration(config, currentBranch);
+            var matchingBranches = LookupBranchConfiguration(config, currentBranch).ToArray();
 
             if (matchingBranches.Length == 0)
             {
@@ -21,44 +24,44 @@ namespace GitVersion
                     "No branch configuration found for branch {0}, falling back to default configuration",
                     currentBranch.FriendlyName));
 
-                var branchConfig = new BranchConfig();
+                var branchConfig = new BranchConfig { Name = string.Empty };
                 ConfigurationProvider.ApplyBranchDefaults(config, branchConfig, "");
-                return new KeyValuePair<string, BranchConfig>(string.Empty, branchConfig);
+                return branchConfig;
             }
+
             if (matchingBranches.Length == 1)
             {
-                var keyValuePair = matchingBranches[0];
-                var branchConfiguration = keyValuePair.Value;
+                var branchConfiguration = matchingBranches[0];
 
                 if (branchConfiguration.Increment == IncrementStrategy.Inherit)
                 {
-                    return InheritBranchConfiguration(onlyEvaluateTrackedBranches, repository, currentCommit, currentBranch, keyValuePair, branchConfiguration, config, excludedInheritBranches);
+                    return InheritBranchConfiguration(onlyEvaluateTrackedBranches, repository, currentCommit, currentBranch, branchConfiguration, config, excludedInheritBranches);
                 }
 
-                return keyValuePair;
+                return branchConfiguration;
             }
 
             const string format = "Multiple branch configurations match the current branch branchName of '{0}'. Matching configurations: '{1}'";
-            throw new Exception(string.Format(format, currentBranch.FriendlyName, string.Join(", ", matchingBranches.Select(b => b.Key))));
+            throw new Exception(string.Format(format, currentBranch.FriendlyName, string.Join(", ", matchingBranches.Select(b => b.Name))));
         }
 
-        static KeyValuePair<string, BranchConfig>[] LookupBranchConfiguration([NotNull] Config config, [NotNull] Branch currentBranch)
+        static IEnumerable<BranchConfig> LookupBranchConfiguration([NotNull] Config config, [NotNull] Branch currentBranch)
         {
             if (config == null)
             {
                 throw new ArgumentNullException("config");
             }
-            
+
             if (currentBranch == null)
             {
                 throw new ArgumentNullException("currentBranch");
             }
 
-            return config.Branches.Where(b => Regex.IsMatch(currentBranch.FriendlyName, "^" + b.Value.Regex, RegexOptions.IgnoreCase)).ToArray();
+            return config.Branches.Where(b => Regex.IsMatch(currentBranch.FriendlyName, "^" + b.Value.Regex, RegexOptions.IgnoreCase)).Select(kvp => kvp.Value);
         }
 
 
-        static KeyValuePair<string, BranchConfig> InheritBranchConfiguration(bool onlyEvaluateTrackedBranches, IRepository repository, Commit currentCommit, Branch currentBranch, KeyValuePair<string, BranchConfig> keyValuePair, BranchConfig branchConfiguration, Config config, IList<Branch> excludedInheritBranches)
+        static BranchConfig InheritBranchConfiguration(bool onlyEvaluateTrackedBranches, IRepository repository, Commit currentCommit, Branch currentBranch, BranchConfig branchConfiguration, Config config, IList<Branch> excludedInheritBranches)
         {
             using (Logger.IndentLog("Attempting to inherit branch configuration from parent branch"))
             {
@@ -74,11 +77,11 @@ namespace GitVersion
                 {
                     excludedInheritBranches = repository.Branches.Where(b =>
                     {
-                        var branchConfig = LookupBranchConfiguration(config, b);
+                        var branchConfig = LookupBranchConfiguration(config, b).ToArray();
 
                         // NOTE: if length is 0 we couldn't find the configuration for the branch e.g. "origin/master"
                         // NOTE: if the length is greater than 1 we cannot decide which merge strategy to pick
-                        return (branchConfig.Length != 1) || (branchConfig.Length == 1 && branchConfig[0].Value.Increment == IncrementStrategy.Inherit);
+                        return (branchConfig.Length != 1) || (branchConfig.Length == 1 && branchConfig[0].Increment == IncrementStrategy.Inherit);
                     }).ToList();
                 }
                 excludedBranches.ToList().ForEach(excludedInheritBranches.Add);
@@ -112,16 +115,14 @@ namespace GitVersion
 
                 if (possibleParents.Count == 1)
                 {
-                    var branchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, possibleParents[0], excludedInheritBranches).Value;
-                    return new KeyValuePair<string, BranchConfig>(
-                        keyValuePair.Key,
-                        new BranchConfig(branchConfiguration)
-                        {
-                            Increment = branchConfig.Increment,
-                            PreventIncrementOfMergedBranchVersion = branchConfig.PreventIncrementOfMergedBranchVersion,
-                            // If we are inheriting from develop then we should behave like develop
-                            IsDevelop = branchConfig.IsDevelop
-                        });
+                    var branchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, possibleParents[0], excludedInheritBranches);
+                    return new BranchConfig(branchConfiguration)
+                    {
+                        Increment = branchConfig.Increment,
+                        PreventIncrementOfMergedBranchVersion = branchConfig.PreventIncrementOfMergedBranchVersion,
+                        // If we are inheriting from develop then we should behave like develop
+                        IsDevelop = branchConfig.IsDevelop
+                    };
                 }
 
                 // If we fail to inherit it is probably because the branch has been merged and we can't do much. So we will fall back to develop's config
@@ -144,16 +145,14 @@ namespace GitVersion
                 var branchName = chosenBranch.FriendlyName;
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
 
-                var inheritingBranchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch).Value;
-                return new KeyValuePair<string, BranchConfig>(
-                    keyValuePair.Key,
-                    new BranchConfig(branchConfiguration)
-                    {
-                        Increment = inheritingBranchConfig.Increment,
-                        PreventIncrementOfMergedBranchVersion = inheritingBranchConfig.PreventIncrementOfMergedBranchVersion,
-                        // If we are inheriting from develop then we should behave like develop
-                        IsDevelop = inheritingBranchConfig.IsDevelop
-                    });
+                var inheritingBranchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch);
+                return new BranchConfig(branchConfiguration)
+                {
+                    Increment = inheritingBranchConfig.Increment,
+                    PreventIncrementOfMergedBranchVersion = inheritingBranchConfig.PreventIncrementOfMergedBranchVersion,
+                    // If we are inheriting from develop then we should behave like develop
+                    IsDevelop = inheritingBranchConfig.IsDevelop
+                };
             }
         }
 

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -18,31 +18,30 @@ namespace GitVersion
         {
             var matchingBranches = LookupBranchConfiguration(config, currentBranch).ToArray();
 
-            if (matchingBranches.Length == 0)
+            if (matchingBranches.Length > 1)
+            {
+                const string format = "Multiple branch configurations match the current branch branchName of '{0}'. Matching configurations: '{1}'";
+                throw new Exception(string.Format(format, currentBranch.FriendlyName, string.Join(", ", matchingBranches.Select(b => b.Name))));
+            }
+
+            BranchConfig branchConfiguration;
+            if (matchingBranches.Length == 1)
+            {
+                branchConfiguration = matchingBranches[0];
+            }
+            else
             {
                 Logger.WriteInfo(string.Format(
                     "No branch configuration found for branch {0}, falling back to default configuration",
                     currentBranch.FriendlyName));
 
-                var branchConfig = new BranchConfig { Name = string.Empty };
-                ConfigurationProvider.ApplyBranchDefaults(config, branchConfig, "");
-                return branchConfig;
+                branchConfiguration = new BranchConfig { Name = string.Empty };
+                ConfigurationProvider.ApplyBranchDefaults(config, branchConfiguration, "");
             }
 
-            if (matchingBranches.Length == 1)
-            {
-                var branchConfiguration = matchingBranches[0];
-
-                if (branchConfiguration.Increment == IncrementStrategy.Inherit)
-                {
-                    return InheritBranchConfiguration(onlyEvaluateTrackedBranches, repository, currentCommit, currentBranch, branchConfiguration, config, excludedInheritBranches);
-                }
-
-                return branchConfiguration;
-            }
-
-            const string format = "Multiple branch configurations match the current branch branchName of '{0}'. Matching configurations: '{1}'";
-            throw new Exception(string.Format(format, currentBranch.FriendlyName, string.Join(", ", matchingBranches.Select(b => b.Name))));
+            return branchConfiguration.Increment == IncrementStrategy.Inherit ?
+                InheritBranchConfiguration(onlyEvaluateTrackedBranches, repository, currentCommit, currentBranch, branchConfiguration, config, excludedInheritBranches) :
+                branchConfiguration;
         }
 
         static IEnumerable<BranchConfig> LookupBranchConfiguration([NotNull] Config config, [NotNull] Branch currentBranch)
@@ -59,7 +58,6 @@ namespace GitVersion
 
             return config.Branches.Where(b => Regex.IsMatch(currentBranch.FriendlyName, "^" + b.Value.Regex, RegexOptions.IgnoreCase)).Select(kvp => kvp.Value);
         }
-
 
         static BranchConfig InheritBranchConfiguration(bool onlyEvaluateTrackedBranches, IRepository repository, Commit currentCommit, Branch currentBranch, BranchConfig branchConfiguration, Config config, IList<Branch> excludedInheritBranches)
         {

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -24,6 +24,7 @@
             IsDevelop = branchConfiguration.IsDevelop;
             IsReleaseBranch = branchConfiguration.IsReleaseBranch;
             IsMainline = branchConfiguration.IsMainline;
+            Name = branchConfiguration.Name;
         }
 
         [YamlMember(Alias = "mode")]
@@ -61,5 +62,11 @@
 
         [YamlMember(Alias = "is-mainline")]
         public bool? IsMainline { get; set; }
+
+        /// <summary>
+        /// The name given to this configuration in the config file.
+        /// </summary>
+        [YamlIgnore]
+        public string Name { get; set; }
     }
 }

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -8,9 +8,11 @@
         {
         }
 
+        /// <summary>
+        /// Creates a clone of the given <paramref name="branchConfiguration"/>.
+        /// </summary>
         public BranchConfig(BranchConfig branchConfiguration)
         {
-            Regex = branchConfiguration.Regex;
             VersioningMode = branchConfiguration.VersioningMode;
             Tag = branchConfiguration.Tag;
             Increment = branchConfiguration.Increment;
@@ -18,6 +20,7 @@
             TagNumberPattern = branchConfiguration.TagNumberPattern;
             TrackMergeTarget = branchConfiguration.TrackMergeTarget;
             CommitMessageIncrementing = branchConfiguration.CommitMessageIncrementing;
+            Regex = branchConfiguration.Regex;
             IsDevelop = branchConfiguration.IsDevelop;
             IsReleaseBranch = branchConfiguration.IsReleaseBranch;
             IsMainline = branchConfiguration.IsMainline;
@@ -43,7 +46,7 @@
 
         [YamlMember(Alias = "track-merge-target")]
         public bool? TrackMergeTarget { get; set; }
-        
+
         [YamlMember(Alias = "commit-message-incrementing")]
         public CommitMessageIncrementMode? CommitMessageIncrementing { get; set; }
 

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -79,7 +79,7 @@
                 value.ToList().ForEach(_ =>
                 {
                     if (!branches.ContainsKey(_.Key))
-                        branches.Add(_.Key, new BranchConfig());
+                        branches.Add(_.Key, new BranchConfig {Name = _.Key});
 
                     branches[_.Key] = MergeObjects(branches[_.Key], _.Value);
                 });

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -99,5 +99,8 @@
 
         [YamlMember(Alias = "ignore")]
         public IgnoreConfig Ignore { get; set; }
+
+        [YamlMember(Alias = "increment")]
+        public IncrementStrategy? Increment { get; set; }
     }
 }

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -29,6 +29,8 @@ namespace GitVersion
         public const string SupportBranchKey = "support";
         public const string DevelopBranchKey = "develop";
 
+        private const IncrementStrategy DefaultIncrementStrategy = IncrementStrategy.Inherit;
+
         public static Config Provide(GitPreparer gitPreparer, IFileSystem fileSystem, bool applyDefaults = true, Config overrideConfig = null)
         {
             var workingDirectory = gitPreparer.WorkingDirectory;
@@ -98,24 +100,44 @@ If the docs do not help you decide on the mode open an issue to discuss what you
 
             var configBranches = config.Branches.ToList();
 
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, MasterBranchKey),
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, MasterBranchKey),
                 MasterBranchRegex,
                 defaultTag: string.Empty,
                 defaultPreventIncrement: true,
+                defaultIncrementStrategy: IncrementStrategy.Patch,
                 isMainline: true);
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, ReleaseBranchKey), ReleaseBranchRegex, defaultTag: "beta", defaultPreventIncrement: true, isReleaseBranch: true);
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, FeatureBranchKey), FeatureBranchRegex, defaultIncrementStrategy: IncrementStrategy.Inherit);
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, PullRequestBranchKey), PullRequestRegex,
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, ReleaseBranchKey),
+                ReleaseBranchRegex,
+                defaultTag: "beta",
+                defaultPreventIncrement: true,
+                defaultIncrementStrategy: IncrementStrategy.Patch,
+                isReleaseBranch: true);
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, FeatureBranchKey),
+                FeatureBranchRegex,
+                defaultIncrementStrategy: IncrementStrategy.Inherit);
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, PullRequestBranchKey),
+                PullRequestRegex,
                 defaultTag: "PullRequest",
                 defaultTagNumberPattern: @"[/-](?<number>\d+)[-/]",
                 defaultIncrementStrategy: IncrementStrategy.Inherit);
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, HotfixBranchKey), HotfixBranchRegex, defaultTag: "beta");
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, SupportBranchKey),
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, HotfixBranchKey),
+                HotfixBranchRegex,
+                defaultTag: "beta",
+                defaultIncrementStrategy: IncrementStrategy.Patch);
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, SupportBranchKey),
                 SupportBranchRegex,
                 defaultTag: string.Empty,
                 defaultPreventIncrement: true,
+                defaultIncrementStrategy: IncrementStrategy.Patch,
                 isMainline: true);
-            ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, DevelopBranchKey),
+            ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, DevelopBranchKey),
                 DevelopBranchRegex,
                 defaultTag: "alpha",
                 defaultIncrementStrategy: IncrementStrategy.Minor,
@@ -123,8 +145,8 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 defaultTrackMergeTarget: true,
                 isDevelop: true);
 
-            // Any user defined branches should have other values defaulted after known branches filled in
-            // This allows users to override one value of
+            // Any user defined branches should have other values defaulted after known branches filled in.
+            // This allows users to override any of the value.
             foreach (var branchConfig in configBranches)
             {
                 var regex = branchConfig.Value.Regex;
@@ -158,7 +180,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             BranchConfig branchConfig,
             string branchRegex,
             string defaultTag = "useBranchName",
-            IncrementStrategy defaultIncrementStrategy = IncrementStrategy.Patch,
+            IncrementStrategy? defaultIncrementStrategy = null, // Looked up from main config
             bool defaultPreventIncrement = false,
             VersioningMode? defaultVersioningMode = null, // Looked up from main config
             bool defaultTrackMergeTarget = false,
@@ -170,7 +192,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             branchConfig.Regex = string.IsNullOrEmpty(branchConfig.Regex) ? branchRegex : branchConfig.Regex;
             branchConfig.Tag = branchConfig.Tag ?? defaultTag;
             branchConfig.TagNumberPattern = branchConfig.TagNumberPattern ?? defaultTagNumberPattern;
-            branchConfig.Increment = branchConfig.Increment ?? defaultIncrementStrategy;
+            branchConfig.Increment = branchConfig.Increment ?? defaultIncrementStrategy ?? config.Increment ?? DefaultIncrementStrategy;
             branchConfig.PreventIncrementOfMergedBranchVersion = branchConfig.PreventIncrementOfMergedBranchVersion ?? defaultPreventIncrement;
             branchConfig.TrackMergeTarget = branchConfig.TrackMergeTarget ?? defaultTrackMergeTarget;
             branchConfig.VersioningMode = branchConfig.VersioningMode ?? defaultVersioningMode ?? config.VersioningMode;

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -124,7 +124,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 isDevelop: true);
 
             // Any user defined branches should have other values defaulted after known branches filled in
-            // This allows users to override one value of 
+            // This allows users to override one value of
             foreach (var branchConfig in configBranches)
             {
                 var regex = branchConfig.Value.Regex;
@@ -146,7 +146,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
         {
             if (!config.Branches.ContainsKey(branchKey))
             {
-                var branchConfig = new BranchConfig();
+                var branchConfig = new BranchConfig {Name = branchKey};
                 config.Branches.Add(branchKey, branchConfig);
                 return branchConfig;
             }

--- a/src/GitVersionCore/Configuration/IncrementStrategy.cs
+++ b/src/GitVersionCore/Configuration/IncrementStrategy.cs
@@ -9,7 +9,8 @@
         Minor,
         Patch,
         /// <summary>
-        /// Uses the increment strategy from the branch the current branch was branched from
+        /// Uses the <see cref="BranchConfig.Increment"/>, <see cref="BranchConfig.PreventIncrementOfMergedBranchVersion"/> and <see cref="BranchConfig.IsDevelop"/>
+        /// of the "parent" branch (i.e. the branch where the current branch was branched from).
         /// </summary>
         Inherit
     }

--- a/src/GitVersionCore/Configuration/Init/SetConfig/ConfigureBranches.cs
+++ b/src/GitVersionCore/Configuration/Init/SetConfig/ConfigureBranches.cs
@@ -29,7 +29,7 @@ namespace GitVersion.Configuration.Init.SetConfig
                     var branchConfig = foundBranch.Value;
                     if (branchConfig == null)
                     {
-                        branchConfig = new BranchConfig();
+                        branchConfig = new BranchConfig {Name = foundBranch.Key};
                         config.Branches.Add(foundBranch.Key, branchConfig);
                     }
                     steps.Enqueue(new ConfigureBranch(foundBranch.Key, branchConfig, Console, FileSystem));

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -85,18 +85,18 @@
         {
             var currentBranchConfig = BranchConfigurationCalculator.GetBranchConfiguration(CurrentCommit, Repository, OnlyEvaluateTrackedBranches, FullConfiguration, CurrentBranch);
 
-            if (!currentBranchConfig.Value.VersioningMode.HasValue)
-                throw new Exception(string.Format("Configuration value for 'Versioning mode' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
-            if (!currentBranchConfig.Value.Increment.HasValue)
-                throw new Exception(string.Format("Configuration value for 'Increment' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
-            if (!currentBranchConfig.Value.PreventIncrementOfMergedBranchVersion.HasValue)
-                throw new Exception(string.Format("Configuration value for 'PreventIncrementOfMergedBranchVersion' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
-            if (!currentBranchConfig.Value.TrackMergeTarget.HasValue)
-                throw new Exception(string.Format("Configuration value for 'TrackMergeTarget' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
-            if (!currentBranchConfig.Value.IsDevelop.HasValue)
-                throw new Exception(string.Format("Configuration value for 'IsDevelop' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
-            if (!currentBranchConfig.Value.IsReleaseBranch.HasValue)
-                throw new Exception(string.Format("Configuration value for 'IsReleaseBranch' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Key));
+            if (!currentBranchConfig.VersioningMode.HasValue)
+                throw new Exception(string.Format("Configuration value for 'Versioning mode' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
+            if (!currentBranchConfig.Increment.HasValue)
+                throw new Exception(string.Format("Configuration value for 'Increment' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
+            if (!currentBranchConfig.PreventIncrementOfMergedBranchVersion.HasValue)
+                throw new Exception(string.Format("Configuration value for 'PreventIncrementOfMergedBranchVersion' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
+            if (!currentBranchConfig.TrackMergeTarget.HasValue)
+                throw new Exception(string.Format("Configuration value for 'TrackMergeTarget' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
+            if (!currentBranchConfig.IsDevelop.HasValue)
+                throw new Exception(string.Format("Configuration value for 'IsDevelop' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
+            if (!currentBranchConfig.IsReleaseBranch.HasValue)
+                throw new Exception(string.Format("Configuration value for 'IsReleaseBranch' for branch {0} has no value. (this should not happen, please report an issue)", currentBranchConfig.Name));
 
             if (!FullConfiguration.AssemblyVersioningScheme.HasValue)
                 throw new Exception("Configuration value for 'AssemblyVersioningScheme' has no value. (this should not happen, please report an issue)");
@@ -109,12 +109,12 @@
             if (!FullConfiguration.CommitsSinceVersionSourcePadding.HasValue)
                 throw new Exception("Configuration value for 'CommitsSinceVersionSourcePadding' has no value. (this should not happen, please report an issue)");
 
-            var versioningMode = currentBranchConfig.Value.VersioningMode.Value;
-            var tag = currentBranchConfig.Value.Tag;
-            var tagNumberPattern = currentBranchConfig.Value.TagNumberPattern;
-            var incrementStrategy = currentBranchConfig.Value.Increment.Value;
-            var preventIncrementForMergedBranchVersion = currentBranchConfig.Value.PreventIncrementOfMergedBranchVersion.Value;
-            var trackMergeTarget = currentBranchConfig.Value.TrackMergeTarget.Value;
+            var versioningMode = currentBranchConfig.VersioningMode.Value;
+            var tag = currentBranchConfig.Tag;
+            var tagNumberPattern = currentBranchConfig.TagNumberPattern;
+            var incrementStrategy = currentBranchConfig.Increment.Value;
+            var preventIncrementForMergedBranchVersion = currentBranchConfig.PreventIncrementOfMergedBranchVersion.Value;
+            var trackMergeTarget = currentBranchConfig.TrackMergeTarget.Value;
 
             var nextVersion = FullConfiguration.NextVersion;
             var assemblyVersioningScheme = FullConfiguration.AssemblyVersioningScheme.Value;
@@ -125,12 +125,12 @@
             var patchMessage = FullConfiguration.PatchVersionBumpMessage;
             var noBumpMessage = FullConfiguration.NoBumpMessage;
 
-            var commitMessageVersionBump = currentBranchConfig.Value.CommitMessageIncrementing ?? FullConfiguration.CommitMessageIncrementing.Value;
+            var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? FullConfiguration.CommitMessageIncrementing.Value;
 
             Configuration = new EffectiveConfiguration(
                 assemblyVersioningScheme, assemblyInformationalFormat, versioningMode, gitTagPrefix,
                 tag, nextVersion, incrementStrategy,
-                currentBranchConfig.Value.Regex,
+                currentBranchConfig.Regex,
                 preventIncrementForMergedBranchVersion,
                 tagNumberPattern, FullConfiguration.ContinuousDeploymentFallbackTag,
                 trackMergeTarget,
@@ -140,8 +140,8 @@
                 FullConfiguration.BuildMetaDataPadding.Value,
                 FullConfiguration.CommitsSinceVersionSourcePadding.Value,
                 FullConfiguration.Ignore.ToFilters(),
-                currentBranchConfig.Value.IsDevelop.Value,
-                currentBranchConfig.Value.IsReleaseBranch.Value);
+                currentBranchConfig.IsDevelop.Value,
+                currentBranchConfig.IsReleaseBranch.Value);
         }
     }
 }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -72,6 +72,7 @@
     <Compile Include="AssemblyVersioningScheme.cs" />
     <Compile Include="AssemblyVersionsGenerator.cs" />
     <Compile Include="Authentication.cs" />
+    <Compile Include="BranchCommit.cs" />
     <Compile Include="BranchConfigurationCalculator.cs" />
     <Compile Include="BuildServers\AppVeyor.cs" />
     <Compile Include="BuildServers\BuildServerBase.cs" />

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -145,7 +145,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\TaggedCommitVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
-    <Compile Include="VersionCalculation\BaseVersionCalculators\VersionInBranchBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\VersionInBranchNameBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\DevelopVersionStrategy.cs" />
     <Compile Include="VersionCalculation\FallbackBaseVersionStrategy.cs" />

--- a/src/GitVersionCore/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/IncrementStrategyFinder.cs
@@ -38,7 +38,7 @@
                 commitMessageIncrement = VersionField.Minor;
             }
 
-            // don't increment for less than the branch config increment, if the absense of commit messages would have
+            // don't increment for less than the branch config increment, if the absence of commit messages would have
             // still resulted in an increment of configuration.Increment
             if (baseVersion.ShouldIncrement && commitMessageIncrement < defaultIncrement)
             {
@@ -54,7 +54,7 @@
             {
                 return null;
             }
-            
+
             var commits = GetIntermediateCommits(context.Repository, baseVersion.BaseVersionSource, context.CurrentCommit);
 
             if (context.Configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -45,7 +45,7 @@ namespace GitVersion
                 throw new ArgumentNullException("branch");
             }
 
-            using (Logger.IndentLog("Finding branch source"))
+            using (Logger.IndentLog(string.Format("Finding branch source of '{0}'", branch.FriendlyName)))
             {
                 if (branch.Tip == null)
                 {
@@ -77,7 +77,7 @@ namespace GitVersion
         /// </summary>
         public static Commit FindMergeBase(this Branch branch, Branch otherBranch, IRepository repository)
         {
-            using (Logger.IndentLog(string.Format("Finding merge base between '{0}' and {1}.", branch.FriendlyName, otherBranch.FriendlyName)))
+            using (Logger.IndentLog(string.Format("Finding merge base between '{0}' and '{1}'.", branch.FriendlyName, otherBranch.FriendlyName)))
             {
                 // Otherbranch tip is a forward merge
                 var commitToFindCommonBase = otherBranch.Tip;

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
@@ -2,6 +2,11 @@
 {
     using System.Collections.Generic;
 
+    /// <summary>
+    /// Version is from NextVersion (the configuration value), unless the current commit is tagged.
+    /// BaseVersionSource is null.
+    /// Does not increment.
+    /// </summary>
     public class ConfigNextVersionBaseVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -6,6 +6,11 @@
     using System.Text.RegularExpressions;
     using LibGit2Sharp;
 
+    /// <summary>
+    /// Version is extracted from older commits's merge messages.
+    /// BaseVersionSource is the commit where the message was found.
+    /// Increments if PreventIncrementForMergedBranchVersion (from the branch config) is false.
+    /// </summary>
     public class MergeMessageBaseVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -5,6 +5,11 @@
     using System.Linq;
     using LibGit2Sharp;
 
+    /// <summary>
+    /// Version is extracted from all tags on the branch which are valid, and not newer than the current commit.
+    /// BaseVersionSource is the tag's commit.
+    /// Increments if the tag is not the current commit.
+    /// </summary>
     public class TaggedCommitVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
@@ -4,6 +4,11 @@
     using System.Collections.Generic;
     using LibGit2Sharp;
 
+    /// <summary>
+    /// Version is extracted from the name of the branch.
+    /// BaseVersionSource is the commit where the branch was branched from its parent.
+    /// Does not increment.
+    /// </summary>
     public class VersionInBranchBaseVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
@@ -27,7 +27,7 @@
             {
                 var commitBranchWasBranchedFrom = currentBranch.FindCommitBranchWasBranchedFrom(repository);
                 var branchNameOverride = branchName.RegexReplace("[-/]" + versionInBranch.Item1, string.Empty);
-                yield return new BaseVersion(context, "Version in branch name", false, versionInBranch.Item2, commitBranchWasBranchedFrom, branchNameOverride);
+                yield return new BaseVersion(context, "Version in branch name", false, versionInBranch.Item2, commitBranchWasBranchedFrom.Commit, branchNameOverride);
             }
         }
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
@@ -9,7 +9,7 @@
     /// BaseVersionSource is the commit where the branch was branched from its parent.
     /// Does not increment.
     /// </summary>
-    public class VersionInBranchBaseVersionStrategy : BaseVersionStrategy
+    public class VersionInBranchNameBaseVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)
         {

--- a/src/GitVersionCore/VersionCalculation/BaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionStrategy.cs
@@ -5,6 +5,15 @@
 
     public abstract class BaseVersionStrategy
     {
+        /// <summary>
+        /// Calculates the <see cref="BaseVersion"/> values for the given <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">
+        /// The context for calculating the <see cref="BaseVersion"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{BaseVersion}"/> of the base version values found by the strategy.
+        /// </returns>
         public abstract IEnumerable<BaseVersion> GetVersions(GitVersionContext context);
     }
 }

--- a/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
@@ -11,7 +11,7 @@ namespace GitVersion.VersionCalculation
     /// Active only when the branch is marked as IsDevelop.
     /// Two different algorithms (results are merged):
     /// <para>
-    /// Using <see cref="VersionInBranchBaseVersionStrategy"/>:
+    /// Using <see cref="VersionInBranchNameBaseVersionStrategy"/>:
     /// Version is that of any child branches marked with IsReleaseBranch (except if they have no commits of their own).
     /// BaseVersionSource is the commit where the child branch was created.
     /// Always increments.
@@ -25,7 +25,7 @@ namespace GitVersion.VersionCalculation
     /// </summary>
     public class DevelopVersionStrategy : BaseVersionStrategy
     {
-        VersionInBranchBaseVersionStrategy releaseVersionStrategy = new VersionInBranchBaseVersionStrategy();
+        VersionInBranchNameBaseVersionStrategy releaseVersionStrategy = new VersionInBranchNameBaseVersionStrategy();
         TaggedCommitVersionStrategy taggedCommitVersionStrategy = new TaggedCommitVersionStrategy();
 
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
@@ -8,7 +8,20 @@ namespace GitVersion.VersionCalculation
     using LibGit2Sharp;
 
     /// <summary>
-    /// Inherit version from release branch and tags on master
+    /// Active only when the branch is marked as IsDevelop.
+    /// Two different algorithms (results are merged):
+    /// <para>
+    /// Using <see cref="VersionInBranchBaseVersionStrategy"/>:
+    /// Version is that of any child branches marked with IsReleaseBranch (except if they have no commits of their own).
+    /// BaseVersionSource is the commit where the child branch was created.
+    /// Always increments.
+    /// </para>
+    /// <para>
+    /// Using <see cref="TaggedCommitVersionStrategy"/>:
+    /// Version is extracted from all tags on the <c>master</c> branch which are valid.
+    /// BaseVersionSource is the tag's commit (same as base strategy).
+    /// Increments if the tag is not the current commit (same as base strategy).
+    /// </para>
     /// </summary>
     public class DevelopVersionStrategy : BaseVersionStrategy
     {
@@ -70,9 +83,13 @@ namespace GitVersion.VersionCalculation
             var tagPrefixRegex = context.Configuration.GitTagPrefix;
             var repository = context.Repository;
 
+            // Find the commit where the child branch was created.
             var baseSource = releaseBranch.FindMergeBase(context.CurrentBranch, repository);
             if (baseSource == context.CurrentCommit)
+            {
+                // Ignore the branch if it has no commits.
                 return new BaseVersion[0];
+            }
 
             return releaseVersionStrategy
                 .GetVersions(context, tagPrefixRegex, releaseBranch, repository)

--- a/src/GitVersionCore/VersionCalculation/FallbackBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/FallbackBaseVersionStrategy.cs
@@ -5,6 +5,11 @@
     using BaseVersionCalculators;
     using LibGit2Sharp;
 
+    /// <summary>
+    /// Version is 0.1.0.
+    /// BaseVersionSource is the "root" commit reachable from the current commit.
+    /// Does not increment.
+    /// </summary>
     public class FallbackBaseVersionStrategy : BaseVersionStrategy
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -21,7 +21,7 @@
                     new ConfigNextVersionBaseVersionStrategy(),
                     new TaggedCommitVersionStrategy(),
                     new MergeMessageBaseVersionStrategy(),
-                    new VersionInBranchBaseVersionStrategy(),
+                    new VersionInBranchNameBaseVersionStrategy(),
                     new DevelopVersionStrategy());
         }
 


### PR DESCRIPTION
Alternative implementation for PR #1004:

By default, branches without an explicit value for `increment` use the value `Inherit` (this was `Patch` before). If the default value should remain Patch, this can be easily changed in ConfigurationProvider.cs.

The default value for `increment` can be set "globally" in the config, just as can be done for `mode`.

Extended and clarified the documentation for increment and the version number sources.

Added a bunch of comments in the code and did some refactoring/cleanup.