### PR TITLE
Pick better merge base

### DIFF
--- a/BREAKING CHANGES.md
+++ b/BREAKING CHANGES.md
@@ -8,6 +8,7 @@ v4.0.0
     - The default keys are: master, develop, feature, release, pull-request, hotfix, support
     - Just run GitVersion.exe in your project directory and it will tell you what to change your config keys to
     - For example, `dev(elop)?(ment)?$` is now just `develop`, we suggest not overring regex's unless you really want to use a different convention.
+ - source-branches added as a configuration option for branches, it helps GitVersion pick the correct source branch
 
 v3.0.0
  - NextVersion.txt has been deprecated, only GitVersionConfig.yaml is supported

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,15 +249,15 @@ Because git is a directed graph GitVersion sometimes cannot tell which branch th
 Take this graph
 
 ```
-  *   feature/foo
-* |   release/1.0.0
+* release/1.0.0   * feature/foo
+| ________________/
 |/
 *
 *
 * (master)
 ```
 
-By looking at this graph, you cannot tell which of these scenarios happened
+By looking at this graph, you cannot tell which of these scenarios happened:
 
 1. feature/foo branches off release/1.0.0
    - Branch release/1.0.0 from master
@@ -270,6 +270,8 @@ By looking at this graph, you cannot tell which of these scenarios happened
    - Branch release/1.0.0 from feature/foo 
    - Add a commit to both release/1.0.0 and feature/foo
    - feature/foo is the base for release/1.0.0
+
+Or put more simply, what branch was created first, `release/1.0.0` or `feature/foo`.
 
 To resolve this issue we give GitVersion a hint to how we normally do our branching, feature branches have a value of:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,11 +273,11 @@ By looking at this graph, you cannot tell which of these scenarios happened:
 
 Or put more simply, what branch was created first, `release/1.0.0` or `feature/foo`.
 
-To resolve this issue we give GitVersion a hint to how we normally do our branching, feature branches have a value of:
+To resolve this issue, we give GitVersion a hint to our branching workflows by telling it what types of branches it can be created from. For example feature branches are by default configured to have the following source branches:
 
 `sourceBranches: ['master', 'develop', 'feature', 'hotfix', 'support']`
 
-This means that we will never bother to evaluate pull requests as merge base options, being explicit like this helps GitVersion be much faster too.
+This means that we will never bother to evaluate pull request branches as merge base options, being explicit like this helps GitVersion be much faster too.
 
 ### is-source-branch-for
 The reverse of the above setting. This property was introduced to keep it easy to extend GitVersion's config.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,6 +243,41 @@ values, but here they are if you need to:
 ### regex
 This is the regex which is used to match the current branch to the correct branch configuration.
 
+### source-branches
+Because git is a directed graph GitVersion sometimes cannot tell which branch the current branch was branched from.
+
+Take this graph
+
+```
+  *   feature/foo
+* |   release/1.0.0
+|/
+*
+*
+* (master)
+```
+
+By looking at this graph, you cannot tell which of these scenarios happened
+
+1. feature/foo branches off release/1.0.0
+   - Branch release/1.0.0 from master
+   - Branch feature/foo from release/1.0.0
+   - Add a commit to both release/1.0.0 and feature/foo
+   - release/1.0.0 is the base for feature/foo
+
+2. release/1.0.0 branches off feature/foo
+   - Branch feature/foo from master
+   - Branch release/1.0.0 from feature/foo 
+   - Add a commit to both release/1.0.0 and feature/foo
+   - feature/foo is the base for release/1.0.0
+
+To resolve this issue we give GitVersion a hint to how we normally do our branching, feature branches have a value of:
+
+`sourceBranches: ['master', 'develop', 'feature', 'hotfix', 'support']`
+
+This means that we will never bother to evaluate pull requests as merge base options, being explicit like this helps GitVersion be much faster too.
+
+
 ### branches
 The header for all the individual branch configuration.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,6 +277,10 @@ To resolve this issue we give GitVersion a hint to how we normally do our branch
 
 This means that we will never bother to evaluate pull requests as merge base options, being explicit like this helps GitVersion be much faster too.
 
