### PR TITLE
Revert "Use dot instead of dash to separate build metadata"

### DIFF
--- a/build/version.cake
+++ b/build/version.cake
@@ -14,7 +14,7 @@ public class BuildVersion
         var vsixVersion = gitVersion.MajorMinorPatch;
 
         if (!string.IsNullOrWhiteSpace(gitVersion.BuildMetaData)) {
-            semVersion += "." + gitVersion.BuildMetaData;
+            semVersion += "-" + gitVersion.BuildMetaData;
             vsixVersion += "." + DateTime.UtcNow.ToString("yyMMddHH");
         }
 


### PR DESCRIPTION
Reverts GitTools/GitVersion#1730