### PR TITLE
Closes #1274 - Removed system.web (replaced databinder.eval)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ attributes.
 Set this to any of the available [variables](/more-info/variables) to change the
 value of the `AssemblyInformationalVersion` attribute. Default set to
 `{InformationalVersion}`. It also supports string interpolation
-(`{MajorMinorPatch}+{Branch}`)
+(`{MajorMinorPatch}+{BranchName}`)
 
 ### mode
 Sets the `mode` of how GitVersion should create a new version. Read more at

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -49,7 +49,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/GitVersionCore/OutputVariables/VariableProvider.cs
+++ b/src/GitVersionCore/OutputVariables/VariableProvider.cs
@@ -53,9 +53,9 @@
             {
                 try
                 {
-                    informationalVersion = config.AssemblyInformationalFormat.FormatWith(semverFormatValues);
+                    informationalVersion = config.AssemblyInformationalFormat.FormatWith<SemanticVersionFormatValues>(semverFormatValues);
                 }
-                catch (FormatException formex)
+                catch (ArgumentException formex)
                 {
                     throw new WarningException(string.Format("Unable to format AssemblyInformationalVersion.  Check your format string: {0}", formex.Message));
                 }

--- a/src/GitVersionCore/StringFormatWith.cs
+++ b/src/GitVersionCore/StringFormatWith.cs
@@ -1,170 +1,78 @@
-﻿#region BSD License
-
-/* 
-Copyright (c) 2010, NETFx
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-* Neither the name of Clarius Consulting nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
-#endregion
-
-// Originally appeared in http://haacked.com/archive/2009/01/14/named-formats-redux.aspx
-// Authored by Henri Wiechers
-// Ported to NETFx by Daniel Cazzulino
-using System;
-using System.IO;
-using System.Text;
-using System.Web;
-using System.Web.UI;
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace GitVersion
 {
-    /// <summary>
-    ///     Requires a reference to System.Web.
-    /// </summary>
+
     static class StringFormatWithExtension
     {
+        private static readonly Regex TokensRegex = new Regex(@"{\w+}", RegexOptions.Compiled);
+
         /// <summary>
-        ///     Formats the string with the given source object.
+        ///     Formats a string template with the given source object.
         ///     Expression like {Id} are replaced with the corresponding
-        ///     property value in the <paramref name="source" />. Supports
-        ///     all DataBinder.Eval expressions formats
-        ///     for property access.
-        /// </summary>
-        /// <nuget id="netfx-System.StringFormatWith" />
-        /// <param name="format" this="true">The string to format</param>
+        ///     property value in the <paramref name="source" />. 
+        ///     Supports property access expressions.
+        /// </summary>       
+        /// <param name="template" this="true">The template to be replaced with values from the source object. The template can contain expressions wrapped in curly braces, that point to properties or fields on the source object to be used as a substitute, e.g '{Foo.Bar.CurrencySymbol} foo {Foo.Bar.Price}'.</param>
         /// <param name="source">The source object to apply to format</param>
-        public static string FormatWith(this string format, object source)
+        public static string FormatWith<T>(this string template, T source)
         {
-            if (format == null)
+            if (template == null)
             {
-                throw new ArgumentNullException("format");
+                throw new ArgumentNullException("template");
             }
 
-            var result = new StringBuilder(format.Length*2);
-
-            using (var reader = new StringReader(format))
+            // {MajorMinorPatch}+{Branch}
+            var objType = source.GetType();
+            foreach (Match match in TokensRegex.Matches(template))
             {
-                var expression = new StringBuilder();
-
-                var state = State.OutsideExpression;
-                do
-                {
-                    int @char;
-                    switch (state)
-                    {
-                        case State.OutsideExpression:
-                            @char = reader.Read();
-                            switch (@char)
-                            {
-                                case -1:
-                                    state = State.End;
-                                    break;
-                                case '{':
-                                    state = State.OnOpenBracket;
-                                    break;
-                                case '}':
-                                    state = State.OnCloseBracket;
-                                    break;
-                                default:
-                                    result.Append((char) @char);
-                                    break;
-                            }
-                            break;
-                        case State.OnOpenBracket:
-                            @char = reader.Read();
-                            switch (@char)
-                            {
-                                case -1:
-                                    throw new FormatException();
-                                case '{':
-                                    result.Append('{');
-                                    state = State.OutsideExpression;
-                                    break;
-                                default:
-                                    expression.Append((char) @char);
-                                    state = State.InsideExpression;
-                                    break;
-                            }
-                            break;
-                        case State.InsideExpression:
-                            @char = reader.Read();
-                            switch (@char)
-                            {
-                                case -1:
-                                    throw new FormatException();
-                                case '}':
-                                    result.Append(OutExpression(source, expression.ToString()));
-                                    expression.Length = 0;
-                                    state = State.OutsideExpression;
-                                    break;
-                                default:
-                                    expression.Append((char) @char);
-                                    break;
-                            }
-                            break;
-                        case State.OnCloseBracket:
-                            @char = reader.Read();
-                            switch (@char)
-                            {
-                                case '}':
-                                    result.Append('}');
-                                    state = State.OutsideExpression;
-                                    break;
-                                default:
-                                    throw new FormatException();
-                            }
-                            break;
-                        default:
-                            throw new InvalidOperationException("Invalid state.");
-                    }
-                } while (state != State.End);
+                var memberAccessExpression = TrimBraces(match.Value);
+                Func<object, string> expression = CompileDataBinder(objType, memberAccessExpression);
+                string propertyValue = expression(source);
+                template = template.Replace(match.Value, propertyValue);
             }
 
-            return result.ToString();
+            return template;
+
         }
 
-        static string OutExpression(object source, string expression)
+
+        static string TrimBraces(string originalExpression)
         {
-            var format = "";
-            var colonIndex = expression.IndexOf(':');
-
-            if (colonIndex > 0)
+            if (!string.IsNullOrWhiteSpace(originalExpression))
             {
-                format = expression.Substring(colonIndex + 1);
-                expression = expression.Substring(0, colonIndex);
+                return originalExpression.TrimStart('{').TrimEnd('}');
             }
-
-            try
-            {
-                if (string.IsNullOrEmpty(format))
-                {
-                    return (DataBinder.Eval(source, expression) ?? "").ToString();
-                }
-                return DataBinder.Eval(source, expression, "{0:" + format + "}");
-            }
-            catch (HttpException)
-            {
-                throw new FormatException("Failed to format '" + expression + "'.");
-            }
+            return originalExpression;
         }
 
-        enum State
+        static Func<object, string> CompileDataBinder(Type type, string expr)
         {
-            OutsideExpression,
-            OnOpenBracket,
-            InsideExpression,
-            OnCloseBracket,
-            End
+            var param = Expression.Parameter(typeof(object));
+            Expression body = Expression.Convert(param, type);
+            var members = expr.Split('.');
+            for (int i = 0; i < members.Length; i++)
+            {
+                body = Expression.PropertyOrField(body, members[i]);
+            }
+            var method = typeof(Convert).GetMethod("ToString", BindingFlags.Static | BindingFlags.Public,
+                null, new Type[] { body.Type }, null);
+            if (method == null)
+            {
+                method = typeof(Convert).GetMethod("ToString", BindingFlags.Static | BindingFlags.Public,
+                    null, new Type[] { typeof(object) }, null);
+                body = Expression.Call(method, Expression.Convert(body, typeof(object)));
+            }
+            else
+            {
+                body = Expression.Call(method, body);
+            }
+
+            return Expression.Lambda<Func<object, string>>(body, param).Compile();
         }
+
     }
 }


### PR DESCRIPTION
Replaced databinder.eval and dropped system.web as a dependency. System.Web should never have been adopted imho :-)
This will unblock my open PR to add netstandard support.
Minor correction in docs.