### PR TITLE
Added 'EnsureWixToolsetInstalled' BeforeTarget to GetVersionTask.targets

### DIFF
--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -67,7 +67,7 @@
     </ItemGroup>
   </Target>
   
-  <Target Name="GetVersion" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec" Condition="$(GetVersion) == 'true'">
+  <Target Name="GetVersion" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec;EnsureWixToolsetInstalled" Condition="$(GetVersion) == 'true'">
 
     <GetVersion SolutionDirectory="$(GitVersionPath)" NoFetch="$(GitVersion_NoFetchEnabled)">
       <Output TaskParameter="Major" PropertyName="GitVersion_Major" />


### PR DESCRIPTION
The [Wix toolset](http://wixtoolset.org/) does not trigger any of the following events/targets: `CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec`, and as a result the `GetVersion` target never gets triggered, which means none of the environment variables are populated as a result of using MSBuild.

The `EnsureWixToolsetInstalled` is set as the default `InitialTargets="EnsureWixToolsetInstalled"` value for all Wix projects.

It would be hugely helpful to have the GitVersion variables seamlessly available as part of the build process for Wix projects!

RFR