### PR TITLE
Add example Powershell for Bamboo Windows build hosts

### DIFF
--- a/docs/input/docs/build-server-support/build-server/bamboo.md
+++ b/docs/input/docs/build-server-support/build-server/bamboo.md
@@ -5,18 +5,30 @@ Title: Bamboo
 
 If you use Bamboo then you will have to use GitVersion from the command line, as
 there is no actively supported app.  You can use the "Inject Bamboo Variables"
-task to read the GitVersion output back into Bamboo.  Below is a Linux example
+task to read the GitVersion output back into Bamboo. Below are two examples
 using the [.NET Core GitVersion global tool](https://www.nuget.org/packages/GitVersion.Tool/).
 
 ## Example
 
 ### Task: Script
 
+This script can be run on a Linux build host.
+
 **Script body**
 
 ```bash
 ~/.dotnet/tools/dotnet-gitversion > gitversion.txt
 sed -i '1d;26d;s/  //;s/"//g;s/,//;s/:/=/' gitversion.txt
+```
+
+### Task: Script
+
+**Script body**
+
+This script can be run on a Windows build host using Powershell.
+
+```powershell
+(dotnet gitversion | ConvertFrom-Json).PSObject.Properties | ForEach-Object { Write-Output "$($_.Name)=$($_.Value)" } | Out-File -Encoding UTF8 -FilePath gitversion.txt
 ```
 
 ### Task: Inject Bamboo variables Configuration

--- a/docs/input/docs/build-server-support/build-server/bamboo.md
+++ b/docs/input/docs/build-server-support/build-server/bamboo.md
@@ -10,9 +10,10 @@ using the [.NET Core GitVersion global tool](https://www.nuget.org/packages/GitV
 
 ## Example
 
-### Task: Script
+The first script can be run on a Linux build host, the second script can be run on
+a Windows build host using Powershell. The build only needs one of the two.
 
-This script can be run on a Linux build host.
+### Task: Script
 
 **Script body**
 
@@ -24,8 +25,6 @@ sed -i '1d;26d;s/  //;s/"//g;s/,//;s/:/=/' gitversion.txt
 ### Task: Script
 
 **Script body**
-
-This script can be run on a Windows build host using Powershell.
 
 ```powershell
 (dotnet gitversion | ConvertFrom-Json).PSObject.Properties | ForEach-Object { Write-Output "$($_.Name)=$($_.Value)" } | Out-File -Encoding UTF8 -FilePath gitversion.txt


### PR DESCRIPTION
## Description
Updates the docs (only) with a new example.

## Related Issue
No issue for this docs-only change.

## Motivation and Context
There was no example for a Windows build host.

## How Has This Been Tested?
Running on a project of my own on a shared Bamboo server.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [n/a ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.
