### PR TITLE
set eol to lf to avoid conflicting with editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 # Auto detect text files and perform LF normalization
-* text=auto eol=crlf
+* text=auto eol=lf
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 
 # Don't check these into the repo as LF to work around TeamCity bug
-*.xml     -text 
+*.xml     -text
 *.targets -text
 
 # Custom for Visual Studio


### PR DESCRIPTION
editorconfig says `end_of_line = lf`
https://github.com/GitTools/GitVersion/blob/f0e5275d974d7bd694dad8dce0ac85e57e33b19f/.editorconfig#L4-L10