### PR TITLE
Ensure that PreReleaseNumber is always a number

### DIFF
--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -5,7 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
-  "PreReleaseNumber":"",
+  "PreReleaseNumber":0,
   "BuildMetaData":5,
   "BuildMetaDataPadded":"0005",
   "FullBuildMetaData":"5.Branch.develop.Sha.commitSha",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -5,7 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
-  "PreReleaseNumber":"",
+  "PreReleaseNumber":0,
   "BuildMetaData":5,
   "BuildMetaDataPadded":"0005",
   "FullBuildMetaData":"5.Sha.commitSha",

--- a/src/GitVersionCore/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/SemanticVersionFormatValues.cs
@@ -45,7 +45,7 @@
 
         public string PreReleaseNumber
         {
-            get { return _semver.PreReleaseTag.HasTag() ? _semver.PreReleaseTag.Number.ToString() : null; }
+            get { return _semver.PreReleaseTag.HasTag() ? _semver.PreReleaseTag.Number.ToString() : "0"; }
         }
 
         public string BuildMetaData


### PR DESCRIPTION
Because of the [JsonOutputFormatter](https://github.com/GitTools/GitVersion/blob/c5ae891d56a8d6d52ac4f756a6727a41071332b1/src/GitVersionCore/OutputFormatters/JsonOutputFormatter.cs), the json output can either be "PreReleaseNumber": number or "PreReleaseNumber": null
this can have impact on desserialization as found on [Cake](https://github.com/cake-build/cake/issues/1798)