### PR TITLE
Bugfix/fix only tracked branches parameter implementation

### DIFF
--- a/src/GitVersionCore.Tests/GitToolsTestingExtensions.cs
+++ b/src/GitVersionCore.Tests/GitToolsTestingExtensions.cs
@@ -19,7 +19,7 @@ namespace GitVersionCore.Tests
 
         static GitToolsTestingExtensions() => sp = ConfigureService();
 
-        public static VersionVariables GetVersion(this RepositoryFixtureBase fixture, Config configuration = null, IRepository repository = null, string commitId = null, bool isForTrackedBranchOnly = true, string targetBranch = null)
+        public static VersionVariables GetVersion(this RepositoryFixtureBase fixture, Config configuration = null, IRepository repository = null, string commitId = null, bool onlyTrackedBranches = true, string targetBranch = null)
         {
             if (configuration == null)
             {
@@ -31,7 +31,7 @@ namespace GitVersionCore.Tests
             var variableProvider = sp.GetService<IVariableProvider>();
             var versionFinder = sp.GetService<IGitVersionFinder>();
 
-            var gitVersionContext = new GitVersionContext(repository ?? fixture.Repository, log, targetBranch, configuration, isForTrackedBranchOnly, commitId);
+            var gitVersionContext = new GitVersionContext(repository ?? fixture.Repository, log, targetBranch, configuration, onlyTrackedBranches, commitId);
             var executeGitVersion = versionFinder.FindVersion(gitVersionContext);
             var variables = variableProvider.GetVariablesFor(executeGitVersion, gitVersionContext.Configuration, gitVersionContext.IsCurrentCommitTagged);
 
@@ -47,19 +47,19 @@ namespace GitVersionCore.Tests
             }
         }
 
-        public static void AssertFullSemver(this RepositoryFixtureBase fixture, string fullSemver, IRepository repository = null, string commitId = null, bool isForTrackedBranchOnly = true, string targetBranch = null)
+        public static void AssertFullSemver(this RepositoryFixtureBase fixture, string fullSemver, IRepository repository = null, string commitId = null, bool onlyTrackedBranches = true, string targetBranch = null)
         {
-            fixture.AssertFullSemver(new Config(), fullSemver, repository, commitId, isForTrackedBranchOnly, targetBranch);
+            fixture.AssertFullSemver(new Config(), fullSemver, repository, commitId, onlyTrackedBranches, targetBranch);
         }
 
-        public static void AssertFullSemver(this RepositoryFixtureBase fixture, Config configuration, string fullSemver, IRepository repository = null, string commitId = null, bool isForTrackedBranchOnly = true, string targetBranch = null)
+        public static void AssertFullSemver(this RepositoryFixtureBase fixture, Config configuration, string fullSemver, IRepository repository = null, string commitId = null, bool onlyTrackedBranches = true, string targetBranch = null)
         {
             configuration.Reset();
             Console.WriteLine("---------");
 
             try
             {
-                var variables = fixture.GetVersion(configuration, repository, commitId, isForTrackedBranchOnly, targetBranch);
+                var variables = fixture.GetVersion(configuration, repository, commitId, onlyTrackedBranches, targetBranch);
                 variables.FullSemVer.ShouldBe(fullSemver);
             }
             catch (Exception)

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -143,7 +143,7 @@ namespace GitVersionCore.Tests.IntegrationTests
             var commit = fixture.Repository.Head.Tip;
             fixture.Repository.MakeACommit();
             Commands.Checkout(fixture.Repository, commit);
-            fixture.AssertFullSemver("1.1.0-alpha.1", isForTrackedBranchOnly: false);
+            fixture.AssertFullSemver("1.1.0-alpha.1", onlyTrackedBranches: false);
         }
 
         [Test]

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -143,7 +143,7 @@ namespace GitVersionCore.Tests.IntegrationTests
             var commit = fixture.Repository.Head.Tip;
             fixture.Repository.MakeACommit();
             Commands.Checkout(fixture.Repository, commit);
-            fixture.AssertFullSemver("1.1.0-alpha.1");
+            fixture.AssertFullSemver("1.1.0-alpha.1", isForTrackedBranchOnly: false);
         }
 
         [Test]

--- a/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
@@ -1,4 +1,4 @@
-﻿using GitTools.Testing;
+using GitTools.Testing;
 using LibGit2Sharp;
 using NUnit.Framework;
 using GitVersion.Configuration;
