### PR TITLE
#1355 Fix develop branch config in mainline mode

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -78,6 +78,17 @@ branches:
     }
 
     [Test]
+    public void AllBranchesModeWhenUsingMainline()
+    {
+        var defaultConfig = ConfigurationProvider.Provide(repoPath, fileSystem);
+        const string text = @"mode: Mainline";
+        SetupConfigFileContent(text);
+        var config = ConfigurationProvider.Provide(repoPath, fileSystem);
+        var branches = config.Branches.Select(x => x.Value);
+        branches.All(branch => branch.VersioningMode == VersioningMode.Mainline).ShouldBe(true);
+    }
+
+    [Test]
     public void CanRemoveTag()
     {
         const string text = @"

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -109,7 +109,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 new List<string>(),
                 defaultTag: "alpha",
                 defaultIncrementStrategy: IncrementStrategy.Minor,
-                defaultVersioningMode: VersioningMode.ContinuousDeployment,
+                defaultVersioningMode: config.VersioningMode == VersioningMode.Mainline? VersioningMode.Mainline : VersioningMode.ContinuousDeployment,
                 defaultTrackMergeTarget: true,
                 tracksReleaseBranches: true);
             ApplyBranchDefaults(config,


### PR DESCRIPTION
Issue #1355 .
Develop branch is always set in the ContinuousDeployment mode in config and even when we use the Mainline mode. Consequently, we can not get the expected version in the develop branch.
If we try to override branch mode in config, we get an error: "Mainline mode only works at the repository level, a single branch cannot be put into mainline mode..."
By default, all other branches inherit the global mode.