### PR TITLE
Allow branch names starting with master

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -47,6 +47,20 @@
         }
 
         [Test]
+        public void AllowHavingVariantsStartingWithMaster()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.Repository.MakeACommit();
+                fixture.Repository.MakeATaggedCommit("1.0.0");
+                fixture.Repository.MakeACommit();
+                Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("masterfix"));
+
+                fixture.AssertFullSemver("1.0.1-masterfix.1+1");
+            }
+        }
+
+        [Test]
         public void AllowHavingMainInsteadOfMaster()
         {
             var config = new Config();

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -95,7 +95,7 @@
         {
             if (branchName == null) throw new ArgumentNullException(nameof(branchName));
             var matches = Branches
-                .Where(b => Regex.IsMatch(branchName, "^" + b.Value.Regex, RegexOptions.IgnoreCase));
+                .Where(b => Regex.IsMatch(branchName, "^" + b.Value.Regex + "$", RegexOptions.IgnoreCase));
 
             try
             {


### PR DESCRIPTION
#1271 _masterfix_ and _fixmaster_ now behave the same way (i.e. in a different
way to _master_, but in the same way as other branches)