### PR TITLE
adds Preview suffix to VSIX task name when appropriate

### DIFF
--- a/build/pack.cake
+++ b/build/pack.cake
@@ -211,6 +211,7 @@ Task("Pack-Vsix")
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$idSuffix$", idSuffix);
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$titleSuffix$", titleSuffix);
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$visibility$", visibility);
+    ReplaceTextInFile(new FilePath(workDir + "/GitVersionTask/task.json"), "$titleSuffix$", titleSuffix);
 
     // update version number
     ReplaceTextInFile(new FilePath(workDir + "/vss-extension.json"), "$version$", parameters.Version.VsixVersion);

--- a/src/GitVersionVsixTask/GitVersionTask/task.json
+++ b/src/GitVersionVsixTask/GitVersionTask/task.json
@@ -1,7 +1,7 @@
 {
     "id": "dd065e3b-6aef-46af-845c-520195836b35",
     "name": "UseGitVersion",
-    "friendlyName": "GitVersion Task",
+    "friendlyName": "GitVersion Task$titleSuffix$",
     "description": "Easy Semantic Versioning (http://semver.org) for projects using Git",
     "author": "GitVersion Contributors",
     "helpMarkDown": "See the [documentation](http://gitversion.readthedocs.org/en/latest/) for help",


### PR DESCRIPTION
Currently the GitVersion tasks from the release and the preview extension are named "GitVersion Task". If both extensions are installed, you cannot distinguish them by name.

This PR adds a " (Preview)" suffix to the task's displayname, just like it's already done for the extension itself.