### PR TITLE
[Bugfix] CommitsSinceVersionSource decreases upon deleting a merged Release branch

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -222,4 +222,80 @@ public class DevelopScenarios : TestBase
             fixture.AssertFullSemver("1.3.0-alpha.2");
         }
     }
+
+    public void CommitsSinceVersionSourceShouldNotGoDownUponGitFlowReleaseFinish()
+    {
+        var config = new Config
+        {
+            VersioningMode = VersioningMode.ContinuousDeployment
+        };
+
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeACommit();
+            fixture.ApplyTag("1.1.0");
+            fixture.BranchTo("develop");
+            fixture.MakeACommit("commit in develop - 1");
+            fixture.AssertFullSemver("1.2.0-alpha.1");
+            fixture.BranchTo("release/1.2.0");
+            fixture.AssertFullSemver("1.2.0-beta.1+0");
+            fixture.Checkout("develop");
+            fixture.MakeACommit("commit in develop - 2");
+            fixture.MakeACommit("commit in develop - 3");
+            fixture.MakeACommit("commit in develop - 4");
+            fixture.MakeACommit("commit in develop - 5");
+            fixture.AssertFullSemver("1.3.0-alpha.4");
+            fixture.Checkout("release/1.2.0");
+            fixture.MakeACommit("commit in release/1.2.0 - 1");
+            fixture.MakeACommit("commit in release/1.2.0 - 2");
+            fixture.MakeACommit("commit in release/1.2.0 - 3");
+            fixture.AssertFullSemver("1.2.0-beta.1+3");
+            fixture.Checkout("master");
+            fixture.MergeNoFF("release/1.2.0");
+            fixture.ApplyTag("1.2.0");
+            fixture.Checkout("develop");
+            fixture.MergeNoFF("release/1.2.0");
+            fixture.MakeACommit("commit in develop - 6");
+            fixture.AssertFullSemver("1.3.0-alpha.9");
+            fixture.SequenceDiagram.Destroy("release/1.2.0");
+            fixture.Repository.Branches.Remove("release/1.2.0");
+
+            var expectedFullSemVer = "1.3.0-alpha.9";
+            fixture.AssertFullSemver(config, expectedFullSemVer);
+        }
+    }
+
+    [Test]
+    public void CommitsSinceVersionSourceShouldNotGoDownUponMergingFeatureOnlyToDevelop()
+    {
+        var config = new Config
+        {
+            VersioningMode = VersioningMode.ContinuousDeployment
+        };
+
+        using (var fixture = new EmptyRepositoryFixture())
+        {
+            fixture.MakeACommit("commit in master - 1");
+            fixture.ApplyTag("1.1.0");
+            fixture.BranchTo("develop");
+            fixture.MakeACommit("commit in develop - 1");
+            fixture.AssertFullSemver("1.2.0-alpha.1");
+            fixture.BranchTo("release/1.2.0");
+            fixture.MakeACommit("commit in release - 1");
+            fixture.MakeACommit("commit in release - 2");
+            fixture.MakeACommit("commit in release - 3");
+            fixture.AssertFullSemver("1.2.0-beta.1+3");
+            fixture.ApplyTag("1.2.0");
+            fixture.Checkout("develop");
+            fixture.MakeACommit("commit in develop - 2");
+            fixture.AssertFullSemver("1.3.0-alpha.1");
+            fixture.MergeNoFF("release/1.2.0");
+            fixture.AssertFullSemver("1.3.0-alpha.5");
+            fixture.SequenceDiagram.Destroy("release/1.2.0");
+            fixture.Repository.Branches.Remove("release/1.2.0");
+
+            var expectedFullSemVer = "1.3.0-alpha.5";
+            fixture.AssertFullSemver(config, expectedFullSemVer);
+        }
+    }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -223,6 +223,7 @@ public class DevelopScenarios : TestBase
         }
     }
 
+    [Test]
     public void CommitsSinceVersionSourceShouldNotGoDownUponGitFlowReleaseFinish()
     {
         var config = new Config

--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -51,7 +51,7 @@ public class ReleaseBranchScenarios : TestBase
             fixture.Repository.MakeACommit();
             fixture.Repository.Branches.Remove("release/1.0.0");
 
-            fixture.AssertFullSemver("1.1.0-alpha.2");
+            fixture.AssertFullSemver("1.1.0-alpha.3");
         }
     }
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -104,7 +104,8 @@ namespace GitVersion.VersionCalculation
             {
                 foreach (var baseVersion in baseVersions)
                 {
-                    if (baseVersion.Version.Source.Contains("Merge message")
+                    if (baseVersion.Version.Source.Contains(
+                        MergeMessageBaseVersionStrategy.MergeMessageStrategyPrefix)
                         && baseVersion.Version.Source.Contains("Merge branch")
                         && baseVersion.Version.Source.Contains("release"))
                     {

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -26,13 +26,15 @@ namespace GitVersion.VersionCalculation.BaseVersionCalculators
                         var shouldIncrement = !context.Configuration.PreventIncrementForMergedBranchVersion;
                         return new[]
                         {
-                            new BaseVersion(context, $"Merge message '{c.Message.Trim()}'", shouldIncrement, mergeMessage.Version, c, null)
+                            new BaseVersion(context, $"{MergeMessageStrategyPrefix} '{c.Message.Trim()}'", shouldIncrement, mergeMessage.Version, c, null)
                         };
                     }
                     return Enumerable.Empty<BaseVersion>();
                 }).ToList();
             return baseVersions;
         }
+
+        public static readonly string MergeMessageStrategyPrefix = "Merge message";
 
         static bool TryParse(Commit mergeCommit, GitVersionContext context, out MergeMessage mergeMessage)
         {


### PR DESCRIPTION
### Problem:
Upon deleting a merged `release` branch, `CommitsSinceVersionSource` decreases as reported in issue  https://github.com/GitTools/GitVersion/issues/1526.

### Root Cause:
After the `release` branch is deleted, we have no way to calculate the `BaseVersionSource` **correctly** from the existing `BaseVersion` calculation strategies.

### Assumptions:
- The `release` branch was merged using the `--no-ff` policy.
- The corresponding merge commit has 2 parents only.
- The merge commit message contains the `Merge branch` and `release` keywords.

### Fix:
The intuition behind the fix is that if a `release` branch was merged with the stated assumptions and deleted, then the `BaseVersionSource` calculated by `MergeMessageBaseVersionStrategy` is updated to point to the `merge-base` of the parents of the merge commit. The existing code then calculates the `CommitsSinceVersionSource` correctly.


 