+### is-source-branch-for
+The reverse of the above setting. This property was introduced to keep it easy to extend GitVersion's config.
+
+When you add a new branch type this allows you to specify both source-branches for the new branch, and also add the new branch to existing branch configurations. For example if you create a new branch called `unstable` you could set a value of `['release', 'master', 'feature']` etc. 
 
 ### branches
 The header for all the individual branch configuration.

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -12,6 +12,17 @@ build-metadata-padding: 4
 commits-since-version-source-padding: 4
 commit-message-incrementing: Enabled
 branches:
+  develop:
+    mode: ContinuousDeployment
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    regex: dev(elop)?(ment)?$
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
   master:
     mode: ContinuousDelivery
     tag: ''
@@ -19,6 +30,9 @@ branches:
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     regex: master
+    source-branches:
+    - develop
+    - release
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: true
@@ -29,6 +43,9 @@ branches:
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     regex: releases?[/-]
+    source-branches:
+    - develop
+    - master
     tracks-release-branches: false
     is-release-branch: true
     is-mainline: false
@@ -39,6 +56,13 @@ branches:
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     regex: features?[/-]
+    source-branches:
+    - develop
+    - master
+    - release
+    - feature
+    - support
+    - hotfix
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: false
@@ -50,6 +74,13 @@ branches:
     tag-number-pattern: '[/-](?<number>\d+)'
     track-merge-target: false
     regex: (pull|pull\-requests|pr)[/-]
+    source-branches:
+    - develop
+    - master
+    - release
+    - feature
+    - support
+    - hotfix
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: false
@@ -60,6 +91,9 @@ branches:
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     regex: hotfix(es)?[/-]
+    source-branches:
+    - develop
+    - master
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: false
@@ -70,18 +104,10 @@ branches:
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     regex: support[/-]
+    source-branches:
+    - master
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: true
-  develop:
-    mode: ContinuousDeployment
-    tag: alpha
-    increment: Minor
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: true
-    regex: dev(elop)?(ment)?$
-    tracks-release-branches: true
-    is-release-branch: false
-    is-mainline: false
 ignore:
   sha: []

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -46,6 +46,8 @@ branches:
     source-branches:
     - develop
     - master
+    - support
+    - release
     tracks-release-branches: false
     is-release-branch: true
     is-mainline: false
@@ -94,6 +96,7 @@ branches:
     source-branches:
     - develop
     - master
+    - support
     tracks-release-branches: false
     is-release-branch: false
     is-mainline: false

--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -100,7 +100,23 @@ branches:
         tag: bugfix";
         SetupConfigFileContent(text);
         var ex = Should.Throw<GitVersionConfigurationException>(() => ConfigurationProvider.Provide(repoPath, fileSystem));
-        ex.Message.ShouldBe("Branch configuration 'bug' is missing required configuration 'regex'");
+        ex.Message.ShouldBe("Branch configuration 'bug' is missing required configuration 'regex'\n\n" +
+            "See http://gitversion.readthedocs.io/en/latest/configuration/ for more info");
+    }
+
+    [Test]
+    public void SourceBranchIsRequired()
+    {
+        const string text = @"
+next-version: 2.0.0
+branches:
+    bug:
+        regex: 'bug[/-]'
+        tag: bugfix";
+        SetupConfigFileContent(text);
+        var ex = Should.Throw<GitVersionConfigurationException>(() => ConfigurationProvider.Provide(repoPath, fileSystem));
+        ex.Message.ShouldBe("Branch configuration 'bug' is missing required configuration 'source-branches'\n\n" +
+            "See http://gitversion.readthedocs.io/en/latest/configuration/ for more info");
     }
 
     [Test]

--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -111,7 +111,8 @@ next-version: 2.0.0
 branches:
     bug:
         regex: 'bug[/-]'
-        tag: bugfix";
+        tag: bugfix
+        source-branches: []";
         SetupConfigFileContent(text);
         var config = ConfigurationProvider.Provide(repoPath, fileSystem);
 

--- a/src/GitVersionCore.Tests/GitRepoMetadataProviderTests.cs
+++ b/src/GitVersionCore.Tests/GitRepoMetadataProviderTests.cs
@@ -52,10 +52,10 @@
 
                 var develop = fixture.Repository.FindBranch("develop");
                 var release = fixture.Repository.FindBranch("release-2.0.0");
-                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(release, develop);
 
-                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(develop, release);
 
                 fixture.Repository.DumpGraph(Console.WriteLine);
@@ -109,10 +109,10 @@
 
                 var develop = fixture.Repository.FindBranch("develop");
                 var release = fixture.Repository.FindBranch("release-2.0.0");
