### PR TITLE
GH2139: GitVersion logging does not include newlines

### DIFF
--- a/src/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -96,7 +96,7 @@ branches:
         tag: bugfix";
             SetupConfigFileContent(text);
             var ex = Should.Throw<GitVersionConfigurationException>(() => configProvider.Provide(repoPath));
-            ex.Message.ShouldBe("Branch configuration 'bug' is missing required configuration 'regex'\n\n" +
+            ex.Message.ShouldBe($"Branch configuration 'bug' is missing required configuration 'regex'{System.Environment.NewLine}" +
                                 "See https://gitversion.net/docs/configuration/ for more info");
         }
 
@@ -111,7 +111,7 @@ branches:
         tag: bugfix";
             SetupConfigFileContent(text);
             var ex = Should.Throw<GitVersionConfigurationException>(() => configProvider.Provide(repoPath));
-            ex.Message.ShouldBe("Branch configuration 'bug' is missing required configuration 'source-branches'\n\n" +
+            ex.Message.ShouldBe($"Branch configuration 'bug' is missing required configuration 'source-branches'{System.Environment.NewLine}" +
                                 "See https://gitversion.net/docs/configuration/ for more info");
         }
 

--- a/src/GitVersionCore.Tests/VariableProviderTests.cs
+++ b/src/GitVersionCore.Tests/VariableProviderTests.cs
@@ -43,7 +43,9 @@ namespace GitVersionCore.Tests
                 Patch = 3,
             };
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var propertyName = nameof(SemanticVersionFormatValues.DefaultInformationalVersion);
+#pragma warning restore CS0618 // Type or member is obsolete
             var config = new TestEffectiveConfiguration(assemblyInformationalFormat: $"{{{propertyName}}}");
             variableProvider.GetVariablesFor(semVer, config, false);
             logMessages.ShouldContain(message => message.Trim().StartsWith("WARN") && message.Contains(propertyName), 1, $"Expected a warning to be logged when using the variable {propertyName} in a configuration format template");

--- a/src/GitVersionCore/BuildServers/TeamCity.cs
+++ b/src/GitVersionCore/BuildServers/TeamCity.cs
@@ -34,11 +34,8 @@ namespace GitVersion.BuildServers
         private void WriteBranchEnvVariableWarning()
         {
             Log.Warning(@"TeamCity doesn't make the current branch available through environmental variables.
-
 Depending on your authentication and transport setup of your git VCS root things may work. In that case, ignore this warning.
-
 In your TeamCity build configuration, add a parameter called `env.Git_Branch` with value %teamcity.build.vcs.branch.<vcsid>%
-
 See https://gitversion.net/docs/build-server-support/build-server/teamcity for more info");
         }
 

--- a/src/GitVersionCore/Configuration/BranchConfigurationCalculator.cs
+++ b/src/GitVersionCore/Configuration/BranchConfigurationCalculator.cs
@@ -145,7 +145,7 @@ namespace GitVersion.Configuration
                 }
 
                 var branchName = chosenBranch.FriendlyName;
-                log.Warning(errorMessage + System.Environment.NewLine + System.Environment.NewLine + "Falling back to " + branchName + " branch config");
+                log.Warning(errorMessage + System.Environment.NewLine + "Falling back to " + branchName + " branch config");
 
                 // To prevent infinite loops, make sure that a new branch was chosen.
                 if (targetBranch.IsSameBranch(chosenBranch))

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -88,14 +88,14 @@ namespace GitVersion.Configuration
                 var regex = branchConfig.Value.Regex;
                 if (regex == null)
                 {
-                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'regex'\n\n" +
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'regex'{System.Environment.NewLine}" +
                                                                "See https://gitversion.net/docs/configuration/ for more info");
                 }
 
                 var sourceBranches = branchConfig.Value.SourceBranches;
                 if (sourceBranches == null)
                 {
-                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'source-branches'\n\n" +
+                    throw new GitVersionConfigurationException($"Branch configuration '{branchConfig.Key}' is missing required configuration 'source-branches'{System.Environment.NewLine}" +
                                                                "See https://gitversion.net/docs/configuration/ for more info");
                 }
 
