### PR TITLE
New Variable: EscapedBranchName

### DIFF
--- a/docs/input/docs/more-info/variables.md
+++ b/docs/input/docs/more-info/variables.md
@@ -29,6 +29,7 @@ Running `GitVersion.exe` in your repo will show you what is available. For the
   "FullSemVer":"3.0.0-beta.1+1",
   "InformationalVersion":"3.0.0-beta.1+1.Branch.release/3.0.0.Sha.28c853159a46b5a87e6cc9c4f6e940c59d6bc68a",
   "BranchName":"release/3.0.0",
+  "EscapedBranchName":"release-3.0.0",
   "Sha":"28c853159a46b5a87e6cc9c4f6e940c59d6bc68a",
   "ShortSha":"28c8531",
   "NuGetVersionV2":"3.0.0-beta0001",

--- a/src/GitVersionCore.Tests/Approved/JsonVersionBuilderTests.Json.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/JsonVersionBuilderTests.Json.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.0-unstable.4+5",
   "InformationalVersion":"1.2.0-unstable.4+5.Branch.feature1.Sha.commitSha",
   "BranchName":"feature1",
+  "EscapedBranchName":"feature1",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.0-unstable0004",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3+5",
   "InformationalVersion":"1.2.3+5.Branch.feature-123.Sha.commitSha",
   "BranchName":"feature/123",
+  "EscapedBranchName":"feature-123",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInformationalFormat.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInformationalFormat.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3+5",
   "InformationalVersion":"1.2.3+5.Branch.feature-123.Sha.commitShortSha",
   "BranchName":"feature/123",
+  "EscapedBranchName":"feature-123",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3-unstable.4+5",
   "InformationalVersion":"1.2.3-unstable.4+5.Branch.develop.Sha.commitSha",
   "BranchName":"develop",
+  "EscapedBranchName":"develop",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3-unstable0004",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3-unstable.4+5",
   "InformationalVersion":"1.2.3-unstable.4+5.Branch.develop.Sha.commitSha",
   "BranchName":"develop",
+  "EscapedBranchName":"develop",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3-unstable00004",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3+5",
   "InformationalVersion":"1.2.3+5.Branch.develop.Sha.commitSha",
   "BranchName":"develop",
+  "EscapedBranchName":"develop",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3-unstable.8",
   "InformationalVersion":"1.2.3-unstable.8+Branch.develop.Sha.commitSha",
   "BranchName":"develop",
+  "EscapedBranchName":"develop",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3-unstable0008",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3-ci.5",
   "InformationalVersion":"1.2.3-ci.5+Branch.develop.Sha.commitSha",
   "BranchName":"develop",
+  "EscapedBranchName":"develop",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3-ci0005",

--- a/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -19,6 +19,7 @@
   "FullSemVer":"1.2.3+5",
   "InformationalVersion":"1.2.3+5.Sha.commitSha",
   "BranchName":"",
+  "EscapedBranchName":"",
   "Sha":"commitSha",
   "ShortSha":"commitShortSha",
   "NuGetVersionV2":"1.2.3",

--- a/src/GitVersionCore.Tests/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?define AssemblySemFileVer="1.2.3.0"?>
   <?define AssemblySemVer="1.2.3.0"?>
@@ -8,6 +8,7 @@
   <?define CommitDate="2019-02-20"?>
   <?define CommitsSinceVersionSource="5"?>
   <?define CommitsSinceVersionSourcePadded="0005"?>
+  <?define EscapedBranchName="develop"?>
   <?define FullBuildMetaData="5.Branch.develop.Sha.commitSha"?>
   <?define FullSemVer="1.2.3+5"?>
   <?define InformationalVersion="1.2.3+5.Branch.develop.Sha.commitSha"?>

--- a/src/GitVersionCore.Tests/Approved/cs/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/cs/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
@@ -31,6 +31,7 @@ static class GitVersionInformation
     public static string FullSemVer = "1.2.3-unstable.4+5";
     public static string InformationalVersion = "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha";
     public static string BranchName = "feature1";
+    public static string EscapedBranchName = "feature1";
     public static string Sha = "commitSha";
     public static string ShortSha = "commitShortSha";
     public static string NuGetVersionV2 = "1.2.3-unstable0004";

--- a/src/GitVersionCore.Tests/Approved/fs/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/fs/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
@@ -31,6 +31,7 @@ module GitVersionInformation
     let FullSemVer = "1.2.3-unstable.4+5"
     let InformationalVersion = "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha"
     let BranchName = "feature1"
+    let EscapedBranchName = "feature1"
     let Sha = "commitSha"
     let ShortSha = "commitShortSha"
     let NuGetVersionV2 = "1.2.3-unstable0004"

--- a/src/GitVersionCore.Tests/Approved/vb/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/Approved/vb/GitVersionInformationGeneratorTests.ShouldCreateFile.approved.txt
@@ -32,6 +32,7 @@ NotInheritable Class GitVersionInformation
     Public Shared FullSemVer As String = "1.2.3-unstable.4+5"
     Public Shared InformationalVersion As String = "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha"
     Public Shared BranchName As String = "feature1"
+    Public Shared EscapedBranchName As String = "feature1"
     Public Shared Sha As String = "commitSha"
     Public Shared ShortSha As String = "commitShortSha"
     Public Shared NuGetVersionV2 As String = "1.2.3-unstable0004"

--- a/src/GitVersionCore.Tests/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/GitVersionExecutorTests.cs
@@ -125,6 +125,7 @@ namespace GitVersionCore.Tests
         FullSemVer: 4.10.3-test.19
         InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         BranchName: feature/test
+        EscapedBranchName: feature-test
         Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         ShortSha: dd2a29af
         NuGetVersionV2: 4.10.3-test0019
