### PR TITLE
Add handling of Assembly attributes that do not end on a new line

### DIFF
--- a/src/GitVersionTask.Tests/InvalidFileCheckerTests.cs
+++ b/src/GitVersionTask.Tests/InvalidFileCheckerTests.cs
@@ -99,6 +99,21 @@ using System.Reflection;
         }
 
         [Test]
+        public void VerifyCommentWithNoNewLineAtEndWorksCSharp([Values("AssemblyVersion", "AssemblyFileVersion", "AssemblyInformationalVersion")]string attribute)
+        {
+            using (var writer = File.CreateText(Path.Combine(projectDirectory, "AssemblyInfo.cs")))
+            {
+                writer.Write(@"
+using System;
+using System.Reflection;
+
+//[assembly: {0}(""1.0.0.0"")]", attribute);
+            }
+
+            FileHelper.CheckForInvalidFiles(new ITaskItem[] { new MockTaskItem { ItemSpec = "AssemblyInfo.cs" } }, projectFile);
+        }
+
+        [Test]
         public void VerifyStringWorksCSharp([Values("AssemblyVersion", "AssemblyFileVersion", "AssemblyInformationalVersion")]string attribute)
         {
             using (var writer = File.CreateText(Path.Combine(projectDirectory, "AssemblyInfo.cs")))
@@ -181,6 +196,21 @@ Imports System.Reflection
 
 '<Assembly: {0}(""1.0.0.0"")>
 ", attribute);
+            }
+
+            FileHelper.CheckForInvalidFiles(new ITaskItem[] { new MockTaskItem { ItemSpec = "AssemblyInfo.vb" } }, projectFile);
+        }
+
+        [Test]
+        public void VerifyCommentWithNoNewLineAtEndWorksVisualBasic([Values("AssemblyVersion", "AssemblyFileVersion", "AssemblyInformationalVersion")]string attribute)
+        {
+            using (var writer = File.CreateText(Path.Combine(projectDirectory, "AssemblyInfo.vb")))
+            {
+                writer.Write(@"
+Imports System
+Imports System.Reflection
+
+'<Assembly: {0}(""1.0.0.0"")>", attribute);
             }
 
             FileHelper.CheckForInvalidFiles(new ITaskItem[] { new MockTaskItem { ItemSpec = "AssemblyInfo.vb" } }, projectFile);

--- a/src/GitVersionTask/FileHelper.cs
+++ b/src/GitVersionTask/FileHelper.cs
@@ -97,6 +97,8 @@ namespace GitVersion.MSBuildTask
             var combine = Path.Combine(Path.GetDirectoryName(projectFile), compileFile);
             var allText = File.ReadAllText(combine);
 
+            allText += System.Environment.NewLine; // Always add a new line, this handles the case for when a file ends with the EOF marker and no new line. If you don't have this newline, the regex will match commented out Assembly*Version tags on the last line.
+
             var blockComments = @"/\*(.*?)\*/";
             var lineComments = @"//(.*?)\r?\n";
             var strings = @"""((\\[^\n]|[^""\n])*)""";
@@ -122,6 +124,8 @@ Assembly(File|Informational)?Version    # The attribute AssemblyVersion, Assembl
         {
             var combine = Path.Combine(Path.GetDirectoryName(projectFile), compileFile);
             var allText = File.ReadAllText(combine);
+
+            allText += System.Environment.NewLine; // Always add a new line, this handles the case for when a file ends with the EOF marker and no new line. If you don't have this newline, the regex will match commented out Assembly*Version tags on the last line.
 
             var lineComments = @"'(.*?)\r?\n";
             var strings = @"""((\\[^\n]|[^""\n])*)""";


### PR DESCRIPTION
- Added tests that fail if we don't have a newline after Assembly attributes
- Updated FileHelper to support commented out Assembly attributes that do not end with a new line

Fixes #1939 and #1802.