### PR TITLE
Replace [^a-zA-Z0-9-] with - in BranchName variable

### DIFF
--- a/src/GitVersionCore/OutputVariables/VariableProvider.cs
+++ b/src/GitVersionCore/OutputVariables/VariableProvider.cs
@@ -5,6 +5,7 @@ using GitVersion.VersionCalculation;
 using GitVersion.VersioningModes;
 using GitVersion.Configuration;
 using GitVersion.Helpers;
+using GitVersion.Extensions;
 
 namespace GitVersion.OutputVariables
 {
@@ -71,7 +72,7 @@ namespace GitVersion.OutputVariables
                 semverFormatValues.BuildMetaData,
                 semverFormatValues.BuildMetaDataPadded,
                 semverFormatValues.FullBuildMetaData,
-                semverFormatValues.BranchName,
+                semverFormatValues.BranchName?.RegexReplace("[^a-zA-Z0-9-]", "-"),
                 semverFormatValues.Sha,
                 semverFormatValues.ShortSha,
                 semverFormatValues.MajorMinorPatch,


### PR DESCRIPTION
Otherwise the branch name variable can never be used in any SemVer spec since it can contain a / when using nested branches.

My reasoning to just always replace it is that people will only use the branch name variable when trying to put together a GitVersion tag, which should be SemVer compliant.  So no need to make this setting driven or introduce a new variable just for this.

Cheers,