### PR TITLE
Update LibGit2Sharp to 0.25.0-preview-0033

### DIFF
--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -70,5 +70,4 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-
 </Project>

--- a/src/GitVersionCore.Tests/Mocks/MockQueryableCommitLog.cs
+++ b/src/GitVersionCore.Tests/Mocks/MockQueryableCommitLog.cs
@@ -36,16 +36,6 @@ public class MockQueryableCommitLog : IQueryableCommitLog
     {
         throw new NotImplementedException();
     }
-    
-    public Commit FindMergeBase(Commit first, Commit second)
-    {
-        return null;
-    }
-
-    public Commit FindMergeBase(IEnumerable<Commit> commits, MergeBaseFindingStrategy strategy)
-    {
-        throw new NotImplementedException();
-    }
 
     public IEnumerable<LogEntry> QueryBy(string path, CommitFilter filter)
     {

--- a/src/GitVersionCore/AssemblyInfo.cs
+++ b/src/GitVersionCore/AssemblyInfo.cs
@@ -3,11 +3,11 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("GitVersionCore")]
 [assembly: AssemblyProduct("GitVersion")]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0.1.0")]
+[assembly: AssemblyFileVersion("4.0.1.0")]
 [assembly: InternalsVisibleTo("GitVersionTask.Tests")]
 [assembly: InternalsVisibleTo("GitVersion")]
 [assembly: InternalsVisibleTo("GitVersionCore.Tests")]
 [assembly: InternalsVisibleTo("GitVersionExe.Tests")]
 
-[assembly: AssemblyInformationalVersion("4.0.0-netstandard.1+1538.Branch.feature/netstandard.Sha.91536c107ba91f755f14904fc69965a9ad70fcb0")]
+[assembly: AssemblyInformationalVersion("4.0.1-feat-UpgradeLibGit2Sharp.1+3.Branch.feat/UpgradeLibGit2Sharp.Sha.5662c303d7f2fd45c73b890f785338fdeee6b19d")]

--- a/src/GitVersionCore/GitVersionCore.csproj
+++ b/src/GitVersionCore/GitVersionCore.csproj
@@ -105,5 +105,4 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/GitVersionExe/AssemblyInfo.cs
+++ b/src/GitVersionExe/AssemblyInfo.cs
@@ -3,10 +3,10 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("GitVersion")]
 [assembly: AssemblyProduct("GitVersion")]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0.1.0")]
+[assembly: AssemblyFileVersion("4.0.1.0")]
 [assembly: InternalsVisibleTo("GitVersionTask.Tests")]
 [assembly: InternalsVisibleTo("AcceptanceTests")]
 [assembly: InternalsVisibleTo("GitVersionExe.Tests")]
 
-[assembly: AssemblyInformationalVersion("4.0.0-netstandard.1+1538.Branch.feature/netstandard.Sha.91536c107ba91f755f14904fc69965a9ad70fcb0")]
+[assembly: AssemblyInformationalVersion("4.0.1-feat-UpgradeLibGit2Sharp.1+3.Branch.feat/UpgradeLibGit2Sharp.Sha.5662c303d7f2fd45c73b890f785338fdeee6b19d")]

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GitVersion</RootNamespace>
     <AssemblyName>GitVersion</AssemblyName>
-    <TargetFrameworks>net40;netcoreapp20</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
     <BuildDir>$(SolutionDir)..\build\</BuildDir>
     
     <GenerateAssemblyFileVersionAttribute Condition="'$(GenerateAssemblyFileVersionAttribute)' == ''">false</GenerateAssemblyFileVersionAttribute>

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -85,5 +85,4 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-
 </Project>

--- a/src/GitVersionTask.Tests/app.config
+++ b/src/GitVersionTask.Tests/app.config
@@ -16,8 +16,8 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.24.0.0" newVersion="0.24.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.0.0" newVersion="0.25.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/src/GitVersionTask.Tests/packages.config
+++ b/src/GitVersionTask.Tests/packages.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentDateTime" version="1.13.0" targetFramework="net45" />
   <package id="Fody" version="2.0.8" targetFramework="net45" developmentDependency="true" />
   <package id="GitTools.Core" version="1.3.0" targetFramework="net45" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.25.0-preview-0033" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	 <package id="Cake" version="0.27.2" />
-	 <package id="Cake.CoreCLR" version="0.27.2" />
+    <package id="Cake" version="0.28.1" />
 </packages>


### PR DESCRIPTION
Based on #1248, this Upgrades `LibGit2Sharp` to `0.25.0-preview-0033`. Getting tests to pass required upgrading `GitTools.Testing` and `GitTools.Core` to the latest version. `GitTools.Testing`'s minimum target is `4.5.2`, so the testing projects had to be upgraded.

Starting with `0.25.0-preview-0073`, `LibGit2Sharp` is `netstandard2.0` only. I ran into target file issues with the targets that add references to the native binaries. I have to look into this more but I believe the simplest solution is to go straight to `netstandard2.0` here (#1175 ?). If you're uncomfortable running on a pre-release, I can re-do this to target 0.24.1 as it still fixes #1415 for me. Let me know what you think.

Fixes #1415 