### PR TITLE
Some light enhancements for GitVersionTask

### DIFF
--- a/src/GitVersionTask.MsBuild/GitVersionTask.MsBuild.csproj
+++ b/src/GitVersionTask.MsBuild/GitVersionTask.MsBuild.csproj
@@ -5,11 +5,11 @@
         <LangVersion>8.0</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
-
+   
     <ItemGroup>
-        <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+        <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Build" Version="16.4.0" NoWarn="NU1701" />
-        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersionTask.MsBuild/GitVersionTaskBase.cs
+++ b/src/GitVersionTask.MsBuild/GitVersionTaskBase.cs
@@ -1,10 +1,16 @@
+using GitVersionTask.MsBuild;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace GitVersion.MSBuildTask
 {
-    public abstract class GitVersionTaskBase : Task
+    public abstract class GitVersionTaskBase : ITask
     {
+        protected GitVersionTaskBase()
+        {
+            this.Log = new TaskLoggingHelper(this);
+        }
+
         [Required]
         public string SolutionDirectory { get; set; }
 
@@ -13,5 +19,22 @@ namespace GitVersion.MSBuildTask
         public bool NoFetch { get; set; }
 
         public bool NoNormalize { get; set; }
+        public IBuildEngine BuildEngine { get; set; }
+        public ITaskHost HostObject { get; set; }
+
+        public TaskLoggingHelper Log { get; }
+
+        public bool Execute()
+        {
+            if (TaskProxy.InitialiseException != null)
+            {
+                throw TaskProxy.InitialiseException;
+            }
+
+            return OnExecute();
+        }
+
+        protected abstract bool OnExecute();
+
     }
 }

