### PR TITLE
Added Homebrew documentation

### DIFF
--- a/docs/usage/command-line.md
+++ b/docs/usage/command-line.md
@@ -1,12 +1,26 @@
 # Command Line
 
-If you want a command line version installed on your machine then you can use [Chocolatey](http://chocolatey.org) to install GitVersion
+If you want a command line version installed on your machine then you can use [Chocolatey](http://chocolatey.org) or [Homebrew](https://brew.sh/) to install GitVersion.
 
-Available on [Chocolatey](http://chocolatey.org) under [GitVersion.Portable](http://chocolatey.org/packages/GitVersion.Portable)
+## Chocolatey
 
- > choco install GitVersion.Portable
+Available on [Chocolatey](http://chocolatey.org) under [GitVersion.Portable](http://chocolatey.org/packages/GitVersion.Portable).
+
+```shell
+choco install GitVersion.Portable
+```
 
 Switches are available with `GitVersion /?`
+
+## Homebrew
+
+To install GitVersion with [Homebrew](https://brew.sh/), type:
+
+```shell
+brew install gitversion
+```
+
+Switches are available with `gitversion --help`. Even though the documentation uses a slash `/` for all switches, you need to use a dash `-` instead, since `/` is interpreted as a root path on POSIX based operating systems.
 
 ## Output
 
@@ -15,7 +29,7 @@ By default GitVersion returns a json object to stdout containing all the [variab
 `GitVersion.exe /output buildserver` will change the mode of GitVersion to write out the variables to whatever build server it is running in. You can then use those variables in your build scripts or run different tools to create versioned NuGet packages or whatever you would like to do. See [build servers](../build-server-support/build-server-support.md) for more information about this.
 
 ## Inject version metadata into the assembly
-`GitVersion.exe /updateassemblyinfo` will recursively search for all `AssemblyInfo.cs` or `AssemblyInfo.vb` files in the git repo and update them. 
+`GitVersion.exe /updateassemblyinfo` will recursively search for all `AssemblyInfo.cs` or `AssemblyInfo.vb` files in the git repo and update them.
 It will update the following assembly attributes:
 
 * `AssemblyVersion` will be set to the `AssemblySemVer` variable.
@@ -24,7 +38,7 @@ It will update the following assembly attributes:
 
 Note that contrary to when using the [MSBuild Task](msbuild-task.md) the attributes must already exist in the `AssemblyInfo.cs` or `AssemblyInfo.vb` files prior to calling GitVersion.
 
-By adding `/updateassemblyinfo <filenames>` the name of AssemblyInfo file to update can be set.  This switch can accept multiple files with the path to the file specified relative to the working directory. 
+By adding `/updateassemblyinfo <filenames>` the name of AssemblyInfo file to update can be set.  This switch can accept multiple files with the path to the file specified relative to the working directory.
 
 GitVersion can generate an assembly info source file for you if it does not already exist.  Use the `/ensureassemblyinfo` switch alongside `/updateassemblyinfo <filename>`, if the filename specified does not exist it will be generated based on a known template that adds:
 
@@ -32,7 +46,7 @@ GitVersion can generate an assembly info source file for you if it does not alre
 * `AssemblyFileVersion` will be set to the `MajorMinorPatch` variable with a appended `.0`.
 * `AssemblyInformationalVersion` will be set to the `InformationalVersion` variable.
 
-This can be done for *.cs, *.vb and *.fs files. 
+This can be done for *.cs, *.vb and *.fs files.
 
 When requesting that GitVersion generate an assembly info file you are limited to only specifying a single `<filename>` within the `/updateassemblyinfo` switch, this is to prevent the creation of mulitple assembly info files with the same assembly version attributes.  If this occurs your build will fail.
 
@@ -57,7 +71,7 @@ Will result in command line argument error
 Will iterate through each file and update known attributes (`AssemblyVersion`, `AssemblyFileVersion`, `AssemblyInformationalVersion`).
 
 ## Override config
-`/overrideconfig [key=value]` will override appropriate key from 'GitVersion.yml'. 
+`/overrideconfig [key=value]` will override appropriate key from 'GitVersion.yml'.
 
 At the moment only `tag-prefix` option is supported. Read more about [Configuration](/configuration/).
 


### PR DESCRIPTION
This PR adds a bit of documentation on how GitVersion can be installed with [Homebrew](https://brew.sh/).