### PR TITLE
Change default increment strategy for release branches to None instead of Patch

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -41,7 +41,7 @@ branches:
   release:
     mode: ContinuousDelivery
     tag: beta
-    increment: Patch
+    increment: None
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     regex: ^releases?[/-]

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -50,7 +50,7 @@ namespace GitVersion.Configuration
                     { "develop", "master", "support", "release" },
                 defaultTag: "beta",
                 defaultPreventIncrement: true,
-                defaultIncrementStrategy: IncrementStrategy.Patch,
+                defaultIncrementStrategy: IncrementStrategy.None,
                 isReleaseBranch: true);
             ApplyBranchDefaults(config, GetOrCreateBranchDefaults(config, Config.FeatureBranchKey), Config.FeatureBranchRegex,
                 new List<string>

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -135,6 +135,11 @@ namespace GitVersion.VersionCalculation
         {
             public SemanticVersion IncrementedVersion { get; set; }
             public BaseVersion Version { get; set; }
+
+            public override string ToString()
+            {
+                return $"{Version} | {IncrementedVersion}";
+            }
         }
     }
 }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -69,6 +69,11 @@ namespace GitVersion.VersionCalculation.BaseVersionCalculators
                 Commit = commit;
                 SemVer = semVer;
             }
+
+            public override string ToString()
+            {
+                return $"{Tag} | {Commit} | {SemVer}";
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1897 