### PR TITLE
Change GITHUB_ACTION to GITHUB_ACTIONS when detect github actions CI.

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/GitHubActionsTests.cs
@@ -22,13 +22,13 @@ namespace GitVersionCore.Tests.BuildServers
             log = new NullLog();
 
             environment = new TestEnvironment();
-            environment.SetEnvironmentVariable("GITHUB_ACTIONS", "true");
+            environment.SetEnvironmentVariable(GitHubActions.EnvironmentVariableName, "true");
         }
 
         [TearDown]
         public void TearDown()
         {
-            environment.SetEnvironmentVariable("GITHUB_ACTIONS", null);
+            environment.SetEnvironmentVariable(GitHubActions.EnvironmentVariableName, null);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace GitVersionCore.Tests.BuildServers
         public void CanApplyToCurrentContextShouldBeFalseWhenEnvironmentVariableIsNotSet()
         {
             // Arrange
-            environment.SetEnvironmentVariable("GITHUB_ACTIONS", "");
+            environment.SetEnvironmentVariable(GitHubActions.EnvironmentVariableName, "");
             var buildServer = new GitHubActions(environment, log);
 
             // Act

--- a/src/GitVersionCore.Tests/BuildServers/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/GitHubActionsTests.cs
@@ -22,13 +22,13 @@ namespace GitVersionCore.Tests.BuildServers
             log = new NullLog();
 
             environment = new TestEnvironment();
-            environment.SetEnvironmentVariable("GITHUB_ACTION", Guid.NewGuid().ToString());
+            environment.SetEnvironmentVariable("GITHUB_ACTIONS", "true");
         }
 
         [TearDown]
         public void TearDown()
         {
-            environment.SetEnvironmentVariable("GITHUB_ACTION", null);
+            environment.SetEnvironmentVariable("GITHUB_ACTIONS", null);
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace GitVersionCore.Tests.BuildServers
         public void CanApplyToCurrentContextShouldBeFalseWhenEnvironmentVariableIsNotSet()
         {
             // Arrange
-            environment.SetEnvironmentVariable("GITHUB_ACTION", "");
+            environment.SetEnvironmentVariable("GITHUB_ACTIONS", "");
             var buildServer = new GitHubActions(environment, log);
 
             // Act

--- a/src/GitVersionCore/BuildServers/GitHubActions.cs
+++ b/src/GitVersionCore/BuildServers/GitHubActions.cs
@@ -11,7 +11,7 @@ namespace GitVersion.BuildServers
         {
         }
 
-        public const string EnvironmentVariableName = "GITHUB_ACTION";
+        public const string EnvironmentVariableName = "GITHUB_ACTIONS";
         protected override string EnvironmentVariable { get; } = EnvironmentVariableName;
 
         public override string GenerateSetVersionMessage(VersionVariables variables)


### PR DESCRIPTION

GITHUB_ACTIONS | Always set to true when GitHub Actions is running the workflow. You can use this variable to differentiate when tests are being run locally or by GitHub Actions.
-- | --


