### PR TITLE
Add CodeBuild support

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/CodeBuildTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/CodeBuildTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using GitVersion;
+using NUnit.Framework;
+using Shouldly;
+using GitVersion.BuildServers;
+using GitVersion.Common;
+using GitVersion.OutputVariables;
+
+namespace GitVersionCore.Tests.BuildServers
+{
+    [TestFixture]
+    public sealed class CodeBuildTests : TestBase
+    {
+        private IEnvironment environment;
+
+        [SetUp]
+        public void SetUp()
+        {
+            environment = new TestEnvironment();
+        }
+
+        [Test]
+        public void CorrectlyIdentifiesCodeBuildPresence()
+        {
+            environment.SetEnvironmentVariable(CodeBuild.HeadRefEnvironmentName, "a value");
+            var cb = new CodeBuild(environment);
+            cb.CanApplyToCurrentContext().ShouldBe(true);
+        }
+
+        [Test]
+        public void PicksUpBranchNameFromEnvironment()
+        {
+            environment.SetEnvironmentVariable(CodeBuild.HeadRefEnvironmentName, "refs/heads/master");
+            var cb = new CodeBuild(environment);
+            cb.GetCurrentBranch(false).ShouldBe("refs/heads/master");
+        }
+
+        [Test]
+        public void WriteAllVariablesToTheTextWriter()
+        {
+            var assemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var f = Path.Combine(assemblyLocation, "codebuild_this_file_should_be_deleted.properties");
+
+            try
+            {
+                AssertVariablesAreWrittenToFile(f);
+            }
+            finally
+            {
+                File.Delete(f);
+            }
+        }
+
+        private void AssertVariablesAreWrittenToFile(string f)
+        {
+            var writes = new List<string>();
+            var semanticVersion = new SemanticVersion
+            {
+                Major = 1,
+                Minor = 2,
+                Patch = 3,
+                PreReleaseTag = "beta1",
+                BuildMetaData = "5"
+            };
+
+            semanticVersion.BuildMetaData.CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z");
+            semanticVersion.BuildMetaData.Sha = "commitSha";
+
+            var config = new TestEffectiveConfiguration();
+
+            var variables = VariableProvider.GetVariablesFor(semanticVersion, config, false);
+
+            var j = new CodeBuild(environment, f);
+
+            j.WriteIntegration(writes.Add, variables);
+
+            writes[1].ShouldBe("1.2.3-beta.1+5");
+
+            File.Exists(f).ShouldBe(true);
+
+            var props = File.ReadAllText(f);
+
+            props.ShouldContain("GitVersion_Major=1");
+            props.ShouldContain("GitVersion_Minor=2");
+        }
+    }
+}

--- a/src/GitVersionCore/BuildServers/BuildServerList.cs
+++ b/src/GitVersionCore/BuildServers/BuildServerList.cs
@@ -45,7 +45,8 @@ namespace GitVersion.BuildServers
                 new VsoAgent(environment),
                 new TravisCI(environment),
                 new EnvRun(environment),
-                new Drone(environment)
+                new Drone(environment),
+                new CodeBuild(environment)
             };
         }
     }

--- a/src/GitVersionCore/BuildServers/CodeBuild.cs
+++ b/src/GitVersionCore/BuildServers/CodeBuild.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using GitVersion.Common;
+using GitVersion.OutputFormatters;
+using GitVersion.OutputVariables;
+
+namespace GitVersion.BuildServers
+{
+    public sealed class CodeBuild : BuildServerBase
+    {
+        public const string HeadRefEnvironmentName = "CODEBUILD_WEBHOOK_HEAD_REF";
+        private readonly string propertiesFileName;
+
+        public CodeBuild(IEnvironment environment, string propertiesFileName = "gitversion.properties") : base(environment)
+        {
+            this.propertiesFileName = propertiesFileName;
+        }
+
+        protected override string EnvironmentVariable { get; } = HeadRefEnvironmentName;
+
+        public override string GenerateSetVersionMessage(VersionVariables variables)
+        {
+            return variables.FullSemVer;
+        }
+
+        public override string[] GenerateSetParameterMessage(string name, string value)
+        {
+            return new[]
+            {
+                $"GitVersion_{name}={value}"
+            };
+        }
+
+        public override string GetCurrentBranch(bool usingDynamicRepos)
+        {
+            return Environment.GetEnvironmentVariable(HeadRefEnvironmentName);
+        }
+
+        public override void WriteIntegration(Action<string> writer, VersionVariables variables)
+        {
+            base.WriteIntegration(writer, variables);
+            writer($"Outputting variables to '{propertiesFileName}' ... ");
+            File.WriteAllLines(propertiesFileName, BuildOutputFormatter.GenerateBuildLogOutput(this, variables));
+        }
+
+        public override bool PreventFetch() => true;
+    }
+}