-                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(release, develop);
 
-                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(develop, release);
 
                 fixture.Repository.DumpGraph(Console.WriteLine);
@@ -184,10 +184,10 @@
 
                 var develop = fixture.Repository.FindBranch("develop");
                 var release = fixture.Repository.FindBranch("release-2.0.0");
-                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var releaseBranchMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(release, develop);
 
-                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository)
+                var developMergeBase = new GitRepoMetadataProvider(fixture.Repository, new Config())
                     .FindMergeBase(develop, release);
 
                 fixture.Repository.DumpGraph(Console.WriteLine);

--- a/src/GitVersionCore.Tests/GitVersionContextTests.cs
+++ b/src/GitVersionCore.Tests/GitVersionContextTests.cs
@@ -5,6 +5,7 @@
     using LibGit2Sharp;
     using NUnit.Framework;
     using Shouldly;
+    using System.Collections.Generic;
 
     public class GitVersionContextTests
     {
@@ -98,8 +99,8 @@
                 VersioningMode = VersioningMode.ContinuousDelivery,
                 Branches =
                 {
-                    { "release/latest", new BranchConfig { Increment = IncrementStrategy.None, Regex = "release/latest", SourceBranches = new string[0] } },
-                    { "release", new BranchConfig { Increment = IncrementStrategy.Patch, Regex = "releases?[/-]", SourceBranches = new string[0] } }
+                    { "release/latest", new BranchConfig { Increment = IncrementStrategy.None, Regex = "release/latest", SourceBranches = new List<string>() } },
+                    { "release", new BranchConfig { Increment = IncrementStrategy.Patch, Regex = "releases?[/-]", SourceBranches = new List<string>() } }
                 }
             }.ApplyDefaults();
 

--- a/src/GitVersionCore.Tests/GitVersionContextTests.cs
+++ b/src/GitVersionCore.Tests/GitVersionContextTests.cs
@@ -98,8 +98,8 @@
                 VersioningMode = VersioningMode.ContinuousDelivery,
                 Branches =
                 {
-                    { "release/latest", new BranchConfig { Increment = IncrementStrategy.None, Regex = "release/latest" } },
-                    { "release", new BranchConfig { Increment = IncrementStrategy.Patch, Regex = "releases?[/-]" } }
+                    { "release/latest", new BranchConfig { Increment = IncrementStrategy.None, Regex = "release/latest", SourceBranches = new string[0] } },
+                    { "release", new BranchConfig { Increment = IncrementStrategy.Patch, Regex = "releases?[/-]", SourceBranches = new string[0] } }
                 }
             }.ApplyDefaults();
 

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -64,7 +64,8 @@ public class DevelopScenarios
                 {
                     "develop", new BranchConfig
                     {
-                        Tag = "alpha"
+                        Tag = "alpha",
+                        SourceBranches = new string[0]
                     }
                 }
             }

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -3,6 +3,7 @@ using GitVersion;
 using GitVersionCore.Tests;
 using LibGit2Sharp;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 [TestFixture]
 public class DevelopScenarios
@@ -65,7 +66,7 @@ public class DevelopScenarios
                     "develop", new BranchConfig
                     {
                         Tag = "alpha",
-                        SourceBranches = new string[0]
+                        SourceBranches = new List<string>()
                     }
                 }
             }

--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -42,9 +42,16 @@ public class FeatureBranchScenarios
         {
             Branches =
             {
-                { "unstable", new BranchConfig {
-                    Increment = IncrementStrategy.Minor, Regex = "unstable", SourceBranches = new string[0]
-                } }
+                {
+                    "unstable",
+                    new BranchConfig
+                    {
+                        Increment = IncrementStrategy.Minor,
+                        Regex = "unstable",
+                        SourceBranches = new List<string>(),
+                        IsSourceBranchFor = new [] { "feature" }
+                    }
+                }
             }
         };
 

--- a/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -42,7 +42,9 @@ public class FeatureBranchScenarios
         {
             Branches =
             {
-                { "unstable", new BranchConfig { Increment = IncrementStrategy.Minor, Regex = "unstable"} }
+                { "unstable", new BranchConfig {
+                    Increment = IncrementStrategy.Minor, Regex = "unstable", SourceBranches = new string[0]
+                } }
             }
         };
 

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -56,7 +56,8 @@
                 Tag = "useBranchName",
                 Increment = IncrementStrategy.Patch,
                 PreventIncrementOfMergedBranchVersion = true,