--- a/src/GitVersionTask.MsBuild/TaskLoggingHelper.cs
+++ b/src/GitVersionTask.MsBuild/TaskLoggingHelper.cs
@@ -1,0 +1,368 @@
+using Microsoft.Build.Framework;
+using System;
+using System.Text;
+
+namespace GitVersionTask.MsBuild
+{
+    /// <summary>
+    /// Copied much of this code from https://github.com/microsoft/msbuild/blob/master/src/Shared/TaskLoggingHelper.cs which is licenced under
+    /// the MIT licence.
+    /// </summary>
+    /// <remarks>In an effort to remove dependency on MsBuild utilities assembly, in order to fix https://github.com/GitTools/GitVersion/issues/2125</remarks>
+    public class TaskLoggingHelper
+    {
+        private ITask _taskInstance;
+        private IBuildEngine _buildEngine;
+
+        /// <summary>
+        /// public constructor
+        /// </summary>
+        /// <param name="taskInstance">task containing an instance of this class</param>
+        public TaskLoggingHelper(ITask taskInstance)
+        {
+            if (taskInstance == null)
+            {
+                throw new ArgumentNullException(nameof(taskInstance));
+            }
+            _taskInstance = taskInstance;
+            TaskName = taskInstance.GetType().Name;
+        }
+
+        /// <summary>
+        /// Public constructor which can be used by task factories to assist them in logging messages.
+        /// </summary>
+        public TaskLoggingHelper(IBuildEngine buildEngine, string taskName)
+        {
+            TaskName = taskName;
+            _buildEngine = buildEngine;
+        }
+
+
+        /// <summary>
+        /// Gets the name of the parent task.
+        /// </summary>
+        /// <value>Task name string.</value>
+        protected string TaskName { get; }
+
+        /// <summary>
+        /// Shortcut property for getting our build engine - we retrieve it from the task instance
+        /// </summary>
+        protected IBuildEngine BuildEngine
+        {
+            get
+            {
+                // If the task instance does not equal null then use its build engine because 
+                // the task instances build engine can be changed for example during tests. This changing of the engine on the same task object is not expected to happen
+                // during normal operation.
+                if (_taskInstance != null)
+                {
+                    return _taskInstance.BuildEngine;
+                }
+
+                return _buildEngine;
+            }
+        }
+
+        public bool HasLoggedErrors { get; private set; }
+
+        private void EnsureBuildEngineInitialised()
+        {
+            if (BuildEngine == null)
+            {
+                throw new InvalidOperationException("Cannot log before BuildEngine is initialised");
+            }
+
+        }
+
+        /// <summary>
+        /// Logs a message using the specified string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogMessage(string message, params object[] messageArgs)
+        {
+            LogMessage(MessageImportance.Normal, message, messageArgs);
+        }
+
+        /// <summary>
+        /// Logs a message of the given importance using the specified string.
+        /// Thread safe.
+        /// </summary>
+        /// <remarks>
+        /// Take care to order the parameters correctly or the other overload will be called inadvertently.
+        /// </remarks>
+        /// <param name="importance">The importance level of the message.</param>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogMessage(MessageImportance importance, string message, params object[] messageArgs)
+        {
+
+            BuildMessageEventArgs e = new BuildMessageEventArgs
+                (
+                    message,                             // message
+                    null,                                // help keyword
+                    TaskName,                            // sender 
+                    importance,                          // importance
+                    DateTime.UtcNow,                     // timestamp
+                    messageArgs                          // message arguments
+                );
+
+            EnsureBuildEngineInitialised();
+
+            BuildEngine.LogMessageEvent(e);
+
+        }
+
+        /// <summary>
+        /// Logs a warning using the specified string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogWarning(string message, params object[] messageArgs)
+        {
+            LogWarning(null, null, null, null, 0, 0, 0, 0, message, messageArgs);
+        }
+
+        /// <summary>
+        /// Logs a warning using the specified string and other warning details.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="subcategory">Description of the warning type (can be null).</param>
+        /// <param name="warningCode">The warning code (can be null).</param>
+        /// <param name="helpKeyword">The help keyword for the host IDE (can be null).</param>
+        /// <param name="file">The path to the file causing the warning (can be null).</param>
+        /// <param name="lineNumber">The line in the file causing the warning (set to zero if not available).</param>
+        /// <param name="columnNumber">The column in the file causing the warning (set to zero if not available).</param>
+        /// <param name="endLineNumber">The last line of a range of lines in the file causing the warning (set to zero if not available).</param>
+        /// <param name="endColumnNumber">The last column of a range of columns in the file causing the warning (set to zero if not available).</param>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogWarning
+        (
+            string subcategory,
+            string warningCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs
+        )
+        {
+            EnsureBuildEngineInitialised();
+
+            // All of our warnings should have an error code, so the user has something
+            // to look up in the documentation. To help find warnings without error codes,
+            // temporarily uncomment this line and run the unit tests.
+            //if (null == warningCode) File.AppendAllText("c:\\warningsWithoutCodes", message + "\n");
+            // We don't have a Debug.Assert for this, because it would be triggered by <Error> and <Warning> tags.
+
+            // If the task has missed out all location information, add the location of the task invocation;
+            // that gives the user something.
+            bool fillInLocation = (String.IsNullOrEmpty(file) && (lineNumber == 0) && (columnNumber == 0));
+
+            var e = new BuildWarningEventArgs
+                (
+                    subcategory,
+                    warningCode,
+                    fillInLocation ? BuildEngine.ProjectFileOfTaskNode : file,
+                    fillInLocation ? BuildEngine.LineNumberOfTaskNode : lineNumber,
+                    fillInLocation ? BuildEngine.ColumnNumberOfTaskNode : columnNumber,
+                    endLineNumber,
+                    endColumnNumber,
+                    message,
+                    helpKeyword,
+                    TaskName,
+                    DateTime.UtcNow,
+                    messageArgs
+                );
+
+            BuildEngine.LogWarningEvent(e);
+        }
+
+        /// <summary>
+        /// Logs a warning using the message from the given exception context.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>exception</c> is null.</exception>
+        public void LogWarningFromException(Exception exception)
+        {
+            LogWarningFromException(exception, false);
+        }
+
+        /// <summary>
+        /// Logs a warning using the message (and optionally the stack-trace) from the given exception context.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        /// <param name="showStackTrace">If true, the exception callstack is appended to the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>exception</c> is null.</exception>
+        public void LogWarningFromException(Exception exception, bool showStackTrace)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            string message = exception.Message;
+
+            if (showStackTrace)
+            {
+                message += System.Environment.NewLine + exception.StackTrace;
+            }
+
+            LogWarning(message);
+        }
+
+        /// <summary>
+        /// Logs an error using the specified string.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogError(string message, params object[] messageArgs)
+        {
+            LogError(null, null, null, null, 0, 0, 0, 0, message, messageArgs);
+        }
+
+        /// <summary>
+        /// Logs an error using the specified string and other error details.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="subcategory">Description of the error type (can be null).</param>
+        /// <param name="errorCode">The error code (can be null).</param>
+        /// <param name="helpKeyword">The help keyword for the host IDE (can be null).</param>
+        /// <param name="file">The path to the file containing the error (can be null).</param>
+        /// <param name="lineNumber">The line in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="columnNumber">The column in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="endLineNumber">The last line of a range of lines in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="endColumnNumber">The last column of a range of columns in the file where the error occurs (set to zero if not available).</param>
+        /// <param name="message">The message string.</param>
+        /// <param name="messageArgs">Optional arguments for formatting the message string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
+        public void LogError
+        (
+            string subcategory,
+            string errorCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs
+        )
+        {
+            EnsureBuildEngineInitialised();
+
+            // If the task has missed out all location information, add the location of the task invocation;
+            // that gives the user something.
+            bool fillInLocation = (String.IsNullOrEmpty(file) && (lineNumber == 0) && (columnNumber == 0));
+
+            var e = new BuildErrorEventArgs
+                (
+                    subcategory,
+                    errorCode,
+                    fillInLocation ? BuildEngine.ProjectFileOfTaskNode : file,
+                    fillInLocation ? BuildEngine.LineNumberOfTaskNode : lineNumber,
+                    fillInLocation ? BuildEngine.ColumnNumberOfTaskNode : columnNumber,
+                    endLineNumber,
+                    endColumnNumber,
+                    message,
+                    helpKeyword,
+                    TaskName,
+                    DateTime.UtcNow,
+                    messageArgs
+                );
+            BuildEngine.LogErrorEvent(e);
+
+            HasLoggedErrors = true;
+        }
+
+        /// <summary>
+        /// Logs an error using the message from the given exception context.
+        /// No callstack will be shown.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>e</c> is null.</exception>
+        public void LogErrorFromException(Exception exception)
+        {
+            LogErrorFromException(exception, false);
+        }
+
+        /// <summary>
+        /// Logs an error using the message (and optionally the stack-trace) from the given exception context.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        /// <param name="showStackTrace">If true, callstack will be appended to message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>exception</c> is null.</exception>
+        public void LogErrorFromException(Exception exception, bool showStackTrace)
+        {
+            LogErrorFromException(exception, showStackTrace, false, null);
+        }
+
+        /// <summary>
+        /// Logs an error using the message, and optionally the stack-trace from the given exception, and
+        /// optionally inner exceptions too.
+        /// Thread safe.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        /// <param name="showStackTrace">If true, callstack will be appended to message.</param>
+        /// <param name="showDetail">Whether to log exception types and any inner exceptions.</param>
+        /// <param name="file">File related to the exception, or null if the project file should be logged</param>
+        /// <exception cref="ArgumentNullException">Thrown when <c>exception</c> is null.</exception>
+        public void LogErrorFromException(Exception exception, bool showStackTrace, bool showDetail, string file)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            string message;
+
+            if (!showDetail && (System.Environment.GetEnvironmentVariable("MSBUILDDIAGNOSTICS") == null)) // This env var is also used in ToolTask
+            {
+                message = exception.Message;
+
+                if (showStackTrace)
+                {
+                    message += System.Environment.NewLine + exception.StackTrace;
+                }
+            }
+            else
+            {
+                // The more comprehensive output, showing exception types
+                // and inner exceptions
+                var builder = new StringBuilder(200);
+                do
+                {
+                    builder.Append(exception.GetType().Name);
+                    builder.Append(": ");
+                    builder.AppendLine(exception.Message);
+                    if (showStackTrace)
+                    {
+                        builder.AppendLine(exception.StackTrace);
+                    }
+                    exception = exception.InnerException;
+                } while (exception != null);
+
+                message = builder.ToString();
+            }
+
+            LogError(null, null, null, file, 0, 0, 0, 0, message);
+        }
+    }
+}

