### PR TITLE
Improve shallow clone exception

### DIFF
--- a/src/GitVersionCore/Configuration/GitVersionConfigurationException.cs
+++ b/src/GitVersionCore/Configuration/GitVersionConfigurationException.cs
@@ -1,19 +1,12 @@
 namespace GitVersion
 {
     using System;
-    using System.Runtime.Serialization;
 
     [Serializable]
     public class GitVersionConfigurationException : GitVersionException
     {
         public GitVersionConfigurationException(string msg)
             : base(msg)
-        {
-        }
-
-
-        protected GitVersionConfigurationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/GitVersionCore/Configuration/GitVersionConfigurationException.cs
+++ b/src/GitVersionCore/Configuration/GitVersionConfigurationException.cs
@@ -1,10 +1,19 @@
 namespace GitVersion
 {
     using System;
+    using System.Runtime.Serialization;
 
-    public class GitVersionConfigurationException : Exception
+    [Serializable]
+    public class GitVersionConfigurationException : GitVersionException
     {
-        public GitVersionConfigurationException(string msg) : base(msg)
+        public GitVersionConfigurationException(string msg)
+            : base(msg)
+        {
+        }
+
+
+        protected GitVersionConfigurationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/GitVersionCore/Configuration/OldConfigurationException.cs
+++ b/src/GitVersionCore/Configuration/OldConfigurationException.cs
@@ -4,15 +4,16 @@ namespace GitVersion
     using System.Runtime.Serialization;
 
     [Serializable]
-    public class OldConfigurationException : Exception
+    public class OldConfigurationException : GitVersionException
     {
-        public OldConfigurationException(string message) : base(message)
+        public OldConfigurationException(string message)
+            : base(message)
         {
         }
 
-        protected OldConfigurationException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
+
+        protected OldConfigurationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/GitVersionCore/Configuration/OldConfigurationException.cs
+++ b/src/GitVersionCore/Configuration/OldConfigurationException.cs
@@ -1,19 +1,12 @@
 namespace GitVersion
 {
     using System;
-    using System.Runtime.Serialization;
 
     [Serializable]
     public class OldConfigurationException : GitVersionException
     {
         public OldConfigurationException(string message)
             : base(message)
-        {
-        }
-
-
-        protected OldConfigurationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -118,6 +118,7 @@
     <Compile Include="GitVersionCache.cs" />
     <Compile Include="GitVersionCacheKey.cs" />
     <Compile Include="GitVersionCacheKeyFactory.cs" />
+    <Compile Include="GitVersionException.cs" />
     <Compile Include="Helpers\EncodingHelper.cs" />
     <Compile Include="Helpers\FileSystem.cs" />
     <Compile Include="Helpers\IFileSystem.cs" />

--- a/src/GitVersionCore/GitVersionException.cs
+++ b/src/GitVersionCore/GitVersionException.cs
@@ -1,0 +1,31 @@
+﻿namespace GitVersion
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    public class GitVersionException : ApplicationException
+    {
+        public GitVersionException()
+        {
+        }
+
+
+        public GitVersionException(string message)
+            : base(message)
+        {
+        }
+
+
+        public GitVersionException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+
+        protected GitVersionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/GitVersionCore/GitVersionException.cs
+++ b/src/GitVersionCore/GitVersionException.cs
@@ -1,16 +1,12 @@
 ﻿namespace GitVersion
 {
     using System;
-    using System.Runtime.Serialization;
+
+    using GitTools;
 
     [Serializable]
-    public class GitVersionException : ApplicationException
+    public class GitVersionException : GitToolsException
     {
-        public GitVersionException()
-        {
-        }
-
-
         public GitVersionException(string message)
             : base(message)
         {
@@ -19,12 +15,6 @@
 
         public GitVersionException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-
-        protected GitVersionException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
Improve upon the `LibGit2Sharp.NotFoundException` thrown when a commit ID can't be found due to a shallow clone by adding instructions to do `git fetch --unshallow`. Fixes #1043.