### PR TITLE
Make VSO Agent more robust

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/VsoAgentTests.cs
@@ -40,4 +40,15 @@ public class VsoAgentTests : TestBase
         vsVersion[0].ShouldBe("##vso[task.setvariable variable=GitVersion.Foo;]0.8.0-unstable568 Branch:'develop' Sha:'ee69bff1087ebc95c6b43aa2124bd58f5722e0cb'");
     }
 
+    [Test]
+    public void MissingEnvShouldNotBlowUp()
+    {
+        Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
+
+        var versionBuilder = new VsoAgent();
+        var semver = "0.0.0-Unstable4";
+        var vars = new TestableVersionVariables(fullSemVer: semver);
+        var vsVersion = versionBuilder.GenerateSetVersionMessage(vars);
+        vsVersion.ShouldBe(semver);
+    }
 }


### PR DESCRIPTION
Add VSO Agent test that [provokes a bug](https://dev.azure.com/GitTools/GitVersion/_build/results?buildId=289&view=logs&jobId=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&taskId=c37637b8-ed57-5a02-c556-da2855a7e2d3&lineStart=11928&lineEnd=11929&colStart=1&colEnd=1) that seems to occur when the `BUILD_BUILDNUMBER` environment variable is null.

I hope to fix the bug as well, I just need to see that the bug is provoked first