### PR TITLE
Don't try to format non-format strings.

### DIFF
--- a/src/GitVersionCore.Tests/Logging/LoggingTests.cs
+++ b/src/GitVersionCore.Tests/Logging/LoggingTests.cs
@@ -1,0 +1,17 @@
+using GitVersion.Logging;
+using NUnit.Framework;
+
+namespace GitVersionCore.Tests.Logging
+{
+    [TestFixture]
+    public class LoggingTests
+    {
+        [Test]
+        public void CanLogNonFormatStrings()
+        {
+            var log = new Log();
+
+            log.Info("Logging using git revision syntax eg. 1.0.0.0^{} shouldn't throw");
+        }
+    }
+}

--- a/src/GitVersionCore/Logging/Log.cs
+++ b/src/GitVersionCore/Logging/Log.cs
@@ -16,7 +16,6 @@ namespace GitVersion.Logging
 
         public Log(): this(Array.Empty<ILogAppender>())
         {
-            
         }
 
         public Log(params ILogAppender[] appenders)
@@ -35,7 +34,8 @@ namespace GitVersion.Logging
                 return;
             }
 
-            var formattedString = FormatMessage(string.Format(format, args), level.ToString().ToUpperInvariant());
+            var message = args.Any() ? string.Format(format, args) : format;
+            var formattedString = FormatMessage(message, level.ToString().ToUpperInvariant());
             foreach (var appender in appenders)
             {
                 appender.WriteTo(level, formattedString);


### PR DESCRIPTION
Many consumers are doing a `log.Info("somestring")` and have no desire to trigger formatstring behavior.  This change allows them to use `{` or `}` without running into formatting exceptions.

Fixes https://github.com/GitTools/GitVersion/issues/1875 - This was triggered by attempts to log remote tips using the `<rev>^{}` revision syntax.


