### PR TITLE
(build) Bump version of Cake.DotNetTool.Module

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 // Install modules
-#module nuget:?package=Cake.DotNetTool.Module&version=0.3.1
+#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 
 // Install addins.
 #addin "nuget:?package=Cake.Codecov&version=0.7.0"


### PR DESCRIPTION
This has been updated to allow better handling of scenarios when the 
requested version of a Module differs from what is installed.  The module
will now first uninstall the current version, and then install the requested
version.