### PR TITLE
[Azure DevOps] Leave the original Build Number when no GitVersion variable in Build Number

### DIFF
--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -213,6 +213,10 @@ Sets the format which will be used to format the `CommitDate` output variable.
 
 The header for ignore configuration.
 
+### update-build-number
+
+Configures GitVersion to update the build number or not when running on a build server.
+
 #### sha
 
 A sequence of SHAs to be excluded from the version calculations. Useful when

--- a/src/GitVersionCore.Tests/BuildAgents/BuildServerBaseTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/BuildServerBaseTests.cs
@@ -50,6 +50,10 @@ namespace GitVersionCore.Tests.BuildAgents
             buildServer.WriteIntegration(writes.Add, variables);
 
             writes[1].ShouldBe("1.2.3-beta.1+5");
+
+            writes = new List<string>();
+            buildServer.WriteIntegration(writes.Add, variables, false);
+            writes.ShouldBeEmpty();
         }
 
         private class BuildAgent : BuildAgentBase

--- a/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
@@ -149,6 +149,23 @@ namespace GitVersionCore.Tests.BuildAgents
         }
 
         [Test]
+        public void ShouldNotWriteIntegration()
+        {
+            // Arrange
+            var vars = new TestableVersionVariables("1.0.0");
+
+            var list = new List<string>();
+
+            // Assert
+            environment.GetEnvironmentVariable("GitVersion_Major").ShouldBeNullOrWhiteSpace();
+
+            // Act
+            buildServer.WriteIntegration(s => { list.Add(s); }, vars, false);
+
+            list.ShouldBeEmpty();
+        }
+
+        [Test]
         public void GetEmptyGenerateSetVersionMessage()
         {
             // Arrange

--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -123,3 +123,4 @@ ignore:
   sha: []
 commit-date-format: yyyy-MM-dd
 merge-message-formats: {}
+update-build-number: false

--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -123,4 +123,4 @@ ignore:
   sha: []
 commit-date-format: yyyy-MM-dd
 merge-message-formats: {}
-update-build-number: false
+update-build-number: true

--- a/src/GitVersionCore.Tests/Helpers/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestEffectiveConfiguration.cs
@@ -35,14 +35,15 @@ namespace GitVersionCore.Tests.Helpers
             IEnumerable<IVersionFilter> versionFilters = null,
             bool tracksReleaseBranches = false,
             bool isRelease = false,
-            string commitDateFormat = "yyyy-MM-dd") :
+            string commitDateFormat = "yyyy-MM-dd",
+            bool updateBuildNumber = false) :
             base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,
                     commitMessageMode, legacySemVerPadding, buildMetaDataPadding, commitsSinceVersionSourcePadding,
                     versionFilters ?? Enumerable.Empty<IVersionFilter>(),
-                    tracksReleaseBranches, isRelease, commitDateFormat, 0)
+                    tracksReleaseBranches, isRelease, commitDateFormat, updateBuildNumber, 0)
         {
         }
     }

--- a/src/GitVersionCore.Tests/Model/CommitDateTests.cs
+++ b/src/GitVersionCore.Tests/Model/CommitDateTests.cs
@@ -29,7 +29,7 @@ namespace GitVersionCore.Tests
                                     },
                                     new EffectiveConfiguration(
                                         AssemblyVersioningScheme.MajorMinorPatch, AssemblyFileVersioningScheme.MajorMinorPatch, "", "", "", VersioningMode.ContinuousDelivery, "", "", "", IncrementStrategy.Inherit,
-                                        "", true, "", "", false, "", "", "", "", CommitMessageIncrementMode.Enabled, 4, 4, 4, Enumerable.Empty<IVersionFilter>(), false, true, format, 0)
+                                        "", true, "", "", false, "", "", "", "", CommitMessageIncrementMode.Enabled, 4, 4, 4, Enumerable.Empty<IVersionFilter>(), false, true, format, false, 0)
                                 );
 
             Assert.That(formatValues.CommitDate, Is.EqualTo(expectedOutcome));

--- a/src/GitVersionCore/BuildAgents/CodeBuild.cs
+++ b/src/GitVersionCore/BuildAgents/CodeBuild.cs
@@ -40,7 +40,7 @@ namespace GitVersion.BuildAgents
             return Environment.GetEnvironmentVariable(EnvironmentVariableName);
         }
 
