### PR TITLE
Caching to improve performance

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -322,7 +322,7 @@ branches:
             LegacyConfigNotifier.Notify(new StringReader(text));
         });
 
-        var expecedMessage = string.Format("'is-develop' is deprecated, use 'track-release-branches' instead.");
-        exception.Message.ShouldContain(expecedMessage);
+        const string expectedMessage = @"'is-develop' is deprecated, use 'track-release-branches' instead.";
+        exception.Message.ShouldContain(expectedMessage);
     }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -514,9 +514,8 @@ public class FeatureBranchScenarios
             fixture.AssertFullSemver(config, "0.10.1-pre.1+1");
 
             // create a feature branch from master and verify the version
-            // TODO this will pass once default becomes inherit
-            //fixture.BranchTo("MyFeatureD");
-            //fixture.AssertFullSemver(config, "0.10.1-MyFeatureD.1+1");
+            fixture.BranchTo("MyFeatureD");
+            fixture.AssertFullSemver(config, "0.10.1-MyFeatureD.1+1");
         }
     }
 }

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -92,12 +92,12 @@ namespace GitVersion
                 }
                 var branchesToEvaluate = repository.Branches.Except(excludedInheritBranches).ToList();
 
-                var branchPoint = context.RepostioryMetadataProvider
-                    .FindCommitBranchWasBranchedFrom(targetBranch, repository, excludedInheritBranches.ToArray());
+                var branchPoint = context.RepositoryMetadataProvider
+                    .FindCommitBranchWasBranchedFrom(targetBranch, excludedInheritBranches.ToArray());
                 List<Branch> possibleParents;
                 if (branchPoint == BranchCommit.Empty)
                 {
-                    possibleParents = context.RepostioryMetadataProvider.GetBranchesContainingCommit(context.CurrentCommit, repository, branchesToEvaluate, true)
+                    possibleParents = context.RepositoryMetadataProvider.GetBranchesContainingCommit(context.CurrentCommit, branchesToEvaluate, true)
                         // It fails to inherit Increment branch configuration if more than 1 parent;
                         // therefore no point to get more than 2 parents
                         .Take(2)
@@ -105,12 +105,12 @@ namespace GitVersion
                 }
                 else
                 {
-                    var branches = context.RepostioryMetadataProvider
-                        .GetBranchesContainingCommit(branchPoint.Commit, repository, branchesToEvaluate, true).ToList();
+                    var branches = context.RepositoryMetadataProvider
+                        .GetBranchesContainingCommit(branchPoint.Commit, branchesToEvaluate, true).ToList();
                     if (branches.Count > 1)
                     {
-                        var currentTipBranches = context.RepostioryMetadataProvider
-                            .GetBranchesContainingCommit(context.CurrentCommit, repository, branchesToEvaluate, true).ToList();
+                        var currentTipBranches = context.RepositoryMetadataProvider
+                            .GetBranchesContainingCommit(context.CurrentCommit, branchesToEvaluate, true).ToList();
                         possibleParents = branches.Except(currentTipBranches).ToList();
                     }
                     else
@@ -154,7 +154,7 @@ namespace GitVersion
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
 
                 // To prevent infinite loops, make sure that a new branch was chosen.
-                if (LibGitExtensions.IsSameBranch(targetBranch, chosenBranch))
+                if (targetBranch.IsSameBranch(chosenBranch))
                 {
                     Logger.WriteWarning("Fallback branch wants to inherit Increment branch configuration from itself. Using patch increment instead.");
                     return new BranchConfig(branchConfiguration)

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -83,7 +83,11 @@ namespace GitVersion
                         return (branchConfig.Length != 1) || (branchConfig.Length == 1 && branchConfig[0].Increment == IncrementStrategy.Inherit);
                     }).ToList();
                 }
-                excludedBranches.ToList().ForEach(excludedInheritBranches.Add);
+                // Add new excluded branches.
+                foreach (var excludedBranch in excludedBranches.ExcludingBranches(excludedInheritBranches))
+                {
+                    excludedInheritBranches.Add(excludedBranch);
+                }
                 var branchesToEvaluate = repository.Branches.Except(excludedInheritBranches).ToList();
 
                 var branchPoint = currentBranch.FindCommitBranchWasBranchedFrom(repository, excludedInheritBranches.ToArray());
