### PR TITLE
Issue #2148: Limit number of commits traversed

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -233,6 +233,34 @@ namespace GitVersionCore.Tests.IntegrationTests
         }
 
         [Test]
+        public void WhenReleaseBranchIsMergedIntoMasterHighestVersionIsTakenWithItEvenWithMoreThanTwoActiveBranches()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.Repository.MakeATaggedCommit("1.0.3");
+            fixture.Repository.MakeCommits(1);
+
+            fixture.Repository.CreateBranch("release-3.0.0");
+            fixture.Checkout("release-3.0.0");
+            fixture.Repository.MakeCommits(4);
+            fixture.Checkout("master");
+            fixture.Repository.MergeNoFF("release-3.0.0", Generate.SignatureNow());
+
+            fixture.Repository.CreateBranch("release-2.0.0");
+            fixture.Checkout("release-2.0.0");
+            fixture.Repository.MakeCommits(4);
+            fixture.Checkout("master");
+            fixture.Repository.MergeNoFF("release-2.0.0", Generate.SignatureNow());
+
+            fixture.Repository.CreateBranch("release-1.0.0");
+            fixture.Checkout("release-1.0.0");
+            fixture.Repository.MakeCommits(4);
+            fixture.Checkout("master");
+            fixture.Repository.MergeNoFF("release-1.0.0", Generate.SignatureNow());
+
+            fixture.AssertFullSemver("3.0.0+10");
+        }
+
+        [Test]
         public void WhenMergingReleaseBackToDevShouldNotResetBetaVersion()
         {
             using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageVersionStrategy.cs
@@ -42,7 +42,9 @@ namespace GitVersion.VersionCalculation
                         };
                     }
                     return Enumerable.Empty<BaseVersion>();
-                }).ToList();
+                })
+                .Take(2)
+                .ToList();
             return baseVersions;
         }
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageVersionStrategy.cs
@@ -43,7 +43,7 @@ namespace GitVersion.VersionCalculation
                     }
                     return Enumerable.Empty<BaseVersion>();
                 })
-                .Take(2)
+                .Take(5)
                 .ToList();
             return baseVersions;
         }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -43,7 +43,7 @@ namespace GitVersion.VersionCalculation
                     return null;
                 })
                 .Where(a => a != null)
-                .Take(2)
+                .Take(5)
                 .ToList();
 
             return tagsOnBranch.Select(t => CreateBaseVersion(context, t));

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -43,6 +43,7 @@ namespace GitVersion.VersionCalculation
                     return null;
                 })
                 .Where(a => a != null)
+                .Take(2)
                 .ToList();
 
             return tagsOnBranch.Select(t => CreateBaseVersion(context, t));


### PR DESCRIPTION
Limit the number of commits traversed when trying to find version from
tags and merge messages to 2 (each).

Closes #2148