-        public override void WriteIntegration(Action<string> writer, VersionVariables variables)
+        public override void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
             base.WriteIntegration(writer, variables);
             writer($"Outputting variables to '{file}' ... ");

--- a/src/GitVersionCore/BuildAgents/GitLabCi.cs
+++ b/src/GitVersionCore/BuildAgents/GitLabCi.cs
@@ -43,7 +43,7 @@ namespace GitVersion.BuildAgents
 
         public override bool PreventFetch() => true;
 
-        public override void WriteIntegration(Action<string> writer, VersionVariables variables)
+        public override void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
             base.WriteIntegration(writer, variables);
             writer($"Outputting variables to '{file}' ... ");

--- a/src/GitVersionCore/BuildAgents/Jenkins.cs
+++ b/src/GitVersionCore/BuildAgents/Jenkins.cs
@@ -58,7 +58,7 @@ namespace GitVersion.BuildAgents
             return IsPipelineAsCode();
         }
 
-        public override void WriteIntegration(Action<string> writer, VersionVariables variables)
+        public override void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
             base.WriteIntegration(writer, variables);
             writer($"Outputting variables to '{file}' ... ");

--- a/src/GitVersionCore/Common/IBuildAgent.cs
+++ b/src/GitVersionCore/Common/IBuildAgent.cs
@@ -6,7 +6,7 @@ namespace GitVersion
     public interface IBuildAgent
     {
         bool CanApplyToCurrentContext();
-        void WriteIntegration(Action<string> writer, VersionVariables variables);
+        void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true);
         string GetCurrentBranch(bool usingDynamicRepos);
         bool PreventFetch();
         bool ShouldCleanUpRemotes();

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -36,7 +36,7 @@ namespace GitVersion.Configuration
             config.BuildMetaDataPadding ??= 4;
             config.CommitsSinceVersionSourcePadding ??= 4;
             config.CommitDateFormat ??= "yyyy-MM-dd";
-            config.UpdateBuildNumber ??= false;
+            config.UpdateBuildNumber ??= true;
 
             var configBranches = config.Branches.ToList();
 
@@ -264,7 +264,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             var patchMessage = configuration.PatchVersionBumpMessage;
             var noBumpMessage = configuration.NoBumpMessage;
             var commitDateFormat = configuration.CommitDateFormat;
-            var updateBuildNumber = configuration.UpdateBuildNumber ?? false;
+            var updateBuildNumber = configuration.UpdateBuildNumber ?? true;
 
             var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? configuration.CommitMessageIncrementing.Value;
 

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -36,6 +36,7 @@ namespace GitVersion.Configuration
             config.BuildMetaDataPadding ??= 4;
             config.CommitsSinceVersionSourcePadding ??= 4;
             config.CommitDateFormat ??= "yyyy-MM-dd";
+            config.UpdateBuildNumber ??= false;
 
             var configBranches = config.Branches.ToList();
 
@@ -263,6 +264,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             var patchMessage = configuration.PatchVersionBumpMessage;
             var noBumpMessage = configuration.NoBumpMessage;
             var commitDateFormat = configuration.CommitDateFormat;
+            var updateBuildNumber = configuration.UpdateBuildNumber ?? false;
 
             var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? configuration.CommitMessageIncrementing.Value;
 
@@ -282,6 +284,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
                 currentBranchConfig.TracksReleaseBranches.Value,
                 currentBranchConfig.IsReleaseBranch.Value,
                 commitDateFormat,
+                updateBuildNumber,
                 preReleaseWeight);
         }
 

--- a/src/GitVersionCore/Core/BuildAgentBase.cs
+++ b/src/GitVersionCore/Core/BuildAgentBase.cs
@@ -28,9 +28,9 @@ namespace GitVersion
         public virtual bool PreventFetch() => true;
         public virtual bool ShouldCleanUpRemotes() => false;
 
-        public virtual void WriteIntegration(Action<string> writer, VersionVariables variables)
+        public virtual void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
-            if (writer == null)
+            if (writer == null || !updateBuildNumber)
             {
                 return;
             }

--- a/src/GitVersionCore/Model/Configuration/Config.cs
+++ b/src/GitVersionCore/Model/Configuration/Config.cs
@@ -118,6 +118,9 @@ namespace GitVersion.Model.Configuration
         [YamlMember(Alias = "merge-message-formats")]
         public Dictionary<string, string> MergeMessageFormats { get; set; } = new Dictionary<string, string>();
 
