### PR TITLE
Allow head to move for dynamic repositories

### DIFF
--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -17,7 +17,12 @@ public class DynamicRepositoryTests : TestBase
         workDirectory = Path.Combine(Path.GetTempPath(), "GV");
 
         // Clean directory upfront, some build agents are having troubles
-        Directory.Delete(workDirectory, true);
+        if (Directory.Exists(workDirectory))
+        {
+            Directory.Delete(workDirectory, true);
+        }
+
+        Directory.CreateDirectory(workDirectory);
     }
 
 

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -40,19 +40,13 @@ public class DynamicRepositoryTests : TestBase
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "71e71359f37581784e18c94e7a45eee72cbeeb30", "5.12.0-alpha.192")]
     [TestCase("Ctl_master", "https://github.com/Catel/Catel", "master", "f5de8964c35180a5f8607f5954007d5828aa849f", "5.10.0")]
-    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
-    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "be0aa94642d6ff1df6209e2180a7fe0de9aab384", "5.12.0-alpha.192")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "0.1.0-alpha.21")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "be0aa94642d6ff1df6209e2180a7fe0de9aab384", "0.1.0-alpha.23")]
     public void FindsVersionInDynamicRepo(string name, string url, string targetBranch, string commitId, string expectedFullSemVer)
     {
         var root = Path.Combine(workDirectory, name);
         var dynamicDirectory = Path.Combine(root, "D"); // dynamic, keeping directory as short as possible
         var workingDirectory = Path.Combine(root, "W"); // working, keeping directory as short as possible
-
-        //// Clear upfront
-        //if (Directory.Exists(root))
-        //{
-        //    Directory.Delete(root, true);
-        //}
 
         Directory.CreateDirectory(dynamicDirectory);
         Directory.CreateDirectory(workingDirectory);

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -40,8 +40,8 @@ public class DynamicRepositoryTests : TestBase
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "71e71359f37581784e18c94e7a45eee72cbeeb30", "5.12.0-alpha.192")]
     [TestCase("Ctl_master", "https://github.com/Catel/Catel", "master", "f5de8964c35180a5f8607f5954007d5828aa849f", "5.10.0")]
