### PR TITLE
Jenkins Pipeline compatibility

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/EnvironmentVariableJenkinsTests.cs
@@ -9,6 +9,7 @@ public class EnvironmentVariableJenkinsTests
     string key = "JENKINS_URL";
     string branch = "GIT_BRANCH";
     string localBranch = "GIT_LOCAL_BRANCH";
+    string pipelineBranch = "BRANCH_NAME";
 
     private void SetEnvironmentVariableForDetection()
     {
@@ -59,5 +60,29 @@ public class EnvironmentVariableJenkinsTests
         // Restore environment variables
         Environment.SetEnvironmentVariable(branch, branchOrig);
         Environment.SetEnvironmentVariable(localBranch, localBranchOrig);
+    }
+
+    [Test]
+    public void JenkinsTakesBranchNameInPipelineAsCode()
+    {
+        // Save original values so they can be restored
+        string branchOrig = Environment.GetEnvironmentVariable(branch);
+        string localBranchOrig = Environment.GetEnvironmentVariable(localBranch);
+        string pipelineBranchOrig = Environment.GetEnvironmentVariable(pipelineBranch);
+
+        // Set BRANCH_NAME in pipeline mode
+        Environment.SetEnvironmentVariable(pipelineBranch, "master");
+        // When Jenkins uses a Pipeline, GIT_BRANCH and GIT_LOCAL_BRANCH are not set:
+        Environment.SetEnvironmentVariable(branch, null);
+        Environment.SetEnvironmentVariable(localBranch, null);
+
+        // Test Jenkins GetCurrentBranch method now returns BRANCH_NAME
+        var j = new Jenkins();
+        j.GetCurrentBranch(true).ShouldBe("master");
+
+        // Restore environment variables
+        Environment.SetEnvironmentVariable(branch, branchOrig);
+        Environment.SetEnvironmentVariable(localBranch, localBranchOrig);
+        Environment.SetEnvironmentVariable(pipelineBranch, pipelineBranchOrig);
     }
 }

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -46,7 +46,7 @@ branches:
     tag: PullRequest
     increment: Inherit
     prevent-increment-of-merged-branch-version: false
-    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    tag-number-pattern: '[/-](?<number>\d+)'
     track-merge-target: false
     regex: (pull|pull\-requests|pr)[/-]
     tracks-release-branches: false

--- a/src/GitVersionCore/BuildServers/BuildServerBase.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerBase.cs
@@ -33,5 +33,10 @@
                 writer(buildParameter);
             }
         }
+
+        public virtual bool ShouldCleanUpRemotes()
+        {
+            return false;
+        }
     }
 }

--- a/src/GitVersionCore/BuildServers/IBuildServer.cs
+++ b/src/GitVersionCore/BuildServers/IBuildServer.cs
@@ -13,5 +13,6 @@
         /// If the build server should not try and fetch
         /// </summary>
         bool PreventFetch();
+        bool ShouldCleanUpRemotes();
     }
 }

--- a/src/GitVersionCore/BuildServers/Jenkins.cs
+++ b/src/GitVersionCore/BuildServers/Jenkins.cs
@@ -36,12 +36,29 @@
 
         public override string GetCurrentBranch(bool usingDynamicRepos)
         {
-            return Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH") ?? Environment.GetEnvironmentVariable("GIT_BRANCH");
+            return IsPipelineAsCode()
+                ? Environment.GetEnvironmentVariable("BRANCH_NAME")
+                : (Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH") ?? Environment.GetEnvironmentVariable("GIT_BRANCH"));
+        }
+
+        private bool IsPipelineAsCode()
+        {
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BRANCH_NAME"));
         }
 
         public override bool PreventFetch()
         {
             return true;
+        }
+
+        /// <summary>
+        /// When Jenkins uses pipeline-as-code, it creates two remotes: "origin" and "origin1".
+        /// This should be cleaned up, so that normizaling the Git repo will not fail.
+        /// </summary>
+        /// <returns></returns>
+        public override bool ShouldCleanUpRemotes()
+        {
+            return IsPipelineAsCode();
         }
 
         public override void WriteIntegration(Action<string> writer, VersionVariables variables)

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -122,7 +122,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 GetOrCreateBranchDefaults(config, PullRequestBranchKey),
                 PullRequestRegex,
                 defaultTag: "PullRequest",
-                defaultTagNumberPattern: @"[/-](?<number>\d+)[-/]",
+                defaultTagNumberPattern: @"[/-](?<number>\d+)",
                 defaultIncrementStrategy: IncrementStrategy.Inherit);
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, HotfixBranchKey),

--- a/src/GitVersionCore/ExecuteCore.cs
+++ b/src/GitVersionCore/ExecuteCore.cs
@@ -25,8 +25,9 @@ namespace GitVersion
             var applicableBuildServers = BuildServerList.GetApplicableBuildServers();
             var buildServer = applicableBuildServers.FirstOrDefault();
             var fetch = noFetch || (buildServer != null && buildServer.PreventFetch());
+            var shouldCleanUpRemotes = buildServer != null && buildServer.ShouldCleanUpRemotes();
             var gitPreparer = new GitPreparer(targetUrl, dynamicRepositoryLocation, authentication, fetch, workingDirectory);
