### PR TITLE
add support for custom merge messages without 'TargetBranch' capture group

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,8 +193,10 @@ merge-message-formats:
 
 The regular expression should contain the following capture groups:
 + SourceBranch - Identifies the source branch of the merge
-+ TargetBranch - Identifies the target of the merge
++ TargetBranch - Identifies the target of the merge (optional)
 + PullRequestNumber - Captures the pull-request number
+
+If regular expression doesn't contain TargetBranch then for matched messages current branch will be used.
 
 Custom merge message formats are evalauted _before_ any built in formats.
 

--- a/src/GitVersionCore/MergeMessage.cs
+++ b/src/GitVersionCore/MergeMessage.cs
@@ -17,7 +17,7 @@ namespace GitVersion
             new MergeMessageFormat("RemoteTracking", @"^Merge remote-tracking branch '(?<SourceBranch>[^\s]*)'(?: into (?<TargetBranch>[^\s]*))*")
         };
 
-        public MergeMessage(string mergeMessage, Config config)
+        public MergeMessage(string mergeMessage, Config config, string currentBranch = default)
         {
             if (mergeMessage == null)
                 throw new NullReferenceException();
@@ -36,9 +36,14 @@ namespace GitVersion
                     FormatName = format.Name;
                     MergedBranch = match.Groups["SourceBranch"].Value;
 
-                    if (match.Groups["TargetBranch"].Success)
+                    var containsTargetBranchGroup = format.Pattern.GetGroupNames().Contains("TargetBranch");
+                    if (containsTargetBranchGroup && match.Groups["TargetBranch"].Success)
                     {
                         TargetBranch = match.Groups["TargetBranch"].Value;
+                    }
+                    else
+                    {
+                        TargetBranch = currentBranch;
                     }
 
                     if (int.TryParse(match.Groups["PullRequestNumber"].Value, out var pullNumber))

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -51,7 +51,7 @@ namespace GitVersion.VersionCalculation.BaseVersionCalculators
                 return null;
             }
 
-            var mergeMessage = new MergeMessage(mergeCommit.Message, context.FullConfiguration);
+            var mergeMessage = new MergeMessage(mergeCommit.Message, context.FullConfiguration, context.CurrentBranch.FriendlyName);
             return mergeMessage;
         }
 

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -269,7 +269,7 @@ namespace GitVersion.VersionCalculation
         {
             if (mergeCommit != null)
             {
-                var mergeMessage = new MergeMessage(mergeCommit.Message, context.FullConfiguration);
+                var mergeMessage = new MergeMessage(mergeCommit.Message, context.FullConfiguration, context.CurrentBranch.FriendlyName);
                 if (mergeMessage.MergedBranch != null)
                 {
                     var config = context.FullConfiguration.GetConfigForBranch(mergeMessage.MergedBranch);


### PR DESCRIPTION
Hello. There is small issue, that doesn't allow to use GV in bitbucket cloud repositories. Bitbucket provides following merge message format for pull requests: "Merged in feature/one (pull request #N)". This message doesn't match the requirements for custom branches because doesn't contain TargetBranch 
> The regular expression should contain the following capture groups:
>     SourceBranch - Identifies the source branch of the merge
>     TargetBranch - Identifies the target of the merge
>     PullRequestNumber - Captures the pull-request number

I passed current branch name to mergeMessage processor to get it if message regex doesn't contain Target branch.
I tested it on Bitbucket project and it works good.