### PR TITLE
Upgrade LibGit2Sharp from v0.23 to v0.24

### DIFF
--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,8 +50,8 @@
       <HintPath>..\packages\GitTools.Testing.1.1.1-beta0001\lib\net4\GitTools.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
@@ -189,8 +189,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\dotnet\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <Import Project="..\packages\Fody.2.0.8\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" />
 </Project>

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\GitTools.Testing.1.1.1-beta0001\lib\net4\GitTools.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">

--- a/src/GitVersionCore.Tests/Mocks/MockQueryableCommitLog.cs
+++ b/src/GitVersionCore.Tests/Mocks/MockQueryableCommitLog.cs
@@ -37,22 +37,6 @@ public class MockQueryableCommitLog : IQueryableCommitLog
         throw new NotImplementedException();
     }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-    public IEnumerable<LogEntry> QueryBy(string path, FollowFilter filter)
-#pragma warning restore CS0618 // Type or member is obsolete
-    {
-        throw new NotImplementedException();
-    }
-
-    public Commit FindMergeBase(Commit first, Commit second)
-    {
-        return null;
-    }
-
-    public Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
-    {
-        throw new NotImplementedException();
-    }
 
     public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
     {

--- a/src/GitVersionCore.Tests/app.config
+++ b/src/GitVersionCore.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionCore.Tests/app.config
+++ b/src/GitVersionCore.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionCore.Tests/packages.config
+++ b/src/GitVersionCore.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="ModuleInit.Fody" version="1.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />

--- a/src/GitVersionCore.Tests/packages.config
+++ b/src/GitVersionCore.Tests/packages.config
@@ -4,8 +4,8 @@
   <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="ModuleInit.Fody" version="1.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -196,8 +196,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets'))" />
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/GitVersionCore/app.config
+++ b/src/GitVersionCore/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionCore/app.config
+++ b/src/GitVersionCore/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -3,7 +3,7 @@
   <package id="Caseless.Fody" version="1.5.0" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net40" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
   <package id="YamlDotNet" version="3.8.0" targetFramework="net40" />

--- a/src/GitVersionCore/packages.config
+++ b/src/GitVersionCore/packages.config
@@ -3,8 +3,8 @@
   <package id="Caseless.Fody" version="1.5.0" targetFramework="net40" developmentDependency="true" />
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net40" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
   <package id="YamlDotNet" version="3.8.0" targetFramework="net40" />
 </packages>

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Testing.1.1.1-beta0001\lib\net4\GitTools.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
@@ -146,6 +146,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
 </Project>

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Testing.1.1.1-beta0001\lib\net4\GitTools.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">

--- a/src/GitVersionExe.Tests/app.config
+++ b/src/GitVersionExe.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionExe.Tests/app.config
+++ b/src/GitVersionExe.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionExe.Tests/packages.config
+++ b/src/GitVersionExe.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />

--- a/src/GitVersionExe.Tests/packages.config
+++ b/src/GitVersionExe.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -45,8 +45,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -212,8 +212,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets'))" />
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <Import Project="..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" />
   <Import Project="..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets')" />

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/GitVersionExe/app.config
+++ b/src/GitVersionExe/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionExe/app.config
+++ b/src/GitVersionExe/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -4,7 +4,7 @@
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.13" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net40" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
 </packages>

--- a/src/GitVersionExe/packages.config
+++ b/src/GitVersionExe/packages.config
@@ -4,7 +4,7 @@
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.13" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net40" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
 </packages>

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -60,8 +60,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net45\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
@@ -189,8 +189,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\dotnet\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <Import Project="..\packages\Fody.2.0.8\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.2.0.8\build\dotnet\Fody.targets')" />
 </Project>

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -60,8 +60,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net45\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />

--- a/src/GitVersionTask.Tests/app.config
+++ b/src/GitVersionTask.Tests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionTask.Tests/app.config
+++ b/src/GitVersionTask.Tests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionTask.Tests/packages.config
+++ b/src/GitVersionTask.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="FluentDateTime" version="1.13.0" targetFramework="net45" />
   <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />

--- a/src/GitVersionTask.Tests/packages.config
+++ b/src/GitVersionTask.Tests/packages.config
@@ -5,8 +5,8 @@
   <package id="FluentDateTime" version="1.13.0" targetFramework="net45" />
   <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.25.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.25.0-preview-0033\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GitTools.Core.1.2.1-beta0001\lib\net4\GitTools.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160922233542\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />
@@ -139,8 +139,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets'))" />
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.160\build\LibGit2Sharp.NativeBinaries.props'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.8\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/GitVersionTask/app.config
+++ b/src/GitVersionTask/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionTask/app.config
+++ b/src/GitVersionTask/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GitVersionTask/packages.config
+++ b/src/GitVersionTask/packages.config
@@ -4,7 +4,7 @@
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.13" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net40" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
   <package id="YamlDotNet" version="3.8.0" targetFramework="net40" />

--- a/src/GitVersionTask/packages.config
+++ b/src/GitVersionTask/packages.config
@@ -4,8 +4,8 @@
   <package id="Fody" version="2.0.8" targetFramework="net40" developmentDependency="true" />
   <package id="GitTools.Core" version="1.2.1-beta0001" targetFramework="net40" />
   <package id="ILRepack" version="2.0.13" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20160922233542" targetFramework="net40" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.160" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net40" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net40" />
   <package id="PepitaPackage" version="1.21.4" targetFramework="net4" developmentDependency="true" />
   <package id="YamlDotNet" version="3.8.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR upgrades `LibGit2Sharp` from version `0.23` to version `0.24` and `LibGit2Sharp.NativeBinaries` from version `1.0.160` to version `1.0.185`.