### PR TITLE
Parse Bitbucket v7 pull request merge message.

### DIFF
--- a/src/GitVersionCore.Tests/MergeMessageTests.cs
+++ b/src/GitVersionCore.Tests/MergeMessageTests.cs
@@ -150,6 +150,34 @@ namespace GitVersionCore.Tests
             sut.Version.ShouldBe(expectedVersion);
         }
 
+        private static readonly object[] BitBucketPullMergeMessagesv7 =
+        {
+            new object[] { @"Pull request #68: Release/2.2
+
+Merge in aaa/777 from release/2.2 to master
+
+* commit '750aa37753dec1a85b22cc16db851187649d9e97':", "release/2.2", "master", new SemanticVersion(2,2,0), 68  }
+        };
+
+        [TestCaseSource(nameof(BitBucketPullMergeMessagesv7))]
+        public void ParsesBitBucketPullMergeMessagev7(
+            string message,
+            string expectedMergedBranch,
+            string expectedTargetBranch,
+            SemanticVersion expectedVersion,
+            int? expectedPullRequestNumber)
+        {
+            // Act
+            var sut = new MergeMessage(message, config);
+
+            // Assert
+            sut.FormatName.ShouldBe("BitBucketPullv7");
+            sut.TargetBranch.ShouldBe(expectedTargetBranch);
+            sut.MergedBranch.ShouldBe(expectedMergedBranch);
+            sut.IsMergedPullRequest.ShouldBeTrue();
+            sut.PullRequestNumber.ShouldBe(expectedPullRequestNumber);
+            sut.Version.ShouldBe(expectedVersion);
+        }
 
         private static readonly object[] SmartGitMergeMessages =
         {

--- a/src/GitVersionCore/MergeMessage.cs
+++ b/src/GitVersionCore/MergeMessage.cs
@@ -13,6 +13,7 @@ namespace GitVersion
             new MergeMessageFormat("Default", @"^Merge (branch|tag) '(?<SourceBranch>[^']*)'(?: into (?<TargetBranch>[^\s]*))*"),
             new MergeMessageFormat("SmartGit",  @"^Finish (?<SourceBranch>[^\s]*)(?: into (?<TargetBranch>[^\s]*))*"),
             new MergeMessageFormat("BitBucketPull", @"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)"),
+            new MergeMessageFormat("BitBucketPullv7", @"^Pull request #(?<PullRequestNumber>\d+).*\r?\n\r?\nMerge in (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)"),
             new MergeMessageFormat("GitHubPull", @"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?:(?<SourceBranch>[^\s]*))(?: into (?<TargetBranch>[^\s]*))*"),
             new MergeMessageFormat("RemoteTracking", @"^Merge remote-tracking branch '(?<SourceBranch>[^\s]*)'(?: into (?<TargetBranch>[^\s]*))*")
         };


### PR DESCRIPTION
## Description
Added new merge message format to DefaultFormats and implemented tests for Bitbucket v7's new pull request commit message.

## Related Issue
Fixes #2175 

## Motivation and Context
The version should be correctly increased with a Bitbucket pull request commit message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
