### PR TITLE
Update mkdocs.yml to fix typo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,5 +55,5 @@ pages:
   - Versioning modes:
     - Versioning modes: reference/versioning-mode.md
     - Mainline development: reference/mainline-development.md
-    - Continous delivery: reference/continuous-delivery.md
+    - Continuous delivery: reference/continuous-delivery.md
     - Continuous deployment: reference/continuous-deployment.md


### PR DESCRIPTION
_Continuous_ was incorrectly written as _Continous_