--- a/src/GitVersionTask.MsBuild/TaskProxy.cs
+++ b/src/GitVersionTask.MsBuild/TaskProxy.cs
@@ -12,19 +12,28 @@ namespace GitVersion.MSBuildTask
         public static Func<UpdateAssemblyInfo, bool> UpdateAssemblyInfo;
         public static Func<WriteVersionInfoToBuildLog, bool> WriteVersionInfoToBuildLog;
 
+        public static Exception InitialiseException = null;
         static TaskProxy()
         {
+            try
+            {
 #if !NETFRAMEWORK
-            GitLoaderContext.Init("GitVersionCore", "LibGit2Sharp");
+                GitLoaderContext.Init("GitVersionCore", "LibGit2Sharp");
 #endif
-            LibGit2SharpLoader.LoadAssembly("GitVersionTask");
+                LibGit2SharpLoader.LoadAssembly("GitVersionTask");
 
-            var type = LibGit2SharpLoader.Instance.Assembly.GetType("GitVersion.MSBuildTask.GitVersionTasks", throwOnError: true).GetTypeInfo();
+                var type = LibGit2SharpLoader.Instance.Assembly.GetType("GitVersion.MSBuildTask.GitVersionTasks", throwOnError: true).GetTypeInfo();
 
-            GetVersion = GetMethod<GetVersion>(type, nameof(GetVersion));
-            GenerateGitVersionInformation = GetMethod<GenerateGitVersionInformation>(type, nameof(GenerateGitVersionInformation));
-            UpdateAssemblyInfo = GetMethod<UpdateAssemblyInfo>(type, nameof(UpdateAssemblyInfo));
-            WriteVersionInfoToBuildLog = GetMethod<WriteVersionInfoToBuildLog>(type, nameof(WriteVersionInfoToBuildLog));
+                GetVersion = GetMethod<GetVersion>(type, nameof(GetVersion));
+                GenerateGitVersionInformation = GetMethod<GenerateGitVersionInformation>(type, nameof(GenerateGitVersionInformation));
+                UpdateAssemblyInfo = GetMethod<UpdateAssemblyInfo>(type, nameof(UpdateAssemblyInfo));
+                WriteVersionInfoToBuildLog = GetMethod<WriteVersionInfoToBuildLog>(type, nameof(WriteVersionInfoToBuildLog));
+            }
+            catch (Exception e)
+            {
+                InitialiseException = e;
+            }
+
         }
 
         private static Func<T, bool> GetMethod<T>(TypeInfo type, string name) => (Func<T, bool>)type.GetDeclaredMethod(name).CreateDelegate(typeof(Func<T, bool>));