@@ -189,7 +189,7 @@ If the docs do not help you decide on the mode open an issue to discuss what you
             }
             catch (InvalidOperationException)
             {
-                var matchingConfigs = String.Concat(matches.Select(m => $"\n - {m.Key}"));
+                var matchingConfigs = String.Concat(matches.Select(m => $"{System.Environment.NewLine} - {m.Key}"));
                 var picked = matches
                     .Select(kvp => kvp.Value)
                     .First();

--- a/src/GitVersionCore/Configuration/Init/SetConfig/ConfigureBranches.cs
+++ b/src/GitVersionCore/Configuration/Init/SetConfig/ConfigureBranches.cs
@@ -46,7 +46,7 @@ namespace GitVersion.Configuration.Init.SetConfig
             return @"Which branch would you like to configure:
 
 0) Go Back
-" + string.Join("\r\n", OrderedBranches(config).Select((c, i) => $"{i + 1}) {c.Key}"));
+" + string.Join(System.Environment.NewLine, OrderedBranches(config).Select((c, i) => $"{i + 1}) {c.Key}"));
         }
 
         private static IOrderedEnumerable<KeyValuePair<string, BranchConfig>> OrderedBranches(Config config)

--- a/src/GitVersionCore/Configuration/Init/Wizard/FinishedSetupStep.cs
+++ b/src/GitVersionCore/Configuration/Init/Wizard/FinishedSetupStep.cs
@@ -10,7 +10,7 @@ namespace GitVersion.Configuration.Init.Wizard
 
         protected override string GetPrompt(Config config, string workingDirectory)
         {
-            return "Questions are all done, you can now edit GitVersion's configuration further\r\n" + base.GetPrompt(config, workingDirectory);
+            return $"Questions are all done, you can now edit GitVersion's configuration further{System.Environment.NewLine}" + base.GetPrompt(config, workingDirectory);
         }
     }
 }

--- a/src/GitVersionCore/Configuration/Init/Wizard/GitFlowSetupStep.cs
+++ b/src/GitVersionCore/Configuration/Init/Wizard/GitFlowSetupStep.cs
@@ -11,7 +11,7 @@ namespace GitVersion.Configuration.Init.Wizard
 
         protected override string GetPrompt(Config config, string workingDirectory)
         {
-            return "By default GitVersion will only increment the version of the 'develop' branch every commit, all other branches will increment when tagged\r\n\r\n" +
+            return $"By default GitVersion will only increment the version of the 'develop' branch every commit, all other branches will increment when tagged{System.Environment.NewLine}{System.Environment.NewLine}" +
                 base.GetPrompt(config, workingDirectory);
         }
     }

--- a/src/GitVersionCore/Configuration/Init/Wizard/GitHubFlowStep.cs
+++ b/src/GitVersionCore/Configuration/Init/Wizard/GitHubFlowStep.cs
@@ -11,7 +11,7 @@ namespace GitVersion.Configuration.Init.Wizard
 
         protected override string GetPrompt(Config config, string workingDirectory)
         {
-            return "By default GitVersion will only increment the version when tagged\r\n\r\n" + base.GetPrompt(config, workingDirectory);
+            return $"By default GitVersion will only increment the version when tagged{System.Environment.NewLine}{System.Environment.NewLine}" + base.GetPrompt(config, workingDirectory);
         }
     }
 }

