### PR TITLE
Add NoUnix test category

### DIFF
--- a/build/pack.cake
+++ b/build/pack.cake
@@ -63,10 +63,17 @@ Task("Test")
                     CoverletOutputName = $"{projectName}.coverage.xml"
                 };
 
+                var filters = new List<string>();
+
                 if (IsRunningOnUnix())
                 {
-                    settings.Filter = "TestCategory!=NoMono";
+                    filters.Add("TestCategory!=NoUnix");
+                    if (string.Equals(framework, parameters.FullFxVersion))
+                        filters.Add("TestCategory!=NoMono");
                 }
+
+                if (filters.Any())
+                    settings.Filter = string.Join(" & ", filters);
 
                 DotNetCoreTest(project.FullPath, settings, coverletSettings);
             });

--- a/src/GitVersionCore.Tests/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/AssemblyInfoFileUpdaterTests.cs
@@ -434,7 +434,7 @@ public class AssemblyInfoFileUpdaterTests
     [TestCase("cs", "[assembly: AssemblyVersion(\"1.0.0.0\")]\r\n[assembly: AssemblyFileVersion(\"1.0.0.0\")]\r\n// comment\r\n")]
     [TestCase("fs", "[<assembly: AssemblyVersion(\"1.0.0.0\")>]\r\n[<assembly: AssemblyFileVersion(\"1.0.0.0\")>]\r\ndo\r\n()\r\n")]
     [TestCase("vb", "<Assembly: AssemblyVersion(\"1.0.0.0\")>\r\n<Assembly: AssemblyFileVersion(\"1.0.0.0\")>\r\n' comment\r\n")]
-    [Category("NoMono")]
+    [Category("NoUnix")]
     [Description("Won't run on Mono due to source information not being available for ShouldMatchApproved.")]
     public void Issue1183_ShouldAddFSharpAssemblyInformationalVersionBesideOtherAttributes(string fileExtension, string assemblyFileContent)
     {

--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -278,7 +278,7 @@ branches: {}";
         {
             ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
         }
-        s.Length.ShouldBe(0);
+        s.ShouldBeEmpty();
     }
 
     string SetupConfigFileContent(string text, string fileName = DefaultConfigFileLocator.DefaultFileName)

--- a/src/GitVersionCore.Tests/DefaultConfigFileLocatorTests.cs
+++ b/src/GitVersionCore.Tests/DefaultConfigFileLocatorTests.cs
@@ -88,7 +88,7 @@ public class DefaultConfigFileLocatorTests : TestBase
         {
             ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
         }
-        s.Length.ShouldBe(0);
+        s.ShouldBeEmpty();
     }
 
     string SetupConfigFileContent(string text, string fileName = DefaultConfigFileLocator.DefaultFileName)

--- a/src/GitVersionCore.Tests/Init/InitScenarios.cs
+++ b/src/GitVersionCore.Tests/Init/InitScenarios.cs
@@ -14,7 +14,7 @@ namespace GitVersionCore.Tests.Init
         }
 
         [Test]
-        [Category("NoMono")]
+        [Category("NoUnix")]
         [Description("Won't run on Mono due to source information not being available for ShouldMatchApproved.")]
         public void CanSetNextVersion()
         {

--- a/src/GitVersionCore.Tests/LoggerTest.cs
+++ b/src/GitVersionCore.Tests/LoggerTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using GitVersion;
 using Shouldly;
@@ -20,7 +20,7 @@ namespace GitVersionCore.Tests
             using (Logger.AddLoggersTemporarily(action, action, action, action))
                 Logger.WriteInfo($"{protocol}://{username}:{password}@workspace.visualstudio.com/DefaultCollection/_git/CAS");
 
-            s.Contains(password).ShouldBe(false);
+            s.ShouldNotContain(password);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace GitVersionCore.Tests
             using (Logger.AddLoggersTemporarily(action, action, action, action))
                 Logger.WriteInfo(repoUrl);
 
-            s.Contains(repoUrl).ShouldBe(true);
+            s.ShouldContain(repoUrl);
         }
     }
 }

--- a/src/GitVersionCore.Tests/NamedConfigFileLocatorTests.cs
+++ b/src/GitVersionCore.Tests/NamedConfigFileLocatorTests.cs
@@ -51,7 +51,7 @@ public class NamedConfigFileLocatorTests : TestBase
         {
             ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
         }
-        s.Length.ShouldBe(0);
+        s.ShouldBeEmpty();
     }
 
     [Test]
@@ -65,7 +65,7 @@ public class NamedConfigFileLocatorTests : TestBase
         {
             ConfigurationProvider.Provide(repoPath, fileSystem, configFileLocator);
         }
-        s.Length.ShouldBe(0);
+        s.ShouldBeEmpty();
     }
 
     string SetupConfigFileContent(string text, string fileName = null, string path = null)

--- a/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersionExe.Tests/ExecCmdLineArgumentTest.cs
@@ -89,7 +89,7 @@ public class ExecCmdLineArgumentTest
     }
 
     [Test]
-    [Category("NoMono")]
+    [Category("NoUnix")]
     [Description("Doesn't work on Mono/Unix because of the path heuristics that needs to be done there in order to figure out whether the first argument actually is a path.")]
     public void WorkingDirectoryDoesNotExistCrashesWithInformativeMessage()
     {

--- a/src/GitVersionExe.Tests/UpdateWixVersionFileTests.cs
+++ b/src/GitVersionExe.Tests/UpdateWixVersionFileTests.cs
@@ -22,7 +22,7 @@ namespace GitVersionExe.Tests
         }
 
         [Test]
-        [Category("NoMono")]
+        [Category("NoUnix")]
         [Description("Doesn't work on Mono/Unix because of the path heuristics that needs to be done there in order to figure out whether the first argument actually is a path.")]
         public void WixVersionFileCreationTest()
         {
@@ -37,7 +37,7 @@ namespace GitVersionExe.Tests
         }
 
         [Test]
-        [Category("NoMono")]
+        [Category("NoUnix")]
         [Description("Doesn't work on Mono/Unix because of the path heuristics that needs to be done there in order to figure out whether the first argument actually is a path.")]
         public void WixVersionFileVarCountTest()
         {
@@ -60,7 +60,7 @@ namespace GitVersionExe.Tests
         }
 
         [Test]
-        [Category("NoMono")]
+        [Category("NoUnix")]
         [Description("Doesn't work on Mono/Unix because of the path heuristics that needs to be done there in order to figure out whether the first argument actually is a path.")]
         public void WixVersionFileContentTest()
         {


### PR DESCRIPTION
The logic for excluding `NoMono` categorized tests really only checks if running on Unix. Instead, add a new `NoUnix` category for that and make `NoMono` actually mean skip Mono (by detecting a full framework test on Unix).

See https://github.com/GitTools/GitVersion/pull/1759#discussion_r315531632 for discussion.