### PR TITLE
Change the implementation of AzureDevops task.

### DIFF
--- a/build/pack.cake
+++ b/build/pack.cake
@@ -193,7 +193,7 @@ Task("Pack-Vsix")
     var idSuffix    = parameters.IsStableRelease() ? "" : "-preview";
     var titleSuffix = parameters.IsStableRelease() ? "" : " (Preview)";
     var visibility  = parameters.IsStableRelease() ? "Public" : "Preview";
-    var taskId      = parameters.IsStableRelease() ? "e5983830-3f75-11e5-82ed-81492570a08e" : "25b46667-d5a9-4665-97f7-e23de366ecdf";
+    var taskId      = parameters.IsStableRelease() ? "bab30d5c-39f3-49b0-a7db-9a5da6676eaa" : "dd065e3b-6aef-46af-845c-520195836b35";
 
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$idSuffix$", idSuffix);
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$titleSuffix$", titleSuffix);

--- a/build/pack.cake
+++ b/build/pack.cake
@@ -177,20 +177,6 @@ Task("Copy-Files")
     // Commandline
     PublishILRepackedGitVersionExe(false, ilMergeDir, cmdlineDir, parameters);
 
-    // Vsix
-    var vsixPath = new DirectoryPath("./src/GitVersionVsixTask/GitVersionTask");
-
-    var vsixPathFull = vsixPath.Combine("full");
-    EnsureDirectoryExists(vsixPathFull);
-    CopyFileToDirectory(portableDir + "/" + "LibGit2Sharp.dll.config", vsixPathFull);
-    CopyFileToDirectory(portableDir + "/" + "GitVersion.exe", vsixPathFull);
-    CopyDirectory(portableDir.Combine("lib"), vsixPathFull.Combine("lib"));
-
-    // Vsix dotnet core
-    var vsixPathCore = vsixPath.Combine("core");
-    EnsureDirectoryExists(vsixPathCore);
-    CopyDirectory(coreFxDir, vsixPathCore);
-
     // Ruby Gem
     var gemPath = new DirectoryPath("./src/GitVersionRubyGem/bin");
     EnsureDirectoryExists(gemPath);
@@ -200,7 +186,7 @@ Task("Copy-Files")
 });
 
 Task("Pack-Vsix")
