### PR TITLE
Improved merge base detection

### DIFF
--- a/src/GitVersionCore.Tests/GitRepoMetadataProviderTests.cs
+++ b/src/GitVersionCore.Tests/GitRepoMetadataProviderTests.cs
@@ -1,0 +1,200 @@
+﻿namespace GitVersionCore.Tests
+{
+    using System;
+    using GitTools;
+    using GitTools.Testing;
+    using GitVersion;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class GitRepoMetadataProviderTests
+    {
+        [Test]
+        public void FindsCorrectMergeBaseForForwardMerge()
+        {
+            //*9dfb8b4 49 minutes ago(develop)
+            //*54f21b2 53 minutes ago
+            //    |\  
+            //    | | *a219831 51 minutes ago(HEAD -> release-2.0.0)
+            //    | |/
+            //    | *4441531 54 minutes ago
+            //    | *89840df 56 minutes ago
+            //    |/
+            //*91bf945 58 minutes ago(master)
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.MakeACommit("initial");
+                fixture.BranchTo("develop");
+                var expectedReleaseMergeBase = fixture.Repository.Head.Tip;
+
+                // Create release from develop
+                fixture.BranchTo("release-2.0.0");
+
+                // Make some commits on release
+                fixture.MakeACommit("release 1");
+                fixture.MakeACommit("release 2");
+                var expectedDevelopMergeBase = fixture.Repository.Head.Tip;
+
+                // First forward merge release to develop
+                fixture.Checkout("develop");
+                fixture.MergeNoFF("release-2.0.0");
+
+                // Make some new commit on release
+                fixture.Checkout("release-2.0.0");
+                fixture.MakeACommit("release 3 - after first merge");
+
+                // Make new commit on develop
+                fixture.Checkout("develop");
+
+                // Checkout to release (no new commits) 
+                fixture.Checkout("release-2.0.0");
+
+                var develop = fixture.Repository.FindBranch("develop");
+                var release = fixture.Repository.FindBranch("release-2.0.0");
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(release, develop);
+
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(develop, release);
+
+                fixture.Repository.DumpGraph(Console.WriteLine);
+
+                releaseBranchMergeBase.ShouldBe(expectedReleaseMergeBase);
+                developMergeBase.ShouldBe(expectedDevelopMergeBase);
+            }
+        }
+
+        [Test]
+        public void FindsCorrectMergeBaseForForwardMergeMovesOn()
+        {
+            //*9dfb8b4 49 minutes ago(develop)
+            //*54f21b2 53 minutes ago
+            //    |\  
+            //    | | *a219831 51 minutes ago(HEAD -> release-2.0.0)
+            //    | |/
+            //    | *4441531 54 minutes ago
+            //    | *89840df 56 minutes ago
+            //    |/
+            //*91bf945 58 minutes ago(master)
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.MakeACommit("initial");
+                fixture.BranchTo("develop");
+                var expectedReleaseMergeBase = fixture.Repository.Head.Tip;
+
+                // Create release from develop
+                fixture.BranchTo("release-2.0.0");
+
+                // Make some commits on release
+                fixture.MakeACommit("release 1");
+                fixture.MakeACommit("release 2");
+                var expectedDevelopMergeBase = fixture.Repository.Head.Tip;
+
+                // First forward merge release to develop
+                fixture.Checkout("develop");
+                fixture.MergeNoFF("release-2.0.0");
+
+                // Make some new commit on release
+                fixture.Checkout("release-2.0.0");
+                fixture.MakeACommit("release 3 - after first merge");
+
+                // Make new commit on develop
+                fixture.Checkout("develop");
+                // Checkout to release (no new commits) 
+                fixture.MakeACommit("develop after merge");
+
+                // Checkout to release (no new commits) 
+                fixture.Checkout("release-2.0.0");
+
+                var develop = fixture.Repository.FindBranch("develop");
+                var release = fixture.Repository.FindBranch("release-2.0.0");
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(release, develop);
+
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(develop, release);
+
+                fixture.Repository.DumpGraph(Console.WriteLine);
+
+                releaseBranchMergeBase.ShouldBe(expectedReleaseMergeBase);
+                developMergeBase.ShouldBe(expectedDevelopMergeBase);
+            }
+        }
+
+        [Test]
+        public void FindsCorrectMergeBaseForMultipleForwardMerges()
+        {
+            //*403b294 44 minutes ago(develop)
+            //|\  
+            //| *306b243 45 minutes ago(HEAD -> release-2.0.0)
+            //| *4cf5969 47 minutes ago
+            //| *4814083 51 minutes ago
+            //* | cddd3cc 49 minutes ago
+            //* | 2b2b52a 53 minutes ago
+            //|\ \  
+            //| |/
+            //| *8113776 54 minutes ago
+            //| *3c0235e 56 minutes ago
+            //|/
+            //*f6f1283 58 minutes ago(master)
+
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.MakeACommit("initial");
+                fixture.BranchTo("develop");
+                var expectedReleaseMergeBase = fixture.Repository.Head.Tip;
+
+                // Create release from develop
+                fixture.BranchTo("release-2.0.0");
+
+                // Make some commits on release
+                fixture.MakeACommit("release 1");
+                fixture.MakeACommit("release 2");
+
+                // First forward merge release to develop
+                fixture.Checkout("develop");
+                fixture.MergeNoFF("release-2.0.0");
+
+                // Make some new commit on release
+                fixture.Checkout("release-2.0.0");
+                fixture.Repository.MakeACommit("release 3 - after first merge");
+
+                // Make new commit on develop
+                fixture.Checkout("develop");
+                // Checkout to release (no new commits) 
+                fixture.Checkout("release-2.0.0");
+                fixture.Checkout("develop");
+                fixture.Repository.MakeACommit("develop after merge");
+
+                // Checkout to release (no new commits) 
+                fixture.Checkout("release-2.0.0");
+
+                // Make some new commit on release
+                fixture.Repository.MakeACommit("release 4");
+                fixture.Repository.MakeACommit("release 5");
+                var expectedDevelopMergeBase = fixture.Repository.Head.Tip;
+
+                // Second merge release to develop
+                fixture.Checkout("develop");
+                fixture.MergeNoFF("release-2.0.0");
+
+                // Checkout to release (no new commits) 
+                fixture.Checkout("release-2.0.0");
+
+                var develop = fixture.Repository.FindBranch("develop");
+                var release = fixture.Repository.FindBranch("release-2.0.0");
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(release, develop);
+
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                    .FindMergeBase(develop, release);
+
+                fixture.Repository.DumpGraph(Console.WriteLine);
+
+                releaseBranchMergeBase.ShouldBe(expectedReleaseMergeBase);
+                developMergeBase.ShouldBe(expectedDevelopMergeBase);
+            }
+        }
+    }
+}

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="BuildServers\TeamCityTests.cs" />
     <Compile Include="Configuration\IgnoreConfigTests.cs" />
     <Compile Include="DynamicRepositoryTests.cs" />
