### PR TITLE
Support for bitbucket pull request merge message

### DIFF
--- a/src/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -54,6 +54,8 @@
         [TestCase("Merge pull request #95 in Particular/issue-94", true, null)]
         [TestCase("Merge pull request #95 in Particular/issue-94", false, null)]
         [TestCase("Merge pull request #64 from arledesma/feature-VS2013_3rd_party_test_framework_support", true, null)]
+        [TestCase("Merge pull request #500 in FOO/bar from Particular/release-1.0.0 to develop)", true, "1.0.0")]
+        [TestCase("Merge pull request #500 in FOO/bar from feature/new-service to develop)", true, null)]
         [TestCase("Finish Release-0.12.0", true, "0.12.0")] //Support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Release' branch
         [TestCase("Finish 0.14.1", true, "0.14.1")] //Support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Hotfix' branch
         [TestCase("Merge branch 'Release-v0.2.0'", true, "0.2.0")]


### PR DESCRIPTION
Hi, I detected that merge message like "Merge pull request #xxx in BIA/project_Name from feature/branch_Name to develop" not supported. This message generates by bitbucket.
I added new regex for support this.