### PR TITLE
Updating libgit2sharp binaries (removes curl/zlib dependency)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,6 @@
  <PropertyGroup>
    <PackageVersion_GitToolsCore>1.3.1</PackageVersion_GitToolsCore>
    <PackageVersion_YamlDotNet>5.2.1</PackageVersion_YamlDotNet>
-   <PackageVersion_LibGit2SharpNativeBinaries>[1.0.185]</PackageVersion_LibGit2SharpNativeBinaries>
+   <PackageVersion_LibGit2SharpNativeBinaries>[1.0.258]</PackageVersion_LibGit2SharpNativeBinaries>
  </PropertyGroup>
 </Project>


### PR DESCRIPTION
See [this](https://github.com/libgit2/libgit2sharp.nativebinaries/pull/84) and [this](https://github.com/libgit2/libgit2sharp.nativebinaries/pull/82).

Using ```gitversion``` on Ubuntu 18.10 currently is broken (because of libcurl4). Updating to this version of the libgit2sharp native binaries should resolve my issue.