-                TrackMergeTarget = false
+                TrackMergeTarget = false,
+                SourceBranches = new string[0]
             });
 
             using (var fixture = new EmptyRepositoryFixture())

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -5,6 +5,7 @@
     using GitVersion;
     using LibGit2Sharp;
     using NUnit.Framework;
+    using System.Collections.Generic;
 
     [TestFixture]
     public class OtherScenarios
@@ -57,7 +58,7 @@
                 Increment = IncrementStrategy.Patch,
                 PreventIncrementOfMergedBranchVersion = true,
                 TrackMergeTarget = false,
-                SourceBranches = new string[0]
+                SourceBranches = new List<string>()
             });
 
             using (var fixture = new EmptyRepositoryFixture())

--- a/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -2,6 +2,7 @@
 using GitVersion;
 using GitVersionCore.Tests;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 [TestFixture]
 public class VersionBumpingScenarios
@@ -17,7 +18,7 @@ public class VersionBumpingScenarios
                     "master", new BranchConfig
                     {
                         Tag = "pre",
-                        SourceBranches = new string[0]
+                        SourceBranches = new List<string>()
                     }
                 }
             }

--- a/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -13,7 +13,13 @@ public class VersionBumpingScenarios
         {
             Branches =
             {
-                { "master", new BranchConfig { Tag = "pre" } }
+                {
+                    "master", new BranchConfig
+                    {
+                        Tag = "pre",
+                        SourceBranches = new string[0]
+                    }
+                }
             }
         };
         using (var fixture = new EmptyRepositoryFixture())

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -67,7 +67,8 @@
                         "custom", new BranchConfig
                         {
                             Regex = "custom/",
-                            Tag = "useBranchName"
+                            Tag = "useBranchName",
+                            SourceBranches = new string[0]
                         }
                     }
                 }
@@ -97,7 +98,8 @@
                         "custom", new BranchConfig
                         {
                             Regex = "custom/",
-                            Tag = "alpha.{BranchName}"
+                            Tag = "alpha.{BranchName}",
+                            SourceBranches = new string[0]
                         }
                     }
                 }

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -68,7 +68,7 @@
                         {
                             Regex = "custom/",
                             Tag = "useBranchName",
-                            SourceBranches = new string[0]
+                            SourceBranches = new List<string>()
                         }
                     }
                 }
@@ -99,7 +99,7 @@
                         {
                             Regex = "custom/",
                             Tag = "alpha.{BranchName}",
-                            SourceBranches = new string[0]
+                            SourceBranches = new List<string>()
                         }
                     }
                 }

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -22,7 +22,7 @@ namespace GitVersion
                     targetBranch.FriendlyName));
 
                 matchingBranches = new BranchConfig { Name = string.Empty };
-                ConfigurationProvider.ApplyBranchDefaults(context.FullConfiguration, matchingBranches, "");
+                ConfigurationProvider.ApplyBranchDefaults(context.FullConfiguration, matchingBranches, "", new string[0]);
             }
 
             return matchingBranches.Increment == IncrementStrategy.Inherit ?

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -22,7 +22,7 @@ namespace GitVersion
                     targetBranch.FriendlyName));
 
                 matchingBranches = new BranchConfig { Name = string.Empty };
-                ConfigurationProvider.ApplyBranchDefaults(context.FullConfiguration, matchingBranches, "", new string[0]);
+                ConfigurationProvider.ApplyBranchDefaults(context.FullConfiguration, matchingBranches, "", new List<string>());
             }
 
             return matchingBranches.Increment == IncrementStrategy.Inherit ?

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -1,5 +1,6 @@
 ﻿namespace GitVersion
 {
+    using System.Collections.Generic;
     using YamlDotNet.Serialization;
 
     public class BranchConfig
@@ -25,6 +26,8 @@
             IsReleaseBranch = branchConfiguration.IsReleaseBranch;
             IsMainline = branchConfiguration.IsMainline;
             Name = branchConfiguration.Name;
+            SourceBranches = branchConfiguration.SourceBranches;
+            IsSourceBranchFor = branchConfiguration.IsSourceBranchFor;
         }
 
         [YamlMember(Alias = "mode")]
@@ -55,7 +58,10 @@
         public string Regex { get; set; }
 
         [YamlMember(Alias = "source-branches")]
