### PR TITLE
Update GitReleaseNotes

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,4 +3,6 @@ branches:
   master:
     tag: beta
 ignore:
-  sha: []
+  sha: 
+    - 0e77e2e16a136a1cd0f0474fe5710f617d508d81
+    - af73f6a349456f146a8d0a413de1331eddf61bc2

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool "nuget:https://www.nuget.org/api/v2?package=NUnit.ConsoleRunner&version=3.7.0"
-#tool "nuget:https://www.nuget.org/api/v2?package=GitReleaseNotes&version=0.7.0"
+#tool "nuget:https://www.nuget.org/api/v2?package=GitReleaseNotes&version=0.7.1"
 #tool "nuget:https://www.nuget.org/api/v2?package=ILRepack&version=2.0.15"
 #addin "nuget:?package=Cake.Incubator"
 


### PR DESCRIPTION
- Updated to latest version of GitReleaseNotes to fix the ssl issue when generating release notes
- fixed the version back to 4.0.0