### PR TITLE
Improvements to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ARG GitVersionZip
 # Add GitVersion
 
 ADD ./releaseArtifacts/$GitVersionZip .
-RUN unzip -d /usr/lib/GitVersion/ $GitVersionZip
-RUN rm $GitVersionZip
+RUN unzip -d /usr/lib/GitVersion/ $GitVersionZip && rm $GitVersionZip
 WORKDIR /usr/lib/GitVersion/
 
 # Libgit2 can't resolve relative paths, patch to absolute path

--- a/src/DockerBase/Dockerfile
+++ b/src/DockerBase/Dockerfile
@@ -5,9 +5,7 @@ MAINTAINER GitTools Maintainers <jake@ginnivan.net>
 # Wheezy doesn't support glibc 2.15 which libgit2sharp requires
 # So we are going to install mono on ubuntu instead
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN apt-get update
-RUN apt-get install libcurl3 tzdata unzip curl git-all -y
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list
-RUN apt-get update
-RUN apt-get install mono-complete -y
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list
+.d/mono-xamarin.list
+RUN apt-get update && apt-get install libcurl3 tzdata unzip curl git-all mono-complete -y && apt-get -yqq clean
 RUN cp /usr/share/zoneinfo/GMT /etc/localtime

--- a/src/DockerBase/Dockerfile
+++ b/src/DockerBase/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER GitTools Maintainers <jake@ginnivan.net>
 # Wheezy doesn't support glibc 2.15 which libgit2sharp requires
 # So we are going to install mono on ubuntu instead
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list
-.d/mono-xamarin.list
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list
 RUN apt-get update && apt-get install libcurl3 tzdata unzip curl git-all mono-complete -y && apt-get -yqq clean
 RUN cp /usr/share/zoneinfo/GMT /etc/localtime

--- a/src/DockerBase/Dockerfile
+++ b/src/DockerBase/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 
 MAINTAINER GitTools Maintainers <jake@ginnivan.net>
 


### PR DESCRIPTION
Related to #1218

Main fixes:
 - Set a version for Ubuntu. Currently using :latest which will change in future
 - Move commands to a single instruction, this reduces the total image size as cache can be cleared