### PR TITLE
Enhance logic of getting current branch in case of drone

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/DroneTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/DroneTests.cs
@@ -46,5 +46,106 @@ namespace GitVersionCore.Tests.BuildServers
             // Assert
             result.ShouldBeFalse();
         }
+
+        [Test]
+        public void GetCurrentBranch_ShouldDroneBranch_InCaseOfPush()
+        {
+            // Arrange
+            const string droneBranch = "droneBranch";
+
+            Environment.SetEnvironmentVariable("DRONE_PULL_REQUEST", "");
+            Environment.SetEnvironmentVariable("DRONE_BRANCH", droneBranch);
+
+            var buildServer = new Drone();
+
+            // Act
+            var result = buildServer.GetCurrentBranch(false);
+
+            // Assert
+            result.ShouldBe(droneBranch);
+        }
+
+        [Test]
+        public void GetCurrentBranch_ShouldUseDroneSourceBranch_InCaseOfPullRequestAndNonEmptyDroneSourceBranch()
+        {
+            // Arrange
+            const string droneSourceBranch = "droneSourceBranch";
+            Environment.SetEnvironmentVariable("DRONE_PULL_REQUEST", "1");
+            Environment.SetEnvironmentVariable("DRONE_SOURCE_BRANCH", droneSourceBranch);
+
+            var buildServer = new Drone();
+
+            // Act
+            var result = buildServer.GetCurrentBranch(false);
+
+            // Assert
+            result.ShouldBe(droneSourceBranch);
+        }
+
+        [Test]
+        public void GetCurrentBranch_ShouldUseSourceBranchFromCiCommitRefSpec_InCaseOfPullRequestAndEmptyDroneSourceBranch()
+        {
+            // Arrange
+            const string droneSourceBranch = "droneSourceBranch";
+            const string droneDestinationBranch = "droneDestinationBranch";
+
+            string ciCommitRefSpec = $"{droneSourceBranch}:{droneDestinationBranch}";
+
+            Environment.SetEnvironmentVariable("DRONE_PULL_REQUEST", "1");
+            Environment.SetEnvironmentVariable("DRONE_SOURCE_BRANCH", "");
+            Environment.SetEnvironmentVariable("CI_COMMIT_REFSPEC", ciCommitRefSpec);
+
+            var buildServer = new Drone();
+
+            // Act
+            var result = buildServer.GetCurrentBranch(false);
+
+            // Assert
+            result.ShouldBe(droneSourceBranch);
+        }
+
+        [Test]
+        public void GetCurrentBranch_ShouldUseDroneBranch_InCaseOfPullRequestAndEmptyDroneSourceBranchAndCiCommitRefSpec()
+        {
+            // Arrange
+            const string droneBranch = "droneBranch";
+
+            Environment.SetEnvironmentVariable("DRONE_PULL_REQUEST", "1");
+            Environment.SetEnvironmentVariable("DRONE_SOURCE_BRANCH", "");
+            Environment.SetEnvironmentVariable("CI_COMMIT_REFSPEC", "");
+            Environment.SetEnvironmentVariable("DRONE_BRANCH", droneBranch);
+
+            var buildServer = new Drone();
+
+            // Act
+            var result = buildServer.GetCurrentBranch(false);
+
+            // Assert
+            result.ShouldBe(droneBranch);
+        }
+
+        [Test]
+        public void GetCurrentBranch_ShouldUseDroneBranch_InCaseOfPullRequestAndEmptyDroneSourceBranchAndInvalidFormatOfCiCommitRefSpec()
+        {
+            // Arrange
+            const string droneBranch = "droneBranch";
+            const string droneSourceBranch = "droneSourceBranch";
+            const string droneDestinationBranch = "droneDestinationBranch";
+
+            string ciCommitRefSpec = $"{droneSourceBranch};{droneDestinationBranch}";
+
+            Environment.SetEnvironmentVariable("DRONE_PULL_REQUEST", "1");
+            Environment.SetEnvironmentVariable("DRONE_SOURCE_BRANCH", "");
+            Environment.SetEnvironmentVariable("CI_COMMIT_REFSPEC", ciCommitRefSpec);
+            Environment.SetEnvironmentVariable("DRONE_BRANCH", droneBranch);
+
+            var buildServer = new Drone();
+
+            // Act
+            var result = buildServer.GetCurrentBranch(false);
+
+            // Assert
+            result.ShouldBe(droneBranch);
+        }
     }
 }

--- a/src/GitVersionCore/BuildServers/Drone.cs
+++ b/src/GitVersionCore/BuildServers/Drone.cs
@@ -24,6 +24,31 @@ namespace GitVersion
 
         public override string GetCurrentBranch(bool usingDynamicRepos)
         {
+            // In Drone DRONE_BRANCH variable is equal to destination branch in case of pull request
+            // https://discourse.drone.io/t/getting-the-branch-a-pull-request-is-created-from/670
+            // Unfortunately, DRONE_REFSPEC isn't populated, however CI_COMMIT_REFSPEC can be used instead of.
+            var pullRequestNumber = Environment.GetEnvironmentVariable("DRONE_PULL_REQUEST");
+            if (!string.IsNullOrWhiteSpace(pullRequestNumber))
+            {
+                // DRONE_SOURCE_BRANCH is available in Drone 1.x.x version
+                var sourceBranch = Environment.GetEnvironmentVariable("DRONE_SOURCE_BRANCH");
+                if (!string.IsNullOrWhiteSpace(sourceBranch))
+                    return sourceBranch;
+
+                // In drone lower than 1.x.x source branch can be parsed from CI_COMMIT_REFSPEC
+                // CI_COMMIT_REFSPEC - {sourceBranch}:{destinationBranch}
+                // https://github.com/drone/drone/issues/2222
+                var ciCommitRefSpec = Environment.GetEnvironmentVariable("CI_COMMIT_REFSPEC");
+                if (!string.IsNullOrWhiteSpace(ciCommitRefSpec))
+                {
+                    var colonIndex = ciCommitRefSpec.IndexOf(':');
+                    if (colonIndex > 0)
+                    {
+                        return ciCommitRefSpec.Substring(0, colonIndex);
+                    }
+                }
+            }
+
             return Environment.GetEnvironmentVariable("DRONE_BRANCH");
         }
     }


### PR DESCRIPTION
Hey, @arturcic!

It's the 2nd PR related to Drone.

Little introduction:
`DRONE_BRANCH` environment variable is equal to destination branch in case of pull request [details](https://discourse.drone.io/t/getting-the-branch-a-pull-request-is-created-from/670). By this reason, in case of pull request, we need to fetch another environment variable to know current branch. Unfortunately, this is also not simple. In the `1.x.x` Drone version it can be fetched from `DRONE_SOURCE_BRANCH`, however in older version it can be done by parsing `CI_COMMIT_REFSPEC` environment variable, which has the following format: `{sourceBranch}:{destinationBranch}`.

The PR implement such logic of fetching current branch name.