### PR TITLE
Add VS extension updater

### DIFF
--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="BuildLogger.cs" />
     <Compile Include="GenerateGitVersionInformation.cs" />
+    <Compile Include="UpdateVsixManifest.cs" />
     <Compile Include="GitVersionTaskBase.cs" />
     <Compile Include="WriteVersionInfoToBuildLog.cs" />
     <Compile Include="GetVersion.cs" />

--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -49,6 +49,9 @@
   <UsingTask
       TaskName="GitVersionTask.WriteVersionInfoToBuildLog"
       AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
+  <UsingTask
+      TaskName="GitVersionTask.UpdateVsixManifest"
+      AssemblyFile="$(GitVersionTaskLibrary)GitVersionTask.dll" />
 
   <Import Project="$(GitVersionCustomizeTargetFile)" Condition="'$(GitVersionCustomizeTargetFile)' != '' and Exists('$(GitVersionCustomizeTargetFile)')" />
 
@@ -136,6 +139,14 @@
       <FileVersion Condition=" '$(FileVersion)' == '' ">$(GitVersion_AssemblySemFileVer)</FileVersion>
     </PropertyGroup>
 
+  </Target>
+
+  <!-- Support for VSIX files -->
+  <Target Name="UpdateVsixManifest" BeforeTargets="CreateVsixContainer" Condition=" '$(CreateVsixContainer)' == 'true' ">
+    <UpdateVsixManifest
+      NoFetch="$(GitVersion_NoFetchEnabled)"
+      VsixManifest="$(IntermediateVsixManifest)"
+      SolutionDirectory="$(GitVersionPath)" />
   </Target>
 
   <!--Support for ncrunch-->

--- a/src/GitVersionTask/UpdateVsixManifest.cs
+++ b/src/GitVersionTask/UpdateVsixManifest.cs
@@ -1,0 +1,74 @@
+﻿namespace GitVersionTask
+{
+    using System;
+    using System.ComponentModel;
+    using System.Xml.Linq;
+    using System.Linq;
+    using GitVersion;
+    using Microsoft.Build.Framework;
+
+    public class UpdateVsixManifest : GitVersionTaskBase
+    {
+        TaskLogger logger;
+
+        public UpdateVsixManifest()
+        {
+            logger = new TaskLogger(this);
+            Logger.SetLoggers(this.LogDebug, this.LogInfo, this.LogWarning, s => this.LogError(s));
+        }
+
+        [Required]
+        public string VsixManifest { get; set; }
+
+        [Required]
+        public string SolutionDirectory { get; set; }
+
+        public bool NoFetch { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                VersionVariables variables;
+                if (ExecuteCore.TryGetVersion(SolutionDirectory, out variables, NoFetch, new Authentication()))
+                {
+                    UpdateManifestFile(variables);
+                }
+
+                return true;
+            }
+            catch (WarningException errorException)
+            {
+                logger.LogWarning(errorException.Message);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError("Error occurred: " + exception);
+                return false;
+            }
+            finally
+            {
+                Logger.Reset();
+            }
+        }
+
+        private void UpdateManifestFile(VersionVariables variables)
+        {
+            const string ns = "http://schemas.microsoft.com/developer/vsx-schema/2011";
+
+            var version = variables.AssemblySemFileVer;
+            var doc = XDocument.Load(VsixManifest);
+            var identity = doc
+                .Root
+                .Descendants(XName.Get("Identity", ns))
+                .Single();
+
+            identity.Attribute("Version").Value = version;
+
+            doc.Save(VsixManifest);
+
+            Log.LogMessage($"Updated {VsixManifest} version to {version}");
+        }
+    }
+}


### PR DESCRIPTION
This adds a task to update VSIX manifest files if they are present in the project. This is done by hooking itself such that it runs right before CreateVsixPackage if it exists. The update is done on the intermediate manifest, so the original copy is not changed and thus the version update is transparent to the user.