### PR TITLE
Added test for issue #1046 & fix proposition

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -178,7 +178,7 @@ public class DevelopScenarios
             fixture.AssertFullSemver("2.1.0-alpha.4");
             fixture.BranchTo("feature/MyFeature");
             fixture.MakeACommit();
-            fixture.AssertFullSemver("2.1.0-MyFeature.1+3");
+            fixture.AssertFullSemver("2.1.0-MyFeature.1+5");
         }
     }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -225,7 +225,7 @@ public class ReleaseBranchScenarios
             Commands.Checkout(fixture.Repository, "develop");
             fixture.Repository.MergeNoFF("release-1.0.0", Generate.SignatureNow());
 
-            fixture.AssertFullSemver("2.1.0-alpha.6");
+            fixture.AssertFullSemver("2.1.0-alpha.11");
         }
     }
 

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -386,13 +386,13 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeACommit("release 2");
             fixture.AssertFullSemver(config, "2.0.0-beta.2");
 
-            // Merge release to develop
+            // First merge release to develop
             Commands.Checkout(fixture.Repository, "develop");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             // Make some new commit on release
             Commands.Checkout(fixture.Repository, "release-2.0.0");
-            fixture.Repository.MakeACommit("release after merge");
+            fixture.Repository.MakeACommit("release 3 - after first merge");
             fixture.AssertFullSemver(config, "2.0.0-beta.3");
 
             // Make new commit on develop
@@ -402,6 +402,19 @@ public class ReleaseBranchScenarios
             // Checkout to release (no new commits) 
             Commands.Checkout(fixture.Repository, "release-2.0.0");
             fixture.AssertFullSemver(config, "2.0.0-beta.3");
+
+            // Make some new commit on release
+            fixture.Repository.MakeACommit("release 4");
+            fixture.Repository.MakeACommit("release 5");
+            fixture.AssertFullSemver(config, "2.0.0-beta.5");
+
+            // Second merge release to develop
+            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
+
+            // Checkout to release (no new commits) 
+            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.AssertFullSemver(config, "2.0.0-beta.5");
         }
     }
 }

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -140,7 +140,7 @@ namespace GitVersion
                         mergeBaseAsForwardMerge = otherBranch.Commits
                             .SkipWhile(c => c != commitToFindCommonBase)
                             .TakeWhile(c => c != findMergeBase)
-                            .FirstOrDefault(c => c.Parents.Contains(findMergeBase));
+                            .LastOrDefault(c => c.Parents.Contains(findMergeBase));
 
                         if (mergeBaseAsForwardMerge != null)
                         {

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -143,13 +143,9 @@ namespace GitVersion
                             .Any(c => c.Parents.Contains(findMergeBase));
                         if (mergeBaseWasForwardMerge)
                         {
-                            var second = commitToFindCommonBase.Parents.First();
-                            var mergeBase = this.Repository.ObjectDatabase.FindMergeBase(commit, second);
-                            if (mergeBase == findMergeBase)
-                            {
-                                break;
-                            }
-                            findMergeBase = mergeBase;
+                            commitToFindCommonBase = commitToFindCommonBase.Parents.First();
+                            findMergeBase = this.Repository.ObjectDatabase.FindMergeBase(commit, commitToFindCommonBase);
+                            
                             Logger.WriteInfo(string.Format("Merge base was due to a forward merge, next merge base is {0}", findMergeBase));
                         }
                     } while (mergeBaseWasForwardMerge);

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -133,22 +133,23 @@ namespace GitVersion
                 {
                     Logger.WriteInfo(string.Format("Found merge base of {0}", findMergeBase.Sha));
                     // We do not want to include merge base commits which got forward merged into the other branch
-                    bool mergeBaseWasForwardMerge;
+                    Commit mergeBaseAsForwardMerge;
                     do
                     {
                         // Now make sure that the merge base is not a forward merge
-                        mergeBaseWasForwardMerge = otherBranch.Commits
+                        mergeBaseAsForwardMerge = otherBranch.Commits
                             .SkipWhile(c => c != commitToFindCommonBase)
                             .TakeWhile(c => c != findMergeBase)
-                            .Any(c => c.Parents.Contains(findMergeBase));
-                        if (mergeBaseWasForwardMerge)
+                            .FirstOrDefault(c => c.Parents.Contains(findMergeBase));
+
+                        if (mergeBaseAsForwardMerge != null)
                         {
-                            commitToFindCommonBase = commitToFindCommonBase.Parents.First();
+                            commitToFindCommonBase = mergeBaseAsForwardMerge.Parents.First();
                             findMergeBase = this.Repository.ObjectDatabase.FindMergeBase(commit, commitToFindCommonBase);
-                            
+
                             Logger.WriteInfo(string.Format("Merge base was due to a forward merge, next merge base is {0}", findMergeBase));
                         }
-                    } while (mergeBaseWasForwardMerge);
+                    } while (mergeBaseAsForwardMerge != null);
                 }
 
                 // Store in cache.


### PR DESCRIPTION
Hi,

I tried to fix issue #1046. I added test for it and I did some investigation.

Here's image describing structure of commits in this test:

![f86dfbe4-cddf-11e6-9a1a-c33859516b6a](https://cloud.githubusercontent.com/assets/9153975/21899210/c122903a-d8ef-11e6-9b6d-125558c0b624.png)

I did fix for this, but after my changes two tests was failing: `ReleaseBranchScenarios.WhenReleaseBranchIsMergedIntoMasterHighestVersionIsTakenWithIt` and `DevelopScenarios.InheritVersionFromReleaseBranch`.

I changed asserts in failing tests, because looks like this tests had same issue as described in #1046. I don't know if it is proper solution. I didn't find this in documentation. Looks like corner cases.

Could someone check this is ok?

### Short description of problem:

    var findMergeBase = this.Repository.ObjectDatabase.FindMergeBase(commit, commitToFindCommonBase);

This line returned `release 2` commit for arguments: `release after merge` and `develop after merge`.

    var second = commitToFindCommonBase.Parents.First();
    var mergeBase = this.Repository.ObjectDatabase.FindMergeBase(commit, second);
                            

Then calculated parent for `develop after merge` was `Merge branch 'release-2.0.0' into develop`. This commits have same merge base -  returned `mergeBase` was also `release 2` (look at image).

    if (mergeBase == findMergeBase)
    {
       break;
    }

Because `findMergeBase` equals `mergeBase`, then loop stopped executing. It shouldn't stop because `mergeBaseWasForwardMerge` condition was still met.

### Solution
`commitToFindCommonBase` should be moved up until there is no other merge bases with `commit` (current branch tip).
