### PR TITLE
Only append /config if the user specified a configFilePath

### DIFF
--- a/src/GitVersionTfsTask/GitVersion.ts
+++ b/src/GitVersionTfsTask/GitVersion.ts
@@ -23,7 +23,7 @@ export class GitVersionTask {
     constructor() {
         this.preferBundledVersion       = tl.getBoolInput('preferBundledVersion') || true;
         this.configFilePathSupplied     = tl.filePathSupplied('configFilePath');
-        this.configFilePath             = tl.getPathInput('configFilePath');
+        this.configFilePath             = tl.getPathInput('configFilePath', false, true);
         this.updateAssemblyInfo         = tl.getBoolInput('updateAssemblyInfo');
 
         this.updateAssemblyInfoFilename = tl.getInput('updateAssemblyInfoFilename');

--- a/src/GitVersionTfsTask/GitVersion.ts
+++ b/src/GitVersionTfsTask/GitVersion.ts
@@ -7,6 +7,7 @@ export class GitVersionTask {
     execOptions: tr.IExecOptions;
 
     preferBundledVersion: boolean;
+    configFilePathSupplied: boolean;
     configFilePath: string;
     updateAssemblyInfo: boolean;
 
@@ -21,6 +22,7 @@ export class GitVersionTask {
 
     constructor() {
         this.preferBundledVersion       = tl.getBoolInput('preferBundledVersion') || true;
+        this.configFilePathSupplied     = tl.filePathSupplied('configFilePath');
         this.configFilePath             = tl.getPathInput('configFilePath');
         this.updateAssemblyInfo         = tl.getBoolInput('updateAssemblyInfo');
 
@@ -58,7 +60,7 @@ export class GitVersionTask {
                 "buildserver",
                 "/nofetch"]);
 
-            if (this.configFilePath) {
+            if (this.configFilePathSupplied && this.configFilePath) {
                 exe.arg(["/config", this.configFilePath]);
             }
 


### PR DESCRIPTION
When reading the new configFilePath parameter, there wasn't a check to see if the file path was actually supplied by the user.

This should fix the bug reported by @Skoucail at https://github.com/GitTools/GitVersion/pull/1691#issuecomment-520844538
