### PR TITLE
Add PrivateAssets="All" to package reference

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,6 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds `PrivateAssets="All"` to the Microsoft.NETFramework.ReferenceAssemblies package reference. This removes this package dependency from the GitVersionTask package.

Fixes #2177 