### PR TITLE
Changing hardcoded master/develop regex

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -136,7 +136,7 @@ Task("Create-Release-Notes")
                     RedirectStandardOutput = true
                 },
                 out redirectedOutput);
-        Information(string.Join("\n"m redirectedOutput));
+        Information(string.Join("\n", redirectedOutput));
 
         if (!System.IO.File.Exists("./build/releasenotes.md") || string.IsNullOrEmpty(System.IO.File.ReadAllText("./build/releasenotes.md"))) {
             System.IO.File.WriteAllText("./build/releasenotes.md", "No issues closed since last release");

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -140,8 +140,11 @@ namespace GitVersion
                 else
                     errorMessage = "Failed to inherit Increment branch configuration, ended up with: " + string.Join(", ", possibleParents.Select(p => p.FriendlyName));
 
-                var chosenBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.FriendlyName, config.Branches[ConfigurationProvider.DevelopBranchKey].Regex, RegexOptions.IgnoreCase)
-                                                                           || Regex.IsMatch(b.FriendlyName, config.Branches[ConfigurationProvider.MasterBranchKey].Regex, RegexOptions.IgnoreCase));
+                var developBranchRegex = config.Branches[ConfigurationProvider.DevelopBranchKey].Regex;
+                var masterBranchRegex = config.Branches[ConfigurationProvider.MasterBranchKey].Regex;
+
+                var chosenBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.FriendlyName, developBranchRegex, RegexOptions.IgnoreCase)
+                                                                           || Regex.IsMatch(b.FriendlyName, masterBranchRegex, RegexOptions.IgnoreCase));
                 if (chosenBranch == null)
                 {
                     // TODO We should call the build server to generate this exception, each build server works differently

--- a/src/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/BranchConfigurationCalculator.cs
@@ -140,8 +140,8 @@ namespace GitVersion
                 else
                     errorMessage = "Failed to inherit Increment branch configuration, ended up with: " + string.Join(", ", possibleParents.Select(p => p.FriendlyName));
 
-                var chosenBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.FriendlyName, "^develop", RegexOptions.IgnoreCase)
-                                                                           || Regex.IsMatch(b.FriendlyName, "master$", RegexOptions.IgnoreCase));
+                var chosenBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.FriendlyName, config.Branches[ConfigurationProvider.DevelopBranchKey].Regex, RegexOptions.IgnoreCase)
+                                                                           || Regex.IsMatch(b.FriendlyName, config.Branches[ConfigurationProvider.MasterBranchKey].Regex, RegexOptions.IgnoreCase));
                 if (chosenBranch == null)
                 {
                     // TODO We should call the build server to generate this exception, each build server works differently


### PR DESCRIPTION
I encountered an issue where in a repository without a master or develop branch if we change the regex for master and develop to point to branches which do exist (and are used as master and develop branches) if there are no tags in the repo gitversion throws the following

```
  INFO [07/12/17 12:06:02:30] End: Getting branches containing the commit 'fa406c74e8eea6aa5a01cee62acc7f5ce1f6416e'. (Took: 3.49ms)
  INFO [07/12/17 12:06:02:30] Found possible parent branches:
INFO [07/12/17 12:06:02:30] End: Attempting to inherit branch configuration from parent branch (Took: 68.00ms)
ERROR [07/12/17 12:06:02:30] An unexpected error occurred:
System.InvalidOperationException: Could not find a 'develop' or 'master' branch, neither locally nor remotely.
   at GitVersion.BranchConfigurationCalculator.InheritBranchConfiguration(GitVersionContext context, Branch targetBranch, BranchConfig branchConfiguration, IList`1 excludedInheritBranches)
   at GitVersion.BranchConfigurationCalculator.GetBranchConfiguration(GitVersionContext context, Branch targetBranch, IList`1 excludedInheritBranches)
   at GitVersion.GitVersionContext.CalculateEffectiveConfiguration()
   at GitVersion.GitVersionContext..ctor(IRepository repository, Branch currentBranch, Config configuration, Boolean onlyEvaluateTrackedBranches, String commitId)
   at GitVersion.ExecuteCore.<>c__DisplayClass6_0.<ExecuteInternal>b__0(IRepository repo)
   at GitVersion.GitPreparer.WithRepository[TResult](Func`2 action)
   at GitVersion.ExecuteCore.ExecuteGitVersion(String targetUrl, String dynamicRepositoryLocation, Authentication authentication, String targetBranch, Boolean noFetch, String workingDirectory, String commitId, Config overrideConfig, Boolean noCache)
   at GitVersion.SpecifiedArgumentRunner.Run(Arguments arguments, IFileSystem fileSystem)
   at GitVersion.Program.VerifyArgumentsAndRun()
```

This fix changes the fallback to use the regex in the config instead of using a hardcoded regex.