-        public string[] SourceBranches { get; set; }
+        public List<string> SourceBranches { get; set; }
+
+        [YamlMember(Alias = "is-source-branch-for")]
+        public string[] IsSourceBranchFor { get; set; }
 
         [YamlMember(Alias = "tracks-release-branches")]
         public bool? TracksReleaseBranches { get; set; }

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -54,6 +54,9 @@
         [YamlMember(Alias = "regex")]
         public string Regex { get; set; }
 
+        [YamlMember(Alias = "source-branches")]
+        public string[] SourceBranches { get; set; }
+
         [YamlMember(Alias = "tracks-release-branches")]
         public bool? TracksReleaseBranches { get; set; }
 

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -161,13 +161,15 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 var regex = branchConfig.Value.Regex;
                 if (regex == null)
                 {
-                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'regex'");
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'regex'\n\n" +
+                        "See http://gitversion.readthedocs.io/en/latest/configuration/ for more info");
                 }
 
                 var sourceBranches = branchConfig.Value.SourceBranches;
                 if (sourceBranches == null)
                 {
-                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'source-branches'");
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'source-branches'\n\n" +
+                        "See http://gitversion.readthedocs.io/en/latest/configuration/ for more info");
                 }
 
                 ApplyBranchDefaults(config, branchConfig.Value, regex, sourceBranches);

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -102,8 +102,18 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             var configBranches = config.Branches.ToList();
 
             ApplyBranchDefaults(config,
+                GetOrCreateBranchDefaults(config, DevelopBranchKey),
+                DevelopBranchRegex,
+                new string[0],
+                defaultTag: "alpha",
+                defaultIncrementStrategy: IncrementStrategy.Minor,
+                defaultVersioningMode: VersioningMode.ContinuousDeployment,
+                defaultTrackMergeTarget: true,
+                tracksReleaseBranches: true);
+            ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, MasterBranchKey),
                 MasterBranchRegex,
+                new string[] { "develop", "release" },
                 defaultTag: string.Empty,
                 defaultPreventIncrement: true,
                 defaultIncrementStrategy: IncrementStrategy.Patch,
@@ -111,6 +121,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, ReleaseBranchKey),
                 ReleaseBranchRegex,
+                new string[] { "develop", "master" },
                 defaultTag: "beta",
                 defaultPreventIncrement: true,
                 defaultIncrementStrategy: IncrementStrategy.Patch,
@@ -118,33 +129,29 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, FeatureBranchKey),
                 FeatureBranchRegex,
+                new string[] { "develop", "master", "release", "feature", "support", "hotfix" },
                 defaultIncrementStrategy: IncrementStrategy.Inherit);
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, PullRequestBranchKey),
                 PullRequestRegex,
+                new string[] { "develop", "master", "release", "feature", "support", "hotfix" },
                 defaultTag: "PullRequest",
                 defaultTagNumberPattern: @"[/-](?<number>\d+)",
                 defaultIncrementStrategy: IncrementStrategy.Inherit);
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, HotfixBranchKey),
                 HotfixBranchRegex,
+                new string[] { "develop", "master" },
                 defaultTag: "beta",
                 defaultIncrementStrategy: IncrementStrategy.Patch);
             ApplyBranchDefaults(config,
                 GetOrCreateBranchDefaults(config, SupportBranchKey),
                 SupportBranchRegex,
+                new string[] { "master" },
                 defaultTag: string.Empty,
                 defaultPreventIncrement: true,
                 defaultIncrementStrategy: IncrementStrategy.Patch,
                 isMainline: true);
-            ApplyBranchDefaults(config,
-                GetOrCreateBranchDefaults(config, DevelopBranchKey),
-                DevelopBranchRegex,
-                defaultTag: "alpha",
-                defaultIncrementStrategy: IncrementStrategy.Minor,
-                defaultVersioningMode: VersioningMode.ContinuousDeployment,
-                defaultTrackMergeTarget: true,
-                tracksReleaseBranches: true);
 
             // Any user defined branches should have other values defaulted after known branches filled in.
             // This allows users to override any of the value.
@@ -153,10 +160,16 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 var regex = branchConfig.Value.Regex;
                 if (regex == null)
                 {
-                    throw new GitVersionConfigurationException(string.Format("Branch configuration '{0}' is missing required configuration 'regex'", branchConfig.Key));
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'regex'");
                 }
 
