### PR TITLE
Fix typo in docs: 'tag-number-pattern' instead of 'tag-name-pattern'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,7 +370,7 @@ branches:
     tag: PullRequest
     increment: Inherit
     track-merge-target: true
-    tag-name-pattern: '[/-](?<number>\d+)[-/]'
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
 ```
 
 ### track-merge-target


### PR DESCRIPTION
Fixes a typo in the docs

(note: I edited this on GitHub directly, not sure where the diff in the last section is coming from, probably a newline that was added removed. I may clean this up later along with the commit history)