--- a/src/GitVersionCore/GitRepoMetadataProvider.cs
+++ b/src/GitVersionCore/GitRepoMetadataProvider.cs
@@ -218,8 +218,8 @@ namespace GitVersion
                 if (possibleBranches.Count > 1)
                 {
                     var first = possibleBranches.First();
-                    log.Info($"Multiple source branches have been found, picking the first one ({first.Branch.FriendlyName}).\n" +
-                        "This may result in incorrect commit counting.\nOptions were:\n " +
+                    log.Info($"Multiple source branches have been found, picking the first one ({first.Branch.FriendlyName}).{System.Environment.NewLine}" +
+                        $"This may result in incorrect commit counting.{System.Environment.NewLine}Options were:{System.Environment.NewLine}" +
                         string.Join(", ", possibleBranches.Select(b => b.Branch.FriendlyName)));
                     return first;
                 }

--- a/src/GitVersionCore/Helpers/GitRepositoryHelper.cs
+++ b/src/GitVersionCore/Helpers/GitRepositoryHelper.cs
@@ -62,7 +62,7 @@ namespace GitVersion.Helpers
                 }
 
                 log.Info($"HEAD is detached and points at commit '{headSha}'.");
-                log.Info(string.Format("Local Refs:\r\n" + string.Join(System.Environment.NewLine, repo.Refs.FromGlob("*").Select(r => $"{r.CanonicalName} ({r.TargetIdentifier})"))));
+                log.Info($"Local Refs:{System.Environment.NewLine}" + string.Join(System.Environment.NewLine, repo.Refs.FromGlob("*").Select(r => $"{r.CanonicalName} ({r.TargetIdentifier})")));
 
                 // In order to decide whether a fake branch is required or not, first check to see if any local branches have the same commit SHA of the head SHA.
                 // If they do, go ahead and checkout that branch
@@ -203,7 +203,7 @@ Please run `git {CreateGitLogArgs(100)}` and submit it along with your build log
                     GetRemoteTipsUsingUsernamePasswordCredentials(repo, remote, authentication.Username, authentication.Password))
                 .ToList();
 
-            log.Info("Remote Refs:\r\n" + string.Join(System.Environment.NewLine, remoteTips.Select(r => r.CanonicalName)));
+            log.Info($"Remote Refs:{System.Environment.NewLine}" + string.Join(System.Environment.NewLine, remoteTips.Select(r => r.CanonicalName)));
 
             var headTipSha = repo.Head.Tip.Sha;
 

--- a/src/GitVersionCore/Logging/FileAppender.cs
+++ b/src/GitVersionCore/Logging/FileAppender.cs
@@ -37,7 +37,7 @@ namespace GitVersion.Logging
 
         private static void WriteLogEntry(string logFilePath, string str)
         {
-            var contents = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t\t{str}\r\n";
+            var contents = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t\t{str}{System.Environment.NewLine}";
             File.AppendAllText(logFilePath, contents);
         }
     }

--- a/src/GitVersionCore/Logging/Log.cs
+++ b/src/GitVersionCore/Logging/Log.cs
@@ -41,7 +41,7 @@ namespace GitVersion.Logging
                 appender.WriteTo(level, formattedString);
             }
 
-            sb.Append(formattedString);
+            sb.AppendLine(formattedString);
         }
 
         public IDisposable IndentLog(string operationDescription)

--- a/src/GitVersionCore/OutputVariables/VariableProvider.cs
+++ b/src/GitVersionCore/OutputVariables/VariableProvider.cs
@@ -154,7 +154,9 @@ namespace GitVersion.OutputVariables
 
         private void WarnIfUsingObsoleteFormatValues(string formatString)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var obsoletePropertyName = nameof(SemanticVersionFormatValues.DefaultInformationalVersion);
