### PR TITLE
GH-2252 - fix GitVersion.Portable and GitVersion.CommandLine packaging

### DIFF
--- a/build.config
+++ b/build.config
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-DOTNET_VERSION=2.1.804,3.1.201
+DOTNET_VERSION=2.1.805,3.1.201

--- a/build/pack.cake
+++ b/build/pack.cake
@@ -17,7 +17,7 @@ Task("Pack-Prepare")
         });
     }
 
-    var sourceDir = parameters.Paths.Directories.Native.Combine(PlatformFamily.Windows.ToString());
+    var sourceDir = parameters.Paths.Directories.Native.Combine(PlatformFamily.Windows.ToString()).Combine("win-x64");
     var sourceFiles = GetFiles(sourceDir + "/*.*");
 
     // Cmdline and Portable


### PR DESCRIPTION
Fixes #2252 