### PR TITLE
Inject into correct point in build pipeline for VS 2017

### DIFF
--- a/docs/usage/msbuild-task.md
+++ b/docs/usage/msbuild-task.md
@@ -4,6 +4,8 @@ The MSBuild Task for GitVersion — **GitVersionTask** — is a simple solution 
 you want to version your assemblies without writing any command line scripts or
 modifying your build process.
 
+It currently works with desktop `MSBuild`. Support for CoreCLR with `dotnet build` is coming soon.
+
 ## TL;DR
 
 ### Install the MSTask targets
@@ -14,6 +16,14 @@ Package into the project you want to be versioned by GitVersion.
 From the Package Manager Console:
 ```shell
 Install-Package GitVersionTask
+```
+
+If you're using `PackageReference` style NuGet dependencies (VS 2017+), add `<PrivateAssets>all</PrivateAssets>` to prevent the task from becoming a dependency of your package:
+
+``` xml
+<PackageReference Include="GitVersionTask" Version="4.0.0-beta*">
+  <PrivateAssets>All</PrivateAssets>
+</PackageReference>
 ```
 
 ### Remove AssemblyInfo attributes
@@ -115,6 +125,17 @@ However at MSBuild time these properties are mapped to MSBuild properties that
 are prefixed with `GitVersion_`. This prevents conflicts with other properties
 in the pipeline.
 
+In addition, the following MSBuild properties are set when `UpdateVersionProperties` is true (the default):
+`Version`, `VersionPrefix`, `VersionSuffix`, `PackageVersion`, `InformationalVersion`, `AssemblyVersion` and `FileVersion`. These are used by the built-in tasks for generating AssemblyInfo's and NuGet package versions.
+
+
+### NuGet packages
+The new SDK-style projects available for .NET Standard libraries (and multi-targeting), have the ability
+to create NuGet packages directly by using the `pack` target: `msbuild /t:pack`. The version is controled by the MSBuild properties described above. 
+
+GitVersionTask has the option to generate SemVer 2.0 compliant NuGet package versions by setting `UseFullSemVerForNuGet` to true in your project (this is off by default for compatibility). Some hosts, like MyGet, support SemVer 2.0 package versions but older NuGet clients and nuget.org do not.
+
+
 #### Accessing variables in MSBuild
 
 Once `GitVersionTask.GetVersion` has been executed, the MSBuild properties can be
@@ -136,7 +157,7 @@ Build Server log in a format that the current Build Server can consume. See
 
 ## Conditional control tasks
 
-Properties `WriteVersionInfoToBuildLog`, `UpdateAssemblyInfo` and `GetVersion`
+Properties `WriteVersionInfoToBuildLog`, `UpdateAssemblyInfo`, `UseFullSemVerForNuGet`, `UpdateVersionProperties` and `GetVersion`
 are checked before running these tasks.
 
 You can disable `GitVersionTask.UpdateAssemblyInfo` by setting
