### PR TITLE
honour increment config value for Mainline

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -339,6 +339,104 @@ public class MainlineDevelopmentMode
             fixture.AssertFullSemver(currentConfig, "1.1.0");
         }
     }
+
+    [Test]
+    public void VerifyIncrementConfigIsHonoured()
+    {
+        var minorIncrementConfig = new Config
+        {
+            VersioningMode = VersioningMode.Mainline,
+            Increment = IncrementStrategy.Minor,
+            Branches = new Dictionary<string, BranchConfig>
+            {
+                {
+                    "master",
+                    new BranchConfig
+                    {
+                        Increment = IncrementStrategy.Minor,
+                        Name = "master",
+                        Regex = "master"
+                    }
+                },
+                {
+                    "feature",
+                    new BranchConfig
+                    {
+                        Increment = IncrementStrategy.Minor,
+                        Name = "feature",
+                        Regex = "features?[/-]"
+                    }
+                }
+            }
+        };
+
+        using ( var fixture = new EmptyRepositoryFixture() )
+        {
+            fixture.Repository.MakeACommit("1");
+            fixture.MakeATaggedCommit("1.0.0");
+
+            fixture.BranchTo("feature/foo", "foo");
+            fixture.MakeACommit("2");
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.0-foo.1");
+            fixture.MakeACommit("2.1");
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.0-foo.2");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo");
+
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.0");
+
+            fixture.BranchTo("feature/foo2", "foo2");
+            fixture.MakeACommit("3 +semver: patch");
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.1-foo2.1");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo2");
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.1");
+
+            fixture.BranchTo("feature/foo3", "foo3");
+            fixture.MakeACommit("4");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo3");
+            fixture.SequenceDiagram.NoteOver("Merge message contains '+semver: patch'", "master");
+            var commit = fixture.Repository.Head.Tip;
+            // Put semver increment in merge message
+            fixture.Repository.Commit(commit.Message + " +semver: patch", commit.Author, commit.Committer, new CommitOptions
+            {
+                AmendPreviousCommit = true
+            });
+            fixture.AssertFullSemver(minorIncrementConfig, "1.1.2");
+
+            fixture.BranchTo("feature/foo4", "foo4");
+            fixture.MakeACommit("5 +semver: major");
+            fixture.AssertFullSemver(minorIncrementConfig, "2.0.0-foo4.1");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo4");
+            fixture.AssertFullSemver(config, "2.0.0");
+
+            // We should evaluate any commits not included in merge commit calculations for direct commit/push or squash to merge commits
+            fixture.MakeACommit("6 +semver: major");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.0.0");
+            fixture.MakeACommit("7");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.0");
+            fixture.MakeACommit("8 +semver: patch");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.1");
+
+            // Finally verify that the merge commits still function properly
+            fixture.BranchTo("feature/foo5", "foo5");
+            fixture.MakeACommit("9 +semver: patch");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.2-foo5.1");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo5");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.2");
+
+            // One more direct commit for good measure
+            fixture.MakeACommit("10 +semver: patch");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.3");
+            // And we can commit without bumping semver
+            fixture.MakeACommit("11 +semver: none");
+            fixture.AssertFullSemver(minorIncrementConfig, "3.1.3");
+            Console.WriteLine(fixture.SequenceDiagram.GetDiagram());
+        }
+    }
 }
 
 static class CommitExtensions

--- a/src/GitVersionCore/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/IncrementStrategyFinder.cs
@@ -126,5 +126,17 @@
         {
             return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
+
+        public static VersionField FindDefaultIncrementForBranch( GitVersionContext context, string branch = null )
+        {
+            var config = context.FullConfiguration.GetConfigForBranch(branch ?? context.CurrentBranch.FriendlyName);
+            if ( config?.Increment != null && config.Increment != IncrementStrategy.Inherit )
+            {
+                return config.Increment.Value.ToVersionField();
+            }
+
+            // Fallback to patch
+            return VersionField.Patch;
+        }
     }
 }

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -3,7 +3,6 @@ using LibGit2Sharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace GitVersion.VersionCalculation
@@ -73,7 +72,7 @@ namespace GitVersion.VersionCalculation
 
                     var branchIncrement = FindMessageIncrement(context, null, mergedHead, findMergeBase, directCommits);
                     // This will increment for any direct commits on master
-                    mainlineVersion = IncrementForEachCommit(context, directCommits, mainlineVersion);
+                    mainlineVersion = IncrementForEachCommit(context, directCommits, mainlineVersion, "master");
                     mainlineVersion.BuildMetaData = metaDataCalculator.Create(findMergeBase, context);
                     // Don't increment if the merge commit is a merge into mainline
                     // this ensures PR's and forward merges end up correct.
@@ -164,14 +163,14 @@ namespace GitVersion.VersionCalculation
             return chosenMainline.Tip;
         }
 
-        private static SemanticVersion IncrementForEachCommit(GitVersionContext context, List<Commit> directCommits, SemanticVersion mainlineVersion)
+        private static SemanticVersion IncrementForEachCommit(GitVersionContext context, List<Commit> directCommits, SemanticVersion mainlineVersion, string branch = null)
         {
             foreach (var directCommit in directCommits)
             {
                 var directCommitIncrement = IncrementStrategyFinder.GetIncrementForCommits(context, new[]
                                             {
                                                 directCommit
-                                            }) ?? VersionField.Patch;
+                                            }) ?? IncrementStrategyFinder.FindDefaultIncrementForBranch(context, branch);
                 mainlineVersion = mainlineVersion.IncrementVersion(directCommitIncrement);
                 Logger.WriteInfo(string.Format("Direct commit on master {0} incremented base versions {1}, now {2}",
                     directCommit.Sha, directCommitIncrement, mainlineVersion));
@@ -210,8 +209,8 @@ namespace GitVersion.VersionCalculation
                 }
             }
 
-            // Fallback to patch
-            return VersionField.Patch;
+            // Fallback to config increment value
+            return IncrementStrategyFinder.FindDefaultIncrementForBranch(context);
         }
 
         private Commit GetMergedHead(Commit mergeCommit)


### PR DESCRIPTION
Adds support to Mainline mode to honour `Increment` value in config. Previously if not a tag or commit message bump would default to `Patch` increment.

Includes:
* Added new method to `IncrementStrategyFinder` to work out default Increment Strategy for a branch
* Updated `MainlineDevelopmentMode` to use new method instead of defaulting to `Patch`
* Added unit test to cover setting increment in config

Fixes #1295