### PR TITLE
Creation of all UsernamePasswordCredentials ensure non-null password

### DIFF
--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -149,14 +149,14 @@ namespace GitVersion
 
             if (auth != null)
             {
-                if (!string.IsNullOrWhiteSpace(auth.Username) && !string.IsNullOrWhiteSpace(auth.Password))
+                if (!string.IsNullOrWhiteSpace(auth.Username))
                 {
                     log.Info($"Setting up credentials using name '{auth.Username}'");
 
                     credentials = new UsernamePasswordCredentials
                     {
                         Username = auth.Username,
-                        Password = auth.Password
+                        Password = auth.Password ?? string.Empty
                     };
                 }
             }

--- a/src/GitVersionCore/Extensions/RepositoryExtensions.cs
+++ b/src/GitVersionCore/Extensions/RepositoryExtensions.cs
@@ -196,7 +196,7 @@ namespace GitVersion.Extensions
             return repository.Network.ListReferences(remote, (url, fromUrl, types) => new UsernamePasswordCredentials
             {
                 Username = username,
-                Password = password
+                Password = password ?? string.Empty
             }).Select(r => r.ResolveToDirectReference());
         }
 

--- a/src/GitVersionCore/Model/AuthenticationInfo.cs
+++ b/src/GitVersionCore/Model/AuthenticationInfo.cs
@@ -17,7 +17,7 @@ namespace GitVersion
                 fetchOptions.CredentialsProvider = (url, user, types) => new UsernamePasswordCredentials
                 {
                     Username = Username,
-                    Password = Password
+                    Password = Password ?? string.Empty
                 };
             }
 


### PR DESCRIPTION
This is to avoid runtime errors when using personal access tokens to authenticate
when fetching etc. from private github repos.

The standard way to authenticate:

new UsernamePasswordCredentials
{
    Username = "github-personal-access-token", // GITVERSION_REMOTE_USERNAME
    Password = string.Empty
};

GitVersion should support this authentication scheme necessary when having 2FA.

When using environment variables to propagate credentials password will end up
being null, because GITVERSION_REMOTE_PASSWORD is not present when passing empty
value.

This commit guards against libgit2sharp throwing LibGit2SharpException:
"UsernamePasswordCredentials contains a null Username or Password."


## Description, Motivation and Context

Fixes #2247.

## How Has This Been Tested?

I have cross-compiled (self-contained) gitversion.exe for win-x64 and seen that all my builds of private github repos with this 5.2.5-xxxx does succeed again.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

My change can be done in various ways. 3 changes (in 3 different files) are where UsernamePasswordCredentials are instantiated and passed to libgit2sharp. Feel free to refactor.
No tests, because the change is trivial, and should not break anybodys use of gitversion.