-    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "0.1.0-alpha.21")]
-    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "be0aa94642d6ff1df6209e2180a7fe0de9aab384", "0.1.0-alpha.23")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "be0aa94642d6ff1df6209e2180a7fe0de9aab384", "0.1.0-alpha.21")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "0.1.0-alpha.23")]
     public void FindsVersionInDynamicRepo(string name, string url, string targetBranch, string commitId, string expectedFullSemVer)
     {
         var root = Path.Combine(workDirectory, name);

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.Diagnostics;
+using System.IO;
 using GitVersion;
 using GitVersionCore.Tests;
 using NUnit.Framework;
@@ -9,7 +10,7 @@ public class DynamicRepositoryTests : TestBase
     string workDirectory;
 
 
-    [SetUp]
+    [OneTimeSetUp]
     public void CreateTemporaryRepository()
     {
         // Note: we can't use guid because paths will be too long
@@ -17,29 +18,40 @@ public class DynamicRepositoryTests : TestBase
     }
 
 
-    //[TearDown]
-    //public void Cleanup()
-    //{
-    //    Directory.Delete(workDirectory, true);
-    //}
+    [OneTimeTearDown]
+    public void Cleanup()
+    {
+        Directory.Delete(workDirectory, true);
+    }
 
-    [Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
-    [TestCase("GV_master_1", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1126")]
-    [TestCase("GV_master_2", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1132")]
+    //[Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
+    [NonParallelizable]
+    [TestCase("GV_master_1", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1086")]
+    [TestCase("GV_master_2", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1092")]
+    // Note: use same name twice to see if changing commits works on same (cached) repository
+    [TestCase("Catel_develop_1", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
+    [TestCase("Catel_develop_1", "https://github.com/Catel/Catel", "develop", "71e71359f37581784e18c94e7a45eee72cbeeb30", "5.12.0-alpha.192")]
+    [TestCase("Catel_master_1", "https://github.com/Catel/Catel", "master", "f5de8964c35180a5f8607f5954007d5828aa849f", "5.10.0")]
     public void FindsVersionInDynamicRepo(string name, string url, string targetBranch, string commitId, string expectedFullSemVer)
     {
         var root = Path.Combine(workDirectory, name);
         var dynamicDirectory = Path.Combine(root, "dynamic");
         var workingDirectory = Path.Combine(root, "working");
 
-        // Clear upfront
-        if (Directory.Exists(root))
-        {
-            Directory.Delete(root, true);
-        }
+        //// Clear upfront
+        //if (Directory.Exists(root))
+        //{
+        //    Directory.Delete(root, true);
+        //}
 
         Directory.CreateDirectory(dynamicDirectory);
         Directory.CreateDirectory(workingDirectory);
+
+        Logger.AddLoggersTemporarily(
+            x => Debug.WriteLine($"[DEBUG]   {x}"),
+            x => Debug.WriteLine($"[INFO]    {x}"),
+            x => Debug.WriteLine($"[WARNING] {x}"),
+            x => Debug.WriteLine($"[ERROR]   {x}"));
 
         var executeCore = new ExecuteCore(new TestFileSystem());
 

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -15,13 +15,16 @@ public class DynamicRepositoryTests : TestBase
     {
         // Note: we can't use guid because paths will be too long
         workDirectory = Path.Combine(Path.GetTempPath(), "GV");
+
+        // Clean directory upfront, some build agents are having troubles
+        Directory.Delete(workDirectory, true);
     }
 
 
     [OneTimeTearDown]
     public void Cleanup()
     {
-        Directory.Delete(workDirectory, true);
+
     }
 
     //[Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -33,9 +33,8 @@ public class DynamicRepositoryTests : TestBase
     }
 
     // Note: use same name twice to see if changing commits works on same (cached) repository
-    //[Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
+    [Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
     [NonParallelizable]
-    [Explicit]
     [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1086")]
     [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1092")]
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -32,14 +32,16 @@ public class DynamicRepositoryTests : TestBase
 
     }
 
+    // Note: use same name twice to see if changing commits works on same (cached) repository
     //[Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
     [NonParallelizable]
-    [TestCase("GV_master_1", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1086")]
-    [TestCase("GV_master_2", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1092")]
-    // Note: use same name twice to see if changing commits works on same (cached) repository
-    [TestCase("Catel_develop_1", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
-    [TestCase("Catel_develop_1", "https://github.com/Catel/Catel", "develop", "71e71359f37581784e18c94e7a45eee72cbeeb30", "5.12.0-alpha.192")]
-    [TestCase("Catel_master_1", "https://github.com/Catel/Catel", "master", "f5de8964c35180a5f8607f5954007d5828aa849f", "5.10.0")]
+    [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1086")]
+    [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1092")]
+    [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
+    [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "71e71359f37581784e18c94e7a45eee72cbeeb30", "5.12.0-alpha.192")]
+    [TestCase("Ctl_master", "https://github.com/Catel/Catel", "master", "f5de8964c35180a5f8607f5954007d5828aa849f", "5.10.0")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]
+    [TestCase("CtlA_develop", "https://github.com/Catel/Catel.Analyzers", "develop", "be0aa94642d6ff1df6209e2180a7fe0de9aab384", "5.12.0-alpha.192")]
     public void FindsVersionInDynamicRepo(string name, string url, string targetBranch, string commitId, string expectedFullSemVer)
     {
         var root = Path.Combine(workDirectory, name);

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -35,6 +35,7 @@ public class DynamicRepositoryTests : TestBase
     // Note: use same name twice to see if changing commits works on same (cached) repository
     //[Ignore("These tests are slow and fail on the second run in Test Explorer and need to be re-written")]
     [NonParallelizable]
+    [Explicit]
     [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "4783d325521463cd6cf1b61074352da84451f25d", "4.0.0+1086")]
     [TestCase("GV_master", "https://github.com/GitTools/GitVersion", "master", "3bdcd899530b4e9b37d13639f317da04a749e728", "4.0.0+1092")]
     [TestCase("Ctl_develop", "https://github.com/Catel/Catel", "develop", "0e2b6c125a730d2fa5e24394ef64abe62c98e9e9", "5.12.0-alpha.188")]

--- a/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/DynamicRepositoryTests.cs
@@ -14,7 +14,7 @@ public class DynamicRepositoryTests : TestBase
     public void CreateTemporaryRepository()
     {
         // Note: we can't use guid because paths will be too long
-        workDirectory = Path.Combine(Path.GetTempPath(), "DynRepoTests");
+        workDirectory = Path.Combine(Path.GetTempPath(), "GV");
     }
 
 
@@ -35,8 +35,8 @@ public class DynamicRepositoryTests : TestBase
     public void FindsVersionInDynamicRepo(string name, string url, string targetBranch, string commitId, string expectedFullSemVer)
     {
         var root = Path.Combine(workDirectory, name);
-        var dynamicDirectory = Path.Combine(root, "dynamic");
-        var workingDirectory = Path.Combine(root, "working");
+        var dynamicDirectory = Path.Combine(root, "D"); // dynamic, keeping directory as short as possible
+        var workingDirectory = Path.Combine(root, "W"); // working, keeping directory as short as possible
 
         //// Clear upfront
         //if (Directory.Exists(root))

--- a/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -40,7 +40,7 @@ public class RemoteRepositoryScenarios : TestBase
                 return repo;
             }))
         {
-            GitRepositoryHelper.NormalizeGitDirectory(fixture.LocalRepositoryFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: string.Empty);
+            GitRepositoryHelper.NormalizeGitDirectory(fixture.LocalRepositoryFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: string.Empty, true);
 
             fixture.AssertFullSemver("1.0.0-beta.1+5");
             fixture.AssertFullSemver("1.0.0-beta.1+5", fixture.LocalRepositoryFixture.Repository);

--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -20,12 +20,11 @@ namespace GitVersion
         {
             this.targetUrl = targetUrl;
             this.dynamicRepositoryLocation = dynamicRepositoryLocation;
-            this.authentication = authentication == null ?
-                null :
+            this.authentication =
                 new AuthenticationInfo
                 {
-                    Username = authentication.Username,
-                    Password = authentication.Password
+                    Username = authentication?.Username,
+                    Password = authentication?.Password
                 };
             this.noFetch = noFetch;
             this.targetPath = targetPath.TrimEnd('/', '\\');

--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -50,7 +50,7 @@ namespace GitVersion
                         {
                             CleanupDuplicateOrigin();
                         }
-                        GitRepositoryHelper.NormalizeGitDirectory(GetDotGitDirectory(), authentication, noFetch, currentBranch);
+                        GitRepositoryHelper.NormalizeGitDirectory(GetDotGitDirectory(), authentication, noFetch, currentBranch, IsDynamicGitRepository);
                     }
                 }
                 return;
@@ -180,7 +180,7 @@ namespace GitVersion
                     Logger.WriteInfo("Git repository already exists");
                     using (Logger.IndentLog($"Normalizing git directory for branch '{targetBranch}'"))
                     {
-                        GitRepositoryHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch, targetBranch);
+                        GitRepositoryHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch, targetBranch, true);
                     }
 
                     return gitDirectory;
@@ -191,7 +191,7 @@ namespace GitVersion
                 using (Logger.IndentLog($"Normalizing git directory for branch '{targetBranch}'"))
                 {
                     // Normalize (download branches) before using the branch
-                    GitRepositoryHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch, targetBranch);
+                    GitRepositoryHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch, targetBranch, true);
                 }
 
                 return gitDirectory;

--- a/src/GitVersionCore/Helpers/GitRepositoryHelper.cs
+++ b/src/GitVersionCore/Helpers/GitRepositoryHelper.cs
@@ -11,7 +11,8 @@ namespace GitVersion
         /// Normalisation of a git directory turns all remote branches into local branches, turns pull request refs into a real branch and a few other things. This is designed to be run *only on the build server* which checks out repositories in different ways.
         /// It is not recommended to run normalisation against a local repository
         /// </summary>
-        public static void NormalizeGitDirectory(string gitDirectory, AuthenticationInfo authentication, bool noFetch, string currentBranch)
+        public static void NormalizeGitDirectory(string gitDirectory, AuthenticationInfo authentication,
+            bool noFetch, string currentBranch, bool isDynamicRepository)
         {
             using (var repo = new Repository(gitDirectory))
             {
@@ -41,7 +42,7 @@ namespace GitVersion
                     // Bug fix for https://github.com/GitTools/GitVersion/issues/1754, head maybe have been changed
                     // if this is a dynamic repository. But only allow this in case the branches are different (branch switch)
                     if (expectedSha != repo.Head.Tip.Sha &&
-                        !expectedBranchName.IsBranch(currentBranch))
+                        (isDynamicRepository || !expectedBranchName.IsBranch(currentBranch)))
                     {
                         var newExpectedSha = repo.Head.Tip.Sha;
                         var newExpectedBranchName = repo.Head.CanonicalName;


### PR DESCRIPTION
I've fixed the tests for the dynamic repositories, they should succeed now. They are "slow" (max 30 seconds on my machine), but I think they are required in order to make sure we don't break this functionality in the future.