### PR TITLE
Fix detection of multi targeting

### DIFF
--- a/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
+++ b/src/GitVersionTask/NugetAssets/build/GitVersionTask.targets
@@ -1,13 +1,8 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup>
-    <PathSeparators Include="/"/>
-    <PathSeparators Include="\"/>
-  </ItemGroup>
-
   <PropertyGroup>
     <GitVersionTaskBuildTools_IsMultiTargeting>false</GitVersionTaskBuildTools_IsMultiTargeting>
-    <GitVersionTaskBuildTools_IsMultiTargeting Condition="$(MSBuildThisFileDirectory.Substring($(MSBuildThisFileDirectory.LastIndexOfAny(@(PathSeparators)))).Substring(1).Contains('buildMultiTargeting'))">true</GitVersionTaskBuildTools_IsMultiTargeting>
+    <GitVersionTaskBuildTools_IsMultiTargeting Condition="$(MSBuildThisFileDirectory.TrimEnd('\').TrimEnd('/').EndsWith('buildMultiTargeting'))">true</GitVersionTaskBuildTools_IsMultiTargeting>
   </PropertyGroup>
 
   <!-- Import infrastructure props for util pack. -->

--- a/src/GitVersionTask/NugetAssets/build/Infrastructure.props
+++ b/src/GitVersionTask/NugetAssets/build/Infrastructure.props
@@ -4,8 +4,8 @@
   <!-- Properties containing paths to functionality files and directories. -->
   <PropertyGroup>
     <GitVersionTaskBuildTools_FunctionalityDir>$(MSBuildThisFileDirectory)functionality/</GitVersionTaskBuildTools_FunctionalityDir>
-    <GitVersionTaskBuildTools_FunctionalityFile Condition="'$(GitVersion_IsMultiTargeting)'!= 'true'">$(GitVersionTaskBuildTools_FunctionalityDir)GitVersionBuild.targets</GitVersionTaskBuildTools_FunctionalityFile>
-    <GitVersionTaskBuildTools_FunctionalityFile Condition="'$(GitVersion_IsMultiTargeting)'== 'true'">$(GitVersionTaskBuildTools_FunctionalityDir)GitVersionMultiTargetBuild.targets</GitVersionTaskBuildTools_FunctionalityFile>
+    <GitVersionTaskBuildTools_FunctionalityFile Condition="'$(GitVersionTaskBuildTools_IsMultiTargeting)'!= 'true'">$(GitVersionTaskBuildTools_FunctionalityDir)GitVersionBuild.targets</GitVersionTaskBuildTools_FunctionalityFile>
+    <GitVersionTaskBuildTools_FunctionalityFile Condition="'$(GitVersionTaskBuildTools_IsMultiTargeting)'== 'true'">$(GitVersionTaskBuildTools_FunctionalityDir)GitVersionMultiTargetBuild.targets</GitVersionTaskBuildTools_FunctionalityFile>
     <GitVersionTaskBuildTools_FunctionalityObjFolder>$(GitVersionTaskBuildTools_FunctionalityDir)obj/</GitVersionTaskBuildTools_FunctionalityObjFolder>
   </PropertyGroup>
 


### PR DESCRIPTION
The previous code always set GitVersionTaskBuildTools_IsMultiTargeting
to `false`, and the property we set didn't get used anywhere.