### PR TITLE
set eol to lf to avoid conflicting with editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 # Auto detect text files and perform LF normalization
-* text=auto eol=crlf
+* text=auto eol=lf
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 
 # Don't check these into the repo as LF to work around TeamCity bug
-*.xml     -text 
+*.xml     -text
 *.targets -text
 
 # Custom for Visual Studio


### PR DESCRIPTION
The reason for this is as follows:

The configuration inside editorconfig will try and convert crlf to lf and git on checkout will convert all files from lf to crlf.
Creating an initial conversion in each file when you save them and on every commit git converts them back to crlf before commiting them as lf into the git repo 😓

by having both gitattributes and editorconfig align on lf the conversion will be avoided.
Also Microsoft recommends lf and UTF-8 without bom for all due to dotnet core.