@@ -185,6 +186,7 @@ namespace GitVersionCore.Tests
         FullSemVer: 4.10.3-test.19
         InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         BranchName: feature/test
+        EscapedBranchName: feature-test
         Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         ShortSha: dd2a29af
         NuGetVersionV2: 4.10.3-test0019
@@ -268,6 +270,7 @@ namespace GitVersionCore.Tests
         FullSemVer: 4.10.3-test.19
         InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         BranchName: feature/test
+        EscapedBranchName: feature-test
         Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         ShortSha: dd2a29af
         NuGetVersionV2: 4.10.3-test0019
@@ -328,6 +331,7 @@ namespace GitVersionCore.Tests
         FullSemVer: 4.10.3-test.19
         InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         BranchName: feature/test
+        EscapedBranchName: feature-test
         Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
         ShortSha: dd2a29af
         NuGetVersionV2: 4.10.3-test0019

--- a/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
@@ -7,15 +7,15 @@ namespace GitVersionCore.Tests.Helpers
         public TestableVersionVariables(
             string major = "", string minor = "", string patch = "", string buildMetaData = "",
             string buildMetaDataPadded = "", string fullBuildMetaData = "", string branchName = "",
-            string sha = "", string shortSha = "", string majorMinorPatch = "", string semVer = "",
-            string legacySemVer = "", string legacySemVerPadded = "", string fullSemVer = "",
+            string escapedBranchName = "", string sha = "", string shortSha = "", string majorMinorPatch = "",
+            string semVer = "", string legacySemVer = "", string legacySemVerPadded = "", string fullSemVer = "",
             string assemblySemVer = "", string assemblySemFileVer = "", string preReleaseTag = "",
             string preReleaseTagWithDash = "", string preReleaseLabel = "", string preReleaseNumber = "",
             string weightedPreReleaseNumber = "", string informationalVersion = "", string commitDate = "",
             string nugetVersion = "", string nugetVersionV2 = "", string nugetPreReleaseTag = "",
             string nugetPreReleaseTagV2 = "", string versionSourceSha = "", string commitsSinceVersionSource = "",
             string commitsSinceVersionSourcePadded = "") : base(
-                major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName,
+                major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, escapedBranchName,
                 sha, shortSha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer,
                 assemblySemVer, assemblySemFileVer, preReleaseTag, weightedPreReleaseNumber, preReleaseTagWithDash,
                 preReleaseLabel, preReleaseNumber, informationalVersion, commitDate, nugetVersion, nugetVersionV2,

--- a/src/GitVersionCore/OutputVariables/VariableProvider.cs
+++ b/src/GitVersionCore/OutputVariables/VariableProvider.cs
@@ -76,6 +76,7 @@ namespace GitVersion.OutputVariables
                 semverFormatValues.BuildMetaDataPadded,
                 semverFormatValues.FullBuildMetaData,
                 semverFormatValues.BranchName,
+                semverFormatValues.EscapedBranchName,
                 semverFormatValues.Sha,
                 semverFormatValues.ShortSha,
                 semverFormatValues.MajorMinorPatch,

--- a/src/GitVersionCore/OutputVariables/VersionVariables.cs
+++ b/src/GitVersionCore/OutputVariables/VersionVariables.cs
@@ -18,6 +18,7 @@ namespace GitVersion.OutputVariables
                                 string buildMetaDataPadded,
                                 string fullBuildMetaData,
                                 string branchName,
+                                string escapedBranchName,
                                 string sha,
                                 string shortSha,
                                 string majorMinorPatch,
@@ -49,6 +50,7 @@ namespace GitVersion.OutputVariables
             BuildMetaDataPadded = buildMetaDataPadded;
             FullBuildMetaData = fullBuildMetaData;
             BranchName = branchName;
+            EscapedBranchName = escapedBranchName;
             Sha = sha;
             ShortSha = shortSha;
             MajorMinorPatch = majorMinorPatch;
@@ -94,6 +96,7 @@ namespace GitVersion.OutputVariables
         public string FullSemVer { get; private set; }
         public string InformationalVersion { get; private set; }
         public string BranchName { get; private set; }
+        public string EscapedBranchName { get; private set; }
         public string Sha { get; private set; }
         public string ShortSha { get; private set; }
         public string NuGetVersionV2 { get; private set; }

--- a/src/GitVersionCore/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -54,6 +54,8 @@ namespace GitVersion
 
         public string BranchName => semver.BuildMetaData.Branch;
 
+        public string EscapedBranchName => semver.BuildMetaData.Branch.RegexReplace("[^a-zA-Z0-9-]", "-");
+
         public string Sha => semver.BuildMetaData.Sha;
 
         public string ShortSha => semver.BuildMetaData.ShortSha;

--- a/src/GitVersionCore/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -54,7 +54,7 @@ namespace GitVersion
 
         public string BranchName => semver.BuildMetaData.Branch;
 
-        public string EscapedBranchName => semver.BuildMetaData.Branch.RegexReplace("[^a-zA-Z0-9-]", "-");
+        public string EscapedBranchName => semver.BuildMetaData.Branch?.RegexReplace("[^a-zA-Z0-9-]", "-");
 
         public string Sha => semver.BuildMetaData.Sha;
 

--- a/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
@@ -65,6 +65,9 @@ namespace GitVersion.MSBuildTask.Tasks
         public string BranchName { get; set; }
 
         [Output]
+        public string EscapedBranchName { get; set; }
+
+        [Output]
         public string Sha { get; set; }
 
         [Output]


### PR DESCRIPTION
Closes #1520 Added another variable `EscapedBranchName`.  This will replace special characters in the BranchName (e.g. `/`) with `-` so that it complies to SemVer.