### PR TITLE
 Allow branch names starting with master

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -29,7 +29,7 @@ branches:
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
-    regex: master
+    regex: master$
     source-branches:
     - develop
     - release

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -47,6 +47,20 @@
         }
 
         [Test]
+        public void AllowHavingVariantsStartingWithMaster()
+        {
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                fixture.Repository.MakeACommit();
+                fixture.Repository.MakeATaggedCommit("1.0.0");
+                fixture.Repository.MakeACommit();
+                Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("masterfix"));
+
+                fixture.AssertFullSemver("1.0.1-masterfix.1+1");
+            }
+        }
+
+        [Test]
         public void AllowHavingMainInsteadOfMaster()
         {
             var config = new Config();

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -21,7 +21,7 @@ namespace GitVersion
         public const string HotfixBranchRegex = "hotfix(es)?[/-]";
         public const string SupportBranchRegex = "support[/-]";
         public const string DevelopBranchRegex = "dev(elop)?(ment)?$";
-        public const string MasterBranchRegex = "master";
+        public const string MasterBranchRegex = "master$";
         public const string MasterBranchKey = "master";
         public const string ReleaseBranchKey = "release";
         public const string FeatureBranchKey = "feature";


### PR DESCRIPTION
#1271 
_masterfix_ and _fixmaster_ now behave the same way (i.e. in a different
way to _master_, but in the same way as other branches)