### PR TITLE
Make sure GetVersion is called for project references

### DIFF
--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -34,6 +34,8 @@
     <GetVersion Condition=" '$(GetVersion)' == '' and '$(NCrunch)' != '' ">false</GetVersion>
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);GetVersion</GetPackageVersionDependsOn>
+
     <GitVersionTaskLibrary>$(MSBuildThisFileDirectory)</GitVersionTaskLibrary>
   </PropertyGroup>
 

--- a/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/buildMultiTargeting/GitVersionTask.targets
@@ -28,6 +28,8 @@
     <GetVersion Condition=" '$(GetVersion)' == '' and '$(NCrunch)' != '' ">false</GetVersion>
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);GetVersion</GetPackageVersionDependsOn>
+
     <!-- Property that enables setting of Version -->
     <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
     <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>


### PR DESCRIPTION
Adding this property ensures that the GetVersion target will be called in the right place when NuGet's Pack target is calculating the version for project references.

This is using the new feature in https://github.com/NuGet/NuGet.Client/pull/1915 to do this, so you won't see it actually doing anything until an updated version of NuGet is released.