### PR TITLE
Don't mark bugs as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 30
 exemptLabels:
   - pinned
   - security
+  - bug
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Configure stalebot to not mark issues labelled `bug` as `stale`.