### PR TITLE
Braces should be removed

### DIFF
--- a/docs/input/docs/build-server-support/build-server/teamcity.md
+++ b/docs/input/docs/build-server-support/build-server/teamcity.md
@@ -34,12 +34,12 @@ use dynamic repositories.
 ### Agent checkout
 
 For GitVersion to pick up pull requests properly you need to promote the
-`%teamcity.build.vcs.branch.{configurationid}%` variable to an environment
+`%teamcity.build.vcs.branch.{vcsid}%` variable to an environment
 variable called `Git_Branch`
 
 Just go to your build configuration, Parameters, click Add, Name should be
 `env.Git_Branch`, value should be `%teamcity.build.vcs.branch.{vcsid}%` where
-vcsid is your VCS root id. You should get auto completion for this.
+`{vcsid}` is your VCS root id. You should get auto completion for this.
 
 For GitVersion to work with any mode requiring other than the currently built
 branch to calculate the version number, you need to set the configuration


### PR DESCRIPTION
1. Make it clear that the braces around `{vcsid}` should not appear in the final string.

2. Consistently refer to `vcsid` instead of `vcsid` and `configurationId`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
