### PR TITLE
Fixes #1053: exclude NCrunch ItemGroup when NCrunch not present

### DIFF
--- a/src/GitVersionTask/NugetAssets/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/GitVersionTask.targets
@@ -81,7 +81,7 @@
   </Target>
 
   <!--Support for ncrunch-->
-  <ItemGroup>
+  <ItemGroup Condition=" $(NCrunch) != '' ">
     <None Include="$(GitVersionTaskDir)GitVersionTask.dll">
       <Visible>False</Visible>
     </None>


### PR DESCRIPTION
This adds a condition to the ItemGroup that is required for NCrunch so that it is excluded when NCrunch is not installed. This is similar to the conditions here and here which also affect a section depending on the presence of NCrunch

This replaces #1082 (which was a PR into the support/3.6.0 branch) at the request of @pascalberger 