### PR TITLE
Skip initial verification in case of dynamic repositories

### DIFF
--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -229,6 +229,13 @@ If the docs do not help you decide on the mode open an issue to discuss what you
 
         public static void Verify(GitPreparer gitPreparer, IFileSystem fileSystem)
         {
+            if (!string.IsNullOrWhiteSpace(gitPreparer.TargetUrl))
+            {
+                // Assuming this is a dynamic repository. At this stage it's unsure whether we have 
+                // any .git info so we need to skip verification
+                return;
+            }
+
             var workingDirectory = gitPreparer.WorkingDirectory;
             var projectRootDirectory = gitPreparer.GetProjectRootDirectory();
 

--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -34,6 +34,11 @@ namespace GitVersion
             LogProvider.SetCurrentLogProvider(new LoggerWrapper());
         }
 
+        public string TargetUrl
+        {
+            get { return targetUrl; }
+        }
+
         public string WorkingDirectory
         {
             get { return targetPath; }


### PR DESCRIPTION
The initial verification breaks dynamic repositories because it requires a .git directory (but we don't have it yet). The change in this PR skips the initial verification in case of dynamic repositories.