### PR TITLE
Enable exporting variables across jobs on Azure Pipelines

### DIFF
--- a/src/GitVersionCore.Tests/BuildServers/AzurePipelinesTests.cs
+++ b/src/GitVersionCore.Tests/BuildServers/AzurePipelinesTests.cs
@@ -44,7 +44,7 @@ namespace GitVersionCore.Tests.BuildServers
             var versionBuilder = new AzurePipelines(environment, log);
             var vsVersion = versionBuilder.GenerateSetParameterMessage("Foo", "0.8.0-unstable568 Branch:'develop' Sha:'ee69bff1087ebc95c6b43aa2124bd58f5722e0cb'");
 
-            vsVersion[0].ShouldBe("##vso[task.setvariable variable=GitVersion.Foo;]0.8.0-unstable568 Branch:'develop' Sha:'ee69bff1087ebc95c6b43aa2124bd58f5722e0cb'");
+            vsVersion[0].ShouldBe("##vso[task.setvariable variable=GitVersion.Foo;isOutput=true]0.8.0-unstable568 Branch:'develop' Sha:'ee69bff1087ebc95c6b43aa2124bd58f5722e0cb'");
         }
 
         [Test]

--- a/src/GitVersionCore/BuildServers/AzurePipelines.cs
+++ b/src/GitVersionCore/BuildServers/AzurePipelines.cs
@@ -21,7 +21,7 @@ namespace GitVersion.BuildServers
         {
             return new[]
             {
-                $"##vso[task.setvariable variable=GitVersion.{name};]{value}"
+                $"##vso[task.setvariable variable=GitVersion.{name};isOutput=true]{value}"
             };
         }
 


### PR DESCRIPTION
This PR tells Azure Pipelines to export GitVersion variables across jobs. Without it the variables are only usable from within the same job. For more information on variables at Azure Pipelines, please see the [official documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables).