### PR TITLE
added option to disable gitversiontask on build

### DIFF
--- a/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
+++ b/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
@@ -1,0 +1,154 @@
+namespace GitVersionTask.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Xml;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Logging;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class GitVersionTaskPropertiesTests
+    {
+        const string projectXml =
+            @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<PropertyGroup>
+            <TargetFramework>net461</TargetFramework>
+            <Configuration>Debug</Configuration>
+            <GitVersionTaskRoot>..\GitVersionTask\build\</GitVersionTaskRoot>
+            <GitVersionAssemblyFile>..\..\GitVersionTask.MsBuild\bin\$(Configuration)\$(TargetFramework)\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>
+</PropertyGroup>
+            <Import Project='$(GitVersionTaskRoot)GitVersionTask.props'/>
+            <Import Project='$(GitVersionTaskRoot)GitVersionTask.targets'/>
+            </Project>";
+
+        (bool failed, Project project) CallMsBuild(IDictionary<string, string> globalProperties)
+        {
+            using (var stringReader = new StringReader(projectXml))
+            {
+                StringBuilder builder;
+                Project project;
+                bool result;
+                using (var collection = new ProjectCollection(globalProperties))
+                {
+                    builder = new StringBuilder();
+                    var writer = new StringWriter(builder);
+                    WriteHandler handler = x => writer.WriteLine(x);
+                    var logger = new ConsoleLogger(LoggerVerbosity.Quiet, handler, null, null);
+                    collection.RegisterLogger(logger);
+                    XmlReader reader = new XmlTextReader(stringReader);
+                    project = collection.LoadProject(reader);
+                    result = project.Build();
+                    collection.UnregisterAllLoggers();
+                }
+
+                var consoleOutput = builder.ToString();
+                Console.WriteLine(consoleOutput);
+
+                return (!result, project);
+            }
+        }
+
+        [Test]
+        public void Zero_properties_should_fail_the_build_because()
+        {
+            var result = CallMsBuild(new Dictionary<string, string>());
+            result.failed.ShouldBeTrue();
+        }
+
+        [Test]
+        public void With_DisableGitVersionTask_the_build_should_work()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+            result.failed.ShouldBeFalse();
+        }
+
+        [Test]
+        public void With_Enabled_GetVersionTask_the_Build_properties_should_be_initialized()
+        {
+            var result = CallMsBuild(new Dictionary<string, string>());
+            PropertyValueShouldBe(result, "DisableGitVersionTask", "false");
+            PropertyValueShouldBe(result, "WriteVersionInfoToBuildLog", "true");
+            PropertyValueShouldBe(result, "UpdateAssemblyInfo", "true");
+            PropertyValueShouldBe(result, "GenerateGitVersionInformation", "true");
+            PropertyValueShouldBe(result, "GetVersion", "true");
+            PropertyValueShouldBe(result, "UpdateVersionProperties", "true");
+        }
+
+
+
+        [Test]
+        public void With_DisabledGetVersionTask_the_WriteVersionInfoToBuildLog_should_be_false()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+            PropertyValueShouldBe(result, "DisableGitVersionTask", "true");
+            PropertyValueShouldBe(result, "WriteVersionInfoToBuildLog", "false");
+        }
+
+        [Test]
+        public void With_DisabledGetVersionTask_the_UpdateAssemblyInfo_should_be_false()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+            PropertyValueShouldBe(result, "UpdateAssemblyInfo", "false");
+        }
+
+        [Test]
+        public void With_DisabledGetVersionTask_the_GenerateGitVersionInformation_should_be_false()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+            PropertyValueShouldBe(result, "GenerateGitVersionInformation", "false");
+        }
+
+        [Test]
+        public void With_DisabledGetVersionTask_the_GetVersion_should_be_false()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+            PropertyValueShouldBe(result, "GetVersion", "false");
+        }
+
+        [Test]
+        public void With_DisabledGetVersionTask_the_UpdateVersionProperties_should_be_false()
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                {"DisableGitVersionTask", "true"}
+            };
+            var result = CallMsBuild(globalProperties);
+
+            PropertyValueShouldBe(result, "UpdateVersionProperties", "false");
+        }
+
+
+        static void PropertyValueShouldBe((bool failed, Project project) result, string propertyName, string expectedValue)
+        {
+            var property = result.project.Properties.First(p => p.Name == propertyName);
+
+            property.EvaluatedValue.ShouldBe(expectedValue);
+        }
+    }
+}

