### PR TITLE
Issue #2165 WorkingTree uses incorrect commit.

### DIFF
--- a/src/GitVersionCore/Extensions/ArgumentExtensions.cs
+++ b/src/GitVersionCore/Extensions/ArgumentExtensions.cs
@@ -26,12 +26,7 @@ namespace GitVersion.Extensions
 
         public static string GetProjectRootDirectory(this Arguments arguments)
         {
-            if (arguments.IsDynamicGitRepository())
-            {
-                return arguments.GetWorkingDirectory();
-            }
-
-            var dotGitDirectory = Repository.Discover(arguments.GetWorkingDirectory());
+            var dotGitDirectory = Repository.Discover(arguments.IsDynamicGitRepository() ? arguments.DynamicGitRepositoryPath : arguments.GetWorkingDirectory());
 
             if (string.IsNullOrEmpty(dotGitDirectory))
                 throw new DirectoryNotFoundException($"Can't find the .git directory in {dotGitDirectory}");

--- a/src/GitVersionCore/GitVersionCalculator.cs
+++ b/src/GitVersionCore/GitVersionCalculator.cs
@@ -61,7 +61,7 @@ namespace GitVersion
         {
             var configuration = configProvider.Provide(overrideConfig: arguments.OverrideConfig);
 
-            using var repo = new Repository(arguments.GetDotGitDirectory());
+            using var repo = new Repository(arguments.GetProjectRootDirectory());
             var targetBranch = repo.GetTargetBranch(arguments.TargetBranch);
             var gitVersionContext = new GitVersionContext(repo, log, targetBranch, configuration, commitId: arguments.CommitId);
             var semanticVersion = nextVersionCalculator.FindVersion(gitVersionContext);


### PR DESCRIPTION
The repository opened for use to do versioning should be the Project Directory, not the DotGit directory.
Also fixes it so the project directory used is based on the DynamicGitDirectory if it is a dynamic repo.

Fixes #2165. Closes #1848.