### PR TITLE
Attempt to fix merge message issue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ build-metadata-padding: 4
 commits-since-version-source-padding: 4
 commit-message-incrementing: Enabled
 commit-date-format: 'yyyy-MM-dd'
+use-merge-message-version: true
 ignore:
   sha: []
   commits-before: yyyy-MM-ddTHH:mm:ss
@@ -179,6 +180,10 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 2015-10-23T12:23:15`) to setup an exclusion range. Effectively any commit before
 `commits-before` will be ignored.
 
+#### use-merge-message-version
+This configuration can be used to disable merge message version detection, where the version
+is infered from the commit message.
+
 ## Branch configuration
 Then we have branch specific configuration, which looks something like this:
 
@@ -286,7 +291,7 @@ By looking at this graph, you cannot tell which of these scenarios happened:
 
 2. release/1.0.0 branches off feature/foo
    - Branch feature/foo from master
-   - Branch release/1.0.0 from feature/foo 
+   - Branch release/1.0.0 from feature/foo
    - Add a commit to both release/1.0.0 and feature/foo
    - feature/foo is the base for release/1.0.0
 

--- a/src/GitVersionCore.Tests/CommitDateTests.cs
+++ b/src/GitVersionCore.Tests/CommitDateTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +28,7 @@ namespace GitVersionCore.Tests
                                     },
                                     new EffectiveConfiguration(
                                         AssemblyVersioningScheme.MajorMinorPatch, AssemblyFileVersioningScheme.MajorMinorPatch, "", "", "", VersioningMode.ContinuousDelivery, "", "", "", IncrementStrategy.Inherit,
-                                        "", true, "", "", false, "", "", "", "", CommitMessageIncrementMode.Enabled, 4, 4, 4, Enumerable.Empty<IVersionFilter>(), false, true, format)
+                                        "", true, "", "", false, "", "", "", "", CommitMessageIncrementMode.Enabled, 4, 4, 4, Enumerable.Empty<IVersionFilter>(), false, true, format, true)
                                 );
 
             Assert.That(formatValues.CommitDate, Is.EqualTo(expectedOutcome));

--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -11,6 +11,7 @@ legacy-semver-padding: 4
 build-metadata-padding: 4
 commits-since-version-source-padding: 4
 commit-message-incrementing: Enabled
+use-merge-message-version: true
 branches:
   develop:
     mode: ContinuousDeployment

--- a/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -33,14 +33,15 @@ namespace GitVersionCore.Tests
             IEnumerable<IVersionFilter> versionFilters = null,
             bool tracksReleaseBranches = false,
             bool isRelease = false,
-            string commitDateFormat = "yyyy-MM-dd") :
+            string commitDateFormat = "yyyy-MM-dd",
+            bool useMergeMessageVersion = true) :
             base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,
                     commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
                     versionFilters ?? Enumerable.Empty<IVersionFilter>(),
-                    tracksReleaseBranches, isRelease, commitDateFormat)
+                    tracksReleaseBranches, isRelease, commitDateFormat, useMergeMessageVersion)
         {
         }
     }

--- a/src/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -1,7 +1,8 @@
-﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+namespace GitVersionCore.Tests.VersionCalculation.Strategies
 {
     using System.Collections.Generic;
     using System.Linq;
+    using GitVersion;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
     using LibGit2Sharp;
     using NUnit.Framework;
@@ -15,14 +16,16 @@
         {
             // When a branch is merged in you want to start building stable packages of that version
             // So we shouldn't bump the version
-            var context = new GitVersionContextBuilder().WithRepository(new MockRepository
-            {
-                Head = new MockBranch("master") { new MockCommit
+            var context = new GitVersionContextBuilder()
+                .WithRepository(new MockRepository
+                {
+                    Head = new MockBranch("master") { new MockCommit
                 {
                     MessageEx = "Merge branch 'hotfix-0.1.5'",
                     ParentsEx = GetParents(true)
                 } }
-            }).Build();
+                }).Build();
+
             var sut = new MergeMessageBaseVersionStrategy();
 
             var baseVersion = sut.GetVersions(context).Single();
@@ -94,7 +97,7 @@
             var parents = GetParents(true);
 
             AssertMergeMessage(commitMessage, null, parents);
-        } 
+        }
 
         static void AssertMergeMessage(string message, string expectedVersion, List<Commit> parents)
         {
@@ -105,6 +108,10 @@
             };
 
             var context = new GitVersionContextBuilder()
+                .WithConfig(new Config()
+                {
+                    UseMergeMessageVersion = true
+                })
                 .WithRepository(new MockRepository
                 {
                     Head = new MockBranch("master")

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -72,9 +72,6 @@ namespace GitVersion
         [YamlMember(Alias = "is-mainline")]
         public bool? IsMainline { get; set; }
 
-        [YamlMember(Alias = "use-merge-message-version")]
-        public bool? UseMergeMessageVersion { get; set; }
-
         /// <summary>
         /// The name given to this configuration in the config file.
         /// </summary>

--- a/src/GitVersionCore/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Configuration/BranchConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion
+namespace GitVersion
 {
     using System.Collections.Generic;
     using YamlDotNet.Serialization;
@@ -71,6 +71,9 @@
 
         [YamlMember(Alias = "is-mainline")]
         public bool? IsMainline { get; set; }
+
+        [YamlMember(Alias = "use-merge-message-version")]
+        public bool? UseMergeMessageVersion { get; set; }
 
         /// <summary>
         /// The name given to this configuration in the config file.

--- a/src/GitVersionCore/Configuration/Config.cs
+++ b/src/GitVersionCore/Configuration/Config.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion
+namespace GitVersion
 {
     using System;
     using System.Collections.Generic;
@@ -78,6 +78,9 @@
 
         [YamlMember(Alias = "commit-message-incrementing")]
         public CommitMessageIncrementMode? CommitMessageIncrementing { get; set; }
+
+        [YamlMember(Alias = "use-merge-message-version")]
+        public bool? UseMergeMessageVersion { get; set; }
 
         [YamlMember(Alias = "branches")]
         public Dictionary<string, BranchConfig> Branches

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -102,7 +102,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             config.BuildMetaDataPadding = config.BuildMetaDataPadding ?? 4;
             config.CommitsSinceVersionSourcePadding = config.CommitsSinceVersionSourcePadding ?? 4;
             config.CommitDateFormat = config.CommitDateFormat ?? "yyyy-MM-dd";
-            config.UseMergeMessageVersion = config.UseMergeMessageVersion ?? false;
+            config.UseMergeMessageVersion = config.UseMergeMessageVersion ?? true;
 
             var configBranches = config.Branches.ToList();
 

--- a/src/GitVersionCore/Configuration/ConfigurationProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationProvider.cs
@@ -102,6 +102,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             config.BuildMetaDataPadding = config.BuildMetaDataPadding ?? 4;
             config.CommitsSinceVersionSourcePadding = config.CommitsSinceVersionSourcePadding ?? 4;
             config.CommitDateFormat = config.CommitDateFormat ?? "yyyy-MM-dd";
+            config.UseMergeMessageVersion = config.UseMergeMessageVersion ?? false;
 
             var configBranches = config.Branches.ToList();
 

--- a/src/GitVersionCore/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/EffectiveConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using GitVersion.VersionFilters;
 
 namespace GitVersion
@@ -32,7 +32,8 @@ namespace GitVersion
             IEnumerable<IVersionFilter> versionFilters,
             bool tracksReleaseBranches,
             bool isCurrentBranchRelease,
-            string commitDateFormat)
+            string commitDateFormat,
+            bool useMergeMessageVersion)
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
             AssemblyFileVersioningScheme = assemblyFileVersioningScheme;
@@ -61,6 +62,7 @@ namespace GitVersion
             TracksReleaseBranches = tracksReleaseBranches;
             IsCurrentBranchRelease = isCurrentBranchRelease;
             CommitDateFormat = commitDateFormat;
+            UseMergeMessageVersion = useMergeMessageVersion;
         }
 
         public bool TracksReleaseBranches { get; private set; }
@@ -115,5 +117,6 @@ namespace GitVersion
         public IEnumerable<IVersionFilter> VersionFilters { get; private set; }
 
         public string CommitDateFormat { get; private set; }
+        public bool UseMergeMessageVersion { get; private set; }
     }
 }

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -134,7 +134,7 @@ namespace GitVersion
             var commitDateFormat = FullConfiguration.CommitDateFormat;
 
             var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? FullConfiguration.CommitMessageIncrementing.Value;
-            var useMergeMessageVersion = currentBranchConfig.UseMergeMessageVersion ?? FullConfiguration.UseMergeMessageVersion.Value;
+            var useMergeMessageVersion = FullConfiguration.UseMergeMessageVersion.Value;
 
             Configuration = new EffectiveConfiguration(
                 assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix,

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion
+namespace GitVersion
 {
     using LibGit2Sharp;
     using System;
@@ -110,6 +110,8 @@
                 throw new Exception("Configuration value for 'BuildMetaDataPadding' has no value. (this should not happen, please report an issue)");
             if (!FullConfiguration.CommitsSinceVersionSourcePadding.HasValue)
                 throw new Exception("Configuration value for 'CommitsSinceVersionSourcePadding' has no value. (this should not happen, please report an issue)");
+            if (!FullConfiguration.UseMergeMessageVersion.HasValue)
+                throw new Exception("Configuration value for 'UseMergeMessageVersion' has no value. (this should not happen, please report an issue)");
 
             var versioningMode = currentBranchConfig.VersioningMode.Value;
             var tag = currentBranchConfig.Tag;
@@ -132,6 +134,7 @@
             var commitDateFormat = FullConfiguration.CommitDateFormat;
 
             var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? FullConfiguration.CommitMessageIncrementing.Value;
+            var useMergeMessageVersion = currentBranchConfig.UseMergeMessageVersion ?? FullConfiguration.UseMergeMessageVersion.Value;
 
             Configuration = new EffectiveConfiguration(
                 assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix,
@@ -148,7 +151,8 @@
                 FullConfiguration.Ignore.ToFilters(),
                 currentBranchConfig.TracksReleaseBranches.Value,
                 currentBranchConfig.IsReleaseBranch.Value,
-                commitDateFormat);
+                commitDateFormat,
+                useMergeMessageVersion);
         }
 
         private static Branch GetTargetBranch(IRepository repository, string targetBranch)

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion.VersionCalculation
+namespace GitVersion.VersionCalculation
 {
     using System;
     using System.Linq;

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -13,6 +13,11 @@
     {
         public override IEnumerable<BaseVersion> GetVersions(GitVersionContext context)
         {
+            if (!context.Configuration.UseMergeMessageVersion)
+            {
+                return Enumerable.Empty<BaseVersion>();
+            }
+
             var commitsPriorToThan = context.CurrentBranch
                 .CommitsPriorToThan(context.CurrentCommit.When());
             var baseVersions = commitsPriorToThan

--- a/src/GitVersionExe.Tests/TestEffectiveConfiguration.cs
+++ b/src/GitVersionExe.Tests/TestEffectiveConfiguration.cs
@@ -33,14 +33,15 @@ namespace GitVersionExe.Tests
             IEnumerable<IVersionFilter> versionFilters = null,
             bool tracksReleaseBranches = false,
             bool isRelease = false,
-            string commitDateFormat = "yyyy-MM-dd") :
+            string commitDateFormat = "yyyy-MM-dd",
+            bool useMergeMessageVersion = true) :
              base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,
                     commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
                     versionFilters ?? Enumerable.Empty<IVersionFilter>(),
-                    tracksReleaseBranches, isRelease, commitDateFormat)
+                    tracksReleaseBranches, isRelease, commitDateFormat, useMergeMessageVersion)
 
         {
         }

--- a/src/GitVersionTask.Tests/Helpers/TestEffectiveConfiguration.cs
+++ b/src/GitVersionTask.Tests/Helpers/TestEffectiveConfiguration.cs
@@ -33,14 +33,15 @@ namespace GitVersionCore.Tests
             IEnumerable<IVersionFilter> versionFilters = null,
             bool tracksReleaseBranches = false,
             bool isRelease = false,
-            string commitDateFormat = "yyyy-MM-dd") :
+            string commitDateFormat = "yyyy-MM-dd",
+            bool useMergeMessageVersion = true) :
             base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,
                     commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
                     versionFilters ?? Enumerable.Empty<IVersionFilter>(),
-                    tracksReleaseBranches, isRelease, commitDateFormat)
+                    tracksReleaseBranches, isRelease, commitDateFormat, useMergeMessageVersion)
         {
         }
     }


### PR DESCRIPTION
This attempts to fix #1468, #1481.

This adds a new configuration value that effectively disables `MergeMessageBaseVersionStrategy`.

What I discovered in my testing is that if a merge message picks up a new version number, that will automatically become the latest the highest base version and then used in the next version calculation.

I feel like there could also be something added to the Merge Message strategy that looks at the branch configuration to determine the source branch, and ensure that it is a release branch (for gitflow).