### PR TITLE
Adds /version switch

### DIFF
--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="MsBuildProjectArgTest.cs" />
     <Compile Include="PullRequestInTeamCityTest.cs" />
     <Compile Include="AssemblyInfoFileUpdateTests.cs" />
+    <Compile Include="VersionWriterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/GitVersionExe.Tests/HelpWriterTests.cs
+++ b/src/GitVersionExe.Tests/HelpWriterTests.cs
@@ -16,7 +16,8 @@ public class HelpWriterTests
             { "TargetBranch", "/b" },
             { "LogFilePath" , "/l" },
             { "DynamicRepositoryLocation" , "/dynamicRepoLocation" },
-            { "IsHelp", "/?" }
+            { "IsHelp", "/?" },
+            { "IsVersion", "/version" }
         };
         string helpText = null;
 

--- a/src/GitVersionExe.Tests/VersionWriterTests.cs
+++ b/src/GitVersionExe.Tests/VersionWriterTests.cs
@@ -6,8 +6,11 @@
     using GitVersion;
     using NUnit.Framework;
 
+    [TestFixture]
     public class VersionWriterTests
     {
+        [Category("NoMono")]
+        [Description("Won't run on Mono because generating an assembly at runtime does not work on mono")]
         [Test]
         public void WriteVersion_ShouldWriteFileVersion_WithNoPrereleaseTag()
         {
@@ -20,6 +23,8 @@
             Assert.AreEqual("1.0.0", version);
         }
 
+        [Category("NoMono")]
+        [Description("Won't run on Mono because generating an assembly at runtime does not work on mono")]
         [Test]
         public void WriteVersion_ShouldWriteFileVersion_WithPrereleaseTag()
         {

--- a/src/GitVersionExe.Tests/VersionWriterTests.cs
+++ b/src/GitVersionExe.Tests/VersionWriterTests.cs
@@ -1,0 +1,63 @@
+﻿namespace GitVersionExe.Tests
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Reflection;
+    using GitVersion;
+    using NUnit.Framework;
+
+    public class VersionWriterTests
+    {
+        [Test]
+        public void WriteVersion_ShouldWriteFileVersion_WithNoPrereleaseTag()
+        {
+            var asm = GenerateAssembly(new Version(1, 0, 0), "");
+
+            string version = null;
+            VersionWriter.WriteTo(asm, v => version = v);
+
+            Assert.IsNotNull(asm);
+            Assert.AreEqual("1.0.0", version);
+        }
+
+        [Test]
+        public void WriteVersion_ShouldWriteFileVersion_WithPrereleaseTag()
+        {
+            var asm = GenerateAssembly(new Version(1, 0, 0), "-beta0004");
+
+            string version = null;
+            VersionWriter.WriteTo(asm, v => version = v);
+
+            Assert.IsNotNull(asm);
+            Assert.AreEqual("1.0.0-beta0004", version);
+        }
+
+        private Assembly GenerateAssembly(Version fileVersion, string prereleaseInfo)
+        {
+            var source = string.Format(@"
+using System.Reflection;
+using System.Runtime.CompilerServices;
+[assembly: AssemblyTitle(""GitVersion.DynamicUnitTests"")]
+[assembly: AssemblyProduct(""GitVersion"")]
+[assembly: AssemblyVersion(""{0}"")]
+[assembly: AssemblyFileVersion(""{0}"")]
+[assembly: AssemblyInformationalVersion(""{0}{1}"")]
+
+public class B
+{{
+    public static int k=7;
+}}
+", fileVersion, prereleaseInfo);
+
+            CompilerParameters parameters = new CompilerParameters
+            {
+                GenerateInMemory = true,
+                GenerateExecutable = false,
+                OutputAssembly = "GitVersion.DynamicUnitTests.dll"
+            };
+
+            var r = CodeDomProvider.CreateProvider("CSharp").CompileAssemblyFromSource(parameters, source);
+            return r.CompiledAssembly;
+        }
+    }
+}

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -65,6 +65,13 @@ namespace GitVersion
                 var values = switchesAndValues.GetValues(name);
                 var value = values != null ? values.FirstOrDefault() : null;
 
+                if (name.IsSwitch("version"))
+                {
+                    EnsureArgumentValueCount(values);
+                    arguments.IsVersion = true;
+                    continue;
+                }
+
                 if (name.IsSwitch("l"))
                 {
                     EnsureArgumentValueCount(values);

--- a/src/GitVersionExe/Arguments.cs
+++ b/src/GitVersionExe/Arguments.cs
@@ -28,6 +28,7 @@ namespace GitVersion
         public bool Init;
         public bool Diag;
 
+        public bool IsVersion;
         public bool IsHelp;
         public string LogFilePath;
         public string ShowVariable;

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -72,6 +72,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyInfoFileUpdate.cs" />
     <Compile Include="SpecifiedArgumentRunner.cs" />
+    <Compile Include="VersionWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/GitVersionExe/HelpWriter.cs
+++ b/src/GitVersionExe/HelpWriter.cs
@@ -11,12 +11,17 @@ namespace GitVersion
 
         public static void WriteTo(Action<string> writeAction)
         {
-            const string message = @"Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.
+            string version = string.Empty;
+            VersionWriter.WriteTo(v => version = v);
+
+            string message = "GitVersion " + version + @"
+Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.
 
 GitVersion [path]
 
     path            The directory containing .git. If not defined current directory is used. (Must be first argument)
     init            Configuration utility for gitversion
+    /version        Displays the version of GitVersion
     /diag           Runs GitVersion with additional diagnostic information (requires git.exe to be installed)
     /h or /?        Shows Help
 

--- a/src/GitVersionExe/HelpWriter.cs
+++ b/src/GitVersionExe/HelpWriter.cs
@@ -1,6 +1,7 @@
 namespace GitVersion
 {
     using System;
+    using System.Reflection;
 
     class HelpWriter
     {
@@ -12,7 +13,8 @@ namespace GitVersion
         public static void WriteTo(Action<string> writeAction)
         {
             string version = string.Empty;
-            VersionWriter.WriteTo(v => version = v);
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            VersionWriter.WriteTo(assembly, v => version = v);
 
             string message = "GitVersion " + version + @"
 Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -57,6 +57,12 @@ namespace GitVersion
                     return 1;
                 }
 
+                if (arguments.IsVersion)
+                {
+                    VersionWriter.Write();
+                    return 0;
+                }
+
                 if (arguments.IsHelp)
                 {
                     HelpWriter.Write();

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -7,6 +7,7 @@ namespace GitVersion
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
 
     class Program
@@ -59,7 +60,8 @@ namespace GitVersion
 
                 if (arguments.IsVersion)
                 {
-                    VersionWriter.Write();
+                    var assembly = Assembly.GetExecutingAssembly();
+                    VersionWriter.Write(assembly);
                     return 0;
                 }
 

--- a/src/GitVersionExe/VersionWriter.cs
+++ b/src/GitVersionExe/VersionWriter.cs
@@ -6,42 +6,29 @@
 
     class VersionWriter
     {
-        /// <summary>
-        /// Gets the xss version
-        /// </summary>
-        private static Version Version
+        public static void Write(Assembly assembly)
         {
-            get { return Assembly.GetExecutingAssembly().GetName().Version; }
+            WriteTo(assembly, Console.WriteLine);
         }
 
-        /// <summary>
-        /// Gets the AssemblyInformationalVersion
-        /// </summary>
-        private static string InformationalVersion
+        public static void WriteTo(Assembly assembly, Action<string> writeAction)
         {
-            get
-            {
-                var attribute = Assembly.GetExecutingAssembly()
+            var version = GetAssemblyVersion(assembly);
+            writeAction(version);
+        }
+
+        private static string GetAssemblyVersion(Assembly assembly)
+        {
+            var attribute = assembly
                     .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
                     .FirstOrDefault() as AssemblyInformationalVersionAttribute;
 
-                if (attribute != null)
-                {
-                    return attribute.InformationalVersion;
-                }
-
-                return Version.ToString();
+            if (attribute != null)
+            {
+                return attribute.InformationalVersion;
             }
-        }
 
-        public static void Write()
-        {
-            WriteTo(Console.WriteLine);
-        }
-
-        public static void WriteTo(Action<string> writeAction)
-        {
-            writeAction(InformationalVersion);
+            return assembly.GetName().Version.ToString();
         }
     }
 }

--- a/src/GitVersionExe/VersionWriter.cs
+++ b/src/GitVersionExe/VersionWriter.cs
@@ -1,0 +1,47 @@
+﻿namespace GitVersion
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+
+    class VersionWriter
+    {
+        /// <summary>
+        /// Gets the xss version
+        /// </summary>
+        private static Version Version
+        {
+            get { return Assembly.GetExecutingAssembly().GetName().Version; }
+        }
+
+        /// <summary>
+        /// Gets the AssemblyInformationalVersion
+        /// </summary>
+        private static string InformationalVersion
+        {
+            get
+            {
+                var attribute = Assembly.GetExecutingAssembly()
+                    .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+                    .FirstOrDefault() as AssemblyInformationalVersionAttribute;
+
+                if (attribute != null)
+                {
+                    return attribute.InformationalVersion;
+                }
+
+                return Version.ToString();
+            }
+        }
+
+        public static void Write()
+        {
+            WriteTo(Console.WriteLine);
+        }
+
+        public static void WriteTo(Action<string> writeAction)
+        {
+            writeAction(InformationalVersion);
+        }
+    }
+}


### PR DESCRIPTION
Closes #947 

The version of GitVersion is now displayed if the /version switch is provided. The version is also included in the help page.