+#pragma warning restore CS0618 // Type or member is obsolete
             if (formatString.Contains($"{{{obsoletePropertyName}}}"))
             {
                 log.Write(LogLevel.Warn, $"Use format variable '{nameof(SemanticVersionFormatValues.InformationalVersion)}' instead of '{obsoletePropertyName}' which is obsolete and will be removed in a future release.");

--- a/src/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/src/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -59,7 +59,9 @@ namespace GitVersionExe.Tests
         public void Exec()
         {
             var arguments = argumentParser.ParseArguments("-exec rake");
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Exec.ShouldBe("rake");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -72,15 +74,19 @@ namespace GitVersionExe.Tests
                 "-execargs",
                 "clean build"
             });
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Exec.ShouldBe("rake");
             arguments.ExecArgs.ShouldBe("clean build");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
         public void Msbuild()
         {
             var arguments = argumentParser.ParseArguments("-proj msbuild.proj");
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Proj.ShouldBe("msbuild.proj");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -93,8 +99,10 @@ namespace GitVersionExe.Tests
                 "-projargs",
                 "/p:Configuration=Debug /p:Platform=AnyCPU"
             });
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Proj.ShouldBe("msbuild.proj");
             arguments.ProjArgs.ShouldBe("/p:Configuration=Debug /p:Platform=AnyCPU");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -102,7 +110,9 @@ namespace GitVersionExe.Tests
         {
             var arguments = argumentParser.ParseArguments("targetDirectoryPath -exec rake");
             arguments.TargetPath.ShouldBe("targetDirectoryPath");
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Exec.ShouldBe("rake");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -374,7 +384,9 @@ namespace GitVersionExe.Tests
         {
             var arguments = argumentParser.ParseArguments("-nofetch -proj foo.sln");
             arguments.NoFetch.ShouldBe(true);
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Proj.ShouldBe("foo.sln");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -382,7 +394,9 @@ namespace GitVersionExe.Tests
         {
             var arguments = argumentParser.ParseArguments("-nonormalize -proj foo.sln");
             arguments.NoNormalize.ShouldBe(true);
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Proj.ShouldBe("foo.sln");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Test]
@@ -390,7 +404,9 @@ namespace GitVersionExe.Tests
         {
             var arguments = argumentParser.ParseArguments("-nocache -proj foo.sln");
             arguments.NoCache.ShouldBe(true);
+#pragma warning disable CS0612 // Type or member is obsolete
             arguments.Proj.ShouldBe("foo.sln");
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [TestCase("-nofetch -nonormalize -nocache")]

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -149,7 +149,9 @@ namespace GitVersion
                 if (name.IsSwitch("exec"))
                 {
                     EnsureArgumentValueCount(values);
+#pragma warning disable CS0612 // Type or member is obsolete
                     arguments.Exec = value;
+#pragma warning restore CS0612 // Type or member is obsolete
                     continue;
                 }
 
@@ -157,21 +159,27 @@ namespace GitVersion
                 if (name.IsSwitch("execargs"))
                 {
                     EnsureArgumentValueCount(values);
+#pragma warning disable CS0612 // Type or member is obsolete
                     arguments.ExecArgs = value;
+#pragma warning restore CS0612 // Type or member is obsolete
                     continue;
                 }
 
                 if (name.IsSwitch("proj"))
                 {
                     EnsureArgumentValueCount(values);
+#pragma warning disable CS0612 // Type or member is obsolete
                     arguments.Proj = value;
+#pragma warning restore CS0612 // Type or member is obsolete
                     continue;
                 }
 
                 if (name.IsSwitch("projargs"))
                 {
                     EnsureArgumentValueCount(values);
+#pragma warning disable CS0612 // Type or member is obsolete
                     arguments.ProjArgs = value;
+#pragma warning restore CS0612 // Type or member is obsolete
                     continue;
                 }
 

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -238,8 +238,8 @@ namespace GitVersion
 
                     if (versionVariable == null)
                     {
-                        var messageFormat = "{0} requires a valid version variable.  Available variables are:\n{1}";
-                        var message = string.Format(messageFormat, name, string.Join(", ", VersionVariables.AvailableVariables.Select(x => string.Concat("'", x, "'"))));
+                        var message = $"{name} requires a valid version variable. Available variables are:{System.Environment.NewLine}" +
+                            string.Join(", ", VersionVariables.AvailableVariables.Select(x => string.Concat("'", x, "'")));
                         throw new WarningException(message);
                     }
 

--- a/src/GitVersionExe/ExecCommand.cs
+++ b/src/GitVersionExe/ExecCommand.cs
@@ -83,16 +83,19 @@ namespace GitVersion
 
         private static bool RunMsBuildIfNeeded(Arguments args, string workingDirectory, VersionVariables variables, ILog log)
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             if (string.IsNullOrEmpty(args.Proj)) return false;
 
             args.Exec = "dotnet";
             args.ExecArgs = $"msbuild \"{args.Proj}\" {args.ProjArgs}";
+#pragma warning restore CS0612 // Type or member is obsolete
 
             return RunExecCommandIfNeeded(args, workingDirectory, variables, log);
         }
 
         private static bool RunExecCommandIfNeeded(Arguments args, string workingDirectory, VersionVariables variables, ILog log)
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             if (string.IsNullOrEmpty(args.Exec)) return false;
 
             log.Info($"Launching {args.Exec} {args.ExecArgs}");
@@ -103,6 +106,7 @@ namespace GitVersion
 
             if (results != 0)
                 throw new WarningException($"Execution of {args.Exec} failed, non-zero return code");
+#pragma warning restore CS0612 // Type or member is obsolete
 
             return true;
         }

--- a/src/GitVersionExe/GitVersionExecutor.cs
+++ b/src/GitVersionExe/GitVersionExecutor.cs
@@ -131,7 +131,6 @@ namespace GitVersion
 
                 if (arguments == null) return 1;
 
-                log.Info(string.Empty);
                 log.Info("Attempting to show the current git graph (please include in issue): ");
                 log.Info("Showing max of 100 commits");
 

--- a/src/GitVersionExe/GitVersionExecutor.cs
+++ b/src/GitVersionExe/GitVersionExecutor.cs
@@ -118,13 +118,13 @@ namespace GitVersion
             }
             catch (WarningException exception)
             {
-                var error = $"An error occurred:\r\n{exception.Message}";
+                var error = $"An error occurred:{System.Environment.NewLine}{exception.Message}";
                 log.Warning(error);
                 return 1;
             }
             catch (Exception exception)
             {
-                var error = $"An unexpected error occurred:\r\n{exception}";
+                var error = $"An unexpected error occurred:{System.Environment.NewLine}{exception}";
                 log.Error(error);
 
                 if (arguments == null) return 1;

--- a/src/GitVersionExe/GitVersionExecutor.cs
+++ b/src/GitVersionExe/GitVersionExecutor.cs
@@ -76,7 +76,9 @@ namespace GitVersion
                     arguments.Output.Add(OutputType.BuildServer);
                 }
 
