### PR TITLE
#1754 Allow head to move when switching branches for dynamic repositories

### DIFF
--- a/src/GitVersionCore.Tests/Extensions/ExtensionMethodsTests.cs
+++ b/src/GitVersionCore.Tests/Extensions/ExtensionMethodsTests.cs
@@ -1,0 +1,22 @@
+using GitVersion;
+using NUnit.Framework;
+
+namespace GitVersionCore.Tests
+{
+    [TestFixture]
+    public class ExtensionMethodsTests
+    {
+        [TestCase("develop", "develop", true)]
+        [TestCase("develop", "master", false)]
+        [TestCase("/refs/head/develop", "develop", true)]
+        [TestCase("/refs/head/master", "develop", false)]
+        [TestCase("superdevelop", "develop", false)]
+        [TestCase("/refs/head/superdevelop", "develop", false)]
+        public void TheIsBranchMethod(string input1, string input2, bool expectedOutput)
+        {
+            var actualOutput = input1.IsBranch(input2);
+
+            Assert.AreEqual(expectedOutput, actualOutput);
+        }
+    }
+}

--- a/src/GitVersionCore/Extensions/ExtensionMethods.cs
+++ b/src/GitVersionCore/Extensions/ExtensionMethods.cs
@@ -7,6 +7,23 @@ namespace GitVersion
 
     static class ExtensionMethods
     {
+        public static bool IsBranch(this string branchName, string branchNameToCompareAgainst)
+        {
+            // "develop" == "develop"
+            if (string.Equals(branchName, branchNameToCompareAgainst, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // "refs/head/develop" == "develop"
+            if (branchName.EndsWith($"/{branchNameToCompareAgainst}", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public static void AppendLineFormat(this StringBuilder stringBuilder, string format, params object[] args)
         {
             stringBuilder.AppendFormat(format, args);

--- a/src/GitVersionCore/GitVersionContext.cs
+++ b/src/GitVersionCore/GitVersionContext.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion
+namespace GitVersion
 {
     using LibGit2Sharp;
     using System;
@@ -163,7 +163,9 @@
             {
                 // There are some edge cases where HEAD is not pointing to the desired branch.
                 // Therefore it's important to verify if 'currentBranch' is indeed the desired branch.
-                if (desiredBranch.CanonicalName != targetBranch)
+
+                // CanonicalName can be "refs/heads/develop", so we need to check for "/{TargetBranch}" as well
+                if (!desiredBranch.CanonicalName.IsBranch(targetBranch))
                 {
                     // In the case where HEAD is not the desired branch, try to find the branch with matching name
                     desiredBranch = repository?.Branches?


### PR DESCRIPTION
Fixes #1754 