### PR TITLE
Fixes #1796 by using a constant file name

### DIFF
--- a/src/GitVersionTask.Tests/FileHelperTests.cs
+++ b/src/GitVersionTask.Tests/FileHelperTests.cs
@@ -1,0 +1,46 @@
+using GitVersion.MSBuildTask;
+using NUnit.Framework;
+
+namespace GitVersionTask.Tests
+{
+    [TestFixture]
+    public class FileHelperTests
+    {
+        [Test]
+        [TestCase("C#", "cs")]
+        [TestCase("F#", "fs")]
+        [TestCase("VB", "vb")]
+        [TestCase("XY", null)]
+        public void GetFileExtensionShouldReturnCorrectExtension(string language, string expectedExtension)
+        {
+            if (expectedExtension != null)
+            {
+                Assert.That(FileHelper.GetFileExtension(language), Is.EqualTo(expectedExtension));
+            }
+            else
+            {
+                Assert.That(() => FileHelper.GetFileExtension(language), Throws.ArgumentException.With.Message.EqualTo($"Unknown language detected: '{language}'"));
+            }
+        }
+
+        [Test]
+        public void GetFileWriteInfoShouldCreateConstantNamedFileWhenIntermediateOutputPath()
+        {
+            var fileInfo = FileHelper.GetFileWriteInfo("MyIntermediateOutputPath", "C#", "MyProject.csproj", "GeneratedVersionInformation");
+
+            Assert.That(fileInfo.WorkingDirectory, Is.EqualTo("MyIntermediateOutputPath"));
+            Assert.That(fileInfo.FileName, Is.EqualTo("GeneratedVersionInformation.g.cs"));
+            Assert.That(fileInfo.FileExtension, Is.EqualTo("cs"));
+        }
+
+        [Test]
+        public void GetFileWriteInfoShouldCreateRandomNamedFileWhenNoIntermediateOutputPath()
+        {
+            var fileInfo = FileHelper.GetFileWriteInfo(null, "C#", "MyProject.csproj", "GeneratedVersionInformation");
+
+            Assert.That(fileInfo.WorkingDirectory, Is.EqualTo(FileHelper.TempPath));
+            Assert.That(fileInfo.FileName, Does.StartWith("GeneratedVersionInformation_MyProject_").And.EndsWith(".g.cs"));
+            Assert.That(fileInfo.FileExtension, Is.EqualTo("cs"));
+        }
+    }
+}

--- a/src/GitVersionTask/FileHelper.cs
+++ b/src/GitVersionTask/FileHelper.cs
@@ -156,12 +156,12 @@ Assembly(File|Informational)?Version    # The attribute AssemblyVersion, Assembl
 
             if (intermediateOutputPath == null)
             {
-                fileName = $"{outputFileName}.g.{fileExtension}";
+                fileName = $"{outputFileName}_{Path.GetFileNameWithoutExtension(projectFile)}_{Path.GetRandomFileName()}.g.{fileExtension}";
                 workingDirectory = TempPath;
             }
             else
             {
-                fileName = $"{outputFileName}_{Path.GetFileNameWithoutExtension(projectFile)}_{Path.GetRandomFileName()}.g.{fileExtension}";
+                fileName = $"{outputFileName}.g.{fileExtension}";
                 workingDirectory = intermediateOutputPath;
             }
             return new FileWriteInfo(workingDirectory, fileName, fileExtension);


### PR DESCRIPTION
When creating a file inside `intermediateOutputPath` the file name must be constant.
When creating a file inside `TempPath` the file name must or should be random.

I am not even sure if using a random file name every time when using `TempPath` is a good idea as we would be polluting the temp path that way.

Fixes #1796.