+    <Compile Include="GitRepoMetadataProviderTests.cs" />
     <Compile Include="GitToolsTestingExtensions.cs" />
     <Compile Include="DocumentationTests.cs" />
     <Compile Include="ConfigProviderTests.cs" />

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using GitTools;
-using GitTools.Testing;
+﻿using GitTools.Testing;
 using GitVersion;
 using GitVersionCore.Tests;
 using LibGit2Sharp;
@@ -17,13 +13,13 @@ public class ReleaseBranchScenarios
         using (var fixture = new EmptyRepositoryFixture())
         {
             fixture.Repository.MakeACommit();
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
+            fixture.BranchTo("develop");
             fixture.Repository.MakeCommits(3);
             var releaseBranch = fixture.Repository.CreateBranch("release/1.0.0");
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release/1.0.0");
             fixture.Repository.ApplyTag("1.0.0");
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
 
             fixture.Repository.Branches.Remove(releaseBranch);
 
@@ -37,24 +33,23 @@ public class ReleaseBranchScenarios
         using (var fixture = new EmptyRepositoryFixture())
         {
             fixture.Repository.MakeACommit();
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
+            fixture.BranchTo("develop");
             fixture.Repository.MakeCommits(3);
-            var releaseBranch = fixture.Repository.CreateBranch("release/1.0.0");
-            Commands.Checkout(fixture.Repository, releaseBranch);
+            fixture.BranchTo("release/1.0.0");
             fixture.Repository.MakeACommit();
 
             // Merge to master
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release/1.0.0");
             fixture.Repository.ApplyTag("1.0.0");
 
             // Merge to develop
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release/1.0.0");
             fixture.AssertFullSemver("1.1.0-alpha.2");
 
             fixture.Repository.MakeACommit();
-            fixture.Repository.Branches.Remove(releaseBranch);
+            fixture.Repository.Branches.Remove("release/1.0.0");
 
             fixture.AssertFullSemver("1.1.0-alpha.2");
         }
@@ -68,7 +63,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.MakeCommits(5);
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
 
             fixture.AssertFullSemver("2.0.0-beta.1+0");
             fixture.Repository.MakeCommits(2);
@@ -84,7 +79,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.MakeCommits(5);
             fixture.Repository.CreateBranch("releases/2.0.0");
-            Commands.Checkout(fixture.Repository, "releases/2.0.0");
+            fixture.Checkout("releases/2.0.0");
 
             fixture.AssertFullSemver("2.0.0-beta.1+0");
             fixture.Repository.MakeCommits(2);
@@ -102,7 +97,7 @@ public class ReleaseBranchScenarios
         using (var fixture = new EmptyRepositoryFixture())
         {
             fixture.Repository.MakeCommits(5);
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release-2.0.0"));
+            fixture.BranchTo("release-2.0.0");
 
             fixture.AssertFullSemver(config, "2.0.0-beta.1+0");
             fixture.Repository.MakeCommits(2);
@@ -125,7 +120,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.MakeCommits(5);
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
 
             fixture.AssertFullSemver(config, "2.0.0-rc.1+0");
             fixture.Repository.MakeCommits(2);
@@ -142,7 +137,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.CreateBranch("develop");
             fixture.Repository.MakeCommits(5);
             fixture.Repository.CreateBranch("release-2.0.0-Final");
-            Commands.Checkout(fixture.Repository, "release-2.0.0-Final");
+            fixture.Checkout("release-2.0.0-Final");
 
             fixture.AssertFullSemver("2.0.0-beta.1+0");
             fixture.Repository.MakeCommits(2);
@@ -160,9 +155,9 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeCommits(1);
 
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             fixture.AssertFullSemver("2.0.0+0");
@@ -179,9 +174,9 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.MakeCommits(1);
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             fixture.AssertFullSemver("2.0.0+0");
@@ -196,9 +191,9 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.MakeCommits(1);
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             fixture.AssertFullSemver("2.0.0+0");
@@ -218,15 +213,15 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeCommits(1);
 
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             fixture.Repository.CreateBranch("release-1.0.0");
-            Commands.Checkout(fixture.Repository, "release-1.0.0");
+            fixture.Checkout("release-1.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release-1.0.0", Generate.SignatureNow());
 
             fixture.AssertFullSemver("2.1.0-alpha.11");
@@ -242,15 +237,15 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeCommits(1);
 
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             fixture.Repository.CreateBranch("release-1.0.0");
-            Commands.Checkout(fixture.Repository, "release-1.0.0");
+            fixture.Checkout("release-1.0.0");
             fixture.Repository.MakeCommits(4);
-            Commands.Checkout(fixture.Repository, "master");
+            fixture.Checkout("master");
             fixture.Repository.MergeNoFF("release-1.0.0", Generate.SignatureNow());
 
             fixture.AssertFullSemver("2.0.0+5");
@@ -265,13 +260,13 @@ public class ReleaseBranchScenarios
             const string TaggedVersion = "1.0.3";
             fixture.Repository.MakeATaggedCommit(TaggedVersion);
             fixture.Repository.CreateBranch("develop");
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
 
             fixture.Repository.MakeCommits(1);
             fixture.AssertFullSemver("1.1.0-alpha.1");
 
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(1);
 
             fixture.AssertFullSemver("2.0.0-beta.1+1");
@@ -284,11 +279,11 @@ public class ReleaseBranchScenarios
             fixture.AssertFullSemver("2.0.0-beta.2+2");
 
             //merge down to develop
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             //but keep working on the release
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.AssertFullSemver("2.0.0-beta.2+2");
             fixture.MakeACommit();
             fixture.AssertFullSemver("2.0.0-beta.2+3");
@@ -307,12 +302,12 @@ public class ReleaseBranchScenarios
             const string TaggedVersion = "1.0.3";
             fixture.Repository.MakeATaggedCommit(TaggedVersion);
             fixture.Repository.CreateBranch("develop");
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
 
             fixture.Repository.MakeCommits(1);
 
             fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeCommits(1);
 
             fixture.AssertFullSemver(config, "2.0.0-beta.1");
@@ -327,7 +322,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeCommits(2);
 
             //but keep working on the release
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MergeNoFF("hotfix-2.0.0", Generate.SignatureNow());
             fixture.Repository.Branches.Remove(fixture.Repository.Branches["hotfix-2.0.0"]);
             fixture.AssertFullSemver(config, "2.0.0-beta.7");
@@ -347,17 +342,17 @@ public class ReleaseBranchScenarios
             const string TaggedVersion = "1.0.3";
             fixture.Repository.MakeATaggedCommit(TaggedVersion);
             fixture.Repository.CreateBranch("develop");
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MakeACommit();
 
             fixture.Repository.CreateBranch("release/2.0.0");
 
             fixture.Repository.CreateBranch("release/2.0.0-xxx");
-            Commands.Checkout(fixture.Repository, "release/2.0.0-xxx");
+            fixture.Checkout("release/2.0.0-xxx");
             fixture.Repository.MakeACommit();
             fixture.AssertFullSemver(config, "2.0.0-beta.1");
 
-            Commands.Checkout(fixture.Repository, "release/2.0.0");
+            fixture.Checkout("release/2.0.0");
             fixture.Repository.MakeACommit();
             fixture.AssertFullSemver(config, "2.0.0-beta.1");
 
@@ -376,35 +371,37 @@ public class ReleaseBranchScenarios
 
         using (var fixture = new EmptyRepositoryFixture())
         {
-            fixture.Repository.MakeACommit("initial");
-            fixture.Repository.CreateBranch("develop");
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.MakeACommit("initial");
+            fixture.BranchTo("develop");
 
             // Create release from develop
-            fixture.Repository.CreateBranch("release-2.0.0");
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.BranchTo("release-2.0.0");
             fixture.AssertFullSemver(config, "2.0.0-beta.0");
 
             // Make some commits on release
-            fixture.Repository.MakeACommit("release 1");
-            fixture.Repository.MakeACommit("release 2");
+            fixture.MakeACommit("release 1");
+            fixture.MakeACommit("release 2");
             fixture.AssertFullSemver(config, "2.0.0-beta.2");
 
-            // First merge release to develop
-            Commands.Checkout(fixture.Repository, "develop");
-            fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
+            // First forward merge release to develop
+            fixture.Checkout("develop");
+            fixture.MergeNoFF("release-2.0.0");
 
             // Make some new commit on release
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.Repository.MakeACommit("release 3 - after first merge");
             fixture.AssertFullSemver(config, "2.0.0-beta.3");
 
             // Make new commit on develop
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
+            // Checkout to release (no new commits) 
+            fixture.Checkout("release-2.0.0");
+            fixture.AssertFullSemver(config, "2.0.0-beta.3");
+            fixture.Checkout("develop");
             fixture.Repository.MakeACommit("develop after merge");
 
             // Checkout to release (no new commits) 
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.AssertFullSemver(config, "2.0.0-beta.3");
 
             // Make some new commit on release
@@ -413,11 +410,11 @@ public class ReleaseBranchScenarios
             fixture.AssertFullSemver(config, "2.0.0-beta.5");
 
             // Second merge release to develop
-            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Checkout("develop");
             fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
 
             // Checkout to release (no new commits) 
-            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.Checkout("release-2.0.0");
             fixture.AssertFullSemver(config, "2.0.0-beta.5");
         }
     }
@@ -430,7 +427,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeACommit("+semver:major");
             fixture.Repository.MakeACommit();
 
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+            fixture.BranchTo("release/2.0");
 
             fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
@@ -445,7 +442,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeACommit("+semver:major");
             fixture.Repository.MakeACommit();
 
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+            fixture.BranchTo("release/2.0");
 
             fixture.Repository.MakeACommit();
 
@@ -461,7 +458,7 @@ public class ReleaseBranchScenarios
             fixture.Repository.MakeATaggedCommit("1.0");
             fixture.Repository.MakeACommit("+semver:major");
 
-            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0"));
+            fixture.BranchTo("release/2.0");
 
             fixture.AssertFullSemver("2.0.0-beta.1+1");
         }


### PR DESCRIPTION
Fixes #1171, there was a bug in the original merge base detection code which would detect the first merge base but not actually work backwards. This caused commit counts to reset when they shouldn't