### PR TITLE
switch GetMainlineTip from using branch config key to using the regex

### DIFF
--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -120,7 +120,7 @@ namespace GitVersion.VersionCalculation
             var mainlineBranches = context.Repository.Branches
                 .Where(b =>
                 {
-                    return mainlineBranchConfigs.Any(c => Regex.IsMatch(b.FriendlyName, c.Key));
+                    return mainlineBranchConfigs.Any(c => Regex.IsMatch(b.FriendlyName, c.Value.Regex));
                 })
                 .Where(b =>
                 {


### PR DESCRIPTION
When finding possible tips for the mainline branch the key is used instead of the regex defined in the branch configuration. This PR corrects that problem. Fixes #1364.