+        [YamlMember(Alias = "update-build-number ")]
+        public bool? UpdateBuildNumber { get; set; }
+
         public override string ToString()
         {
             var stringBuilder = new StringBuilder();

--- a/src/GitVersionCore/Model/Configuration/Config.cs
+++ b/src/GitVersionCore/Model/Configuration/Config.cs
@@ -118,17 +118,15 @@ namespace GitVersion.Model.Configuration
         [YamlMember(Alias = "merge-message-formats")]
         public Dictionary<string, string> MergeMessageFormats { get; set; } = new Dictionary<string, string>();
 
-        [YamlMember(Alias = "update-build-number ")]
+        [YamlMember(Alias = "update-build-number")]
         public bool? UpdateBuildNumber { get; set; }
 
         public override string ToString()
         {
             var stringBuilder = new StringBuilder();
-            using (var stream = new StringWriter(stringBuilder))
-            {
-                ConfigSerializer.Write(this, stream);
-                stream.Flush();
-            }
+            using var stream = new StringWriter(stringBuilder);
+            ConfigSerializer.Write(this, stream);
+            stream.Flush();
             return stringBuilder.ToString();
         }
 

--- a/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
@@ -120,7 +120,7 @@ namespace GitVersion.Model.Configuration
         public IEnumerable<IVersionFilter> VersionFilters { get; private set; }
 
         public string CommitDateFormat { get; private set; }
-        
+
         public bool UpdateBuildNumber { get; private set; }
 
         public int PreReleaseWeight { get; private set; }

--- a/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
@@ -34,6 +34,7 @@ namespace GitVersion.Model.Configuration
             bool tracksReleaseBranches,
             bool isCurrentBranchRelease,
             string commitDateFormat,
+            bool updateBuildNumber,
             int preReleaseWeight)
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
@@ -63,6 +64,7 @@ namespace GitVersion.Model.Configuration
             TracksReleaseBranches = tracksReleaseBranches;
             IsCurrentBranchRelease = isCurrentBranchRelease;
             CommitDateFormat = commitDateFormat;
+            UpdateBuildNumber = updateBuildNumber;
             PreReleaseWeight = preReleaseWeight;
         }
 
@@ -118,6 +120,8 @@ namespace GitVersion.Model.Configuration
         public IEnumerable<IVersionFilter> VersionFilters { get; private set; }
 
         public string CommitDateFormat { get; private set; }
+        
+        public bool UpdateBuildNumber { get; private set; }
 
         public int PreReleaseWeight { get; private set; }
     }

--- a/src/GitVersionCore/VersionConverters/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersionCore/VersionConverters/OutputGenerator/OutputGenerator.cs
@@ -15,13 +15,15 @@ namespace GitVersion.VersionConverters.OutputGenerator
         private readonly IConsole console;
         private readonly IFileSystem fileSystem;
         private readonly IOptions<GitVersionOptions> options;
+        private readonly Lazy<GitVersionContext> versionContext;
         private readonly ICurrentBuildAgent buildAgent;
 
-        public OutputGenerator(ICurrentBuildAgent buildAgent, IConsole console, IFileSystem fileSystem, IOptions<GitVersionOptions> options)
+        public OutputGenerator(ICurrentBuildAgent buildAgent, IConsole console, IFileSystem fileSystem, IOptions<GitVersionOptions> options, Lazy<GitVersionContext> versionContext)
         {
             this.console = console ?? throw new ArgumentNullException(nameof(console));
             this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.versionContext = versionContext;
             this.buildAgent = buildAgent;
         }
 
@@ -30,7 +32,7 @@ namespace GitVersion.VersionConverters.OutputGenerator
             var gitVersionOptions = options.Value;
             if (gitVersionOptions.Output.Contains(OutputType.BuildServer))
             {
-                buildAgent?.WriteIntegration(console.WriteLine, variables);
+                buildAgent?.WriteIntegration(console.WriteLine, variables, versionContext.Value.Configuration.UpdateBuildNumber);
             }
             if (gitVersionOptions.Output.Contains(OutputType.File))
             {


### PR DESCRIPTION
The Build number should not replaced when there is no GitVersion variable in it.

This is discussed in #1457 