### PR TITLE
Properly get project root directory

### DIFF
--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -160,9 +160,12 @@ namespace GitVersion
             }
 
             var dotGetGitDirectory = GetDotGitDirectory();
-            var result = Directory.GetParent(dotGetGitDirectory).FullName;
-            Logger.WriteInfo($"Returning Project Root from DotGitDirectory: {dotGetGitDirectory} - {result}");
-            return result;
+            using (var repo = new Repository(dotGetGitDirectory))
+            {
+                var result = repo.Info.WorkingDirectory;
+                Logger.WriteInfo($"Returning Project Root from DotGitDirectory: {dotGetGitDirectory} - {result}");
+                return result;
+            }
         }
 
         static string CreateDynamicRepository(string targetPath, AuthenticationInfo authentication, string repositoryUrl, string targetBranch, bool noFetch)


### PR DESCRIPTION
This returns the correct workdir when using worktrees where the git
repo resides inside of the main working tree. Partial fix for #1063.