### PR TITLE
Fixed entrypoint for github actions

### DIFF
--- a/src/Docker/Dockerfile
+++ b/src/Docker/Dockerfile
@@ -8,4 +8,4 @@ ARG contentFolder
 WORKDIR /app
 COPY $contentFolder/ ./
 
-ENTRYPOINT ["dotnet", "GitVersion.dll"]
+ENTRYPOINT ["dotnet", "/app/GitVersion.dll"]


### PR DESCRIPTION
Github actions can take advantage of the GitVersion docker image, but they ignore the working directory, so the entrypoint `["dotnet", "GitVersion.dll"]` fails to load. Pointing to the absolute path for the DLL solves the issue.