### PR TITLE
Invalid release version after commit beetween merge release to develop

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -421,7 +421,45 @@ public class ReleaseBranchScenarios
             fixture.AssertFullSemver(config, "2.0.0-beta.5");
         }
     }
-  
+
+    [Test]
+    public void CommitBeetweenMergeReleaseToDevelop_ShouldNotResetCount()
+    {
+        var config = new Config
+        {
+            VersioningMode = VersioningMode.ContinuousDeployment
+        };
+
+        using(var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.Repository.MakeACommit("initial");
+            fixture.Repository.CreateBranch("develop");
+            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Repository.CreateBranch("release-2.0.0");
+            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.AssertFullSemver(config, "2.0.0-beta.0");
+
+            // Make some commits on release
+            var commit1 = fixture.Repository.MakeACommit();
+            var commit2 = fixture.Repository.MakeACommit();
+            fixture.AssertFullSemver(config, "2.0.0-beta.2");
+
+            // Merge release to develop - emulate commit beetween other person release commit push and this commit merge to develop
+            Commands.Checkout(fixture.Repository, "develop");
+            fixture.Repository.Merge(commit1, Generate.SignatureNow(), new MergeOptions { FastForwardStrategy = FastForwardStrategy.NoFastForward });
+            fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
+
+            // Check version on release after merge to develop
+            Commands.Checkout(fixture.Repository, "release-2.0.0");
+            fixture.AssertFullSemver(config, "2.0.0-beta.2");
+            
+            // Check version on release after making some new commits
+            fixture.Repository.MakeACommit();
+            fixture.Repository.MakeACommit();
+            fixture.AssertFullSemver(config, "2.0.0-beta.4");
+        }
+    }
+
     public void ReleaseBranchShouldUseBranchNameVersionDespiteBumpInPreviousCommit()
     {
         using (var fixture = new EmptyRepositoryFixture())

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -140,6 +140,7 @@ namespace GitVersion
                         mergeBaseAsForwardMerge = otherBranch.Commits
                             .SkipWhile(c => c != commitToFindCommonBase)
                             .TakeWhile(c => c != findMergeBase)
+                            .OrderBy(c => c.Parents.Count())
                             .LastOrDefault(c => c.Parents.Contains(findMergeBase));
 
                         if (mergeBaseAsForwardMerge != null)


### PR DESCRIPTION
We detected problem with version calculating when someone will push commit beetween other person commit to release and merge to develop. Here's screen describing problem:
![develop](https://cloud.githubusercontent.com/assets/9153975/25183275/6a3eb00e-2517-11e7-822b-2da1ea5711c6.png)

Actions in repo which are required:
1. Person A created & pushed commit 1 on release branch.
2. Person A created merge commit (3) of release branch to develop.
3. Person B created & pushed commit 2 on release branch.
4. Person A pushed previously created merge commit (3) to remote repo.
5. Person B created & pushed merge commit (4) of release branch to develop.

I reproduced that situation in unit test by using commit merge instead of branch merge.
