### PR TITLE
Add failing test to PullRequestScenarios

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -109,4 +109,19 @@ public class PullRequestScenarios
             fixture.AssertFullSemver("2.0.0-PullRequest0002.0");
         }
     }
+
+    [Test]
+    public void CalculatesCorrectVersionForPullRequestFromReleaseToMasterInGitFlowBranchingModel()
+    {
+        using (var fixture = new BaseGitFlowRepositoryFixture("1.0.0"))
+        {
+            fixture.MakeACommit();
+            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("release/2.0.0"));
+            fixture.MakeACommit();
+
+            fixture.Repository.CreatePullRequestRef("release/2.0.0", "master", normalise: true);
+
+            fixture.AssertFullSemver("2.0.0-PullRequest0002.0");
+        }
+    }
 }


### PR DESCRIPTION
I think this scenario should return same Semver like at https://github.com/GitTools/GitVersion/blob/6dfa28cd09bc8b89ff9303f0b4e695dd5f466b2f/src/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs#L97

but calculates "2.1.0-PullRequest0002.4"

Test output: 
```
INFO [03/26/18 16:26:38:20] Using latest commit on specified branch
INFO [03/26/18 16:26:38:26] Begin: Attempting to inherit branch configuration from parent branch
  INFO [03/26/18 16:26:38:28] HEAD is merge commit, this is likely a pull request using release/2.0.0 as base
  INFO [03/26/18 16:26:38:29] Begin: Finding branch source of 'release/2.0.0'
    INFO [03/26/18 16:26:38:32] Begin: Finding merge base between 'release/2.0.0' and 'develop'.
      INFO [03/26/18 16:26:38:33] Found merge base of 9f140eeac8d9a6453d64c4b99df9cac85a302732
      INFO [03/26/18 16:26:38:35] Merge base of release/2.0.0' and 'develop is 9f140eeac8d9a6453d64c4b99df9cac85a302732
    INFO [03/26/18 16:26:38:35] End: Finding merge base between 'release/2.0.0' and 'develop'. (Took: 31.00ms)
    INFO [03/26/18 16:26:38:35] Begin: Finding merge base between 'release/2.0.0' and 'master'.
      INFO [03/26/18 16:26:38:35] Found merge base of 04471345d938df58fbead6906d0f2eea35d3ac5d
      INFO [03/26/18 16:26:38:35] Merge base of release/2.0.0' and 'master is 04471345d938df58fbead6906d0f2eea35d3ac5d
    INFO [03/26/18 16:26:38:35] End: Finding merge base between 'release/2.0.0' and 'master'. (Took: 1.00ms)
    INFO [03/26/18 16:26:38:37] Multiple source branches have been found, picking the first one (develop).
This may result in incorrect commit counting.
Options were:
 develop, master
  INFO [03/26/18 16:26:38:37] End: Finding branch source of 'release/2.0.0' (Took: 83.01ms)
  INFO [03/26/18 16:26:38:38] Begin: Getting branches containing the commit '9f140eeac8d9a6453d64c4b99df9cac85a302732'.
    INFO [03/26/18 16:26:38:38] Trying to find direct branches.
    INFO [03/26/18 16:26:38:38] No direct branches found, searching through tracked branches.
    INFO [03/26/18 16:26:38:39] Searching for commits reachable from 'develop'.
    INFO [03/26/18 16:26:38:39] The branch 'develop' has a matching commit.
    INFO [03/26/18 16:26:38:39] Searching for commits reachable from 'master'.
    INFO [03/26/18 16:26:38:39] The branch 'master' has no matching commits.
  INFO [03/26/18 16:26:38:39] End: Getting branches containing the commit '9f140eeac8d9a6453d64c4b99df9cac85a302732'. (Took: 10.00ms)
  INFO [03/26/18 16:26:38:39] Found possible parent branches: develop
INFO [03/26/18 16:26:38:39] End: Attempting to inherit branch configuration from parent branch (Took: 131.01ms)
INFO [03/26/18 16:26:38:42] Running against branch: pull/2/merge (98d4156c74dca82364e4522167a4d21027a532a0)
INFO [03/26/18 16:26:38:42] Begin: Calculating base versions
  INFO [03/26/18 16:26:38:43] Fallback base version: 0.1.0 with commit count source 04471345d938df58fbead6906d0f2eea35d3ac5d (Incremented: None)
  INFO [03/26/18 16:26:38:52] Git tag '1.0.0': 1.0.0 with commit count source 04471345d938df58fbead6906d0f2eea35d3ac5d (Incremented: 1.1.0)
  INFO [03/26/18 16:26:38:55] Merge message 'Merge branch 'release/2.0.0'': 2.0.0 with commit count source 98d4156c74dca82364e4522167a4d21027a532a0 (Incremented: 2.1.0)
  INFO [03/26/18 16:26:38:56] Begin: Finding merge base between 'release/2.0.0' and 'pull/2/merge'.
    INFO [03/26/18 16:26:38:57] Found merge base of 04471345d938df58fbead6906d0f2eea35d3ac5d
    INFO [03/26/18 16:26:38:57] Merge base of release/2.0.0' and 'pull/2/merge is 04471345d938df58fbead6906d0f2eea35d3ac5d
  INFO [03/26/18 16:26:38:57] End: Finding merge base between 'release/2.0.0' and 'pull/2/merge'. (Took: 2.00ms)
  INFO [03/26/18 16:26:38:57] Begin: Finding branch source of 'release/2.0.0'
    DEBUG [03/26/18 16:26:38:57] Cache hit for getting merge commits for branch refs/heads/release/2.0.0.
    INFO [03/26/18 16:26:38:57] Multiple source branches have been found, picking the first one (develop).
This may result in incorrect commit counting.
Options were:
 develop, master
  INFO [03/26/18 16:26:38:57] End: Finding branch source of 'release/2.0.0' (Took: 1.00ms)
  INFO [03/26/18 16:26:38:59] Release branch exists -> Version in branch name: 2.0.0 with commit count source 04471345d938df58fbead6906d0f2eea35d3ac5d (Incremented: 2.1.0)
  INFO [03/26/18 16:26:38:61] Git tag '1.0.0': 1.0.0 with commit count source 04471345d938df58fbead6906d0f2eea35d3ac5d (Incremented: 1.1.0)
  INFO [03/26/18 16:26:38:62] Found multiple base versions which will produce the same SemVer (2.1.0), taking oldest source for commit counting (Release branch exists -> Version in branch name)
  INFO [03/26/18 16:26:38:64] Base version used: Release branch exists -> Version in branch name: 2.0.0 with commit count source 04471345d938df58fbead6906d0f2eea35d3ac5d (Incremented: 2.1.0)
INFO [03/26/18 16:26:38:64] End: Calculating base versions (Took: 214.02ms)
INFO [03/26/18 16:26:38:65] 4 commits found between 04471345d938df58fbead6906d0f2eea35d3ac5d and 98d4156c74dca82364e4522167a4d21027a532a0
INFO [03/26/18 16:26:38:65] Begin: Getting version tags from branch 'refs/heads/pull/2/merge'.
INFO [03/26/18 16:26:38:66] End: Getting version tags from branch 'refs/heads/pull/2/merge'. (Took: 4.00ms)
*   98d4156 51 minutes ago  (HEAD -> pull/2/merge, refs/pull/2/merge)
|\  
| * b08445b 52 minutes ago  (release/2.0.0)
| * 9f140ee 54 minutes ago  (develop)
| * 77889f5 56 minutes ago 
|/  
* 0447134 58 minutes ago  (tag: 1.0.0, master)