### PR DESCRIPTION
Add [CodeBuild ](https://aws.amazon.com/codebuild/) support based on the `CODEBUILD_WEBHOOK_HEAD_REF` environment variable documented [here](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html). It seems like currently, this is the only way to determine the branch name in CodeBuild.

Though the documentation states that `CODEBUILD_SOURCE_VERSION` for `GitHub` can also be 
> branch name, or tag name associated with the version of the source code to be built

this is what an `export` output shows for a build triggered by a GitHub webhook:

```
export CODEBUILD_AGENT_ENDPOINT='http://127.0.0.1:7831'
export CODEBUILD_AUTH_TOKEN='359a05a3-4ca9-4e45-8237-297e076628bf'
export CODEBUILD_BMR_URL='https://CODEBUILD_AGENT:3000'
export CODEBUILD_BUILD_ARN='arn:aws:codebuild:eu-west-1:527837446413:build/DZ-DELETEME:4d2cce79-1e48-4525-bfc4-22c1c0f3088b''
export CODEBUILD_BUILD_ID='DZ-DELETEME:4d2cce79-1e48-4525-bfc4-22c1c0f3088b'
export CODEBUILD_BUILD_IMAGE='aws/codebuild/standard:2.0'
export CODEBUILD_BUILD_SUCCEEDING='1'
export CODEBUILD_BUILD_URL=[REDACTED]
export CODEBUILD_CI='true'
export CODEBUILD_CONTAINER_NAME='default'
export CODEBUILD_EXECUTION_ROLE_BUILD=''
export CODEBUILD_GOPATH='/codebuild/output/src322582804'
export CODEBUILD_INITIATOR='GitHub-Hookshot/951dca1'
export CODEBUILD_KMS_KEY_ID=[REDACTED]
export CODEBUILD_LAST_EXIT='0'
export CODEBUILD_LOG_PATH='9a1704b1-6113-4858-8e28-d19b156c9da3'
export CODEBUILD_PROJECT_UUID='a419f548-3f2a-419b-aff9-becca6830831'
export CODEBUILD_RESOLVED_SOURCE_VERSION='9f74be745a0ea7b2a088581305ac0a2e8c62e173'
export CODEBUILD_SOURCE_REPO_URL='https://github.com/derwasp/somerepo'
export CODEBUILD_SOURCE_VERSION='9f74be745a0ea7b2a088581305ac0a2e8c62e173'
export CODEBUILD_SRC_DIR='/codebuild/output/src322582804/src/github.com/derwasp/somerepo'
export CODEBUILD_START_TIME='1569507961804'
export CODEBUILD_WEBHOOK_ACTOR_ACCOUNT_ID='99999999'
export CODEBUILD_WEBHOOK_EVENT='PUSH'
export CODEBUILD_WEBHOOK_HEAD_REF='refs/heads/feature/testfeature'
export CODEBUILD_WEBHOOK_PREV_COMMIT='0000000000000000000000000000000000000000'
export CODEBUILD_WEBHOOK_TRIGGER='branch/feature/testfeature'
```

Here the branch name is `feature/testfeature` and as it can be seen it's only mentioned in `CODEBUILD_WEBHOOK_HEAD_REF` and `CODEBUILD_WEBHOOK_TRIGGER`.

`CODEBUILD_WEBHOOK_HEAD_REF` seems to be a direct map from [Github's push event's `ref` field](https://developer.github.com/v3/activity/events/types/#events-api-payload-33).

Closes #1771