### PR TITLE
Fix git system hash for worktrees

### DIFF
--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -25,10 +25,28 @@ namespace GitVersion
         {
             var dotGitDirectory = gitPreparer.GetDotGitDirectory();
 
+            // get repo .git directory -- not the worktree gitdir
+            dotGitDirectory = GetWorktreeParentDotGetDirectory(dotGitDirectory);
+
             // traverse the directory and get a list of files, use that for GetHash
             var contents = CalculateDirectoryContents(Path.Combine(dotGitDirectory, "refs"));
 
             return GetHash(contents.ToArray());
+        }
+
+        static string GetWorktreeParentDotGetDirectory(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+
+            var parentPath = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(parentPath)) return path;
+
+            var worktreesPath = Path.Combine(".git", "worktrees");
+
+            if (!parentPath.EndsWith(worktreesPath, StringComparison.Ordinal))
+                return path;
+
+            return parentPath.Substring(0, parentPath.Length - 10);
         }
 
         // based on https://msdn.microsoft.com/en-us/library/bb513869.aspx

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -42,7 +42,7 @@ namespace GitVersion
 
             if (!Directory.Exists(root))
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"Root directory does not exist: {root}");
             }
 
             dirs.Push(root);


### PR DESCRIPTION
Running GitVersion from a git worktree nearly works for me -- I just get an exception when `GitVersionCacheKeyFactory.GetGitSystemHash()` is called.

To come up with the `gitSystemHash` portion of the composite hash, `.git/refs/*` are enumerated and all file names are included. This falls down for worktrees because the .git directory returned is actually `.git/worktrees/<worktree name>` and there isn't a `refs` folder here.

So, this PR just does some string matching to see if the path looks like a worktree and if so, return the parent .git dir path instead. I didn't see an easy way using LibGit2Sharp to jump from a worktree to its parent repo path and I figured string matching on the path is probably safe enough for this case.

Also, I added a more meaningful message when throwing an ArgumentException() when the refs folder couldn't be found.