@@ -150,6 +171,7 @@ this:
   ...
 </PropertyGroup>
 ```
+For SDK-style projects, `UpdateVersionProperties` controls setting the default variables: `Version`, `VersionPrefix`, `VersionSuffix`, `PackageVersion`, `InformationalVersion`, `AssemblyVersion` and `FileVersion`.
 
 ## My Git repository requires authentication. What should I do?
 

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -128,7 +128,6 @@
     <Copy SourceFiles="$(TargetDir)GitVersionTask.dll.mdb" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)GitVersionTask.dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\build\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\buildMultiTargeting\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\buildMultiTargeting" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\buildMultiTargeting\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\buildCrossTargeting" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.nuspec" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetTaskBuild" MetadataAssembly="$(ILMergeTemp)GitVersionTask.dll" Version="$(GitVersion_NuGetVersion)" />
     <Delete Files="@(TempFiles)" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -79,9 +79,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="NugetAssets\GitVersionTask.targets">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="NugetAssets\buildMultiTargeting\GitVersionTask.targets" />
+    <None Include="NugetAssets\build\GitVersionTask.targets" />
     <None Include="NugetAssets\GitVersionTask.nuspec">
       <SubType>Designer</SubType>
     </None>
@@ -127,7 +126,9 @@
     <Copy SourceFiles="$(TargetDir)ILMergeTemp\GitVersionTask.dll" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)ILMergeTemp\GitVersionTask.dll')" />
     <Copy SourceFiles="$(TargetDir)GitVersionTask.pdb" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)GitVersionTask.pdb')" />
     <Copy SourceFiles="$(TargetDir)GitVersionTask.dll.mdb" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" Condition="Exists('$(TargetDir)GitVersionTask.dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\build\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\build" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\buildMultiTargeting\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\buildMultiTargeting" />
+    <Copy SourceFiles="$(ProjectDir)NugetAssets\buildMultiTargeting\GitVersionTask.targets" DestinationFolder="$(BuildDir)NuGetTaskBuild\buildCrossTargeting" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\GitVersionTask.nuspec" DestinationFolder="$(BuildDir)NuGetTaskBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(BuildDir)NuGetTaskBuild" MetadataAssembly="$(ILMergeTemp)GitVersionTask.dll" Version="$(GitVersion_NuGetVersion)" />
     <Delete Files="@(TempFiles)" />

--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -8,8 +8,13 @@
     <!-- Property that enables WriteVersionInfoToBuildLog -->
     <WriteVersionInfoToBuildLog Condition=" '$(WriteVersionInfoToBuildLog)' == '' ">true</WriteVersionInfoToBuildLog>
 
-    <!-- Property that enables UpdateAssemblyInfo -->
+    <!-- Property that enables UpdateAssemblyInfo. Default to off for SDK builds -->
+    <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' and '$(TargetFramework)' != '' ">false</UpdateAssemblyInfo>
     <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
+    
+    <!-- Property that enables setting of Version -->
+    <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
+    <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>
 
     <!-- Property that enables GetVersion -->
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
@@ -77,6 +82,18 @@
       <Output TaskParameter="CommitsSinceVersionSource" PropertyName="GitVersion_CommitsSinceVersionSource" />
       <Output TaskParameter="CommitsSinceVersionSourcePadded" PropertyName="GitVersion_CommitsSinceVersionSourcePadded" />
     </GetVersion>
+    
+    <PropertyGroup Condition=" '$(UpdateVersionProperties)' == 'true' ">
+      <Version>$(GitVersion_FullSemVer)</Version>
+      <VersionPrefix>$(GitVersion_MajorMinorPatch)</VersionPrefix>
+      <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetPreReleaseTag)</VersionSuffix>
+      <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_PreReleaseTag)</VersionSuffix>
+      <PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetVersion)</PackageVersion>
+      <PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_FullSemVer)</PackageVersion>
+      <InformationalVersion Condition=" '$(InformationalVersion)' == '' ">$(GitVersion_InformationalVersion)</InformationalVersion>
+      <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">$(GitVersion_AssemblySemVer)</AssemblyVersion>
+      <FileVersion Condition=" '$(FileVersion)' == '' ">$(GitVersion_MajorMinorPatch).$(GitVersion_CommitsSinceVersionSource)</FileVersion>
+    </PropertyGroup>
 
   </Target>
 
@@ -94,5 +111,3 @@
   </ItemGroup>
 
 </Project>
-
-

--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+    <IntermediateOutputPath Condition="$(IntermediateOutputPath) == '' Or $(IntermediateOutputPath) == '*Undefined*'">$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
+    <GitVersion_NoFetchEnabled Condition="$(GitVersion_NoFetchEnabled) == ''">false</GitVersion_NoFetchEnabled>
+
+    <!-- Property that enables WriteVersionInfoToBuildLog -->
+    <WriteVersionInfoToBuildLog Condition=" '$(WriteVersionInfoToBuildLog)' == '' ">true</WriteVersionInfoToBuildLog>
+
+    <!-- Property that enables UpdateAssemblyInfo -->
+    <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
+
+    <!-- Property that enables GetVersion -->
+    <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
+
+    <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)</GitVersionTaskLibrary>
+  </PropertyGroup>
+
+  <UsingTask
+      TaskName="GitVersionTask.UpdateAssemblyInfo"
+      AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
+  <UsingTask
+    TaskName="GitVersionTask.GetVersion"
+    AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll"  />
+  <UsingTask
+      TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
+      AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
+
+  <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
+    <WriteVersionInfoToBuildLog SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
+  </Target>
+  
+  <Target Name="UpdateAssemblyInfo" BeforeTargets="CoreCompile" Condition="$(UpdateAssemblyInfo) == 'true'">
+    <UpdateAssemblyInfo
+    SolutionDirectory="$(SolutionDir)"
+    NoFetch="$(GitVersion_NoFetchEnabled)"
+    ProjectFile="$(MSBuildProjectFullPath)"
+    IntermediateOutputPath="$(IntermediateOutputPath)"
+    RootNamespace="$(RootNamespace)"
+    CompileFiles ="@(Compile)">
+      <Output
+        TaskParameter="AssemblyInfoTempFilePath"
+        PropertyName="AssemblyInfoTempFilePath" />
+    </UpdateAssemblyInfo>
+
+    <ItemGroup>
+      <Compile Include="$(AssemblyInfoTempFilePath)" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="GetVersion" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec" Condition="$(GetVersion) == 'true'">
+
+    <GetVersion SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)">
+      <Output TaskParameter="Major" PropertyName="GitVersion_Major" />
+      <Output TaskParameter="Minor" PropertyName="GitVersion_Minor" />
+      <Output TaskParameter="Patch" PropertyName="GitVersion_Patch" />
+      <Output TaskParameter="BuildMetaData" PropertyName="GitVersion_BuildMetaData" />
+      <Output TaskParameter="BuildMetaDataPadded" PropertyName="GitVersion_BuildMetaDataPadded" />
+      <Output TaskParameter="FullBuildMetaData" PropertyName="GitVersion_FullBuildMetaData" />
+      <Output TaskParameter="BranchName" PropertyName="GitVersion_BranchName" />
+      <Output TaskParameter="Sha" PropertyName="GitVersion_Sha" />
+      <Output TaskParameter="MajorMinorPatch" PropertyName="GitVersion_MajorMinorPatch" />
+      <Output TaskParameter="SemVer" PropertyName="GitVersion_SemVer" />
+      <Output TaskParameter="LegacySemVer" PropertyName="GitVersion_LegacySemVer" />
+      <Output TaskParameter="LegacySemVerPadded" PropertyName="GitVersion_LegacySemVerPadded" />
+      <Output TaskParameter="FullSemVer" PropertyName="GitVersion_FullSemVer" />
+      <Output TaskParameter="AssemblySemVer" PropertyName="GitVersion_AssemblySemVer" />
+      <Output TaskParameter="NuGetVersion" PropertyName="GitVersion_NuGetVersion" />
+      <Output TaskParameter="NuGetPreReleaseTag" PropertyName="GitVersion_NuGetPreReleaseTag" />
+      <Output TaskParameter="PreReleaseTag" PropertyName="GitVersion_PreReleaseTag" />
+      <Output TaskParameter="PreReleaseTagWithDash" PropertyName="GitVersion_PreReleaseTagWithDash" />
+      <Output TaskParameter="PreReleaseLabel" PropertyName="GitVersion_PreReleaseLabel" />
+      <Output TaskParameter="PreReleaseNumber" PropertyName="GitVersion_PreReleaseNumber" />
+      <Output TaskParameter="InformationalVersion" PropertyName="GitVersion_InformationalVersion" />
+      <Output TaskParameter="CommitDate" PropertyName="GitVersion_CommitDate" />
+      <Output TaskParameter="CommitsSinceVersionSource" PropertyName="GitVersion_CommitsSinceVersionSource" />
+      <Output TaskParameter="CommitsSinceVersionSourcePadded" PropertyName="GitVersion_CommitsSinceVersionSourcePadded" />
+    </GetVersion>
+
+  </Target>
+
+  <!--Support for ncrunch-->
+  <ItemGroup Condition=" $(NCrunch) != '' ">
+    <None Include="$(GitVersionTaskDir)GitVersionTask.dll">
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(GitVersionTaskDir)GitVersionTask.pdb">
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(GitVersionTaskDir)NativeBinaries\**\*">
+      <Visible>False</Visible>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+

--- a/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
@@ -12,8 +12,7 @@
     <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
 
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
-    
-    
+       
     <!-- Property that enables setting of Version -->
     <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
     <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>

--- a/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
@@ -7,8 +7,16 @@
     <!-- Property that enables WriteVersionInfoToBuildLog -->
     <WriteVersionInfoToBuildLog Condition=" '$(WriteVersionInfoToBuildLog)' == '' ">true</WriteVersionInfoToBuildLog>
 
-    <!-- Property that enables GetVersion -->
+    <!-- Property that enables UpdateAssemblyInfo. Default to off for SDK builds -->
+    <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' and '$(TargetFramework)' != '' ">false</UpdateAssemblyInfo>
+    <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
+
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
+    
+    
+    <!-- Property that enables setting of Version -->
+    <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
+    <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>
 
     <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)..\build\</GitVersionTaskLibrary>
   </PropertyGroup>
@@ -23,11 +31,11 @@
       TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
       AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
 
-  <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="DispatchToInnerBuilds" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
+  <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="DispatchToInnerBuilds;GenerateNuspec" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
     <WriteVersionInfoToBuildLog SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
   </Target>
   
-  <Target Name="GetVersion" BeforeTargets="DispatchToInnerBuilds" Condition="$(GetVersion) == 'true'">
+  <Target Name="GetVersion" BeforeTargets="DispatchToInnerBuilds;GenerateNuspec" Condition="$(GetVersion) == 'true'">
 
     <GetVersion SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)">
       <Output TaskParameter="Major" PropertyName="GitVersion_Major" />
@@ -55,8 +63,18 @@
       <Output TaskParameter="CommitsSinceVersionSource" PropertyName="GitVersion_CommitsSinceVersionSource" />
       <Output TaskParameter="CommitsSinceVersionSourcePadded" PropertyName="GitVersion_CommitsSinceVersionSourcePadded" />
     </GetVersion>
+    
+    <PropertyGroup Condition=" '$(UpdateVersionProperties)' == 'true' ">
+      <Version>$(GitVersion_FullSemVer)</Version>
+      <VersionPrefix>$(GitVersion_MajorMinorPatch)</VersionPrefix>
+      <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetPreReleaseTag)</VersionSuffix>
+      <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_PreReleaseTag)</VersionSuffix>
+      <PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetVersion)</PackageVersion>
+      <PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_FullSemVer)</PackageVersion>
+      <InformationalVersion Condition=" '$(InformationalVersion)' == '' ">$(GitVersion_InformationalVersion)</InformationalVersion>
+      <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">$(GitVersion_AssemblySemVer)</AssemblyVersion>
+      <FileVersion Condition=" '$(FileVersion)' == '' ">$(GitVersion_MajorMinorPatch).$(GitVersion_CommitsSinceVersionSource)</FileVersion>
+    </PropertyGroup>
 
   </Target>
 </Project>
-
-

--- a/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
@@ -2,19 +2,15 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
-    <IntermediateOutputPath Condition="$(IntermediateOutputPath) == '' Or $(IntermediateOutputPath) == '*Undefined*'">$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
     <GitVersion_NoFetchEnabled Condition="$(GitVersion_NoFetchEnabled) == ''">false</GitVersion_NoFetchEnabled>
 
     <!-- Property that enables WriteVersionInfoToBuildLog -->
     <WriteVersionInfoToBuildLog Condition=" '$(WriteVersionInfoToBuildLog)' == '' ">true</WriteVersionInfoToBuildLog>
 
-    <!-- Property that enables UpdateAssemblyInfo -->
-    <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
-
     <!-- Property that enables GetVersion -->
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
-    <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)</GitVersionTaskLibrary>
+    <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)..\build\</GitVersionTaskLibrary>
   </PropertyGroup>
 
   <UsingTask
@@ -27,29 +23,11 @@
       TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
       AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
 
-  <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="CoreCompile" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
+  <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="DispatchToInnerBuilds" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
     <WriteVersionInfoToBuildLog SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
   </Target>
   
-  <Target Name="UpdateAssemblyInfo" BeforeTargets="CoreCompile" Condition="$(UpdateAssemblyInfo) == 'true'">
-    <UpdateAssemblyInfo
-    SolutionDirectory="$(SolutionDir)"
-    NoFetch="$(GitVersion_NoFetchEnabled)"
-    ProjectFile="$(MSBuildProjectFullPath)"
-    IntermediateOutputPath="$(IntermediateOutputPath)"
-    RootNamespace="$(RootNamespace)"
-    CompileFiles ="@(Compile)">
-      <Output
-        TaskParameter="AssemblyInfoTempFilePath"
-        PropertyName="AssemblyInfoTempFilePath" />
-    </UpdateAssemblyInfo>
-
-    <ItemGroup>
-      <Compile Include="$(AssemblyInfoTempFilePath)" />
-    </ItemGroup>
-  </Target>
-  
-  <Target Name="GetVersion" BeforeTargets="CoreCompile" Condition="$(GetVersion) == 'true'">
+  <Target Name="GetVersion" BeforeTargets="DispatchToInnerBuilds" Condition="$(GetVersion) == 'true'">
 
     <GetVersion SolutionDirectory="$(SolutionDir)" NoFetch="$(GitVersion_NoFetchEnabled)">
       <Output TaskParameter="Major" PropertyName="GitVersion_Major" />
@@ -79,20 +57,6 @@
     </GetVersion>
 
   </Target>
-
-  <!--Support for ncrunch-->
-  <ItemGroup Condition=" $(NCrunch) != '' ">
-    <None Include="$(GitVersionTaskDir)GitVersionTask.dll">
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(GitVersionTaskDir)GitVersionTask.pdb">
-      <Visible>False</Visible>
-    </None>
-    <None Include="$(GitVersionTaskDir)NativeBinaries\**\*">
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
-
 </Project>
 
 


### PR DESCRIPTION
This is an initial attempt at implementing the .NET Desktop side of #1118.

Notably, it's a bit "whack a mole" in terms of ensuring the `GetVersion` target is executed early enough. Then, without trying to overwrite what the user wants, the user will have to add something like this into their project file in order to copy the generated values into the correct version variables:

```csproj
  <Target Name="UpdateVersionVars" AfterTargets="GetVersion">
    <PropertyGroup>
      <Version>$(GitVersion_SemVer)</Version>
      <PackageVersion>$(GitVersion_SemVer)</PackageVersion>
    </PropertyGroup>
  </Target>
```

Copying to `Version` at that stage will ensure that the `AssemblyFileVersion` and `AssemblyVersion` are set based on that `Version` turns into the informational version. I'm not sure if you can use the `FullSemVer` there or if that'll cause the parsing to barf.... either way, the user is in control of what variables they assign to what there.

If there's a better way to do this than to have the user supply an `AfterTargets`, then I'm all for it. I tested this locally and it did correctly generate the file/assembly versions and the package version when using the pack command.