@@ -93,7 +93,7 @@ namespace GitVersionCore.Tests.IntegrationTests
             Commands.Checkout(fixture.Repository, commit);
 
             // When
-            fixture.AssertFullSemver("0.1.0+2");
+            fixture.AssertFullSemver("0.1.0+2", isForTrackedBranchOnly: false);
         }
 
         [Test]

--- a/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs
@@ -93,7 +93,7 @@ namespace GitVersionCore.Tests.IntegrationTests
             Commands.Checkout(fixture.Repository, commit);
 
             // When
-            fixture.AssertFullSemver("0.1.0+2", isForTrackedBranchOnly: false);
+            fixture.AssertFullSemver("0.1.0+2", onlyTrackedBranches: false);
         }
 
         [Test]

--- a/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -68,7 +68,7 @@ namespace GitVersionCore.Tests.IntegrationTests
                 fixture.LocalRepositoryFixture.Repository,
                 fixture.LocalRepositoryFixture.Repository.Head.Tip);
 
-            Should.Throw<WarningException>(() => fixture.AssertFullSemver("0.1.0+4", fixture.LocalRepositoryFixture.Repository, isForTrackedBranchOnly: false),
+            Should.Throw<WarningException>(() => fixture.AssertFullSemver("0.1.0+4", fixture.LocalRepositoryFixture.Repository, onlyTrackedBranches: false),
                 $"It looks like the branch being examined is a detached Head pointing to commit '{fixture.LocalRepositoryFixture.Repository.Head.Tip.Id.ToString(7)}'. Without a proper branch name GitVersion cannot determine the build version.");
         }
 

