### PR TITLE
Generate assembly info for System.Web precompiled projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ config.wyam.hash
 config.wyam.packages.xml
 /test/core/build
 /test/full/build
+/test/systemweb/build

--- a/build/utils/utils.cake
+++ b/build/utils/utils.cake
@@ -1,5 +1,7 @@
 #load "./docker.cake"
 
+using System.Reflection;
+
 public static FilePath FindToolInPath(this ICakeContext context, string tool)
 {
     var pathEnv = context.EnvironmentVariable("PATH");
@@ -140,6 +142,15 @@ void ValidateOutput(string cmd, string args, string expected)
     Information(outputStr);
 
     Assert.Equal(expected, outputStr);
+}
+
+void ValidateAssemblyVersion(string path, string expected)
+{
+    var assembly = Assembly.LoadFrom(path);
+    var versionStr = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+    Information(versionStr);
+
+    Assert.Equal(expected, versionStr);
 }
 
 void RunGitVersionOnCI(BuildParameters parameters)

--- a/src/GitVersionTask/build/GitVersionTask.props
+++ b/src/GitVersionTask/build/GitVersionTask.props
@@ -22,6 +22,9 @@
         <UpdateAssemblyInfo Condition=" '$(UsingMicrosoftNETSdk)' == 'true' ">false</UpdateAssemblyInfo>
         <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
 
+        <!-- Property that enables Assembly Info generation for System.Web projects -->
+        <GenerateAspNetAssemblyInfo Condition=" '$(GenerateAspNetAssemblyInfo)' == '' ">True</GenerateAspNetAssemblyInfo>
+
         <!-- Property that enables GenerateGitVersionInformation -->
         <GenerateGitVersionInformation Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GenerateGitVersionInformation>
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' ">true</GenerateGitVersionInformation>

--- a/src/GitVersionTask/build/GitVersionTask.targets
+++ b/src/GitVersionTask/build/GitVersionTask.targets
@@ -41,6 +41,27 @@
 
     </Target>
 
+    <!-- System.Web publishing: The targets below are used when 'UseMerge' has been set 'True' in the publish profile -->
+    <Target Name="UpdateAspNetPublishPipelineTargetsForGitAssemblyInfo" BeforeTargets="AspNetPreCompile" Condition="'$(GenerateAspNetAssemblyInfo)' == 'True'">
+        <PropertyGroup>
+            <GenerateAssemblyInfoDependsOn>SetGitAssemblyInfoForAspNetPublishPipeline;$(GenerateAssemblyInfoDependsOn)</GenerateAssemblyInfoDependsOn>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="SetGitAssemblyInfoForAspNetPublishPipeline" DependsOnTargets="GetVersion">
+        <ItemGroup>
+            <AssemblyAttributes Include="AssemblyVersionAttribute">
+                <Value>$(GitVersion_AssemblySemVer)</Value>
+            </AssemblyAttributes>
+            <AssemblyAttributes Include="AssemblyInformationalVersionAttribute">
+                <Value>$(GitVersion_InformationalVersion)</Value>
+            </AssemblyAttributes>
+            <AssemblyAttributes Include="AssemblyFileVersionAttribute">
+                <Value>$(GitVersion_AssemblySemFileVer)</Value>
+            </AssemblyAttributes>
+        </ItemGroup>
+    </Target>
+
     <Target Name="GenerateGitVersionInformation" BeforeTargets="CoreCompile" Condition="$(GenerateGitVersionInformation) == 'true'">
 
         <GenerateGitVersionInformation SolutionDirectory="$(GitVersionPath)"

--- a/test/systemweb/Default.aspx
+++ b/test/systemweb/Default.aspx
@@ -1,0 +1,14 @@
+<%@ Page Language="C#" Inherits="System.Web.UI.Page" %>
+
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head runat="server">
+    <title></title>
+</head>
+<body>
+    <form runat="server">
+        <!-- This file is here to be precompiled -->
+    </form>
+</body>
+</html>

--- a/test/systemweb/Properties/AssemblyInfo.cs
+++ b/test/systemweb/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/systemweb/Properties/PublishProfiles/TestPublish.pubxml
+++ b/test/systemweb/Properties/PublishProfiles/TestPublish.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PrecompileBeforePublish>True</PrecompileBeforePublish>
+    <EnableUpdateable>False</EnableUpdateable>
+    <DebugSymbols>False</DebugSymbols>
+    <WDPMergeOption>MergeAllOutputsToASingleAssembly</WDPMergeOption>
+    <UseMerge>True</UseMerge>
+    <SingleAssemblyName>TestPublishAssembly</SingleAssemblyName>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <publishUrl>$(OutputPath)\TestPublish</publishUrl>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/test/systemweb/Web.config
+++ b/test/systemweb/Web.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8" />
+    <httpRuntime targetFramework="4.8" />
+  </system.web>
+</configuration>

--- a/test/systemweb/test.csproj
+++ b/test/systemweb/test.csproj
@@ -1,0 +1,53 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AE610E63-FF81-4804-803D-3EB52D94D751}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>test</RootNamespace>
+    <AssemblyName>test</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Default.aspx" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <None Include="Properties\PublishProfiles\TestPublish.pubxml" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+</Project>


### PR DESCRIPTION
This only works for precompiled and merged publications. Unmerged published DLLs don't allow any custom handling of assembly information.

Fixes #2192.

## Description
Added targets that hook into the correct stage of the System.Web precompilation publishing pipeline. The first target is needed because a `XxxDependsOn` property is used and we must inject our task execution at the right stage. Then, the other target injects the attributes which are used in the merge assembly compilation.

## Related Issue
[#2192 - Support injecting assembly information in precompiled website binary](https://github.com/GitTools/GitVersion/issues/2192)

## Motivation and Context
Currently no version information is stored at all in the precompiled DLL, so you can't tell from which commit, or codebase it has been compiled.

## How Has This Been Tested?

1. Create a ASP.NET Web Forms or MVC project with content.
2. Create a publish profile and enable "precompilation", disable "updateable" and enable merging. Eventually you end up with a publish profile that looks like this:
```
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup>
    <WebPublishMethod>FileSystem</WebPublishMethod>
    <PublishProvider>FileSystem</PublishProvider>
    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
    <LastUsedPlatform>Any CPU</LastUsedPlatform>
    <SiteUrlToLaunchAfterPublish />
    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
    <PrecompileBeforePublish>True</PrecompileBeforePublish>
    <EnableUpdateable>False</EnableUpdateable>
    <DebugSymbols>True</DebugSymbols>
    <WDPMergeOption>MergeAllOutputsToASingleAssembly</WDPMergeOption>
    <UseMerge>True</UseMerge>
    <SingleAssemblyName>_MergedWebAssembly</SingleAssemblyName>
    <publishUrl>bin\Release\Publish</publishUrl>
  </PropertyGroup>
</Project>
```
3. Publish the project, either through Visual Studio, or by invoking MSBuild with these parameters:

    /t:Rebuild /p:DeployOnBuild=true /p:PublishProfile=[filename of publish profile without extension]

4. Find the `_MergedWebAssembly.dll` file in the folder of the `publishUrl` parameter in the publish profile. Note it has no assembly information (version is set to 0.0.0.0).

5. Include the updated GitVersion targets in the project or install the compiled NuGet package. 

6. Re-execute step 3. Like in step 4, find the file again and notice the assembly information has now been injected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. --> I added a flag to allow disabling the code generation, but I don't see many of the current flags documented either. Do we want to document this flag?
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. --> I'm not sure if your existing tests allow full integration testing of the MSBuild publish pipeline. 
- [x] All new and existing tests passed.