-            gitPreparer.Initialise(buildServer != null, ResolveCurrentBranch(buildServer, targetBranch, !string.IsNullOrWhiteSpace(dynamicRepositoryLocation)));
+            gitPreparer.Initialise(buildServer != null, ResolveCurrentBranch(buildServer, targetBranch, !string.IsNullOrWhiteSpace(dynamicRepositoryLocation)), shouldCleanUpRemotes);
             var dotGitDirectory = gitPreparer.GetDotGitDirectory();
             var projectRoot = gitPreparer.GetProjectRootDirectory();
 

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="HelpWriterTests.cs" />
     <Compile Include="JsonOutputOnBuildServer.cs" />
     <Compile Include="MsBuildProjectArgTest.cs" />
+    <Compile Include="PullRequestInJenkinsPipelineTest.cs" />
     <Compile Include="PullRequestInTeamCityTest.cs" />
     <Compile Include="AssemblyInfoFileUpdateTests.cs" />
     <Compile Include="VersionWriterTests.cs" />

--- a/src/GitVersionExe.Tests/PullRequestInJenkinsPipelineTest.cs
+++ b/src/GitVersionExe.Tests/PullRequestInJenkinsPipelineTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using GitTools.Testing;
+using LibGit2Sharp;
+using NUnit.Framework;
+using Shouldly;
+
+[TestFixture]
+public class PullRequestInJenkinsTest
+{
+    [TestCase]
+    public void GivenJenkinsPipelineHasDuplicatedOrigin_VersionIsCalculatedProperly()
+    {
+        string pipelineBranch = "BRANCH_NAME";
+        string pipelineBranchOrig = Environment.GetEnvironmentVariable(pipelineBranch);
+
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            var remoteRepositoryPath = PathHelper.GetTempPath();
+            Repository.Init(remoteRepositoryPath);
+            using (var remoteRepository = new Repository(remoteRepositoryPath))
+            {
+                remoteRepository.Config.Set("user.name", "Test");
+                remoteRepository.Config.Set("user.email", "test@email.com");
+                fixture.Repository.Network.Remotes.Add("origin", remoteRepositoryPath);
+                // Jenkins Pipeline will create a duplicate origin:
+                fixture.Repository.Network.Remotes.Add("origin1", remoteRepositoryPath);
+                Console.WriteLine("Created git repository at {0}", remoteRepositoryPath);
+                remoteRepository.MakeATaggedCommit("1.0.3");
+
+                var branch = remoteRepository.CreateBranch("FeatureBranch");
+                Commands.Checkout(remoteRepository, branch);
+                remoteRepository.MakeCommits(2);
+                Commands.Checkout(remoteRepository, remoteRepository.Head.Tip.Sha);
+                //Emulate merge commit
+                var mergeCommitSha = remoteRepository.MakeACommit().Sha;
+                Commands.Checkout(remoteRepository, "master"); // HEAD cannot be pointing at the merge commit
+                remoteRepository.Refs.Add("refs/heads/pull/5/head", new ObjectId(mergeCommitSha));
+
+                // Checkout PR commit
+                Commands.Fetch((Repository)fixture.Repository, "origin", new string[0], new FetchOptions(), null);
+                Commands.Checkout(fixture.Repository, mergeCommitSha);
+            }
+
+            // Emulating Jenkins environment variable
+            Environment.SetEnvironmentVariable(pipelineBranch, "PR-5");
+            Environment.SetEnvironmentVariable("JENKINS_URL", "url", EnvironmentVariableTarget.Process);
+
+            var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath);
+            
+            result.ExitCode.ShouldBe(0);
+            result.OutputVariables.FullSemVer.ShouldBe("1.0.4-PullRequest0005.3");
+
+            // Cleanup repository files
+            DirectoryHelper.DeleteDirectory(remoteRepositoryPath);
+
+            Environment.SetEnvironmentVariable(pipelineBranch, pipelineBranchOrig);
+            Environment.SetEnvironmentVariable("JENKINS_URL", null, EnvironmentVariableTarget.Process);
+        }
+    }
+}


### PR DESCRIPTION
GitVersion includes support for Jenkins as a build system, but this only supports traditional Jenkins jobs, not the new way of using [Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/).

Currently, you can find all kinds of workarounds on the web to make GitVersion play nicely with Jenkins Pipeline-as-code. This pull request aims to fix it within GitVersion so that one doesn't need workarounds in his pipeline.

Current problems:
- GitVersion expects the branch name in the environment variable `GIT_BRANCH` while using Jenkins. This is true for the old Git plugin, but when using Jenkins pipeline, the branch name is stored in `BRANCH_NAME` instead.
A workaround that people use is to add `env.GIT_BRANCH = env.BRANCH_NAME` in the Jenkinsfile, but this pollutes the pipeline.
- Somehow Jenkins will add two remotes `origin` and `origin1` when executing the Pipeline.
[GitTools](https://github.com/GitTools/GitTools.Core/blob/master/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs) will therefore fail with the error "2 remote(s) have been detected"
A workaround to remove the duplicate origin has been posted at http://stackoverflow.com/questions/39475135/gitversion-in-a-jenkins-multibranch-pipeline-job
- Within a pull request, both the pull request number and the number of commit should be taken into account, e.g., `1.0.4-PullRequest0005.3`. However, the actual result was `1.0.4-PullRequest.3`, missing the PR number and therefore leading to duplicates. This can be fixed by changing the default tag number pattern from `[/-](?<number>\d+)[/-]` to `[/-](?<number>\d+)`.
