### PR TITLE
Add the xml namespace to work with MSBuild v14

### DIFF
--- a/src/GitVersionTask/build/GitVersionTask.props
+++ b/src/GitVersionTask/build/GitVersionTask.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <GitVersionAssemblyFile Condition="$(GitVersionAssemblyFile) == '' And '$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>
         <GitVersionAssemblyFile Condition="$(GitVersionAssemblyFile) == '' And '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netstandard2.0\GitVersionTask.MsBuild.dll</GitVersionAssemblyFile>

--- a/src/GitVersionTask/build/GitVersionTask.targets
+++ b/src/GitVersionTask/build/GitVersionTask.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <UsingTask TaskName="GetVersion" AssemblyFile="$(GitVersionAssemblyFile)"/>
     <UsingTask TaskName="GenerateGitVersionInformation" AssemblyFile="$(GitVersionAssemblyFile)"/>
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)" />

--- a/src/GitVersionTask/buildMultiTargeting/GitVersionTask.props
+++ b/src/GitVersionTask/buildMultiTargeting/GitVersionTask.props
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)..\build\$(MSBuildThisFile)"/>
 </Project>

--- a/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <UsingTask TaskName="GetVersion" AssemblyFile="$(GitVersionAssemblyFile)"/>
     <UsingTask TaskName="WriteVersionInfoToBuildLog" AssemblyFile="$(GitVersionAssemblyFile)" />
 


### PR DESCRIPTION
This fixes #1823.

Tests have been done with with MSBuild-14, MSBuild-15.8 and NetSdk-2.2 (aka MSBuild-15.9).
MSBuild-15 works without this patch, but MSBuild-14 seems to require the namespace, otherwise you'll encounter the following error:
```
C:\...\GitVersionTask.props(2,1): error MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="http://schemas.microsoft.com/developer/msbuild/2003" to the <Project> element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format. [C:\...\MyProject.csproj]
```