-    .IsDependentOn("Copy-Files")
+    .IsDependentOn("Test")
     .Does<BuildParameters>((parameters) =>
 {
     var workDir = "./src/GitVersionVsixTask";

--- a/build/utils/paths.cake
+++ b/build/utils/paths.cake
@@ -43,7 +43,7 @@ public class BuildPaths
         var gemOutputFilePath  = buildArtifactDir.CombineWithFilePath("gitversion-" + version.GemVersion + ".gem");
 
         var vsixSuffix = parameters.IsStableRelease() ? "" : "preview-";
-        var vsixOutputFilePath = buildArtifactDir.CombineWithFilePath("gittools.gitversion-" + vsixSuffix + version.VsixVersion + ".vsix");
+        var vsixOutputFilePath = buildArtifactDir.CombineWithFilePath("gittools.usegitversion-" + vsixSuffix + version.VsixVersion + ".vsix");
 
         // Directories
         var buildDirectories = new BuildDirectories(

--- a/src/GitVersionVsixTask/GitVersion.ts
+++ b/src/GitVersionVsixTask/GitVersion.ts
@@ -1,26 +1,31 @@
 import * as path from 'path';
-import * as os from 'os';
 
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from 'azure-pipelines-task-lib/toolrunner';
 
+import { ToolInstaller } from './ToolInstaller';
+
 export class GitVersionTask {
     execOptions: tr.IExecOptions;
 
-    preferBundledVersion: boolean;
+    versionSpec: string;
+    includePrerelease: boolean;
+    targetPath: string;
+
     useConfigFile: boolean;
     configFilePath: string;
-    updateAssemblyInfo: boolean;
 
+    updateAssemblyInfo: boolean;
     updateAssemblyInfoFilename: string;
+
     additionalArguments: string;
-    targetPath: string;
+
     sourcesDirectory: string;
-    gitVersionPath: string;
-    runtime: string;
 
     constructor() {
 
+        this.versionSpec                = tl.getInput('versionSpec', true);
+        this.includePrerelease          = tl.getBoolInput('includePrerelease');
         this.targetPath                 = tl.getInput('targetPath');
 
         this.useConfigFile              = tl.getBoolInput('useConfigFile');
@@ -28,10 +33,6 @@ export class GitVersionTask {
 
         this.updateAssemblyInfo         = tl.getBoolInput('updateAssemblyInfo');
         this.updateAssemblyInfoFilename = tl.getInput('updateAssemblyInfoFilename');
-
-        this.preferBundledVersion       = tl.getBoolInput('preferBundledVersion');
-        this.runtime                    = tl.getInput('runtime') || 'core';
-        this.gitVersionPath             = tl.getInput('gitVersionPath');
 
         this.additionalArguments        = tl.getInput('additionalArguments');
 
@@ -51,8 +52,10 @@ export class GitVersionTask {
 
     public async execute() {
         try {
+            let toolPath = await this.installTool(this.versionSpec, this.includePrerelease);
+
             let workingDirectory = this.getWorkingDirectory(this.targetPath);
-            let exe = this.getExecutable();
+            let exe = tl.tool('dotnet-gitversion');
             exe.arg([
                 workingDirectory,
                 "/output",
@@ -95,48 +98,14 @@ export class GitVersionTask {
         }
     }
 
-    public getExecutable(){
-        let exe: tr.ToolRunner;
-
-        switch (this.runtime) {
-            case "full":
-                const isWin32 = os.platform() == "win32";
-                let exePath = this.getExecutablePath("GitVersion.exe") || tl.which("GitVersion.exe", true);
-                if (isWin32) {
-                    exe = tl.tool(exePath);
-                } else {
-                    exe = tl.tool("mono");
-                    exe.arg(exePath);
-                }
-                break;
-            case "core":
-                let assemblyPath = this.getExecutablePath("GitVersion.dll");
-                let dotnetPath = tl.which("dotnet", true);
-                exe = tl.tool(dotnetPath);
-                exe.arg(assemblyPath);
-                break;
+    async installTool(version: string, includePrerelease: boolean) : Promise<string> {
+        let installTool = tl.getVariable("INSTALL_TOOL");
+        if (installTool === null || installTool === undefined || installTool.toUpperCase() == "TRUE") {
+            return await new ToolInstaller().downloadAndInstall("GitVersion.Tool", version, false, includePrerelease);
         }
-
-        return exe;
     }
 
-    public getExecutablePath(exeName:string) {
-        let exePath;
-        if (this.preferBundledVersion) {
-            let currentDirectory = __dirname;
-            exePath = path.join(currentDirectory, this.runtime, exeName);
-        } else {
-            if (tl.filePathSupplied('gitVersionPath') && tl.exist(this.gitVersionPath) && tl.stats(this.gitVersionPath).isFile()) {
-                exePath = this.gitVersionPath;
-            } else{
-                throw new Error('GitVersion executable not found at ' + this.gitVersionPath);
-            }
-        }
-
-        return exePath.replace(/\\/g, '/');
-    }
-
-    public getWorkingDirectory(targetPath: string) {
+    getWorkingDirectory(targetPath: string) {
         let workDir;
 
         if (!targetPath){

--- a/src/GitVersionVsixTask/GitVersionTask/task.json
+++ b/src/GitVersionVsixTask/GitVersionTask/task.json
@@ -8,48 +8,47 @@
     "category": "Build",
     "demands": [],
     "version": {
-        "Major": "4",
+        "Major": "5",
         "Minor": "0",
-        "Patch": "0"
+        "Patch": "2"
     },
     "minimumAgentVersion": "2.115.0",
     "groups": [{
-        "name": "gitversionDetails",
-        "displayName": "GitVersion details",
-        "isExpanded": true,
-        "visibleRule": "preferBundledVersion = false"
-    }, {
-        "name": "additional",
-        "displayName": "Additional Options",
-        "isExpanded": false
-    }],
+            "name": "gitversionDetails",
+            "displayName": "GitVersion details",
+            "isExpanded": true
+        },
+        {
+            "name": "additional",
+            "displayName": "Additional Options",
+            "isExpanded": false
+        }
+    ],
     "instanceNameFormat": "GitVersion",
     "inputs": [{
-            "name": "runtime",
-            "type": "radio",
-            "label": "Runtime",
-            "defaultValue": "core",
-            "required": true,
-            "options": {
-                "core": "dotnet core",
-                "full": "dotnet fullframework (or mono)"
-            },
-            "helpMarkDown": "Specify the runtime used for running the tool"
-        }, {
-            "name": "preferBundledVersion",
-            "type": "boolean",
-            "label": "Prefer bundled GitVersion",
-            "defaultValue": "true",
-            "required": false,
-            "helpMarkDown": "If checked it will prefer the bundled version over a version found in path"
-        }, {
-            "name": "gitVersionPath",
+            "name": "versionSpec",
             "type": "string",
-            "label": "Path to GitVersion",
+            "label": "The version spec",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Required version in the form of 5.x or exact version like 5.0.0"
+        },
+        {
+            "name": "includePrerelease",
+            "type": "boolean",
+            "label": "Include pre-release versions",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Include pre-release versions when matching a version"
+        },
+        {
+            "name": "targetPath",
+            "type": "string",
+            "label": "Working directory path",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Optionally supply the path to GitVersion",
-            "visibleRule": "preferBundledVersion = true"
+            "helpMarkDown": "Optionally supply the path to the working directory",
+            "groupName": "gitversionDetails"
         },
         {
             "name": "useConfigFile",
@@ -58,7 +57,8 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Whether to use a custom configuration file"
-        }, {
+        },
+        {
             "name": "configFilePath",
             "type": "filePath",
             "label": "Configuration file",
@@ -66,14 +66,16 @@
             "required": false,
             "helpMarkDown": "Optional path to config file (defaults to GitVersion.yml)",
             "visibleRule": "useConfigFile = true"
-        }, {
+        },
+        {
             "name": "updateAssemblyInfo",
             "type": "boolean",
             "label": "Update AssemblyInfo files",
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Whether to update versions in the AssemblyInfo files"
-        }, {
+        },
+        {
             "name": "updateAssemblyInfoFilename",
             "type": "string",
             "label": "Update Assembly File",
@@ -81,15 +83,8 @@
             "required": false,
             "helpMarkDown": "Update versions in specified file",
             "visibleRule": "updateAssemblyInfo = true"
-        }, {
-            "name": "targetPath",
-            "type": "string",
-            "label": "Working directory path",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Optionally supply the path to the working directory",
-            "groupName": "gitversionDetails"
-        }, {
+        },
+        {
             "name": "additionalArguments",
             "type": "string",
             "label": "Additional GitVersion arguments",

--- a/src/GitVersionVsixTask/GitVersionTask/task.json
+++ b/src/GitVersionVsixTask/GitVersionTask/task.json
@@ -1,6 +1,6 @@
 {
-    "id": "e5983830-3f75-11e5-82ed-81492570a08e",
-    "name": "GitVersion",
+    "id": "dd065e3b-6aef-46af-845c-520195836b35",
+    "name": "UseGitVersion",
     "friendlyName": "GitVersion Task",
     "description": "Easy Semantic Versioning (http://semver.org) for projects using Git",
     "author": "GitVersion Contributors",
@@ -13,7 +13,8 @@
         "Patch": "2"
     },
     "minimumAgentVersion": "2.115.0",
-    "groups": [{
+    "groups": [
+        {
             "name": "gitversionDetails",
             "displayName": "GitVersion details",
             "isExpanded": true
@@ -25,7 +26,8 @@
         }
     ],
     "instanceNameFormat": "GitVersion",
-    "inputs": [{
+    "inputs": [
+        {
             "name": "versionSpec",
             "type": "string",
             "label": "The version spec",

--- a/src/GitVersionVsixTask/ToolInstaller.ts
+++ b/src/GitVersionVsixTask/ToolInstaller.ts
@@ -1,0 +1,133 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+import * as httpm from 'typed-rest-client/HttpClient';
+
+import * as im from 'azure-pipelines-task-lib/internal';
+import * as toolLib from 'azure-pipelines-tool-lib/tool';
+import * as taskLib from 'azure-pipelines-task-lib/task';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+
+export class ToolInstaller {
+    constructor() {
+        this.httpClient = new httpm.HttpClient("ToolInstaller");
+    }
+
+    public async downloadAndInstall(toolName: string, versionSpec: string, checkLatest: boolean, includePrerelease: boolean): Promise<string> {
+        console.log('');
+        console.log('--------------------------');
+        console.log(`Installing ${toolName} version ` + versionSpec);
+        console.log('--------------------------');
+
+        if (toolLib.isExplicitVersion(versionSpec)) {
+            checkLatest = false; // check latest doesn't make sense when explicit version
+        }
+
+        let toolPath: string;
+        if (!checkLatest) {
+            //
+            // Let's try and resolve the version spec locally first
+            //
+            toolPath = toolLib.findLocalTool(toolName, versionSpec);
+        }
+
+        if (!toolPath) {
+            let version: string;
+            if (toolLib.isExplicitVersion(versionSpec)) {
+                //
+                // Explicit version was specified. No need to query for list of versions.
+                //
+                version = versionSpec;
+            }
+            else {
+                //
+                // Let's query and resolve the latest version for the versionSpec.
+                // If the version is an explicit version (1.1.1 or v1.1.1) then no need to query.
+                // If your tool doesn't offer a mechanism to query,
+                // then it can only support exact version inputs.
+                //
+                version = await this.queryLatestMatch(toolName, versionSpec, includePrerelease);
+                if (!version) {
+                    throw new Error(`Unable to find ${toolName} version '${versionSpec}'.`);
+                }
+
+                //
+                // Check the cache for the resolved version.
+                //
+                toolPath = toolLib.findLocalTool(toolName, version)
+            }
+            if (!toolPath) {
+                //
+                // Download, extract, cache
+                //
+                toolPath = await this.acquireTool(toolName, version);
+            }
+        }
+
+        //
+        // Prepend the tools path. This prepends the PATH for the current process and
+        // instructs the agent to prepend for each task that follows.
+        //
+        taskLib.debug(`toolPath: ${toolPath}`);
+
+        if (os.platform() != 'win32') {
+            let dotnetRoot = path.dirname(fs.readlinkSync(im._which("dotnet")));
+            taskLib.setVariable('DOTNET_ROOT', dotnetRoot);
+        }
+        toolLib.prependPath(toolPath);
+
+        return toolPath;
+    }
+
+    private async queryLatestMatch(toolName: string, versionSpec: string, includePrerelease: boolean): Promise<string> {
+        taskLib.debug(`querying tool versions for ${toolName}${versionSpec ? `@${versionSpec}` : ""} ${includePrerelease ? "including pre-releases" : ""}`);
+
+        var downloadPath = `https://api-v2v3search-0.nuget.org/query?q=${encodeURIComponent(toolName.toLowerCase())}&prerelease=${includePrerelease ? "true" : "false"}&semVerLevel=2.0.0`;
+        var res = await this.httpClient.get(downloadPath);
+
+        if (!res || res.message.statusCode != 200)
+        {
+            return null;
+        }
+
+        let body: string = await res.readBody();
+        var data = JSON.parse(body).data;
+
+        const versions = (<Array<{ version: string }>>data[0].versions).map(x => x.version);
+        if (!versions || !versions.length)
+        {
+            return null;
+        }
+
+        taskLib.debug(`got versions: ${versions.join(", ")}`);
+
+        return toolLib.evaluateVersions(versions, versionSpec);
+    }
+
+    private async acquireTool(toolName: string, version: string): Promise<string> {
+        let tr: ToolRunner = taskLib.tool("dotnet");
+
+        let tempDirectory = taskLib.getVariable('Agent.TempDirectory');
+        let args = ["tool", "install", toolName, "--tool-path", tempDirectory];
+
+        if (version) {
+            version = toolLib.cleanVersion(version);
+            args = args.concat(["--version", version]);
+        }
+
+        tr.arg(args);
+
+        var result = tr.execSync();
+
+        taskLib.debug(`tool install result: ${result.code === 0 ? "success" : "failure"} ${result.error ? result.error.message : ""}`)
+
+        if (result.code) {
+            throw new Error("Error installing tool");
+        }
+
+        return await toolLib.cacheDir(tempDirectory, toolName, version);
+    }
+
+    private httpClient: httpm.HttpClient;
+}

--- a/src/GitVersionVsixTask/package-lock.json
+++ b/src/GitVersionVsixTask/package-lock.json
@@ -11,16 +11,28 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.7.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-            "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
-            "dev": true
+            "version": "12.7.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+            "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw=="
         },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
+        },
+        "@types/semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+        },
+        "@types/uuid": {
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
+            "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "ansi-colors": {
             "version": "3.2.3",
@@ -126,6 +138,20 @@
                 "q": "^1.1.2",
                 "semver": "^5.1.0",
                 "shelljs": "^0.3.0",
+                "uuid": "^3.0.1"
+            }
+        },
+        "azure-pipelines-tool-lib": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+            "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
+            "requires": {
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.0.1",
+                "azure-pipelines-task-lib": "^2.8.0",
+                "semver": "^5.3.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "1.0.9",
                 "uuid": "^3.0.1"
             }
         },
@@ -758,9 +784,9 @@
             "dev": true
         },
         "is-buffer": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+            "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
             "dev": true
         },
         "is-callable": {
@@ -1126,9 +1152,9 @@
             }
         },
         "mocha": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
-            "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.1.tgz",
+            "integrity": "sha512-VCcWkLHwk79NYQc8cxhkmI8IigTIhsCwZ6RTxQsqK6go4UvEhzJkYuHm8B2YtlSxcYq2fY+ucr4JBwoD6ci80A==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -1151,9 +1177,9 @@
                 "supports-color": "6.0.0",
                 "which": "1.3.1",
                 "wide-align": "1.1.3",
-                "yargs": "13.2.2",
-                "yargs-parser": "13.0.0",
-                "yargs-unparser": "1.5.0"
+                "yargs": "13.3.0",
+                "yargs-parser": "13.1.1",
+                "yargs-unparser": "1.6.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1161,6 +1187,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
                 },
                 "get-caller-file": {
                     "version": "2.0.5",
@@ -1208,29 +1245,39 @@
                         "ansi-regex": "^4.1.0"
                     }
                 },
-                "yargs": {
-                    "version": "13.2.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-                    "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+                    "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
                         "find-up": "^3.0.0",
                         "get-caller-file": "^2.0.1",
-                        "os-locale": "^3.1.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^2.0.0",
                         "set-blocking": "^2.0.0",
                         "string-width": "^3.0.0",
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
-                        "yargs-parser": "^13.0.0"
+                        "yargs-parser": "^13.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "13.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-                    "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+                    "version": "13.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+                    "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
@@ -1734,6 +1781,11 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -1987,13 +2039,28 @@
         "tunnel": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-            "dev": true
+            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+        },
+        "typed-rest-client": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+            "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+            "requires": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                }
+            }
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
             "dev": true
         },
         "underscore": {
@@ -2279,14 +2346,110 @@
             }
         },
         "yargs-unparser": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-            "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
             "dev": true,
             "requires": {
                 "flat": "^4.1.0",
-                "lodash": "^4.17.11",
-                "yargs": "^12.0.5"
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+                    "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+                    "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
             }
         },
         "zip-stream": {

--- a/src/GitVersionVsixTask/package.json
+++ b/src/GitVersionVsixTask/package.json
@@ -12,16 +12,17 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "azure-pipelines-task-lib": "2.8.0"
+        "azure-pipelines-task-lib": "2.8.0",
+        "azure-pipelines-tool-lib": "0.12.0"
     },
     "devDependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "12.7.2",
+        "@types/node": "12.7.11",
         "@types/q": "1.5.2",
         "copy-node-modules": "^1.1.1",
-        "mocha": "^6.2.0",
+        "mocha": "^6.2.1",
         "mocha-xunit-reporter": "^1.1.0",
         "tfx-cli": "0.6.3",
-        "typescript": "^3.5.3"
+        "typescript": "^3.6.3"
     }
 }

--- a/src/GitVersionVsixTask/tests/test-shared.ts
+++ b/src/GitVersionVsixTask/tests/test-shared.ts
@@ -1,13 +1,12 @@
 export let TestEnvVars = {
-    preferBundledVersion: "__preferBundledVersion__",
+    versionSpec: "__versionSpec__",
+    includePrerelease: "__includePrerelease__",
+    targetPath: "__targetPath__",
     useConfigFile: "__useConfigFile__",
     configFilePath: "__configFilePath__",
     updateAssemblyInfo: "__updateAssemblyInfo__",
     updateAssemblyInfoFilename: "__updateAssemblyInfoFilename__",
-    additionalArguments: "__additionalArguments__",
-    targetPath: "__targetPath__",
-    runtime: "__runtime__",
-    gitVersionPath: "__gitVersionPath__",
+    additionalArguments: "__additionalArguments__"
 }
 
 export let SharedValues = {

--- a/src/GitVersionVsixTask/tests/test-suite.ts
+++ b/src/GitVersionVsixTask/tests/test-suite.ts
@@ -17,20 +17,15 @@ function runValidations(validator: () => void, tr: ttm.MockTestRunner, done: Moc
     }
 }
 
-let taskDir = path.join(__dirname, '..', 'GitVersionTask').replace(/\\/g, '/');
-
 describe('GitVersion Vsix Task tests', function () {
 
     beforeEach(() => {
-        delete process.env[shared.TestEnvVars.preferBundledVersion];
         delete process.env[shared.TestEnvVars.useConfigFile];
         delete process.env[shared.TestEnvVars.configFilePath];
         delete process.env[shared.TestEnvVars.updateAssemblyInfo];
         delete process.env[shared.TestEnvVars.updateAssemblyInfoFilename];
         delete process.env[shared.TestEnvVars.additionalArguments];
         delete process.env[shared.TestEnvVars.targetPath];
-        delete process.env[shared.TestEnvVars.runtime];
-        delete process.env[shared.TestEnvVars.gitVersionPath];
     });
 
     after(() => {
@@ -52,34 +47,9 @@ describe('GitVersion Vsix Task tests', function () {
             assert(tr.errorIssues.length == 0, "should have no errors");
             assert(tr.stderr.length == 0, 'should not have written to stderr');
             assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-            assert(tr.ran("dotnet " + taskDir + "/core/GitVersion.dll /user/build /output buildserver /nofetch"));
+            assert(tr.ran("dotnet-gitversion /user/build /output buildserver /nofetch"));
 
             assert(tr.stdOutContained('GitVersion run successfully with defaults'), "should display 'GitVersion run successfully with defaults'");
-
-        }, tr, done);
-    });
-
-    it('Succeeds: Runs GitVersion default configurations', function (done: MochaDone) {
-        this.timeout(1000);
-        process.env[shared.TestEnvVars.runtime] = 'full';
-
-        let tp = path.join(__dirname, 'test-setup.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-
-        runValidations(() => {
-
-            assert(tr.succeeded, 'should have succeeded');
-            assert(tr.warningIssues.length == 0, "should have no warnings");
-            assert(tr.errorIssues.length == 0, "should have no errors");
-            assert(tr.stderr.length == 0, 'should not have written to stderr');
-            assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-
-            var exec = os.platform() != 'win32' ? "mono " : "";
-            assert(tr.ran(exec + taskDir + "/full/GitVersion.exe /user/build /output buildserver /nofetch"));
-
-            assert(tr.stdOutContained('GitVersion.exe run successfully with defaults'), "should display 'GitVersion.exe run successfully with defaults'");
 
         }, tr, done);
     });
@@ -124,7 +94,7 @@ describe('GitVersion Vsix Task tests', function () {
             assert(tr.errorIssues.length == 0, "should have no errors");
             assert(tr.stderr.length == 0, 'should not have written to stderr');
             assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-            assert(tr.ran("dotnet " + taskDir + "/core/GitVersion.dll /user/build/src /output buildserver /nofetch"));
+            assert(tr.ran("dotnet-gitversion /user/build/src /output buildserver /nofetch"));
 
             assert(tr.stdOutContained('GitVersion run successfully with custom targetPath'), "should display 'GitVersion run successfully with custom targetPath'");
 
@@ -196,7 +166,7 @@ describe('GitVersion Vsix Task tests', function () {
             assert(tr.errorIssues.length == 0, "should have no error");
             assert(tr.stderr.length == 0, 'should not have written to stderr');
             assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-            assert(tr.ran("dotnet " + taskDir + "/core/GitVersion.dll /user/build /output buildserver /nofetch /config customConfig.yml"));
+            assert(tr.ran("dotnet-gitversion /user/build /output buildserver /nofetch /config customConfig.yml"));
 
             assert(tr.stdOutContained('GitVersion run successfully with custom config'), "should display 'GitVersion run successfully with custom config'");
 
@@ -268,82 +238,10 @@ describe('GitVersion Vsix Task tests', function () {
             assert(tr.errorIssues.length == 0, "should have no errors");
             assert(tr.stderr.length == 0, 'should not have written to stderr');
             assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-            assert(tr.ran("dotnet " + taskDir + "/core/GitVersion.dll /user/build /output buildserver /nofetch /updateassemblyinfo GlobalAssemblyInfo.cs"));
+            assert(tr.ran("dotnet-gitversion /user/build /output buildserver /nofetch /updateassemblyinfo GlobalAssemblyInfo.cs"));
 
             assert(tr.stdOutContained('GitVersion run successfully with custom assembly info'), "should display 'GitVersion run successfully with custom  assembly info'");
 
         }, tr, done);
     });
-
-    it('Fails: Runs GitVersion with no custom executable', function (done: MochaDone) {
-        this.timeout(1000);
-
-        process.env[shared.TestEnvVars.preferBundledVersion] = 'false';
-
-        let tp = path.join(__dirname, 'test-setup.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-
-        runValidations(() => {
-
-            assert(tr.failed, 'should have failed');
-            assert(tr.warningIssues.length == 0, "should have no warnings");
-            assert(tr.errorIssues.length == 1, "should have thrown an error");
-            assert(tr.stderr.length == 0, 'should not have written to stderr');
-            assert(tr.invokedToolCount == 0, 'should not have invoked tool. actual: ' + tr.invokedToolCount);
-
-            assert(tr.stdOutContained('GitVersion executable not found'), "should display 'GitVersion executable not found'");
-
-        }, tr, done);
-    });
-
-    it('Fails: Runs GitVersion with wrong custom executable', function (done: MochaDone) {
-        this.timeout(1000);
-
-        process.env[shared.TestEnvVars.preferBundledVersion] = 'false';
-        process.env[shared.TestEnvVars.gitVersionPath] = 'wrongGitversion.dll';
-
-        let tp = path.join(__dirname, 'test-setup.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-
-        runValidations(() => {
-
-            assert(tr.failed, 'should have failed');
-            assert(tr.warningIssues.length == 0, "should have no warnings");
-            assert(tr.errorIssues.length == 1, "should have thrown an error");
-            assert(tr.stderr.length == 0, 'should not have written to stderr');
-            assert(tr.invokedToolCount == 0, 'should not have invoked tool. actual: ' + tr.invokedToolCount);
-
-            assert(tr.stdOutContained('GitVersion executable not found'), "should display 'GitVersion executable not found'");
-
-        }, tr, done);
-    });
-
-    it('Succeeds: Runs GitVersion with correct custom executable', function (done: MochaDone) {
-        this.timeout(1000);
-
-        process.env[shared.TestEnvVars.preferBundledVersion] = 'false';
-        process.env[shared.TestEnvVars.gitVersionPath] = 'TestGitversion.dll';
-
-        let tp = path.join(__dirname, 'test-setup.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-
-        runValidations(() => {
-
-            assert(tr.succeeded, 'should have succeeded');
-            assert(tr.warningIssues.length == 0, "should have no warnings");
-            assert(tr.errorIssues.length == 0, "should have no errors");
-            assert(tr.stderr.length == 0, 'should not have written to stderr');
-            assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
-            assert(tr.ran("dotnet TestGitversion.dll /user/build /output buildserver /nofetch"));
-
-            assert(tr.stdOutContained('GitVersion run successfully with custom exe'), "should display 'GitVersion run successfully with custom exe'");
-        }, tr, done);
-    });
-
 });

--- a/src/GitVersionVsixTask/vss-extension.json
+++ b/src/GitVersionVsixTask/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
-    "id": "gitversion$idSuffix$",
-    "name": "GitVersion$titleSuffix$",
+    "id": "usegitversion$idSuffix$",
+    "name": "UseGitVersion$titleSuffix$",
     "publisher": "gittools",
     "public": true,
     "author": "GitVersion Contributors",


### PR DESCRIPTION
Change the implementation of AzureDevops task. Instead of embedding the executables, installing GitVersion.Tool with a versionSpec

``` yaml
  - task: UseGitVersion@5
    inputs:
      versionSpec: '>5.0.2-beta1'
      includePrerelease: true
```

This way we can install different versions of the Gitversion by either specifying the exact version, or a semver range. You can have a look here on the versionSpec

https://semver.npmjs.com/