@@ -144,7 +148,7 @@ namespace GitVersion
                 var branchName = chosenBranch.FriendlyName;
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
 
-                var inheritingBranchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch);
+                var inheritingBranchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch, excludedInheritBranches);
                 return new BranchConfig(branchConfiguration)
                 {
                     Increment = inheritingBranchConfig.Increment,

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -148,6 +148,16 @@ namespace GitVersion
                 var branchName = chosenBranch.FriendlyName;
                 Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
 
+                // To prevent infinite loops, make sure that a new branch was chosen.
+                if (LibGitExtensions.IsSameBranch(currentBranch, chosenBranch))
+                {
+                    Logger.WriteWarning("Fallback branch wants to inherit Increment branch configuration from itself. Using patch increment instead.");
+                    return new BranchConfig(branchConfiguration)
+                    {
+                        Increment = IncrementStrategy.Patch
+                    };
+                }
+
                 var inheritingBranchConfig = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, chosenBranch, excludedInheritBranches);
                 return new BranchConfig(branchConfiguration)
                 {

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -2,7 +2,6 @@ namespace GitVersion
 {
     using Configuration.Init.Wizard;
     using GitVersion.Helpers;
-    using System;
     using System.IO;
     using System.Linq;
     using System.Text;

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -1,0 +1,233 @@
+﻿using JetBrains.Annotations;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitVersion
+{
+    public class GitRepoMetadataProvider
+    {
+        private Dictionary<Branch, List<BranchCommit>> mergeBaseCommitsCache;
+        private Dictionary<Tuple<Branch, Branch>, MergeBaseData> mergeBaseCache;
+        private Dictionary<Branch, List<SemanticVersion>> semanticVersionTagsOnBranchCache;
+        private IRepository repository;
+        const string missingTipFormat = "{0} has no tip. Please see http://example.com/docs for information on how to fix this.";
+
+
+        public GitRepoMetadataProvider(IRepository repository)
+        {
+            mergeBaseCache = new Dictionary<Tuple<Branch, Branch>, MergeBaseData>();
+            mergeBaseCommitsCache = new Dictionary<Branch, List<BranchCommit>>();
+            semanticVersionTagsOnBranchCache = new Dictionary<Branch, List<SemanticVersion>>();
+            this.repository = repository;
+        }
+
+        public IEnumerable<SemanticVersion> GetVersionTagsOnBranch(Branch branch, IRepository repository, string tagPrefixRegex)
+        {
+            if (semanticVersionTagsOnBranchCache.ContainsKey(branch))
+            {
+                Logger.WriteDebug(string.Format("Cache hit for version tags on branch '{0}", branch.CanonicalName));
+                return semanticVersionTagsOnBranchCache[branch];
+            }
+
+            using (Logger.IndentLog(string.Format("Getting version tags from branch '{0}'.", branch.CanonicalName)))
+            {
+                var tags = repository.Tags.Select(t => t).ToList();
+
+                var versionTags = repository.Commits.QueryBy(new CommitFilter
+                {
+                    IncludeReachableFrom = branch.Tip
+                })
+                .SelectMany(c => tags.Where(t => c.Sha == t.Target.Sha).SelectMany(t =>
+                {
+                    SemanticVersion semver;
+                    if (SemanticVersion.TryParse(t.FriendlyName, tagPrefixRegex, out semver))
+                        return new[] { semver };
+                    return new SemanticVersion[0];
+                })).ToList();
+
+                semanticVersionTagsOnBranchCache.Add(branch, versionTags);
+                return versionTags;
+            }
+        }
+
+        // TODO Should we cache this?
+        public IEnumerable<Branch> GetBranchesContainingCommit([NotNull] Commit commit, IRepository repository, IList<Branch> branches, bool onlyTrackedBranches)
+        {
+            if (commit == null)
+            {
+                throw new ArgumentNullException("commit");
+            }
+            Logger.WriteDebug("Heh");
+            using (Logger.IndentLog(string.Format("Getting branches containing the commit '{0}'.", commit.Id)))
+            {
+                var directBranchHasBeenFound = false;
+                Logger.WriteInfo("Trying to find direct branches.");
+                // TODO: It looks wasteful looping through the branches twice. Can't these loops be merged somehow? @asbjornu
+                foreach (var branch in branches)
+                {
+                    if (branch.Tip != null && branch.Tip.Sha != commit.Sha || (onlyTrackedBranches && !branch.IsTracking))
+                    {
+                        continue;
+                    }
+
+                    directBranchHasBeenFound = true;
+                    Logger.WriteInfo(string.Format("Direct branch found: '{0}'.", branch.FriendlyName));
+                    yield return branch;
+                }
+
+                if (directBranchHasBeenFound)
+                {
+                    yield break;
+                }
+
+                Logger.WriteInfo(string.Format("No direct branches found, searching through {0} branches.", onlyTrackedBranches ? "tracked" : "all"));
+                foreach (var branch in branches.Where(b => onlyTrackedBranches && !b.IsTracking))
+                {
+                    Logger.WriteInfo(string.Format("Searching for commits reachable from '{0}'.", branch.FriendlyName));
+
+                    var commits = repository.Commits.QueryBy(new CommitFilter
+                    {
+                        IncludeReachableFrom = branch
+                    }).Where(c => c.Sha == commit.Sha);
+
+                    if (!commits.Any())
+                    {
+                        Logger.WriteInfo(string.Format("The branch '{0}' has no matching commits.", branch.FriendlyName));
+                        continue;
+                    }
+
+                    Logger.WriteInfo(string.Format("The branch '{0}' has a matching commit.", branch.FriendlyName));
+                    yield return branch;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Find the merge base of the two branches, i.e. the best common ancestor of the two branches' tips.
+        /// </summary>
+        public Commit FindMergeBase(Branch branch, Branch otherBranch, IRepository repository)
+        {
+            var key = Tuple.Create(branch, otherBranch);
+
+            if (mergeBaseCache.ContainsKey(key))
+            {
+                Logger.WriteDebug(string.Format(
+                    "Cache hit for merge base between '{0}' and '{1}'.",
+                    branch.FriendlyName, otherBranch.FriendlyName));
+                return mergeBaseCache[key].MergeBase;
+            }
+
+            using (Logger.IndentLog(string.Format("Finding merge base between '{0}' and '{1}'.", branch.FriendlyName, otherBranch.FriendlyName)))
+            {
+                // Otherbranch tip is a forward merge
+                var commitToFindCommonBase = otherBranch.Tip;
+                var commit = branch.Tip;
+                if (otherBranch.Tip.Parents.Contains(commit))
+                {
+                    commitToFindCommonBase = otherBranch.Tip.Parents.First();
+                }
+
+                var findMergeBase = repository.ObjectDatabase.FindMergeBase(commit, commitToFindCommonBase);
+                if (findMergeBase != null)
+                {
+                    Logger.WriteInfo(string.Format("Found merge base of {0}", findMergeBase.Sha));
+                    // We do not want to include merge base commits which got forward merged into the other branch
+                    bool mergeBaseWasForwardMerge;
+                    do
+                    {
+                        // Now make sure that the merge base is not a forward merge
+                        mergeBaseWasForwardMerge = otherBranch.Commits
+                            .SkipWhile(c => c != commitToFindCommonBase)
+                            .TakeWhile(c => c != findMergeBase)
+                            .Any(c => c.Parents.Contains(findMergeBase));
+                        if (mergeBaseWasForwardMerge)
+                        {
+                            var second = commitToFindCommonBase.Parents.First();
+                            var mergeBase = repository.ObjectDatabase.FindMergeBase(commit, second);
+                            if (mergeBase == findMergeBase)
+                            {
+                                break;
+                            }
+                            findMergeBase = mergeBase;
+                            Logger.WriteInfo(string.Format("Merge base was due to a forward merge, next merge base is {0}", findMergeBase));
+                        }
+                    } while (mergeBaseWasForwardMerge);
+                }
+
+                // Store in cache.
+                mergeBaseCache.Add(key, new MergeBaseData(branch, otherBranch, repository, findMergeBase));
+
+                return findMergeBase;
+            }
+        }
+
+        /// <summary>
+        /// Find the commit where the given branch was branched from another branch.
+        /// If there are multiple such commits and branches, returns the newest commit.
+        /// </summary>
+        public BranchCommit FindCommitBranchWasBranchedFrom([NotNull] Branch branch, IRepository repository, params Branch[] excludedBranches)
+        {
+            if (branch == null)
+            {
+                throw new ArgumentNullException("branch");
+            }
+
+            using (Logger.IndentLog(string.Format("Finding branch source of '{0}'", branch.FriendlyName)))
+            {
+                if (branch.Tip == null)
+                {
+                    Logger.WriteWarning(string.Format(missingTipFormat, branch.FriendlyName));
+                    return BranchCommit.Empty;
+                }
+
+                return GetMergeCommitsForBranch(branch).ExcludingBranches(excludedBranches).FirstOrDefault(b => !branch.IsSameBranch(b.Branch));
+            }
+        }
+
+
+        List<BranchCommit> GetMergeCommitsForBranch(Branch branch)
+        {
+            if (mergeBaseCommitsCache.ContainsKey(branch))
+            {
+                Logger.WriteDebug(string.Format(
+                    "Cache hit for getting merge commits for branch {0}.",
+                    branch.CanonicalName));
+                return mergeBaseCommitsCache[branch];
+            }
+
+            var branchMergeBases = repository.Branches.Select(otherBranch =>
+            {
+                if (otherBranch.Tip == null)
+                {
+                    Logger.WriteWarning(string.Format(missingTipFormat, otherBranch.FriendlyName));
+                    return BranchCommit.Empty;
+                }
+
+                var findMergeBase = FindMergeBase(branch, otherBranch, repository);
+                return new BranchCommit(findMergeBase, otherBranch);
+            }).Where(b => b.Commit != null).OrderByDescending(b => b.Commit.Committer.When).ToList();
+            mergeBaseCommitsCache.Add(branch, branchMergeBases);
+
+            return branchMergeBases;
+        }
+
+        private class MergeBaseData
+        {
+            public Branch Branch { get; private set; }
+            public Branch OtherBranch { get; private set; }
+            public IRepository Repository { get; private set; }
+
+            public Commit MergeBase { get; private set; }
+
+            public MergeBaseData(Branch branch, Branch otherBranch, IRepository repository, Commit mergeBase)
+            {
+                Branch = branch;
+                OtherBranch = otherBranch;
+                Repository = repository;
+                MergeBase = mergeBase;
+            }
+        }
+    }
+}

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -123,7 +123,15 @@
 
         private static string GetRepositorySnapshotHash(GitPreparer gitPreparer)
         {
-            var repositorySnapshot = gitPreparer.WithRepository(repo => string.Join(":", repo.Head.CanonicalName, repo.Head.Tip.Sha));
+            var repositorySnapshot = gitPreparer.WithRepository(repo => {
+                var head = repo.Head;
+                if (head.Tip == null)
+                {
+                    return head.CanonicalName;
+                }
+                var hash = string.Join(":", head.CanonicalName, head.Tip.Sha);
+                return hash;
+            });
             return GetHash(repositorySnapshot);
         }
 

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -17,7 +17,7 @@
         public GitVersionContext(IRepository repository, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = true, string commitId = null)
         {
             Repository = repository;
-            RepostioryMetadataProvider = new GitRepoMetadataProvider(repository);
+            RepositoryMetadataProvider = new GitRepoMetadataProvider(repository);
             FullConfiguration = configuration;
             OnlyEvaluateTrackedBranches = onlyEvaluateTrackedBranches;
 
@@ -47,7 +47,7 @@
 
             if (currentBranch.IsDetachedHead())
             {
-                CurrentBranch = RepostioryMetadataProvider.GetBranchesContainingCommit(CurrentCommit, repository, repository.Branches.ToList(), OnlyEvaluateTrackedBranches).OnlyOrDefault() ?? currentBranch;
+                CurrentBranch = RepositoryMetadataProvider.GetBranchesContainingCommit(CurrentCommit, repository.Branches.ToList(), OnlyEvaluateTrackedBranches).OnlyOrDefault() ?? currentBranch;
             }
             else
             {
@@ -79,7 +79,7 @@
         public Branch CurrentBranch { get; private set; }
         public Commit CurrentCommit { get; private set; }
         public bool IsCurrentCommitTagged { get; private set; }
-        public GitRepoMetadataProvider RepostioryMetadataProvider { get; private set; }
+        public GitRepoMetadataProvider RepositoryMetadataProvider { get; private set; }
 
         void CalculateEffectiveConfiguration()
         {

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -16,6 +16,9 @@
 
         public GitVersionContext(IRepository repository, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = true, string commitId = null)
         {
+            // With a new context, clear any in-memory caches.
+            LibGitExtensions.ClearInMemoryCache();
+
             Repository = repository;
             FullConfiguration = configuration;
             OnlyEvaluateTrackedBranches = onlyEvaluateTrackedBranches;

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -122,6 +122,7 @@
     <Compile Include="ExecuteCore.cs" />
     <Compile Include="Extensions\ReadEmbeddedResourceExtensions.cs" />
     <Compile Include="GitPreparer.cs" />
+    <Compile Include="GitRepoMetadataProvider.cs" />
     <Compile Include="GitVersionCache.cs" />
     <Compile Include="GitVersionCacheKey.cs" />
     <Compile Include="GitVersionCacheKeyFactory.cs" />

--- a/src/GitVersionCore/GitVersionFinder.cs
+++ b/src/GitVersionCore/GitVersionFinder.cs
@@ -8,7 +8,10 @@ namespace GitVersion
     {
         public SemanticVersion FindVersion(GitVersionContext context)
         {
-            Logger.WriteInfo(string.Format("Running against branch: {0} ({1})", context.CurrentBranch.FriendlyName, context.CurrentCommit.Sha));
+            Logger.WriteInfo(string.Format(
+                "Running against branch: {0} ({1})",
+                context.CurrentBranch.FriendlyName,
+                context.CurrentCommit == null ? "-" : context.CurrentCommit.Sha));
             EnsureMainTopologyConstraints(context);
 
             var filePath = Path.Combine(context.Repository.GetRepositoryDirectory(), "NextVersion.txt");

--- a/src/GitVersionCore/LibGitExtensions.cs
+++ b/src/GitVersionCore/LibGitExtensions.cs
@@ -4,7 +4,6 @@ namespace GitVersion
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     using LibGit2Sharp;
@@ -16,127 +15,10 @@ namespace GitVersion
             return commit.Committer.When;
         }
 
-        public static IEnumerable<SemanticVersion> GetVersionTagsOnBranch(this Branch branch, IRepository repository, string tagPrefixRegex)
-        {
-            var tags = repository.Tags.Select(t => t).ToList();
-
-            return repository.Commits.QueryBy(new CommitFilter
-            {
-                IncludeReachableFrom = branch.Tip
-            })
-            .SelectMany(c => tags.Where(t => c.Sha == t.Target.Sha).SelectMany(t =>
-            {
-                SemanticVersion semver;
-                if (SemanticVersion.TryParse(t.FriendlyName, tagPrefixRegex, out semver))
-                    return new [] { semver };
-                return new SemanticVersion[0];
-            }));
-        }
-
-        private static List<BranchCommit> cacheMergeBaseCommits;
-
-        /// <summary>
-        /// Find the commit where the given branch was branched from another branch.
-        /// If there are multiple such commits and branches, returns the newest commit.
-        /// </summary>
-        public static BranchCommit FindCommitBranchWasBranchedFrom([NotNull] this Branch branch, IRepository repository, params Branch[] excludedBranches)
-        {
-            const string missingTipFormat = "{0} has no tip. Please see http://example.com/docs for information on how to fix this.";
-
-            if (branch == null)
-            {
-                throw new ArgumentNullException("branch");
-            }
-
-            using (Logger.IndentLog(string.Format("Finding branch source of '{0}'", branch.FriendlyName)))
-            {
-                if (branch.Tip == null)
-                {
-                    Logger.WriteWarning(string.Format(missingTipFormat, branch.FriendlyName));
-                    return BranchCommit.Empty;
-                }
-
-                if (cacheMergeBaseCommits == null)
-                {
-                    cacheMergeBaseCommits = repository.Branches.Select(otherBranch =>
-                    {
-                        if (otherBranch.Tip == null)
-                        {
-                            Logger.WriteWarning(string.Format(missingTipFormat, otherBranch.FriendlyName));
-                            return BranchCommit.Empty;
-                        }
-
-                        var findMergeBase = FindMergeBase(branch, otherBranch, repository);
-                        return new BranchCommit(findMergeBase, otherBranch);
-                    }).Where(b => b.Commit != null).OrderByDescending(b => b.Commit.Committer.When).ToList();
-                }
-
-                return cacheMergeBaseCommits.ExcludingBranches(excludedBranches).FirstOrDefault(b => !IsSameBranch(branch, b.Branch));
-            }
-        }
-
-        private static List<MergeBaseData> cachedMergeBase = new List<MergeBaseData>();
-
-        /// <summary>
-        /// Find the merge base of the two branches, i.e. the best common ancestor of the two branches' tips.
-        /// </summary>
-        public static Commit FindMergeBase(this Branch branch, Branch otherBranch, IRepository repository)
-        {
-            using (Logger.IndentLog(string.Format("Finding merge base between '{0}' and '{1}'.", branch.FriendlyName, otherBranch.FriendlyName)))
-            {
-                // Check the cache.
-                var cachedData = cachedMergeBase.FirstOrDefault(data => IsSameBranch(branch, data.Branch) && IsSameBranch(otherBranch, data.OtherBranch) && repository == data.Repository);
-                if (cachedData != null)
-                {
-                    return cachedData.MergeBase;
-                }
-
-                // Otherbranch tip is a forward merge
-                var commitToFindCommonBase = otherBranch.Tip;
-                var commit = branch.Tip;
-                if (otherBranch.Tip.Parents.Contains(commit))
-                {
-                    commitToFindCommonBase = otherBranch.Tip.Parents.First();
-                }
-
-                var findMergeBase = repository.ObjectDatabase.FindMergeBase(commit, commitToFindCommonBase);
-                if (findMergeBase != null)
-                {
-                    Logger.WriteInfo(string.Format("Found merge base of {0}", findMergeBase.Sha));
-                    // We do not want to include merge base commits which got forward merged into the other branch
-                    bool mergeBaseWasForwardMerge;
-                    do
-                    {
-                        // Now make sure that the merge base is not a forward merge
-                        mergeBaseWasForwardMerge = otherBranch.Commits
-                            .SkipWhile(c => c != commitToFindCommonBase)
-                            .TakeWhile(c => c != findMergeBase)
-                            .Any(c => c.Parents.Contains(findMergeBase));
-                        if (mergeBaseWasForwardMerge)
-                        {
-                            var second = commitToFindCommonBase.Parents.First();
-                            var mergeBase = repository.ObjectDatabase.FindMergeBase(commit, second);
-                            if (mergeBase == findMergeBase)
-                            {
-                                break;
-                            }
-                            findMergeBase = mergeBase;
-                            Logger.WriteInfo(string.Format("Merge base was due to a forward merge, next merge base is {0}", findMergeBase));
-                        }
-                    } while (mergeBaseWasForwardMerge);
-                }
-
-                // Store in cache.
-                cachedMergeBase.Add(new MergeBaseData(branch, otherBranch, repository, findMergeBase));
-
-                return findMergeBase;
-            }
-        }
-
         /// <summary>
         /// Checks if the two branch objects refer to the same branch (have the same friendly name).
         /// </summary>
-        public static bool IsSameBranch(Branch branch, Branch otherBranch)
+        public static bool IsSameBranch(this Branch branch, Branch otherBranch)
         {
             // For each branch, fixup the friendly name if the branch is remote.
             var otherBranchFriendlyName = otherBranch.IsRemote ?
@@ -165,73 +47,14 @@ namespace GitVersion
             return branches.Where(b => branchesToExclude.All(bte => !IsSameBranch(b, bte)));
         }
 
-        public static IEnumerable<Branch> GetBranchesContainingCommit([NotNull] this Commit commit, IRepository repository, IList<Branch> branches, bool onlyTrackedBranches)
-        {
-            if (commit == null)
-            {
-                throw new ArgumentNullException("commit");
-            }
-
-            using (Logger.IndentLog(string.Format("Getting branches containing the commit '{0}'.", commit.Id)))
-            {
-                var directBranchHasBeenFound = false;
-                Logger.WriteInfo("Trying to find direct branches.");
-                // TODO: It looks wasteful looping through the branches twice. Can't these loops be merged somehow? @asbjornu
-                foreach (var branch in branches)
-                {
-                    if (branch.Tip != null && branch.Tip.Sha != commit.Sha || (onlyTrackedBranches && !branch.IsTracking))
-                    {
-                        continue;
-                    }
-
-                    directBranchHasBeenFound = true;
-                    Logger.WriteInfo(string.Format("Direct branch found: '{0}'.", branch.FriendlyName));
-                    yield return branch;
-                }
-
-                if (directBranchHasBeenFound)
-                {
-                    yield break;
-                }
-
-                Logger.WriteInfo(string.Format("No direct branches found, searching through {0} branches.", onlyTrackedBranches ? "tracked" : "all"));
-                foreach (var branch in branches.Where(b => onlyTrackedBranches && !b.IsTracking))
-                {
-                    Logger.WriteInfo(string.Format("Searching for commits reachable from '{0}'.", branch.FriendlyName));
-
-                    var commits = repository.Commits.QueryBy(new CommitFilter
-                    {
-                        IncludeReachableFrom = branch
-                    }).Where(c => c.Sha == commit.Sha);
-
-                    if (!commits.Any())
-                    {
-                        Logger.WriteInfo(string.Format("The branch '{0}' has no matching commits.", branch.FriendlyName));
-                        continue;
-                    }
-
-                    Logger.WriteInfo(string.Format("The branch '{0}' has a matching commit.", branch.FriendlyName));
-                    yield return branch;
-                }
-            }
-        }
-
-        private static Dictionary<string, GitObject> _cachedPeeledTarget = new Dictionary<string, GitObject>();
-
         public static GitObject PeeledTarget(this Tag tag)
         {
-            GitObject cachedTarget;
-            if (_cachedPeeledTarget.TryGetValue(tag.Target.Sha, out cachedTarget))
-            {
-                return cachedTarget;
-            }
             var target = tag.Target;
 
             while (target is TagAnnotation)
             {
                 target = ((TagAnnotation)(target)).Target;
             }
-            _cachedPeeledTarget.Add(tag.Target.Sha, target);
             return target;
         }
 
@@ -297,30 +120,6 @@ namespace GitVersion
                 {
                     Logger.WriteWarning(string.Format("  An error occurred while checking out '{0}': '{1}'", fileName, ex.Message));
                 }
-            }
-        }
-
-        internal static void ClearInMemoryCache()
-        {
-            cacheMergeBaseCommits = null;
-            cachedMergeBase.Clear();
-            _cachedPeeledTarget.Clear();
-        }
-
-        private class MergeBaseData
-        {
-            public Branch Branch { get; private set; }
-            public Branch OtherBranch { get; private set; }
-            public IRepository Repository { get; private set; }
-
-            public Commit MergeBase { get; private set; }
-
-            public MergeBaseData(Branch branch, Branch otherBranch, IRepository repository, Commit mergeBase)
-            {
-                Branch = branch;
-                OtherBranch = otherBranch;
-                Repository = repository;
-                MergeBase = mergeBase;
             }
         }
     }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
@@ -25,7 +25,7 @@
             var versionInBranch = GetVersionInBranch(branchName, tagPrefixRegex);
             if (versionInBranch != null)
             {
-                var commitBranchWasBranchedFrom = context.RepostioryMetadataProvider.FindCommitBranchWasBranchedFrom(currentBranch, repository);
+                var commitBranchWasBranchedFrom = context.RepositoryMetadataProvider.FindCommitBranchWasBranchedFrom(currentBranch);
                 var branchNameOverride = branchName.RegexReplace("[-/]" + versionInBranch.Item1, string.Empty);
                 yield return new BaseVersion(context, "Version in branch name", false, versionInBranch.Item2, commitBranchWasBranchedFrom.Commit, branchNameOverride);
             }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameBaseVersionStrategy.cs
@@ -25,7 +25,7 @@
             var versionInBranch = GetVersionInBranch(branchName, tagPrefixRegex);
             if (versionInBranch != null)
             {
-                var commitBranchWasBranchedFrom = currentBranch.FindCommitBranchWasBranchedFrom(repository);
+                var commitBranchWasBranchedFrom = context.RepostioryMetadataProvider.FindCommitBranchWasBranchedFrom(currentBranch, repository);
                 var branchNameOverride = branchName.RegexReplace("[-/]" + versionInBranch.Item1, string.Empty);
                 yield return new BaseVersion(context, "Version in branch name", false, versionInBranch.Item2, commitBranchWasBranchedFrom.Commit, branchNameOverride);
             }

--- a/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
@@ -84,7 +84,7 @@ namespace GitVersion.VersionCalculation
             var repository = context.Repository;
 
             // Find the commit where the child branch was created.
-            var baseSource = releaseBranch.FindMergeBase(context.CurrentBranch, repository);
+            var baseSource = context.RepostioryMetadataProvider.FindMergeBase(releaseBranch, context.CurrentBranch, repository);
             if (baseSource == context.CurrentCommit)
             {
                 // Ignore the branch if it has no commits.

--- a/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/DevelopVersionStrategy.cs
@@ -66,7 +66,7 @@ namespace GitVersion.VersionCalculation
                         // Need to drop branch overrides and give a bit more context about
                         // where this version came from
                         var source1 = "Release branch exists -> " + baseVersion.Source;
-                        return new BaseVersion(context, 
+                        return new BaseVersion(context,
                             source1,
                             baseVersion.ShouldIncrement,
                             baseVersion.SemanticVersion,
@@ -84,7 +84,7 @@ namespace GitVersion.VersionCalculation
             var repository = context.Repository;
 
             // Find the commit where the child branch was created.
-            var baseSource = context.RepostioryMetadataProvider.FindMergeBase(releaseBranch, context.CurrentBranch, repository);
+            var baseSource = context.RepositoryMetadataProvider.FindMergeBase(releaseBranch, context.CurrentBranch);
             if (baseSource == context.CurrentCommit)
             {
                 // Ignore the branch if it has no commits.

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -258,8 +258,8 @@
 
             int? number = null;
 
-            var lastTag = context.RepostioryMetadataProvider
-                .GetVersionTagsOnBranch(context.CurrentBranch, context.Repository, context.Configuration.GitTagPrefix)
+            var lastTag = context.RepositoryMetadataProvider
+                .GetVersionTagsOnBranch(context.CurrentBranch, context.Configuration.GitTagPrefix)
                 .FirstOrDefault(v => v.PreReleaseTag.Name == tagToUse);
 
             if (lastTag != null &&

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -258,8 +258,8 @@
 
             int? number = null;
 
-            var lastTag = context.CurrentBranch
-                .GetVersionTagsOnBranch(context.Repository, context.Configuration.GitTagPrefix)
+            var lastTag = context.RepostioryMetadataProvider
+                .GetVersionTagsOnBranch(context.CurrentBranch, context.Repository, context.Configuration.GitTagPrefix)
                 .FirstOrDefault(v => v.PreReleaseTag.Name == tagToUse);
 
             if (lastTag != null &&

--- a/src/GitVersionTask.Tests/GitVersionTaskDirectoryTests.cs
+++ b/src/GitVersionTask.Tests/GitVersionTaskDirectoryTests.cs
@@ -61,6 +61,7 @@ public class GitVersionTaskDirectoryTests
         }
         catch (Exception ex)
         {
+            // TODO I think this test is wrong.. It throws a different exception
             // `RepositoryNotFoundException` means that it couldn't find the .git directory,
             // any other exception means that the .git was found but there was some other issue that this test doesn't care about.
             Assert.IsNotAssignableFrom<RepositoryNotFoundException>(ex);


### PR DESCRIPTION
When I use GitVersion on my repository (about 30k commits and 14 branches), it gets very slow. The main reason is that it calculates lots of merge bases and their commits. However, this data is ephemeral, so it gets recalculated multiple times.

Here I add two caches to improve this. The first commit caches the result of FindMergeBase(). The second caches the internal list of FindCommitBranchWasBranchedFrom().

Improvement in run times (on my machine):

||Time|
| --- | --- |
|No Caching|4m 51s|
|Caching of FindMergeBase()|1m 34s|
|Both caches|30s|

This builds upon my other PR (#1085), since I use some of the refactorings I made as part of it.