### PR TITLE
Allow overriding of the config file path

### DIFF
--- a/src/GitVersionCore.Tests/DefaultConfigFileLocatorTests.cs
+++ b/src/GitVersionCore.Tests/DefaultConfigFileLocatorTests.cs
@@ -1,0 +1,125 @@
+using GitVersion;
+using GitVersion.Helpers;
+using GitVersionCore.Tests;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.IO;
+
+[TestFixture]
+public class DefaultConfigFileLocatorTests : TestBase
+{
+    private const string DefaultRepoPath = @"c:\MyGitRepo";
+    private const string DefaultWorkingPath = @"c:\MyGitRepo\Working";
+
+    string repoPath;
+    string workingPath;
+    IFileSystem fileSystem;
+    DefaultConfigFileLocator configFileLocator;
+
+    [SetUp]
+    public void Setup()
+    {
+        fileSystem = new TestFileSystem();
+        configFileLocator = new DefaultConfigFileLocator();
+        repoPath = DefaultRepoPath;
+        workingPath = DefaultWorkingPath;
+
+        ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+    }
+    
+    [TestCase(DefaultRepoPath)]
+    [TestCase(DefaultWorkingPath)]
+    public void WarnOnExistingGitVersionConfigYamlFile(string path)
+    {
+        SetupConfigFileContent(string.Empty, DefaultConfigFileLocator.ObsoleteFileName, path);
+
+        var logOutput = string.Empty;
+        Action<string> action = info => { logOutput = info; };
+        using (Logger.AddLoggersTemporarily(action, action, action, action))
+        {
+            configFileLocator.Verify(workingPath, repoPath, fileSystem);
+        }
+        var configFileDeprecatedWarning = string.Format("{0}' is deprecated, use '{1}' instead", DefaultConfigFileLocator.ObsoleteFileName, DefaultConfigFileLocator.DefaultFileName);
+        logOutput.Contains(configFileDeprecatedWarning).ShouldBe(true);
+    }
+
+    [TestCase(DefaultRepoPath)]
+    [TestCase(DefaultWorkingPath)]
+    public void WarnOnAmbiguousConfigFilesAtTheSameProjectRootDirectory(string path)
+    {
+        SetupConfigFileContent(string.Empty, DefaultConfigFileLocator.ObsoleteFileName, path);
+        SetupConfigFileContent(string.Empty, DefaultConfigFileLocator.DefaultFileName, path);
+
+        var logOutput = string.Empty;
+        Action<string> action = info => { logOutput = info; };
+        using (Logger.AddLoggersTemporarily(action, action, action, action))
+        {
+            configFileLocator.Verify(workingPath, repoPath, fileSystem);
+        }
+
+        var configFileDeprecatedWarning = string.Format("Ambiguous config files at '{0}'", path);
+        logOutput.Contains(configFileDeprecatedWarning).ShouldBe(true);
+    }
+
+    [TestCase(DefaultConfigFileLocator.DefaultFileName, DefaultConfigFileLocator.DefaultFileName)]
+    [TestCase(DefaultConfigFileLocator.DefaultFileName, DefaultConfigFileLocator.ObsoleteFileName)]
+    [TestCase(DefaultConfigFileLocator.ObsoleteFileName, DefaultConfigFileLocator.DefaultFileName)]
+    [TestCase(DefaultConfigFileLocator.ObsoleteFileName, DefaultConfigFileLocator.ObsoleteFileName)]
+    public void ThrowsExceptionOnAmbiguousConfigFileLocation(string repoConfigFile, string workingConfigFile)
+    {
+        var repositoryConfigFilePath = SetupConfigFileContent(string.Empty, repoConfigFile, repoPath);
+        var workingDirectoryConfigFilePath = SetupConfigFileContent(string.Empty, workingConfigFile, workingPath);
+
+        WarningException exception = Should.Throw<WarningException>(() => { configFileLocator.Verify(workingPath, repoPath, fileSystem); });
+
+        var expecedMessage = string.Format("Ambiguous config file selection from '{0}' and '{1}'", workingDirectoryConfigFilePath, repositoryConfigFilePath);
+        exception.Message.ShouldBe(expecedMessage);
+    }
+
+    [Test]
+    public void NoWarnOnGitVersionYmlFile()
+    {
+        SetupConfigFileContent(string.Empty);
+
+        var s = string.Empty;
+        Action<string> action = info => { s = info; };
+        using (Logger.AddLoggersTemporarily(action, action, action, action))
+        {
+            ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
+        }
+        s.Length.ShouldBe(0);
+    }
+
+    string SetupConfigFileContent(string text, string fileName = DefaultConfigFileLocator.DefaultFileName)
+    {
+        return SetupConfigFileContent(text, fileName, repoPath);
+    }
+
+    string SetupConfigFileContent(string text, string fileName, string path)
+    {
+        var fullPath = Path.Combine(path, fileName);
+        fileSystem.WriteAllText(fullPath, text);
+
+        return fullPath;
+    }
+
+    [Test]
+    public void WarnOnObsoleteIsDevelopBranchConfigurationSetting()
+    {
+        const string text = @"
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  master:
+    tag: beta
+    is-develop: true";
+
+        OldConfigurationException exception = Should.Throw<OldConfigurationException>(() =>
+        {
+            LegacyConfigNotifier.Notify(new StringReader(text));
+        });
+
+        const string expectedMessage = @"'is-develop' is deprecated, use 'tracks-release-branches' instead.";
+        exception.Message.ShouldContain(expectedMessage);
+    }
+}

