### PR TITLE
More logging when preparing the git repository

### DIFF
--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -4,6 +4,7 @@ namespace GitVersion
     using System.IO;
     using System.Linq;
     using GitTools.Git;
+    using GitTools.Logging;
     using LibGit2Sharp;
 
     public class GitPreparer
@@ -28,6 +29,9 @@ namespace GitVersion
                 };
             this.noFetch = noFetch;
             this.targetPath = targetPath.TrimEnd('/', '\\');
+
+            // GitTools has its own logging. So that it actually outputs something, it needs to be initialized.
+            LogProvider.SetCurrentLogProvider(new LoggerWrapper());
         }
 
         public string WorkingDirectory

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Helpers\ServiceMessageEscapeHelper.cs" />
     <Compile Include="Helpers\ThreadSleep.cs" />
     <Compile Include="IncrementStrategyFinder.cs" />
+    <Compile Include="LoggerWrapper.cs" />
     <Compile Include="OutputVariables\VersionVariables.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />
     <Compile Include="SemanticVersionFormatValues.cs" />

--- a/src/GitVersionCore/LoggerWrapper.cs
+++ b/src/GitVersionCore/LoggerWrapper.cs
@@ -1,0 +1,84 @@
+﻿namespace GitVersion
+{
+    using System;
+    using GitTools.Logging;
+
+    /// <summary>
+    /// Wraps the <see cref="Logger" /> for use by GitTools.
+    /// </summary>
+    public class LoggerWrapper : ILogProvider
+    {
+        public GitTools.Logging.Logger GetLogger(string name)
+        {
+            return Log;
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable OpenMappedContext(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static bool Log(LogLevel loglevel, Func<string> messagefunc, Exception exception, object[] formatparameters)
+        {
+            // Create the main message. Careful of string format errors.
+            string message;
+            if (messagefunc == null)
+            {
+                message = null;
+            }
+            else
+            {
+                if (formatparameters == null || formatparameters.Length == 0)
+                {
+                    message = messagefunc();
+                }
+                else
+                {
+                    try
+                    {
+                        message = string.Format(messagefunc(), formatparameters);
+                    }
+                    catch (FormatException)
+                    {
+                        message = messagefunc();
+                        Logger.WriteError(string.Format("LoggerWrapper.Log(): Incorrectly formatted string: message: '{0}'; formatparameters: {1}", message, string.Join(";", formatparameters)));
+                    }
+                }
+            }
+
+            if (exception != null)
+            {
+                // Append the exception to the end of the message.
+                message = string.IsNullOrEmpty(message) ? exception.ToString() : string.Format("{0}\n{1}", message, exception);
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                switch (loglevel)
+                {
+                    case LogLevel.Trace:
+                    case LogLevel.Debug:
+                        Logger.WriteDebug(message);
+                        break;
+                    case LogLevel.Info:
+                        Logger.WriteInfo(message);
+                        break;
+                    case LogLevel.Warn:
+                        Logger.WriteWarning(message);
+                        break;
+                    case LogLevel.Error:
+                    case LogLevel.Fatal:
+                        Logger.WriteError(message);
+                        break;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Adds some more logging in GitPreparer:

- Use Logger.IndentLog() to show where time is spent.
- Enable the logging of GitTools.Core.