### PR TITLE
Add WiX define constants

### DIFF
--- a/src/GitVersionTask/NugetAssets/build/functionality/GitVersionBuild.targets
+++ b/src/GitVersionTask/NugetAssets/build/functionality/GitVersionBuild.targets
@@ -86,6 +86,36 @@
       <FileVersion Condition=" '$(FileVersion)' == '' ">$(GitVersion_AssemblySemFileVer)</FileVersion>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(WixTargetsImported)' == 'true' And '$(GenerateGitVersionWixDefines)' == 'true' ">
+      <DefineConstants Condition=" '$(GitVersion_Major)' != '' ">GitVersion_Major=$(GitVersion_Major);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_Minor)' != '' ">GitVersion_Minor=$(GitVersion_Minor);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_Patch)' != '' ">GitVersion_Patch=$(GitVersion_Patch);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_PreReleaseTag)' != '' ">GitVersion_PreReleaseTag=$(GitVersion_PreReleaseTag);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_PreReleaseTagWithDash)' != '' ">GitVersion_PreReleaseTagWithDash=$(GitVersion_PreReleaseTagWithDash);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_PreReleaseLabel)' != '' ">GitVersion_PreReleaseLabel=$(GitVersion_PreReleaseLabel);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_PreReleaseNumber)' != '' ">GitVersion_PreReleaseNumber=$(GitVersion_PreReleaseNumber);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_BuildMetaData)' != '' ">GitVersion_BuildMetaData=$(GitVersion_BuildMetaData);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_BuildMetaDataPadded)' != '' ">GitVersion_BuildMetaDataPadded=$(GitVersion_BuildMetaDataPadded);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_FullBuildMetaData)' != '' ">GitVersion_FullBuildMetaData=$(GitVersion_FullBuildMetaData);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_MajorMinorPatch)' != '' ">GitVersion_MajorMinorPatch=$(GitVersion_MajorMinorPatch);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_SemVer)' != '' ">GitVersion_SemVer=$(GitVersion_SemVer);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_LegacySemVer)' != '' ">GitVersion_LegacySemVer=$(GitVersion_LegacySemVer);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_LegacySemVerPadded)' != '' ">GitVersion_LegacySemVerPadded=$(GitVersion_LegacySemVerPadded);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_AssemblySemVer)' != '' ">GitVersion_AssemblySemVer=$(GitVersion_AssemblySemVer);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_AssemblySemFileVer)' != '' ">GitVersion_AssemblySemFileVer=$(GitVersion_AssemblySemFileVer);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_FullSemVer)' != '' ">GitVersion_FullSemVer=$(GitVersion_FullSemVer);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_InformationalVersion)' != '' ">GitVersion_InformationalVersion=$(GitVersion_InformationalVersion);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_BranchName)' != '' ">GitVersion_BranchName=$(GitVersion_BranchName);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_Sha)' != '' ">GitVersion_Sha=$(GitVersion_Sha);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_NuGetVersionV2)' != '' ">GitVersion_NuGetVersionV2=$(GitVersion_NuGetVersionV2);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_NuGetVersion)' != '' ">GitVersion_NuGetVersion=$(GitVersion_NuGetVersion);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_NuGetPreReleaseTagV2)' != '' ">GitVersion_NuGetPreReleaseTagV2=$(GitVersion_NuGetPreReleaseTagV2);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_NuGetPreReleaseTag)' != '' ">GitVersion_NuGetPreReleaseTag=$(GitVersion_NuGetPreReleaseTag);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_CommitDate)' != '' ">GitVersion_CommitDate=$(GitVersion_CommitDate);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_CommitsSinceVersionSource)' != '' ">GitVersion_CommitsSinceVersionSource=$(GitVersion_CommitsSinceVersionSource);$(DefineConstants)</DefineConstants>
+      <DefineConstants Condition=" '$(GitVersion_CommitsSinceVersionSourcePadded)' != '' ">GitVersion_CommitsSinceVersionSourcePadded=$(GitVersion_CommitsSinceVersionSourcePadded);$(DefineConstants)</DefineConstants>
+    </PropertyGroup>
+
   </Target>
 
   <!--Support for ncrunch-->

--- a/src/GitVersionTask/NugetAssets/build/functionality/GitVersionCommon.props
+++ b/src/GitVersionTask/NugetAssets/build/functionality/GitVersionCommon.props
@@ -26,6 +26,9 @@
     <GetVersion Condition=" '$(GetVersion)' == '' and '$(NCrunch)' != '' ">false</GetVersion>
     <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
+    <GenerateGitVersionWixDefines Condition=" '$(GenerateGitVersionWixDefines)' == '' and '$(NCrunch)' != '' ">false</GenerateGitVersionWixDefines>
+    <GenerateGitVersionWixDefines Condition=" '$(GenerateGitVersionWixDefines)' == '' ">true</GenerateGitVersionWixDefines>
+
     <!--
       Ensure GetVersion runs prior to XAML's Markup Compiler in order to have the assembly version available.
       Otherwise the generated resource URI's are ambiguous when multiple versions are loaded simultaneously (i.e. in plugins)


### PR DESCRIPTION
When a WiX project has been detected via the property WixTargetsImported
and GenerateGitVersionWixDefines is true, the GitVersion_* properties
are passed to the WiX compiler so that they me be used as
$(var.GitVersion_*) in .wxs files.  This avoids the need to run the
executable version to generate a .wxi file.

-----

Now that I can build within Visual Studio...
This adds the GitVersion_* values as defines to WiX projects when using the build task (via the targets).  This seems a lot cleaner and "out of the box" than instructing people to do a manual step (either running the executable to generate a .wxi file, or to manually edit the wixproj file).

My question is: the executable, when generating the wxi, was introduced in #1599.  However, there is a discrepancy between the defines produced and the defines the Task produces.  The task creates the defines as matching the actual MSBuild property (e.g. -dGitVersion_Major=$(GitVersion_Major).  The defines generated by the executable, however, do not have these prefixed.  I believe they need to be consistent so that people running the executable with the include file can also utilize the same .wxs in a msbuild environment.  Personally, I believe that the defines created by the executable via the GitVersionCore/WixVersionFileUpdater.cs should be prefixed with the GitVersion_ string to avoid potential collisions (especially with Major, Minor, and Patch), however, since that has been already merged, I can easily remove the prefix from the targets.  Or if someone has a different preferred methodology, I can use that.  Regardless, before this PR is merged, the discrepancy should be fixed.

This way the "Using" section of the documentation just needs to state they need to reference $(var.GitVersion_*) whether they use the GitVersionExe generate include .wxi method OR the GitVersionTask method.

Neither PR #1645 nor PR #1634 are affected by this change.