--- a/src/GitVersionCore.Tests/ExecuteCoreTests.cs
+++ b/src/GitVersionCore.Tests/ExecuteCoreTests.cs
@@ -30,10 +30,11 @@ public class ExecuteCoreTests : TestBase
             var targetUrl = "https://github.com/GitTools/GitVersion.git";
             var targetBranch = "refs/head/master";
             var gitPreparer = new GitPreparer(targetUrl, null, new Authentication(), false, fixture.RepositoryPath);
+            var configFileLocator = new DefaultConfigFileLocator();
             gitPreparer.Initialise(true, targetBranch);
-            var cacheKey1 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+            var cacheKey1 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null, configFileLocator);
             gitPreparer.Initialise(true, targetBranch);
-            var cacheKey2 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null);
+            var cacheKey2 = GitVersionCacheKeyFactory.Create(fileSystem, gitPreparer, null, configFileLocator);
 
             cacheKey2.Value.ShouldBe(cacheKey1.Value);
         });

--- a/src/GitVersionCore.Tests/Init/InitScenarios.cs
+++ b/src/GitVersionCore.Tests/Init/InitScenarios.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersionCore.Tests.Init
+namespace GitVersionCore.Tests.Init
 {
     using GitVersion;
     using GitVersion.Configuration.Init;
@@ -24,7 +24,8 @@
         {
             var testFileSystem = new TestFileSystem();
             var testConsole = new TestConsole("3", "2.0.0", "0");
-            ConfigurationProvider.Init("c:\\proj", testFileSystem, testConsole);
+            var configFileLocator = new DefaultConfigFileLocator();
+            ConfigurationProvider.Init("c:\\proj", testFileSystem, testConsole, configFileLocator);
 
             testFileSystem.ReadAllText("c:\\proj\\GitVersion.yml").ShouldMatchApproved();
         }

--- a/src/GitVersionCore.Tests/NamedConfigFileLocatorTests.cs
+++ b/src/GitVersionCore.Tests/NamedConfigFileLocatorTests.cs
@@ -1,0 +1,80 @@
+using GitVersion;
+using GitVersion.Helpers;
+using GitVersionCore.Tests;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.IO;
+
+[TestFixture]
+public class NamedConfigFileLocatorTests : TestBase
+{
+    private const string DefaultRepoPath = @"c:\MyGitRepo";
+    private const string DefaultWorkingPath = @"c:\MyGitRepo\Working";
+
+    string repoPath;
+    string workingPath;
+    IFileSystem fileSystem;
+    NamedConfigFileLocator configFileLocator;
+
+    [SetUp]
+    public void Setup()
+    {
+        fileSystem = new TestFileSystem();
+        configFileLocator = new NamedConfigFileLocator("my-config.yaml");
+        repoPath = DefaultRepoPath;
+        workingPath = DefaultWorkingPath;
+
+        ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+    }
+
+    [Test]
+    public void ThrowsExceptionOnAmbiguousConfigFileLocation()
+    {
+        var repositoryConfigFilePath = SetupConfigFileContent(string.Empty, path: repoPath);
+        var workingDirectoryConfigFilePath = SetupConfigFileContent(string.Empty, path: workingPath);
+
+        var exception = Should.Throw<WarningException>(() => { configFileLocator.Verify(workingPath, repoPath, fileSystem); });
+
+        var expectedMessage = $"Ambiguous config file selection from '{workingDirectoryConfigFilePath}' and '{repositoryConfigFilePath}'";
+        exception.Message.ShouldBe(expectedMessage);
+    }
+
+    [Test]
+    public void NoWarnOnCustomYmlFile()
+    {
+        SetupConfigFileContent(string.Empty);
+
+        var s = string.Empty;
+        Action<string> action = info => { s = info; };
+        using (Logger.AddLoggersTemporarily(action, action, action, action))
+        {
+            ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
+        }
+        s.Length.ShouldBe(0);
+    }
+
+    [Test]
+    public void NoWarnOnCustomYmlFileOutsideRepoPath()
+    {
+        SetupConfigFileContent(string.Empty, path: @"c:\\Unrelated\\path");
+
+        var s = string.Empty;
+        Action<string> action = info => { s = info; };
+        using (Logger.AddLoggersTemporarily(action, action, action, action))
+        {
+            ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
+        }
+        s.Length.ShouldBe(0);
+    }
+
+    string SetupConfigFileContent(string text, string fileName = null, string path = null)
+    {
+        if (string.IsNullOrEmpty(fileName)) fileName = configFileLocator.FilePath;
+        var filePath = fileName;
+        if (!string.IsNullOrEmpty(path))
+            filePath = Path.Combine(path, filePath);
+        fileSystem.WriteAllText(filePath, text);
+        return filePath;
+    }
+}

--- a/src/GitVersionCore/Configuration/ConfigFileLocator.cs
+++ b/src/GitVersionCore/Configuration/ConfigFileLocator.cs
@@ -1,0 +1,62 @@
+namespace GitVersion
+{
+    using GitVersion.Helpers;
+    using System.IO;
+
+    public abstract class ConfigFileLocator
+    {
+
+        public static readonly ConfigFileLocator Default = new DefaultConfigFileLocator();
+
+        public static ConfigFileLocator GetLocator(string filePath = null) =>
+             !string.IsNullOrEmpty(filePath) ? new NamedConfigFileLocator(filePath) : Default;
+
+        public abstract bool HasConfigFileAt(string workingDirectory, IFileSystem fileSystem);
+
+        public abstract string GetConfigFilePath(string workingDirectory, IFileSystem fileSystem);
+
+        public abstract void Verify(string workingDirectory, string projectRootDirectory, IFileSystem fileSystem);
+
+        public string SelectConfigFilePath(GitPreparer gitPreparer, IFileSystem fileSystem)
+        {
+            var workingDirectory = gitPreparer.WorkingDirectory;
+            var projectRootDirectory = gitPreparer.GetProjectRootDirectory();
+
+            if (HasConfigFileAt(workingDirectory, fileSystem))
+            {
+                return GetConfigFilePath(workingDirectory, fileSystem);
+            }
+
+            return GetConfigFilePath(projectRootDirectory, fileSystem);
+        }
+
+        public Config ReadConfig(string workingDirectory, IFileSystem fileSystem)
+        {
+            var configFilePath = GetConfigFilePath(workingDirectory, fileSystem);
+
+            if (fileSystem.Exists(configFilePath))
+            {
+                var readAllText = fileSystem.ReadAllText(configFilePath);
+                LegacyConfigNotifier.Notify(new StringReader(readAllText));
+                return ConfigSerialiser.Read(new StringReader(readAllText));
+            }
+
+            return new Config();
+        }
+
+        public void Verify(GitPreparer gitPreparer, IFileSystem fileSystem)
+        {
+            if (!string.IsNullOrWhiteSpace(gitPreparer.TargetUrl))
+            {
+                // Assuming this is a dynamic repository. At this stage it's unsure whether we have
+                // any .git info so we need to skip verification
+                return;
+            }
+
+            var workingDirectory = gitPreparer.WorkingDirectory;
+            var projectRootDirectory = gitPreparer.GetProjectRootDirectory();
+
+            Verify(workingDirectory, projectRootDirectory, fileSystem);
+        }
+    }
+}

--- a/src/GitVersionCore/Configuration/DefaultConfigFileLocator.cs
+++ b/src/GitVersionCore/Configuration/DefaultConfigFileLocator.cs
@@ -1,0 +1,94 @@
+namespace GitVersion
+{
+    using GitVersion.Helpers;
+    using System.IO;
+
+    public class DefaultConfigFileLocator : ConfigFileLocator
+    {
+
+        public const string DefaultFileName = "GitVersion.yml";
+
+        public const string ObsoleteFileName = "GitVersionConfig.yaml";
+
+        public override bool HasConfigFileAt(string workingDirectory, IFileSystem fileSystem)
+        {
+            var defaultConfigFilePath = Path.Combine(workingDirectory, DefaultFileName);
+            if (fileSystem.Exists(defaultConfigFilePath))
+            {
+                return true;
+            }
+
+            var deprecatedConfigFilePath = Path.Combine(workingDirectory, ObsoleteFileName);
+            if (fileSystem.Exists(deprecatedConfigFilePath))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override string GetConfigFilePath(string workingDirectory, IFileSystem fileSystem)
+        {
+            var ymlPath = Path.Combine(workingDirectory, DefaultFileName);
+            if (fileSystem.Exists(ymlPath))
+            {
+                return ymlPath;
+            }
+
+            var deprecatedPath = Path.Combine(workingDirectory, ObsoleteFileName);
+            if (fileSystem.Exists(deprecatedPath))
+            {
+                return deprecatedPath;
+            }
+
+            return ymlPath;
+        }
+
+        public override void Verify(string workingDirectory, string projectRootDirectory, IFileSystem fileSystem)
+        {
+            if (fileSystem.PathsEqual(workingDirectory, projectRootDirectory))
+            {
+                WarnAboutObsoleteConfigFile(workingDirectory, fileSystem);
+                return;
+            }
+
+            WarnAboutObsoleteConfigFile(workingDirectory, fileSystem);
+            WarnAboutObsoleteConfigFile(projectRootDirectory, fileSystem);
+
+            WarnAboutAmbiguousConfigFileSelection(workingDirectory, projectRootDirectory, fileSystem);
+        }
+
+        private void WarnAboutAmbiguousConfigFileSelection(string workingDirectory, string projectRootDirectory, IFileSystem fileSystem)
+        {
+            var workingConfigFile = GetConfigFilePath(workingDirectory, fileSystem);
+            var projectRootConfigFile = GetConfigFilePath(projectRootDirectory, fileSystem);
+
+            bool hasConfigInWorkingDirectory = fileSystem.Exists(workingConfigFile);
+            bool hasConfigInProjectRootDirectory = fileSystem.Exists(projectRootConfigFile);
+            if (hasConfigInProjectRootDirectory && hasConfigInWorkingDirectory)
+            {
+                throw new WarningException(string.Format("Ambiguous config file selection from '{0}' and '{1}'", workingConfigFile, projectRootConfigFile));
+            }
+        }
+
+        private void WarnAboutObsoleteConfigFile(string workingDirectory, IFileSystem fileSystem)
+        {
+            var deprecatedConfigFilePath = Path.Combine(workingDirectory, ObsoleteFileName);
+            if (!fileSystem.Exists(deprecatedConfigFilePath))
+            {
+                return;
+            }
+
+            var defaultConfigFilePath = Path.Combine(workingDirectory, DefaultFileName);
+            if (fileSystem.Exists(defaultConfigFilePath))
+            {
+                Logger.WriteWarning(string.Format("Ambiguous config files at '{0}': '{1}' (deprecated) and '{2}'. Will be used '{2}'", workingDirectory, ObsoleteFileName, DefaultFileName));
+                return;
+            }
+
+            Logger.WriteWarning(string.Format("'{0}' is deprecated, use '{1}' instead.", deprecatedConfigFilePath, DefaultFileName));
+        }
+
+    }
+
+}

--- a/src/GitVersionCore/Configuration/NamedConfigFileLocator.cs
+++ b/src/GitVersionCore/Configuration/NamedConfigFileLocator.cs
@@ -1,0 +1,47 @@
+namespace GitVersion
+{
+
+    using System;
+
+    using GitVersion.Helpers;
+    using System.IO;
+
+    public class NamedConfigFileLocator : ConfigFileLocator
+    {
+
+        public NamedConfigFileLocator(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException(nameof(filePath), "Empty file path provided!");
+            FilePath = filePath;
+        }
+
+        public string FilePath { get; }
+
+        public override bool HasConfigFileAt(string workingDirectory, IFileSystem fileSystem) =>
+            fileSystem.Exists(Path.Combine(workingDirectory, FilePath));
+
+        public override string GetConfigFilePath(string workingDirectory, IFileSystem fileSystem) =>
+            Path.Combine(workingDirectory, FilePath);
+
+        public override void Verify(string workingDirectory, string projectRootDirectory, IFileSystem fileSystem)
+        {
+            if (!Path.IsPathRooted(FilePath))
+            {
+                WarnAboutAmbiguousConfigFileSelection(workingDirectory, projectRootDirectory, fileSystem);
+            }
+        }
+
+        private void WarnAboutAmbiguousConfigFileSelection(string workingDirectory, string projectRootDirectory, IFileSystem fileSystem)
+        {
+            var workingConfigFile = GetConfigFilePath(workingDirectory, fileSystem);
+            var projectRootConfigFile = GetConfigFilePath(projectRootDirectory, fileSystem);
+
+            var hasConfigInWorkingDirectory = fileSystem.Exists(workingConfigFile);
+            var hasConfigInProjectRootDirectory = fileSystem.Exists(projectRootConfigFile);
+            if (hasConfigInProjectRootDirectory && hasConfigInWorkingDirectory)
+            {
+                throw new WarningException(string.Format("Ambiguous config file selection from '{0}' and '{1}'", workingConfigFile, projectRootConfigFile));
+            }
+        }
+    }
+}

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion
+namespace GitVersion
 {
     using Helpers;
     using System;
@@ -10,10 +10,10 @@
 
     class GitVersionCacheKeyFactory
     {
-        public static GitVersionCacheKey Create(IFileSystem fileSystem, GitPreparer gitPreparer, Config overrideConfig)
+        public static GitVersionCacheKey Create(IFileSystem fileSystem, GitPreparer gitPreparer, Config overrideConfig, ConfigFileLocator configFileLocator)
         {
             var gitSystemHash = GetGitSystemHash(gitPreparer);
-            var configFileHash = GetConfigFileHash(fileSystem, gitPreparer);
+            var configFileHash = GetConfigFileHash(fileSystem, gitPreparer, configFileLocator);
             var repositorySnapshotHash = GetRepositorySnapshotHash(gitPreparer);
             var overrideConfigHash = GetOverrideConfigHash(overrideConfig);
 
@@ -155,11 +155,11 @@
             return GetHash(configContent);
         }
 
-        private static string GetConfigFileHash(IFileSystem fileSystem, GitPreparer gitPreparer)
+        private static string GetConfigFileHash(IFileSystem fileSystem, GitPreparer gitPreparer, ConfigFileLocator configFileLocator)
         {
             // will return the same hash even when config file will be moved 
             // from workingDirectory to rootProjectDirectory. It's OK. Config essentially is the same.
-            var configFilePath = ConfigurationProvider.SelectConfigFilePath(gitPreparer, fileSystem);
+            var configFilePath = configFileLocator.SelectConfigFilePath(gitPreparer, fileSystem);
             if (!fileSystem.Exists(configFilePath))
             {
                 return string.Empty;

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -78,6 +78,13 @@ namespace GitVersion
                     continue;
                 }
 
+                if (name.IsSwitch("config"))
+                {
+                    EnsureArgumentValueCount(values);
+                    arguments.ConfigFileLocator = new NamedConfigFileLocator(value);
+                    continue;
+                }
+
                 if (name.IsSwitch("targetpath"))
                 {
                     EnsureArgumentValueCount(values);

--- a/src/GitVersionExe/Arguments.cs
+++ b/src/GitVersionExe/Arguments.cs
@@ -17,6 +17,7 @@ namespace GitVersion
 
         public Config OverrideConfig;
         public bool HasOverrideConfig { get; set; }
+        public ConfigFileLocator ConfigFileLocator { get; set; } = ConfigFileLocator.GetLocator();
 
         public string TargetPath;
 

--- a/src/GitVersionExe/HelpWriter.cs
+++ b/src/GitVersionExe/HelpWriter.cs
@@ -33,6 +33,7 @@ GitVersion [path]
     /showvariable   Used in conjuntion with /output json, will output just a particular variable. 
                     eg /output json /showvariable SemVer - will output `1.2.3+beta.4`
     /l              Path to logfile.
+    /config         Path to config file (defaults to GitVersion.yml)
     /showconfig     Outputs the effective GitVersion config (defaults + custom from GitVersion.yml) in yaml format
     /overrideconfig Overrides GitVersion config values inline (semicolon-separated key value pairs e.g. /overrideconfig tag-prefix=Foo)
                     Currently supported config overrides: tag-prefix

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -96,12 +96,12 @@ namespace GitVersion
 
                 if (arguments.Init)
                 {
-                    ConfigurationProvider.Init(arguments.TargetPath, fileSystem, new ConsoleAdapter());
+                    ConfigurationProvider.Init(arguments.TargetPath, fileSystem, new ConsoleAdapter(), arguments.ConfigFileLocator);
                     return 0;
                 }
                 if (arguments.ShowConfig)
                 {
-                    Console.WriteLine(ConfigurationProvider.GetEffectiveConfigAsString(arguments.TargetPath, fileSystem));
+                    Console.WriteLine(ConfigurationProvider.GetEffectiveConfigAsString(arguments.TargetPath, fileSystem, arguments.ConfigFileLocator));
                     return 0;
                 }
 
@@ -149,7 +149,7 @@ namespace GitVersion
         static void VerifyConfiguration(Arguments arguments, IFileSystem fileSystem)
         {
             var gitPreparer = new GitPreparer(arguments.TargetUrl, arguments.DynamicRepositoryLocation, arguments.Authentication, arguments.NoFetch, arguments.TargetPath);
-            ConfigurationProvider.Verify(gitPreparer, fileSystem);
+            arguments.ConfigFileLocator.Verify(gitPreparer, fileSystem);
         }
 
         static void ConfigureLogging(Arguments arguments)

--- a/src/GitVersionExe/SpecifiedArgumentRunner.cs
+++ b/src/GitVersionExe/SpecifiedArgumentRunner.cs
@@ -24,7 +24,7 @@ namespace GitVersion
             var overrideConfig = arguments.HasOverrideConfig ? arguments.OverrideConfig : null;
             var noCache = arguments.NoCache;
 
-            var executeCore = new ExecuteCore(fileSystem);
+            var executeCore = new ExecuteCore(fileSystem, arguments.ConfigFileLocator);
             var variables = executeCore.ExecuteGitVersion(targetUrl, dynamicRepositoryLocation, authentication, targetBranch, noFetch, targetPath, commitId, overrideConfig, noCache);
 
             if (arguments.Output == OutputType.BuildServer)

--- a/src/GitVersionTask.MsBuild/GitVersionTaskBase.cs
+++ b/src/GitVersionTask.MsBuild/GitVersionTaskBase.cs
@@ -8,6 +8,8 @@ namespace GitVersionTask.MsBuild
         [Required]
         public string SolutionDirectory { get; set; }
 
+        public string ConfigFilePath { get; set; }
+
         public bool NoFetch { get; set; }
     }
 }

--- a/src/GitVersionTask/GitVersionTasks.cs
+++ b/src/GitVersionTask/GitVersionTasks.cs
@@ -108,6 +108,6 @@ namespace GitVersionTask
         }
 
         private static bool GetVersionVariables(GitVersionTaskBase task, out VersionVariables versionVariables)
-            => new ExecuteCore(new FileSystem()).TryGetVersion(task.SolutionDirectory, out versionVariables, task.NoFetch, new Authentication());
+            => new ExecuteCore(new FileSystem(), ConfigFileLocator.GetLocator(task.ConfigFilePath)).TryGetVersion(task.SolutionDirectory, out versionVariables, task.NoFetch, new Authentication());
     }
 }

--- a/src/GitVersionTask/build/GitVersionTask.targets
+++ b/src/GitVersionTask/build/GitVersionTask.targets
@@ -7,7 +7,7 @@
 
     <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
 
-        <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
+        <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" ConfigFilePath="$(GitVersionConfig)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
 
     </Target>
 
@@ -15,6 +15,7 @@
 
         <UpdateAssemblyInfo
             SolutionDirectory="$(GitVersionPath)"
+            ConfigFilePath="$(GitVersionConfig)"
             NoFetch="$(GitVersion_NoFetchEnabled)"
             ProjectFile="$(MSBuildProjectFullPath)"
             IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -34,6 +35,7 @@
 
         <GenerateGitVersionInformation
             SolutionDirectory="$(GitVersionPath)"
+            ConfigFilePath="$(GitVersionConfig)"
             NoFetch="$(GitVersion_NoFetchEnabled)"
             ProjectFile="$(MSBuildProjectFullPath)"
             IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -51,7 +53,7 @@
 
     <Target Name="GetVersion" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec;_GetOutputItemsFromPack;EnsureWixToolsetInstalled" Condition="$(GetVersion) == 'true'"> 
 
-        <GetVersion SolutionDirectory="$(GitVersionPath)" NoFetch="$(GitVersion_NoFetchEnabled)">
+        <GetVersion SolutionDirectory="$(GitVersionPath)" ConfigFilePath="$(GitVersionConfig)" NoFetch="$(GitVersion_NoFetchEnabled)">
             <Output TaskParameter="Major" PropertyName="GitVersion_Major" />
             <Output TaskParameter="Minor" PropertyName="GitVersion_Minor" />
             <Output TaskParameter="Patch" PropertyName="GitVersion_Patch" />

--- a/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
@@ -4,7 +4,7 @@
     <UsingTask TaskName="WriteVersionInfoToBuildLog" AssemblyFile="$(GitVersionAssemblyFile)" />
 
     <Target Name="WriteVersionInfoToBuildLog" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec" Condition="$(WriteVersionInfoToBuildLog) == 'true'">
-        <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
+        <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" ConfigFilePath="$(GitVersionConfig)" NoFetch="$(GitVersion_NoFetchEnabled)"/>
     </Target>
 
     <Target Name="UpdateAssemblyInfo" DependsOnTargets="_UpdateAssemblyInfo;DispatchToInnerBuilds" />
@@ -22,7 +22,7 @@
     </Target>
 
     <Target Name="GetVersion" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec;EnsureWixToolsetInstalled" Condition="$(GetVersion) == 'true'">
-        <GetVersion SolutionDirectory="$(GitVersionPath)" NoFetch="$(GitVersion_NoFetchEnabled)">
+        <GetVersion SolutionDirectory="$(GitVersionPath)" ConfigFilePath="$(GitVersionConfig)" NoFetch="$(GitVersion_NoFetchEnabled)">
             <Output TaskParameter="Major" PropertyName="GitVersion_Major" />
             <Output TaskParameter="Minor" PropertyName="GitVersion_Minor" />
             <Output TaskParameter="Patch" PropertyName="GitVersion_Patch" />

--- a/src/GitVersionTfsTask/GitVersion.ts
+++ b/src/GitVersionTfsTask/GitVersion.ts
@@ -7,6 +7,7 @@ export class GitVersionTask {
     execOptions: tr.IExecOptions;
 
     preferBundledVersion: boolean;
+    configFilePath: string;
     updateAssemblyInfo: boolean;
 
     updateAssemblyInfoFilename: string;
@@ -20,6 +21,7 @@ export class GitVersionTask {
 
     constructor() {
         this.preferBundledVersion       = tl.getBoolInput('preferBundledVersion') || true;
+        this.configFilePath             = tl.getPathInput('configFilePath');
         this.updateAssemblyInfo         = tl.getBoolInput('updateAssemblyInfo');
 
         this.updateAssemblyInfoFilename = tl.getInput('updateAssemblyInfoFilename');
@@ -55,6 +57,10 @@ export class GitVersionTask {
                 "/output",
                 "buildserver",
                 "/nofetch"]);
+
+            if (this.configFilePath) {
+                exe.arg(["/config", this.configFilePath]);
+            }
 
             if (this.updateAssemblyInfo) {
                 exe.arg("/updateassemblyinfo");

--- a/src/GitVersionTfsTask/GitVersionTask/task.json
+++ b/src/GitVersionTfsTask/GitVersionTask/task.json
@@ -43,6 +43,13 @@
         "required": false,
         "helpMarkDown": "If checked it will prefer the bundled version over a version found in path"
     }, {
+        "name": "configFilePath",
+        "type": "filePath",
+        "label": "Config file",
+        "defaultValue": "",
+        "required": false,
+        "helpMarkDown": "Optional path to config file (defaults to GitVersion.yml)"
+    }, {
         "name": "updateAssemblyInfo",
         "type": "boolean",
         "label": "Update AssemblyInfo files",


### PR DESCRIPTION
This adds a new abstract `ConfigFileLocator` class, which has two implementations:
- `DefaultConfigFileLocator`, which is the current logic (`GitVersion.yml` and `GitVersionConfig.yaml` in working and project root directories).
- `NamedConfigFileLocator` that will only look for a specific file path (it can be a relative or absolute path).

`GitVersionExe` has a new optional `/config` argument which takes a path.

`GitVersionTask` has a new `ConfigFilePath` property on all inputs and is exposed via the MSBuild `GitVersionConfig` property.

`GitVersionTfsTask` has a new `configFilePath` input.

This resolves #894.