### PR TITLE
Issue #2257 Ensure Valid Wix Version File

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?define AssemblySemFileVer="1.2.3.0"?>
+  <?define AssemblySemVer="1.2.3.0"?>
+  <?define BranchName="develop"?>
+  <?define BuildMetaData="5"?>
+  <?define BuildMetaDataPadded="05"?>
+  <?define CommitDate="2019-02-20"?>
+  <?define CommitsSinceVersionSource="5"?>
+  <?define CommitsSinceVersionSourcePadded="0005"?>
+  <?define EscapedBranchName="develop"?>
+  <?define FullBuildMetaData="5.Branch.develop.Sha.commitSha"?>
+  <?define FullSemVer="1.2.3+5"?>
+  <?define InformationalVersion="1.2.3+5.Branch.develop.Sha.commitSha"?>
+  <?define LegacySemVer="1.2.3"?>
+  <?define LegacySemVerPadded="1.2.3"?>
+  <?define Major="1"?>
+  <?define MajorMinorPatch="1.2.3"?>
+  <?define Minor="2"?>
+  <?define NuGetPreReleaseTag=""?>
+  <?define NuGetPreReleaseTagV2=""?>
+  <?define NuGetVersion="1.2.3"?>
+  <?define NuGetVersionV2="1.2.3"?>
+  <?define Patch="3"?>
+  <?define PreReleaseLabel=""?>
+  <?define PreReleaseNumber=""?>
+  <?define PreReleaseTag=""?>
+  <?define PreReleaseTagWithDash=""?>
+  <?define SemVer="1.2.3"?>
+  <?define Sha="commitSha"?>
+  <?define ShortSha="commitShortSha"?>
+  <?define VersionSourceSha="versionSourceSha"?>
+  <?define WeightedPreReleaseNumber=""?>
+</Include>

--- a/src/GitVersionCore.Tests/VersionConverters/WixFileTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/WixFileTests.cs
@@ -67,5 +67,55 @@ namespace GitVersionCore.Tests
                 .ReadAllText(file)
                 .ShouldMatchApproved(c => c.SubFolder(Path.Combine("Approved")));
         }
+
+        [Test]
+        [Category(NoMono)]
+        [Description(NoMonoDescription)]
+        public void UpdateWixVersionFileWhenFileAlreadyExists()
+        {
+            var workingDir = Path.GetTempPath();
+            var semVer = new SemanticVersion
+            {
+                Major = 1,
+                Minor = 2,
+                Patch = 3,
+                BuildMetaData = "5.Branch.develop"
+            };
+
+            semVer.BuildMetaData.VersionSourceSha = "versionSourceSha";
+            semVer.BuildMetaData.Sha = "commitSha";
+            semVer.BuildMetaData.ShortSha = "commitShortSha";
+            semVer.BuildMetaData.CommitDate = DateTimeOffset.Parse("2019-02-20 23:59:59Z");
+
+            var config = new TestEffectiveConfiguration(buildMetaDataPadding: 2, legacySemVerPadding: 5);
+
+            var stringBuilder = new StringBuilder();
+            void Action(string s) => stringBuilder.AppendLine(s);
+
+            var logAppender = new TestLogAppender(Action);
+            var log = new Log(logAppender);
+
+            var sp = ConfigureServices(service =>
+            {
+                service.AddSingleton<ILog>(log);
+            });
+
+            var fileSystem = sp.GetService<IFileSystem>();
+            var variableProvider = sp.GetService<IVariableProvider>();
+            var versionVariables = variableProvider.GetVariablesFor(semVer, config, false);
+
+            using var wixVersionFileUpdater = sp.GetService<IWixVersionFileUpdater>();
+
+            // fake an already existing file
+            var file = Path.Combine(workingDir, WixVersionFileUpdater.WixVersionFileName);
+            fileSystem.WriteAllText(file, new string('x', 1024 * 1024));
+
+            wixVersionFileUpdater.Execute(versionVariables, new WixVersionContext(workingDir));
+
+            fileSystem
+                .ReadAllText(file)
+                .ShouldMatchApproved(c => c.SubFolder(Path.Combine("Approved")));
+        }
+
     }
 }

--- a/src/GitVersionCore/VersionConverters/WixUpdater/WixVersionFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/WixUpdater/WixVersionFileUpdater.cs
@@ -12,14 +12,12 @@ namespace GitVersion.VersionConverters.WixUpdater
     }
     public class WixVersionFileUpdater : IWixVersionFileUpdater
     {
-        private readonly IFileSystem fileSystem;
         private readonly ILog log;
         private string wixVersionFile;
         public const string WixVersionFileName = "GitVersion_WixVersion.wxi";
 
-        public WixVersionFileUpdater(IFileSystem fileSystem, ILog log)
+        public WixVersionFileUpdater(ILog log)
         {
-            this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             this.log = log ?? throw new ArgumentNullException(nameof(log));
         }
 
@@ -35,8 +33,7 @@ namespace GitVersion.VersionConverters.WixUpdater
             var root = doc.DocumentElement;
             doc.InsertBefore(xmlDecl, root);
 
-            using var fs = fileSystem.OpenWrite(wixVersionFile);
-            doc.Save(fs);
+            doc.Save(wixVersionFile);
         }
 
         private static string GetWixFormatFromVersionVariables(VersionVariables variables)

--- a/src/GitVersionCore/VersionConverters/WixUpdater/WixVersionFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/WixUpdater/WixVersionFileUpdater.cs
@@ -12,12 +12,14 @@ namespace GitVersion.VersionConverters.WixUpdater
     }
     public class WixVersionFileUpdater : IWixVersionFileUpdater
     {
+        private readonly IFileSystem fileSystem;
         private readonly ILog log;
         private string wixVersionFile;
         public const string WixVersionFileName = "GitVersion_WixVersion.wxi";
 
-        public WixVersionFileUpdater(ILog log)
+        public WixVersionFileUpdater(IFileSystem fileSystem, ILog log)
         {
+            this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             this.log = log ?? throw new ArgumentNullException(nameof(log));
         }
 
@@ -33,7 +35,9 @@ namespace GitVersion.VersionConverters.WixUpdater
             var root = doc.DocumentElement;
             doc.InsertBefore(xmlDecl, root);
 
-            doc.Save(wixVersionFile);
+            fileSystem.Delete(wixVersionFile);
+            using var fs = fileSystem.OpenWrite(wixVersionFile);
+            doc.Save(fs);
         }
 
         private static string GetWixFormatFromVersionVariables(VersionVariables variables)


### PR DESCRIPTION
This PR fixes #2257

Note 1: The first commit would also fix the issue but does not the IFileStream as an abstraction layer. The second commit does.

Note 2: The added unit test also succeeds without the fix :(. As far as I saw, this is because the `OpenWrite()` function of the `TestFileSystem` class does not behave the way as it documented in https://docs.microsoft.com/en-us/dotnet/api/system.io.file.openwrite?view=netcore-3.1 in regards to existing files.