--- a/src/GitVersionTask.MsBuild/Tasks/GenerateGitVersionInformation.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GenerateGitVersionInformation.cs
@@ -16,6 +16,7 @@ namespace GitVersion.MSBuildTask.Tasks
         [Output]
         public string GitVersionInformationFilePath { get; set; }
 
-        public override bool Execute() => TaskProxy.GenerateGitVersionInformation(this);
+        protected override bool OnExecute() => TaskProxy.GenerateGitVersionInformation(this);
+
     }
 }

--- a/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
@@ -94,6 +94,7 @@ namespace GitVersion.MSBuildTask.Tasks
         [Output]
         public string CommitsSinceVersionSourcePadded { get; set; }
 
-        public override bool Execute() => TaskProxy.GetVersion(this);
+        protected override bool OnExecute() => TaskProxy.GetVersion(this);
+
     }
 }

--- a/src/GitVersionTask.MsBuild/Tasks/UpdateAssemblyInfo.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/UpdateAssemblyInfo.cs
@@ -19,6 +19,6 @@ namespace GitVersion.MSBuildTask.Tasks
         [Output]
         public string AssemblyInfoTempFilePath { get; set; }
 
-        public override bool Execute() => TaskProxy.UpdateAssemblyInfo(this);
+        protected override bool OnExecute() => TaskProxy.UpdateAssemblyInfo(this);
     }
 }

--- a/src/GitVersionTask.MsBuild/Tasks/WriteVersionInfoToBuildLog.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/WriteVersionInfoToBuildLog.cs
@@ -2,6 +2,6 @@ namespace GitVersion.MSBuildTask.Tasks
 {
     public class WriteVersionInfoToBuildLog : GitVersionTaskBase
     {
-        public override bool Execute() => TaskProxy.WriteVersionInfoToBuildLog(this);
+        protected override bool OnExecute() => TaskProxy.WriteVersionInfoToBuildLog(this);
     }
 }

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
 
         <PackageId>GitVersionTask</PackageId>
         <Title>GitVersionTask</Title>