--- a/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
+++ b/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
@@ -15,22 +15,27 @@ namespace GitVersionTask.Tests
     [TestFixture]
     public class GitVersionTaskPropertiesTests
     {
-        const string projectXml =
-            @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-<PropertyGroup>
-            <TargetFramework>net461</TargetFramework>
-            <Configuration>Debug</Configuration>
-            <GitVersionTaskRoot>..\GitVersionTask\build\</GitVersionTaskRoot>
-            <GitVersionTaskRoot Condition=""!Exists('$(GitVersionTaskRoot)GitVersionTask.props')"">.\src\GitVersionTask\build\</GitVersionTaskRoot>
-            <GitVersionAssemblyFile>..\..\GitVersionTask.MsBuild\bin\$(Configuration)\$(TargetFramework)\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>
-</PropertyGroup>
-            <Import Project='$(GitVersionTaskRoot)GitVersionTask.props'/>
-            <Import Project='$(GitVersionTaskRoot)GitVersionTask.targets'/>
+
+
+        static string CreateProjectXml()
+        {
+            var currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            return $@"
+            <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                <PropertyGroup>
+                    <TargetFramework>net461</TargetFramework>
+                    <Configuration>Debug</Configuration>
+                    <GitVersionTaskRoot>{currentDirectory}\..\..\..\..\GitVersionTask\build\</GitVersionTaskRoot>
+                    <GitVersionAssemblyFile>{currentDirectory}\..\..\GitVersionTask.MsBuild\bin\$(Configuration)\$(TargetFramework)\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>
+                </PropertyGroup>
+                <Import Project='$(GitVersionTaskRoot)GitVersionTask.props'/>
+                <Import Project='$(GitVersionTaskRoot)GitVersionTask.targets'/>
             </Project>";
+        }
 
         (bool failed, Project project) CallMsBuild(IDictionary<string, string> globalProperties)
         {
-            using (var stringReader = new StringReader(projectXml))
+            using (var stringReader = new StringReader(CreateProjectXml()))
             {
                 StringBuilder builder;
                 Project project;
@@ -48,8 +53,11 @@ namespace GitVersionTask.Tests
                     collection.UnregisterAllLoggers();
                 }
 
-                var consoleOutput = builder.ToString();
-                Console.WriteLine(consoleOutput);
+                if (!result)
+                {
+                    var consoleOutput = builder.ToString();
+                    TestContext.Error.Write(consoleOutput);
+                }
 
                 return (!result, project);
             }

--- a/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
+++ b/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
@@ -56,6 +56,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void Zero_properties_should_fail_the_build_because()
         {
             var result = CallMsBuild(new Dictionary<string, string>());
@@ -63,6 +64,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_DisableGitVersionTask_the_build_should_work()
         {
             var globalProperties = new Dictionary<string, string>
@@ -74,6 +76,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_Enabled_GetVersionTask_the_Build_properties_should_be_initialized()
         {
             var result = CallMsBuild(new Dictionary<string, string>());
@@ -88,6 +91,7 @@ namespace GitVersionTask.Tests
 
 
         [Test]
+        [Category("NoMono")]
         public void With_DisabledGetVersionTask_the_WriteVersionInfoToBuildLog_should_be_false()
         {
             var globalProperties = new Dictionary<string, string>
@@ -100,6 +104,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_DisabledGetVersionTask_the_UpdateAssemblyInfo_should_be_false()
         {
             var globalProperties = new Dictionary<string, string>
@@ -111,6 +116,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_DisabledGetVersionTask_the_GenerateGitVersionInformation_should_be_false()
         {
             var globalProperties = new Dictionary<string, string>
@@ -122,6 +128,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_DisabledGetVersionTask_the_GetVersion_should_be_false()
         {
             var globalProperties = new Dictionary<string, string>
@@ -133,6 +140,7 @@ namespace GitVersionTask.Tests
         }
 
         [Test]
+        [Category("NoMono")]
         public void With_DisabledGetVersionTask_the_UpdateVersionProperties_should_be_false()
         {
             var globalProperties = new Dictionary<string, string>

--- a/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
+++ b/src/GitVersionTask.Tests/GitVersionTaskPropertiesTests.cs
@@ -21,6 +21,7 @@ namespace GitVersionTask.Tests
             <TargetFramework>net461</TargetFramework>
             <Configuration>Debug</Configuration>
             <GitVersionTaskRoot>..\GitVersionTask\build\</GitVersionTaskRoot>
+            <GitVersionTaskRoot Condition=""!Exists('$(GitVersionTaskRoot)GitVersionTask.props')"">.\src\GitVersionTask\build\</GitVersionTaskRoot>
             <GitVersionAssemblyFile>..\..\GitVersionTask.MsBuild\bin\$(Configuration)\$(TargetFramework)\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>
 </PropertyGroup>
             <Import Project='$(GitVersionTaskRoot)GitVersionTask.props'/>

--- a/src/GitVersionTask/build/GitVersionTask.props
+++ b/src/GitVersionTask/build/GitVersionTask.props
@@ -40,7 +40,6 @@
         <!-- Property that enables setting of Version -->
         <UpdateVersionProperties Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UpdateVersionProperties>
         <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
-        <UseFullSemVerForNuGet Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UseFullSemVerForNuGet>
         <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>
     </PropertyGroup>
 </Project>

--- a/src/GitVersionTask/build/GitVersionTask.props
+++ b/src/GitVersionTask/build/GitVersionTask.props
@@ -10,18 +10,25 @@
 
         <GitVersion_NoFetchEnabled Condition="$(GitVersion_NoFetchEnabled) == ''">false</GitVersion_NoFetchEnabled>
 
+        <DisableGitVersionTask Condition=" '$(DisableGitVersionTask)' == '' ">false</DisableGitVersionTask>
+
         <!-- Property that enables WriteVersionInfoToBuildLog -->
+        <WriteVersionInfoToBuildLog Condition=" '$(DisableGitVersionTask)' == 'true' ">false</WriteVersionInfoToBuildLog>
         <WriteVersionInfoToBuildLog Condition=" '$(WriteVersionInfoToBuildLog)' == '' ">true</WriteVersionInfoToBuildLog>
 
         <!-- Property that enables UpdateAssemblyInfo. Default to off for SDK builds -->
+        <UpdateAssemblyInfo Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UpdateAssemblyInfo>
         <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
 
         <!-- Property that enables GenerateGitVersionInformation -->
+        <GenerateGitVersionInformation Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GenerateGitVersionInformation>
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' ">true</GenerateGitVersionInformation>
 
         <!-- Property that enables GetVersion -->
+        <GetVersion Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GetVersion>
         <GetVersion Condition=" '$(GetVersion)' == '' ">true</GetVersion>
 
+        <GenerateGitVersionWixDefines Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GenerateGitVersionWixDefines>
         <GenerateGitVersionWixDefines Condition=" '$(GenerateGitVersionWixDefines)' == '' ">true</GenerateGitVersionWixDefines>
         <!--
           Ensure GetVersion runs prior to XAML's Markup Compiler in order to have the assembly version available.
@@ -31,7 +38,9 @@
         <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);GetVersion</GetPackageVersionDependsOn>
 
         <!-- Property that enables setting of Version -->
+        <UpdateVersionProperties Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UpdateVersionProperties>
         <UpdateVersionProperties Condition=" '$(UpdateVersionProperties)' == '' ">true</UpdateVersionProperties>
+        <UseFullSemVerForNuGet Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UseFullSemVerForNuGet>
         <UseFullSemVerForNuGet Condition=" '$(UseFullSemVerForNuGet)' == '' ">false</UseFullSemVerForNuGet>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
- this resolves #1723
- setting the DisableGitVersionTask property to true disables all activities if needed (e.g. NCrunch)
- there is no conditional disabling in the .props file because it must have priority and simple disable it