--- a/src/GitVersionCore/Configuration/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/Configuration/BranchConfigurationCalculator.cs
@@ -26,7 +26,7 @@ namespace GitVersion.Configuration
         public BranchConfig GetBranchConfiguration(Branch targetBranch, IList<Branch> excludedInheritBranches = null)
         {
             var matchingBranches = context.FullConfiguration.GetConfigForBranch(targetBranch.NameWithoutRemote());
-            
+
             if (matchingBranches == null)
             {
                 log.Info($"No branch configuration found for branch {targetBranch.FriendlyName}, falling back to default configuration");
@@ -84,7 +84,7 @@ namespace GitVersion.Configuration
                 List<Branch> possibleParents;
                 if (branchPoint == BranchCommit.Empty)
                 {
-                    possibleParents = context.RepositoryMetadataProvider.GetBranchesContainingCommit(targetBranch.Tip, branchesToEvaluate, true)
+                    possibleParents = context.RepositoryMetadataProvider.GetBranchesContainingCommit(targetBranch.Tip, branchesToEvaluate, false)
                         // It fails to inherit Increment branch configuration if more than 1 parent;
                         // therefore no point to get more than 2 parents
                         .Take(2)
@@ -93,11 +93,11 @@ namespace GitVersion.Configuration
                 else
                 {
                     var branches = context.RepositoryMetadataProvider
-                        .GetBranchesContainingCommit(branchPoint.Commit, branchesToEvaluate, true).ToList();
+                        .GetBranchesContainingCommit(branchPoint.Commit, branchesToEvaluate, false).ToList();
                     if (branches.Count > 1)
                     {
                         var currentTipBranches = context.RepositoryMetadataProvider
-                            .GetBranchesContainingCommit(context.CurrentCommit, branchesToEvaluate, true).ToList();
+                            .GetBranchesContainingCommit(context.CurrentCommit, branchesToEvaluate, false).ToList();
                         possibleParents = branches.Except(currentTipBranches).ToList();
                     }
                     else

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -81,7 +81,7 @@ namespace GitVersion
                 // TODO: It looks wasteful looping through the branches twice. Can't these loops be merged somehow? @asbjornu
                 foreach (var branch in branches)
                 {
-                    if (branch.Tip != null && branch.Tip.Sha != commit.Sha || (onlyTrackedBranches && !branch.IsTracking))
+                    if (branch.Tip != null && branch.Tip.Sha != commit.Sha || ((onlyTrackedBranches && branch.IsTracking) || !onlyTrackedBranches))
                     {
                         continue;
                     }
@@ -97,7 +97,7 @@ namespace GitVersion
                 }
 
                 log.Info($"No direct branches found, searching through {(onlyTrackedBranches ? "tracked" : "all")} branches.");
-                foreach (var branch in branches.Where(b => onlyTrackedBranches && !b.IsTracking))
+                foreach (var branch in branches.Where(b => (onlyTrackedBranches && b.IsTracking) || !onlyTrackedBranches))
                 {
                     log.Info($"Searching for commits reachable from '{branch.FriendlyName}'.");
 

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -14,12 +14,12 @@ namespace GitVersion
     {
         private readonly ILog log;
 
-        public GitVersionContext(IRepository repository, ILog log, string targetBranch, Config configuration, bool onlyEvaluateTrackedBranches = true, string commitId = null)
+        public GitVersionContext(IRepository repository, ILog log, string targetBranch, Config configuration, bool onlyEvaluateTrackedBranches = false, string commitId = null)
              : this(repository, log, GetTargetBranch(repository, targetBranch), configuration, onlyEvaluateTrackedBranches, commitId)
         {
         }
 
-        public GitVersionContext(IRepository repository, ILog log, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = true, string commitId = null)
+        public GitVersionContext(IRepository repository, ILog log, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = false, string commitId = null)
         {
             this.log = log;
             Repository = repository;

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -14,18 +14,18 @@ namespace GitVersion
     {
         private readonly ILog log;
 
-        public GitVersionContext(IRepository repository, ILog log, string targetBranch, Config configuration, bool onlyEvaluateTrackedBranches = false, string commitId = null)
-             : this(repository, log, GetTargetBranch(repository, targetBranch), configuration, onlyEvaluateTrackedBranches, commitId)
+        public GitVersionContext(IRepository repository, ILog log, string targetBranch, Config configuration, bool onlyTrackedBranches = false, string commitId = null)
+             : this(repository, log, GetTargetBranch(repository, targetBranch), configuration, onlyTrackedBranches, commitId)
         {
         }
 
-        public GitVersionContext(IRepository repository, ILog log, Branch currentBranch, Config configuration, bool onlyEvaluateTrackedBranches = false, string commitId = null)
+        public GitVersionContext(IRepository repository, ILog log, Branch currentBranch, Config configuration, bool onlyTrackedBranches = false, string commitId = null)
         {
             this.log = log;
             Repository = repository;
             RepositoryMetadataProvider = new GitRepoMetadataProvider(repository, log, configuration);
             FullConfiguration = configuration;
-            OnlyEvaluateTrackedBranches = onlyEvaluateTrackedBranches;
+            OnlyTrackedBranches = onlyTrackedBranches;
 
             if (currentBranch == null)
                 throw new InvalidOperationException("Need a branch to operate on");
@@ -53,7 +53,7 @@ namespace GitVersion
 
             if (currentBranch.IsDetachedHead())
             {
-                CurrentBranch = RepositoryMetadataProvider.GetBranchesContainingCommit(CurrentCommit, repository.Branches.ToList(), OnlyEvaluateTrackedBranches).OnlyOrDefault() ?? currentBranch;
+                CurrentBranch = RepositoryMetadataProvider.GetBranchesContainingCommit(CurrentCommit, repository.Branches.ToList(), OnlyTrackedBranches).OnlyOrDefault() ?? currentBranch;
             }
             else
             {
@@ -78,7 +78,7 @@ namespace GitVersion
         /// </summary>
         public Config FullConfiguration { get; }
         public SemanticVersion CurrentCommitTaggedVersion { get; }
-        public bool OnlyEvaluateTrackedBranches { get; }
+        public bool OnlyTrackedBranches { get; }
         public EffectiveConfiguration Configuration { get; private set; }
         public IRepository Repository { get; }
         public Branch CurrentBranch { get; }


### PR DESCRIPTION
Hey there

I'm currently playing around with GitVersion because we have some weird behaviors with our current branching strategy and what better way to learn something about git, branching and versioning then getting muddy in the code.

Anyway, it's late, my jokes get terrible and I found small bug. 
In the class GitRepoMetadataProvider, the method GetBranchesContainingCommit has a parameter onlyTrackedBranches that parameter is actually implemented exactly the other way arround, so when set to true, all branches get scanned, with false only the tracked ones. I'll add a comment into the PR at the point.

I thought about renaming the parameter to allBranches or something like that, but that felt wrong naming wise, as it doesn't refer to tracking branches which this parameter is about. So I fixed up the implementation, and changed existing functionality to adapt the original behavior again. Three tests seem to be dependent on non-tracked branches which have been fixed up too. 

If you have a better alternative name and prefer to just rename the parameter, just discard this PR. but it's not actually less work as the naming spreads through the hole call chain too :)

Have a good night. 