-                ApplyBranchDefaults(config, branchConfig.Value, regex);
+                var sourceBranches = branchConfig.Value.SourceBranches;
+                if (sourceBranches == null)
+                {
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'source-branches'");
+                }
+
+                ApplyBranchDefaults(config, branchConfig.Value, regex, sourceBranches);
             }
         }
 
@@ -180,6 +193,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
         public static void ApplyBranchDefaults(Config config,
             BranchConfig branchConfig,
             string branchRegex,
+            string[] sourceBranches,
             string defaultTag = "useBranchName",
             IncrementStrategy? defaultIncrementStrategy = null, // Looked up from main config
             bool defaultPreventIncrement = false,
@@ -191,6 +205,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             bool isMainline = false)
         {
             branchConfig.Regex = string.IsNullOrEmpty(branchConfig.Regex) ? branchRegex : branchConfig.Regex;
+            branchConfig.SourceBranches = sourceBranches;
             branchConfig.Tag = branchConfig.Tag ?? defaultTag;
             branchConfig.TagNumberPattern = branchConfig.TagNumberPattern ?? defaultTagNumberPattern;
             branchConfig.Increment = branchConfig.Increment ?? defaultIncrementStrategy ?? config.Increment ?? DefaultIncrementStrategy;

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace GitVersion
 {
@@ -12,13 +13,15 @@ namespace GitVersion
         private Dictionary<Branch, List<SemanticVersion>> semanticVersionTagsOnBranchCache;
         private IRepository Repository { get; set; }
         const string missingTipFormat = "{0} has no tip. Please see http://example.com/docs for information on how to fix this.";
+        private Config configuration;
 
-        public GitRepoMetadataProvider(IRepository repository)
+        public GitRepoMetadataProvider(IRepository repository, Config configuration)
         {
             mergeBaseCache = new Dictionary<Tuple<Branch, Branch>, MergeBaseData>();
             mergeBaseCommitsCache = new Dictionary<Branch, List<BranchCommit>>();
             semanticVersionTagsOnBranchCache = new Dictionary<Branch, List<SemanticVersion>>();
-            this.Repository = repository;
+            Repository = repository;
+            this.configuration = configuration;
         }
 
         public IEnumerable<SemanticVersion> GetVersionTagsOnBranch(Branch branch, string tagPrefixRegex)
@@ -144,6 +147,7 @@ namespace GitVersion
 
                         if (forwardMerge != null)
                         {
+                            // TODO Fix the logging up in this section
                             var second = forwardMerge.Parents.First();
                             Logger.WriteDebug("Second " + second.Sha);
                             var mergeBase = Repository.ObjectDatabase.FindMergeBase(commit, second);
@@ -177,7 +181,7 @@ namespace GitVersion
 
         /// <summary>
         /// Find the commit where the given branch was branched from another branch.
-        /// If there are multiple such commits and branches, returns the newest commit.
+        /// If there are multiple such commits and branches, tries to guess based on commit histories.
         /// </summary>
         public BranchCommit FindCommitBranchWasBranchedFrom(Branch branch, params Branch[] excludedBranches)
         {
@@ -194,7 +198,21 @@ namespace GitVersion
                     return BranchCommit.Empty;
                 }
 
-                return GetMergeCommitsForBranch(branch).ExcludingBranches(excludedBranches).FirstOrDefault(b => !branch.IsSameBranch(b.Branch));
+                var possibleBranches = GetMergeCommitsForBranch(branch)
+                    .ExcludingBranches(excludedBranches)
+                    .Where(b => !branch.IsSameBranch(b.Branch))
+                    .ToList();
+
+                if (possibleBranches.Count > 1)
+                {
+                    var first = possibleBranches.First();
+                    Logger.WriteInfo($"Multiple source branches have been found, picking the first one ({first.Branch.FriendlyName}).\n" +
+                        "This may result in incorrect commit counting.\nOptions were:\n " +
+                        string.Join(", ", possibleBranches.Select(b => b.Branch.FriendlyName)));
+                    return first;
+                }
+
+                return possibleBranches.SingleOrDefault();
             }
         }
 
@@ -208,17 +226,32 @@ namespace GitVersion
                 return mergeBaseCommitsCache[branch];
             }
 
