### PR TITLE
Commit message counted twice?

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -360,4 +360,18 @@ public class ReleaseBranchScenarios
             fixture.AssertFullSemver(config, "2.0.0-beta.2");
         }
     }
+
+    [Test]
+    public void ReleaseBranchShouldUseBranchNameVersionDespiteBumpInPreviousCommit()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeATaggedCommit("1.0");
+            fixture.Repository.MakeACommit("+semver:major");
+
+            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+
+            fixture.AssertFullSemver("2.0.0-beta.1+0");
+        }
+    }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using GitTools;
 using GitTools.Testing;
@@ -375,7 +376,7 @@ public class ReleaseBranchScenarios
 
             Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
 
-            fixture.AssertFullSemver("2.0.0-beta.1+0");
+            fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
     }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -379,4 +379,35 @@ public class ReleaseBranchScenarios
             fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
     }
+
+    [Test]
+    public void ReleaseBranchWithACommitShouldUseBranchNameVersionDespiteBumpInPreviousCommit()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeATaggedCommit("1.0");
+            fixture.Repository.MakeACommit("+semver:major");
+            fixture.Repository.MakeACommit();
+
+            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+
+            fixture.Repository.MakeACommit();
+
+            fixture.AssertFullSemver("2.0.0-beta.1+3");
+        }
+    }
+
+    [Test]
+    public void ReleaseBranchedAtCommitWithSemverMessageShouldUseBranchNameVersion()
+    {
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeATaggedCommit("1.0");
+            fixture.Repository.MakeACommit("+semver:major");
+
+            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+
+            fixture.AssertFullSemver("2.0.0-beta.1+1");
+        }
+    }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -1,4 +1,7 @@
-﻿using GitTools.Testing;
+﻿using System;
+using System.Diagnostics;
+using GitTools;
+using GitTools.Testing;
 using GitVersion;
 using GitVersionCore.Tests;
 using LibGit2Sharp;
@@ -368,6 +371,7 @@ public class ReleaseBranchScenarios
         {
             fixture.Repository.MakeATaggedCommit("1.0");
             fixture.Repository.MakeACommit("+semver:major");
+            fixture.Repository.MakeACommit();
 
             Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -51,7 +51,9 @@
                 BaseVersion baseVersionWithOldestSource;
                 if (matchingVersionsOnceIncremented.Any())
                 {
-                    baseVersionWithOldestSource = matchingVersionsOnceIncremented.Aggregate((v1, v2) => v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When ? v1 : v2).Version;
+                    var oldest = matchingVersionsOnceIncremented.Aggregate((v1, v2) => v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When ? v1 : v2);
+                    baseVersionWithOldestSource = oldest.Version;
+                    maxVersion = oldest;
                     Logger.WriteInfo(string.Format(
                         "Found multiple base versions which will produce the same SemVer ({0}), taking oldest source for commit counting ({1})",
                         maxVersion.IncrementedVersion,


### PR DESCRIPTION
Hi,

git init

add some file
commit to master
tag the commit "1.0"

make a new commit to master, with message "+semver:major"

create release branch (release/2.0) from master

run GitVersion from release branch.


For the given scenario, GitVersion thinks semver should be 3.0.0-beta.1+1. I think it should be 2.0.0-beta.1+0.

I might be mistaken, but I assume this is not the intended behaviour?

What do you think?