### PR TITLE
Fix several issues related to worktree

### DIFF
--- a/src/GitVersionCore/GitPreparer.cs
+++ b/src/GitVersionCore/GitPreparer.cs
@@ -160,9 +160,12 @@ namespace GitVersion
             }
 
             var dotGetGitDirectory = GetDotGitDirectory();
-            var result = Directory.GetParent(dotGetGitDirectory).FullName;
-            Logger.WriteInfo($"Returning Project Root from DotGitDirectory: {dotGetGitDirectory} - {result}");
-            return result;
+            using (var repo = new Repository(dotGetGitDirectory))
+            {
+                var result = repo.Info.WorkingDirectory;
+                Logger.WriteInfo($"Returning Project Root from DotGitDirectory: {dotGetGitDirectory} - {result}");
+                return result;
+            }
         }
 
         static string CreateDynamicRepository(string targetPath, AuthenticationInfo authentication, string repositoryUrl, string targetBranch, bool noFetch)

--- a/src/GitVersionCore/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/GitVersionCacheKeyFactory.cs
@@ -42,7 +42,7 @@ namespace GitVersion
 
             if (!Directory.Exists(root))
             {
-                throw new ArgumentException();
+                throw new DirectoryNotFoundException($"Root directory does not exist: {root}");
             }
 
             dirs.Push(root);


### PR DESCRIPTION
This PR includes my previous PR (#1792) and generalizes the fix from chuseman (#1759).

Besides fixing the cache key creation when using worktrees it will also fix the location of the GitVersion cache so that the cache directory gets shared between all the worktrees.