-            var branchMergeBases = Repository.Branches.Select(otherBranch =>
-            {
-                if (otherBranch.Tip == null)
+            var currentBranchConfig = configuration.GetConfigForBranch(branch.FriendlyName);
+            var regexesToCheck = currentBranchConfig == null
+                ? new [] { ".*" } // Match anything if we can't find a branch config
+                : currentBranchConfig.SourceBranches.Select(sb => configuration.Branches[sb].Regex);
+            var branchMergeBases = Repository.Branches
+                .Where(b =>
                 {
-                    Logger.WriteWarning(string.Format(missingTipFormat, otherBranch.FriendlyName));
-                    return BranchCommit.Empty;
-                }
+                    if (b == branch) return false;
+                    var branchCanBeMergeBase = regexesToCheck.Any(regex => Regex.IsMatch(b.FriendlyName, regex));
 
-                var findMergeBase = FindMergeBase(branch, otherBranch);
-                return new BranchCommit(findMergeBase, otherBranch);
-            }).Where(b => b.Commit != null).OrderByDescending(b => b.Commit.Committer.When).ToList();
+                    return branchCanBeMergeBase;
+                })
+                .Select(otherBranch =>
+                {
+                    if (otherBranch.Tip == null)
+                    {
+                        Logger.WriteWarning(string.Format(missingTipFormat, otherBranch.FriendlyName));
+                        return BranchCommit.Empty;
+                    }
+
+                    var findMergeBase = FindMergeBase(branch, otherBranch);
+                    return new BranchCommit(findMergeBase, otherBranch);
+                })
+                .Where(b => b.Commit != null)
+                .OrderByDescending(b => b.Commit.Committer.When)
+                .ToList();
             mergeBaseCommitsCache.Add(branch, branchMergeBases);
 
             return branchMergeBases;

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -17,7 +17,7 @@
         public GitVersionContext(IRepository repository, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = true, string commitId = null)
         {
             Repository = repository;
-            RepositoryMetadataProvider = new GitRepoMetadataProvider(repository);
+            RepositoryMetadataProvider = new GitRepoMetadataProvider(repository, configuration);
             FullConfiguration = configuration;
             OnlyEvaluateTrackedBranches = onlyEvaluateTrackedBranches;
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -51,15 +51,7 @@
                 BaseVersion baseVersionWithOldestSource;
                 if (matchingVersionsOnceIncremented.Any())
                 {
-                    var oldest = matchingVersionsOnceIncremented.Aggregate((v1, v2) => {
-                        var picked = v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When
-                        ? v1 : v2;
-                        Logger.WriteInfo(
-                            $"{v1.Version.BaseVersionSource.Sha} @ {v1.Version.BaseVersionSource.Committer.When}\n" +
-                            $"{v2.Version.BaseVersionSource.Sha} @ {v2.Version.BaseVersionSource.Committer.When}\n" +
-                            picked);
-                        return picked;
-                    });
+                    var oldest = matchingVersionsOnceIncremented.Aggregate((v1, v2) => v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When ? v1 : v2);
                     baseVersionWithOldestSource = oldest.Version;
                     maxVersion = oldest;
                     Logger.WriteInfo(string.Format(

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -51,7 +51,15 @@
                 BaseVersion baseVersionWithOldestSource;
                 if (matchingVersionsOnceIncremented.Any())
                 {
-                    var oldest = matchingVersionsOnceIncremented.Aggregate((v1, v2) => v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When ? v1 : v2);
+                    var oldest = matchingVersionsOnceIncremented.Aggregate((v1, v2) => {
+                        var picked = v1.Version.BaseVersionSource.Committer.When < v2.Version.BaseVersionSource.Committer.When
+                        ? v1 : v2;
+                        Logger.WriteInfo(
+                            $"{v1.Version.BaseVersionSource.Sha} @ {v1.Version.BaseVersionSource.Committer.When}\n" +
+                            $"{v2.Version.BaseVersionSource.Sha} @ {v2.Version.BaseVersionSource.Committer.When}\n" +
+                            picked);
+                        return picked;
+                    });
                     baseVersionWithOldestSource = oldest.Version;
                     maxVersion = oldest;
                     Logger.WriteInfo(string.Format(


### PR DESCRIPTION
Builds on #1224, includes the test from #1204 and gets it passing.

This change allows GitVersion to better decide which branch the current branch was likely branched from. Have added some new configuration options and updated the related docs.

Would love any other ideas on how to solve this problem better. 