+#pragma warning disable CS0612 // Type or member is obsolete
                 if (!string.IsNullOrEmpty(arguments.Proj) || !string.IsNullOrEmpty(arguments.Exec))
+#pragma warning restore CS0612 // Type or member is obsolete
                 {
                     arguments.Output.Add(OutputType.BuildServer);
                 }

--- a/src/GitVersionTask.MsBuild/GitVersionTask.MsBuild.csproj
+++ b/src/GitVersionTask.MsBuild/GitVersionTask.MsBuild.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageReference Include="Microsoft.Build" Version="16.4.0" />
+        <PackageReference Include="Microsoft.Build" Version="16.4.0" NoWarn="NU1701" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
     </ItemGroup>
 

--- a/src/GitVersionTask/MsBuildAppender.cs
+++ b/src/GitVersionTask/MsBuildAppender.cs
@@ -29,7 +29,7 @@ namespace GitVersion.Logging
 
         private void WriteLogEntry(LogLevel level, string str)
         {
-            var contents = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t\t{str}\r\n";
+            var contents = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t\t{str}{System.Environment.NewLine}";
             switch (level)
             {
                 case LogLevel.None:


### PR DESCRIPTION
Fixes #2139.

I also tried to fix newlines to be platform agnostic.
Finally, I suppressed CS0618 and NU1701 build warnings.