@@ -11,10 +11,12 @@
         <DevelopmentDependency>true</DevelopmentDependency>
 
         <LangVersion>8.0</LangVersion>
-    </PropertyGroup>
+    </PropertyGroup>   
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(PackageVersion_MicrosoftExtensions)" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(PackageVersion_MicrosoftExtensions)" PrivateAssets="All">
+            <Publish>true</Publish>
+        </PackageReference>
         <PackageReference Include="LibGit2Sharp" Version="$(PackageVersion_LibGit2Sharp)" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/GitVersionTask/GitVersionTasks.cs
+++ b/src/GitVersionTask/GitVersionTasks.cs
@@ -3,7 +3,7 @@ using GitVersion.Exceptions;
 using GitVersion.Extensions;
 using GitVersion.Logging;
 using GitVersion.MSBuildTask.Tasks;
-using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -44,7 +44,7 @@ namespace GitVersion.MSBuildTask
             return !taskLog.HasLoggedErrors;
         }
 
-        private static void Configure(IServiceProvider sp, Task task)
+        private static void Configure(IServiceProvider sp, GitVersionTaskBase task)
         {
             var log = sp.GetService<ILog>();
             var buildServerResolver = sp.GetService<IBuildServerResolver>();

--- a/src/GitVersionTask/MsBuildAppender.cs
+++ b/src/GitVersionTask/MsBuildAppender.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.Build.Utilities;
+using GitVersionTask.MsBuild;
 
 namespace GitVersion.Logging
 {

--- a/src/GitVersionTask/README.md
+++ b/src/GitVersionTask/README.md
@@ -1,0 +1,17 @@
+## UNDERSTAND THIS
+
+1. On .NET Core, our MSBuild tasks cannot be executed within the AssemblyLoadContext that they are loaded into my MsBuild.
+This is because our MSBuild tasks have dependencies that must be loaded (like libgit2sharp etc) and we have no way to extend
+the MsBuild AssemblyLoadContext that MsBuild has loaded them into, to help satisfy loading these dependencies from the nuget package folder.
+
+2. When running on the full .NET framework this isn't a problem because in that case we can access the current AppDomain and add AssemblyResolve handlers to load these dependencies as needed.
+
+3. On .NET Core then, we create a new AssemblyLoadContext, and load try to execute our task within it but this is tricky because:
+   - If you try to load the same task Type and use it in another AssemblyloadContext (for example by creating an instance of it and calling Execute) you will
+   get weird errors along the lines of "cannot cast type A to type B"even though the two types are the same.
+
+   To workaround this issue then, the Task running within MsBuild's AssemblyLoadContext must load a Type that is not being used in it's AssemblyLoadContext. It can then interact with that type by invoking methods via reflection.
+   It's the responsibility of this "reverse proxy" to execute the required task logic within our custom AssemblyLoadContext, where any dependencies that are needed will be loaded on demand from the Nuget package folder location.
+
+4. Even though things need to be done differently on full .NET and .NET Core due to the issues above,
+   we want the execution pipeline for our MsBuild tasks to look consistent irrespective of Platform.


### PR DESCRIPTION
- Added a README to GitVersionTask with hopefully some useful tidbits of info that may help devs.
- Build Tweaks:
    - PackageReference for `System.Runtime.Loader` now conditional to .NET Core only.
    - Removed unnecessary target framework form GitVersionTask's csproj - didn't seem to be used anywhere.

- Removed dependency on `Microsoft.Build.Tasks.Core` which we used for its base `Task` implementation. Not sure how much this will help with keeping compatibility accross different msbuild versions, but it can't hurt the cause.

- Debugging tweak: was having trouble debugging the static initialisers as I couldn't get a breakpoint to be hit within them - made a slight tweak to capture the exception that occurs in the static type initilaiser, and then re-throw it on Task execution in an effort to aid debug-ability.


I tested this version of GitVersionTask locally, and it seems to work the same as current master: 5.1.4-beta1.220 package. Both versions seem to work fine for me, except under `dotnet sdk 3.1.200-preview-014977` - for which both versions seem to exhibit the same bug - which isn't addressed by this PR.