### PR TITLE
Improved version calculation for feature branches in mainline mode - …

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -65,7 +65,6 @@ public class RemoteRepositoryScenarios
     [Test]
     public void GivenARemoteGitRepositoryWhenCheckingOutDetachedhead_UsingExistingImplementationThrowsException()
     {
-
         using (var fixture = new RemoteRepositoryFixture())
         {
             Commands.Checkout(

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -49,12 +49,12 @@ namespace GitVersion
         {
             if (config == null)
             {
-                throw new ArgumentNullException("config");
+                throw new ArgumentNullException(nameof(config));
             }
 
             if (currentBranch == null)
             {
-                throw new ArgumentNullException("currentBranch");
+                throw new ArgumentNullException(nameof(currentBranch));
             }
 
             return config.Branches.Where(b => Regex.IsMatch(currentBranch.FriendlyName, "^" + b.Value.Regex, RegexOptions.IgnoreCase)).Select(kvp => kvp.Value);


### PR DESCRIPTION
…fixes #1154

In short when calculating the direct commits to master we need to remove any commits which are not on master. Otherwise we bump the mainline version on feature branches way too much. We also need to increment feature branches at the end of feature calculation unless the HEAD is a merge commit into the mainline branch (to cater for pull requests).