### PR TITLE
Spike showing new CLI usage - got one command working

### DIFF
--- a/src/GitVersion.sln
+++ b/src/GitVersion.sln
@@ -4,8 +4,6 @@ VisualStudioVersion = 16.0.28714.193
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionExe", "GitVersionExe\GitVersionExe.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionTask.Tests", "GitVersionTask.Tests\GitVersionTask.Tests.csproj", "{5A86453B-96FB-4B6E-A283-225BB9F753D3}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionCore.Tests", "GitVersionCore.Tests\GitVersionCore.Tests.csproj", "{BF905F84-382C-440D-92F5-C61108626D8D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3EFFC5D6-88D0-49D9-BB53-E1B7EB49DD45}"
@@ -29,10 +27,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionCore", "GitVersio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionExe.Tests", "GitVersionExe.Tests\GitVersionExe.Tests.csproj", "{75C2BE85-1DAF-4E34-8305-B17AFAA982A6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionTask", "GitVersionTask\GitVersionTask.csproj", "{F7AC0E71-3E9A-4F6D-B986-E004825A48E1}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitVersionTask.MsBuild", "GitVersionTask.MsBuild\GitVersionTask.MsBuild.csproj", "{0F1AEC4E-E81D-4F84-B2E8-3415A1A4DBF4}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,10 +37,6 @@ Global
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5A86453B-96FB-4B6E-A283-225BB9F753D3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BF905F84-382C-440D-92F5-C61108626D8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BF905F84-382C-440D-92F5-C61108626D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF905F84-382C-440D-92F5-C61108626D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -59,14 +49,6 @@ Global
 		{75C2BE85-1DAF-4E34-8305-B17AFAA982A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75C2BE85-1DAF-4E34-8305-B17AFAA982A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75C2BE85-1DAF-4E34-8305-B17AFAA982A6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F7AC0E71-3E9A-4F6D-B986-E004825A48E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F7AC0E71-3E9A-4F6D-B986-E004825A48E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F7AC0E71-3E9A-4F6D-B986-E004825A48E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F7AC0E71-3E9A-4F6D-B986-E004825A48E1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0F1AEC4E-E81D-4F84-B2E8-3415A1A4DBF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F1AEC4E-E81D-4F84-B2E8-3415A1A4DBF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0F1AEC4E-E81D-4F84-B2E8-3415A1A4DBF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0F1AEC4E-E81D-4F84-B2E8-3415A1A4DBF4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
@@ -418,7 +418,7 @@ namespace GitVersionCore.Tests
 
                 sp = GetServiceProvider(gitVersionOptions);
 
-                gitVersionOptions.ProjectRootDirectory.TrimEnd('/', '\\').ShouldBe(worktreePath);
+                gitVersionOptions.GitRepositoryWorkingDirectory.TrimEnd('/', '\\').ShouldBe(worktreePath);
             }
             finally
             {
@@ -441,7 +441,7 @@ namespace GitVersionCore.Tests
             sp = GetServiceProvider(gitVersionOptions);
 
             var expectedPath = fixture.RepositoryPath.TrimEnd('/', '\\');
-            gitVersionOptions.ProjectRootDirectory.TrimEnd('/', '\\').ShouldBe(expectedPath);
+            gitVersionOptions.GitRepositoryWorkingDirectory.TrimEnd('/', '\\').ShouldBe(expectedPath);
         }
 
         [Test]

--- a/src/GitVersionCore/Configuration/ConfigFileLocator.cs
+++ b/src/GitVersionCore/Configuration/ConfigFileLocator.cs
@@ -22,7 +22,7 @@ namespace GitVersion.Configuration
         public string SelectConfigFilePath(GitVersionOptions gitVersionOptions)
         {
             var workingDirectory = gitVersionOptions.WorkingDirectory;
-            var projectRootDirectory = gitVersionOptions.ProjectRootDirectory;
+            var projectRootDirectory = gitVersionOptions.GitRepositoryWorkingDirectory;
 
             return GetConfigFilePath(HasConfigFileAt(workingDirectory) ? workingDirectory : projectRootDirectory);
         }
@@ -50,7 +50,7 @@ namespace GitVersion.Configuration
             }
 
             var workingDirectory = gitVersionOptions.WorkingDirectory;
-            var projectRootDirectory = gitVersionOptions.ProjectRootDirectory;
+            var projectRootDirectory = gitVersionOptions.GitRepositoryWorkingDirectory;
 
             Verify(workingDirectory, projectRootDirectory);
         }

--- a/src/GitVersionCore/Configuration/ConfigProvider.cs
+++ b/src/GitVersionCore/Configuration/ConfigProvider.cs
@@ -28,7 +28,7 @@ namespace GitVersion.Configuration
         {
             var gitVersionOptions = options.Value;
             var workingDirectory = gitVersionOptions.WorkingDirectory;
-            var projectRootDirectory = gitVersionOptions.ProjectRootDirectory;
+            var projectRootDirectory = gitVersionOptions.GitRepositoryWorkingDirectory;
 
             var rootDirectory = configFileLocator.HasConfigFileAt(workingDirectory) ? workingDirectory : projectRootDirectory;
             return Provide(rootDirectory, applyDefaults, overrideConfig);

--- a/src/GitVersionCore/Core/GitVersionTool.cs
+++ b/src/GitVersionCore/Core/GitVersionTool.cs
@@ -93,13 +93,14 @@ namespace GitVersion
         {
             var gitVersionOptions = options.Value;
 
-            if (gitVersionOptions.AssemblyInfo.ShouldUpdate)
-            {
-                using (assemblyInfoFileUpdater)
-                {
-                    assemblyInfoFileUpdater.Execute(variables, new AssemblyInfoContext(gitVersionOptions.WorkingDirectory, gitVersionOptions.AssemblyInfo.EnsureAssemblyInfo, gitVersionOptions.AssemblyInfo.Files.ToArray()));
-                }
-            }
+            throw new NotImplementedException();
+            //if (gitVersionOptions.AssemblyInfo.ShouldUpdate)
+            //{
+            //    using (assemblyInfoFileUpdater)
+            //    {
+            //        assemblyInfoFileUpdater.Execute(variables, new AssemblyInfoContext(gitVersionOptions.WorkingDirectory, gitVersionOptions.AssemblyInfo.EnsureAssemblyInfo, gitVersionOptions.AssemblyInfo.Files.ToArray()));
+            //    }
+            //}
         }
 
         public void UpdateWixVersionFile(VersionVariables variables)

--- a/src/GitVersionCore/Extensions/GitVersionOptionsExtensions.cs
+++ b/src/GitVersionCore/Extensions/GitVersionOptionsExtensions.cs
@@ -9,9 +9,7 @@ namespace GitVersion.Extensions
     {
         public static string GetDotGitDirectory(this GitVersionOptions gitVersionOptions)
         {
-            var dotGitDirectory = !string.IsNullOrWhiteSpace(gitVersionOptions.DynamicGitRepositoryPath)
-                ? gitVersionOptions.DynamicGitRepositoryPath
-                : Repository.Discover(gitVersionOptions.WorkingDirectory);
+            var dotGitDirectory = Repository.Discover(gitVersionOptions.WorkingDirectory);
 
             dotGitDirectory = dotGitDirectory?.TrimEnd('/', '\\');
             if (string.IsNullOrEmpty(dotGitDirectory))
@@ -22,20 +20,11 @@ namespace GitVersion.Extensions
                 : dotGitDirectory;
         }
 
-        public static string GetProjectRootDirectory(this GitVersionOptions gitVersionOptions)
+        public static string GetRepositoryWorkingDirectory(this GitVersionOptions gitVersionOptions)
         {
-            if (!string.IsNullOrWhiteSpace(gitVersionOptions.DynamicGitRepositoryPath))
-            {
-                return gitVersionOptions.WorkingDirectory;
-            }
-
-            var dotGitDirectory = Repository.Discover(gitVersionOptions.WorkingDirectory);
-
-            if (string.IsNullOrEmpty(dotGitDirectory))
-                throw new DirectoryNotFoundException($"Can't find the .git directory in {dotGitDirectory}");
-
-            using var repository = new Repository(dotGitDirectory);
-            return repository.Info.WorkingDirectory;
+            //return gitVersionOptions.WorkingDirectory;
+            using var repository = new Repository(gitVersionOptions.DotGitDirectory);
+            return repository.Info.WorkingDirectory;          
         }
 
         public static string GetDynamicGitRepositoryPath(this GitVersionOptions gitVersionOptions)

--- a/src/GitVersionCore/Model/GitVersionOptions.cs
+++ b/src/GitVersionCore/Model/GitVersionOptions.cs
@@ -9,23 +9,23 @@ namespace GitVersion
     public class GitVersionOptions
     {
         private Lazy<string> dotGitDirectory;
-        private Lazy<string> projectRootDirectory;
-        private Lazy<string> dynamicGitRepositoryPath;
+        private Lazy<string> gitRepositoryWorkingDirectory;
 
         public GitVersionOptions()
         {
+            WorkingDirectory = System.Environment.CurrentDirectory;
             dotGitDirectory = new Lazy<string>(this.GetDotGitDirectory);
-            projectRootDirectory = new Lazy<string>(this.GetProjectRootDirectory);
-            dynamicGitRepositoryPath = new Lazy<string>(this.GetDynamicGitRepositoryPath);
+            gitRepositoryWorkingDirectory = new Lazy<string>(this.GetRepositoryWorkingDirectory);
         }
 
+        public string[] Args { get; set; }
         public string WorkingDirectory { get; set; }
-
         public string DotGitDirectory => dotGitDirectory.Value;
-        public string ProjectRootDirectory => projectRootDirectory.Value;
-        public string DynamicGitRepositoryPath => dynamicGitRepositoryPath.Value;
+        public string GitRepositoryWorkingDirectory => gitRepositoryWorkingDirectory.Value;
+        public bool LogToConsole { get; set; } = false;
+        public string LogFilePath;
 
-        public AssemblyInfoData AssemblyInfo { get; } = new AssemblyInfoData();
+        //public AssemblyInfoData AssemblyInfo { get; } = new AssemblyInfoData();
         public AuthenticationInfo Authentication { get; } = new AuthenticationInfo();
         public ConfigInfo ConfigInfo { get; } = new ConfigInfo();
         public RepositoryInfo RepositoryInfo { get; } = new RepositoryInfo();
@@ -37,19 +37,10 @@ namespace GitVersion
         public bool IsVersion;
         public bool IsHelp;
 
-        public string LogFilePath;
         public string ShowVariable;
         public string OutputFile;
         public ISet<OutputType> Output = new HashSet<OutputType>();
         public Verbosity Verbosity = Verbosity.Normal;
 
-        [Obsolete]
-        public string Proj;
-        [Obsolete]
-        public string ProjArgs;
-        [Obsolete]
-        public string Exec;
-        [Obsolete]
-        public string ExecArgs;
     }
 }

--- a/src/GitVersionExe/Commands/CalculateCommand.cs
+++ b/src/GitVersionExe/Commands/CalculateCommand.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Options;
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+
+namespace GitVersion
+{
+    public class CalculateCommand : Command
+    {
+        private readonly IGitVersionTool gitversionTool;
+        private readonly Logging.IConsole console;
+
+        public CalculateCommand(IGitVersionTool gitversionTool, Logging.IConsole console) : base("calculate", "Calculates version information from your git repository")
+        {
+            this.gitversionTool = gitversionTool;
+            this.console = console;
+            this.AddOption(new Option<bool>(
+            "--normalize",
+            "Attempt to mutate your git repository so gitversion has enough information (local branches, commit history etc) to calculate."));
+            this.Handler = CommandHandler.Create<bool?>(ExecuteAsync);            
+        }
+
+        private async Task ExecuteAsync(bool? normalize)
+        {
+            if (normalize ?? false)
+            {
+                await Normalize();
+            }
+
+            var variables = this.gitversionTool.CalculateVersionVariables();
+            console.WriteLine(variables.ToString());
+        }
+
+        private Task Normalize()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/GitVersionExe/Commands/GitVersionRootCommand.cs
+++ b/src/GitVersionExe/Commands/GitVersionRootCommand.cs
@@ -1,19 +1,19 @@
-using Microsoft.Extensions.Options;
 using System.CommandLine;
 
 namespace GitVersion
 {
     public class GitVersionRootCommand : RootCommand
     {
-        public GitVersionRootCommand(CalculateCommand calculateCommand, IOptions<GitVersionOptions> globalOptions) : base("Versioning for your git repository, solved!")
+        public GitVersionRootCommand(CalculateCommand calculateCommand) : base("Versioning for your git repository, solved!")
         {
-            // this.AddGlobalOption()
-            //this.AddGlobalOption(new Option("--target-path") { Argument = new Argument<LoggingMethod>() });
-            //this.AddGlobalOption(new Option("--logging-method") { Argument = new Argument<LoggingMethod>() });
-            GlobalOptions = globalOptions.Value;
-            this.AddCommand(calculateCommand);
-        }
+            var loggingMethodOptions = new Option("--logging-method") { Argument = new Argument<LoggingMethod>() };
+            this.AddGlobalOption(loggingMethodOptions);
 
-        public GitVersionOptions GlobalOptions { get; }
+            var logFileOption = new Option("--logfilepath") { Argument = new Argument<string> { } };
+            logFileOption.Required = false;
+            this.AddGlobalOption(logFileOption);
+
+            this.AddCommand(calculateCommand);
+        }      
     }
 }

--- a/src/GitVersionExe/Commands/GitVersionRootCommand.cs
+++ b/src/GitVersionExe/Commands/GitVersionRootCommand.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Options;
+using System.CommandLine;
+
+namespace GitVersion
+{
+    public class GitVersionRootCommand : RootCommand
+    {
+        public GitVersionRootCommand(CalculateCommand calculateCommand, IOptions<GitVersionOptions> globalOptions) : base("Versioning for your git repository, solved!")
+        {
+            // this.AddGlobalOption()
+            //this.AddGlobalOption(new Option("--target-path") { Argument = new Argument<LoggingMethod>() });
+            //this.AddGlobalOption(new Option("--logging-method") { Argument = new Argument<LoggingMethod>() });
+            GlobalOptions = globalOptions.Value;
+            this.AddCommand(calculateCommand);
+        }
+
+        public GitVersionOptions GlobalOptions { get; }
+    }
+}

--- a/src/GitVersionExe/Commands/LoggingMethod.cs
+++ b/src/GitVersionExe/Commands/LoggingMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace GitVersion
+{
+    public enum LoggingMethod
+    {
+        Console = 1,
+        File = 2,
+    }
+}

--- a/src/GitVersionExe/GitVersionApp.cs
+++ b/src/GitVersionExe/GitVersionApp.cs
@@ -14,7 +14,11 @@ namespace GitVersion
         private readonly ILog log;
         private readonly IOptions<GitVersionOptions> options;
 
-        public GitVersionApp(IHostApplicationLifetime applicationLifetime, IGitVersionExecutor gitVersionExecutor, ILog log, IOptions<GitVersionOptions> options)
+        public GitVersionApp(
+            IHostApplicationLifetime applicationLifetime,
+            IGitVersionExecutor gitVersionExecutor,
+            ILog log,
+            IOptions<GitVersionOptions> options)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));

--- a/src/GitVersionExe/GitVersionCommandExecutor.cs
+++ b/src/GitVersionExe/GitVersionCommandExecutor.cs
@@ -1,0 +1,74 @@
+using GitVersion.Extensions;
+using GitVersion.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace GitVersion
+{
+    /// <summary>
+    /// The purpose of this class is to wrap execution of each subcommand's logic,
+    /// to have a centralised location to handle exceptions, and log those exceptions,
+    /// based on the global option arguments used to control log output.
+    /// </summary>
+    /// <remarks>This is evolving in a similar way to <see cref="GitVersionExecutor"/> but for executing the new commands, and using the GlobalOptions for the new cli instead.
+    /// Allowing <see cref="GitVersionExecutor"/> to serve as a reference until the port is finished.
+    ///</remarks>
+    public class GitVersionCommandExecutor
+    {
+        public GitVersionCommandExecutor(ILog log)
+        {
+            Log = log;            
+        }
+
+        public async Task<int> Execute(GlobalCommandOptions globalOptions, Func<Task<int>> execute)
+        {
+            if (globalOptions.LoggingMethod == LoggingMethod.Console)
+            {
+                Log.AddLogAppender(new ConsoleAppender());
+            }
+            else if (globalOptions.LoggingMethod == LoggingMethod.File && globalOptions.LogFilePath != "console")
+            {
+                Log.AddLogAppender(new FileAppender(globalOptions.LogFilePath));
+            }
+
+            try
+            {
+                //gitVersionTool.OutputVariables(variables);
+                //gitVersionTool.UpdateAssemblyInfo(variables);
+                //gitVersionTool.UpdateWixVersionFile(variables);
+                var result = await execute.Invoke();
+                return result;
+            }
+            catch (WarningException exception)
+            {
+                var error = $"An error occurred:{System.Environment.NewLine}{exception.Message}";
+                Log.Warning(error);
+                return 1;
+            }
+            catch (Exception exception)
+            {
+                var error = $"An unexpected error occurred:{System.Environment.NewLine}{exception}";
+                Log.Error(error);
+
+                Log.Info("Attempting to show the current git graph (please include in issue): ");
+                Log.Info("Showing max of 100 commits");
+
+                try
+                {
+                    // I am not sure here if we should be passing in working directory, or the dot git directory?
+                    // current behaviour was to pass in working directory (environment current directory) so sticking with that.
+                    LibGitExtensions.DumpGraph(globalOptions.WorkingDirectory, mess => Log.Info(mess), 100);
+                }
+                catch (Exception dumpGraphException)
+                {
+                    Log.Error("Couldn't dump the git graph due to the following error: " + dumpGraphException);
+                }
+                return 1;               
+            }
+
+            
+        }
+
+        public ILog Log { get; set; }
+    }
+}

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -28,8 +28,16 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Remove="ArgumentParser.cs" />
+      <Compile Remove="Arguments.cs" />
+      <Compile Remove="ExecCommand.cs" />
+      <Compile Remove="IExecCommand.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(PackageVersion_MicrosoftExtensions)" />
       <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(PackageVersion_MicrosoftExtensions)" />
+      <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersionExe/GitVersionExeModule.cs
+++ b/src/GitVersionExe/GitVersionExeModule.cs
@@ -6,14 +6,11 @@ namespace GitVersion
     {
         public void RegisterTypes(IServiceCollection services)
         {
-            services.AddSingleton<IArgumentParser, ArgumentParser>();
             services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
 
             services.AddSingleton<IHelpWriter, HelpWriter>();
             services.AddSingleton<IVersionWriter, VersionWriter>();
             services.AddSingleton<IGitVersionExecutor, GitVersionExecutor>();
-
-            services.AddTransient<IExecCommand, ExecCommand>();
         }
     }
 }

--- a/src/GitVersionExe/GitVersionExecutor.cs
+++ b/src/GitVersionExe/GitVersionExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CommandLine;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
@@ -19,7 +20,8 @@ namespace GitVersion
         private readonly IConfigProvider configProvider;
         private readonly IVersionWriter versionWriter;
 
-        public GitVersionExecutor(ILog log,
+        public GitVersionExecutor(
+            ILog log,
             Logging.IConsole console,
             IConfigFileLocator configFileLocator,
             IConfigProvider configProvider,
@@ -170,6 +172,7 @@ namespace GitVersion
         {
             // Could always log to console unless by default.
             // We can log variables within a control statement when log output to console is enabled.
+            //if(execCommand.Options.Contains())
             if (gitVersionOptions.LogToConsole)
             {
                 log.AddLogAppender(new ConsoleAppender());

--- a/src/GitVersionExe/GlobalCommandOptions.cs
+++ b/src/GitVersionExe/GlobalCommandOptions.cs
@@ -1,0 +1,9 @@
+namespace GitVersion
+{
+    public class GlobalCommandOptions
+    {
+        public string WorkingDirectory { get; set; } = System.Environment.CurrentDirectory;     
+        public LoggingMethod LoggingMethod { get; set; }
+        public string LogFilePath { get; set; }
+    }
+}

--- a/src/GitVersionExe/IArgumentParser.cs
+++ b/src/GitVersionExe/IArgumentParser.cs
@@ -1,8 +1,0 @@
-namespace GitVersion
-{
-    public interface IArgumentParser
-    {
-        Arguments ParseArguments(string commandLineArguments);
-        Arguments ParseArguments(string[] commandLineArguments);
-    }
-}

--- a/src/GitVersionExe/IGitVersionExecutor.cs
+++ b/src/GitVersionExe/IGitVersionExecutor.cs
@@ -2,6 +2,6 @@ namespace GitVersion
 {
     public interface IGitVersionExecutor
     {
-        int Execute(GitVersionOptions gitVersionOptions);
+        int Execute(GitVersionOptions options);
     }
 }

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -1,4 +1,8 @@
 using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO.IsolatedStorage;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using GitVersion.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -38,16 +42,33 @@ namespace GitVersion
                     services.AddModule(new GitVersionCoreModule());
                     services.AddModule(new GitVersionExeModule());
 
-                    services.AddSingleton(sp =>
-                    {
-                        var arguments = sp.GetService<IArgumentParser>().ParseArguments(args);
-                        var gitVersionOptions = arguments.ToOptions();
-                        return Options.Create(gitVersionOptions);
-                    });
+                    // return Options.Create(gitVersionOptions);
+
+                    //services.AddSingleton(sp =>
+                    //{
+                    //    var arguments = sp.GetService<IArgumentParser>().ParseArguments(args);
+                    //    var gitVersionOptions = arguments.ToOptions();
+
+                    //});                
+                    services.AddOptions<GitVersionOptions>()
+                            .PostConfigure(a => a.Args = args);
+
+                    services.AddSingleton<GitVersionRootCommand>();
+                    services.AddSingleton<CalculateCommand>();
+                    //services.AddSingleton(sp =>
+                    //{                       
+                    //    return BuildCommand(sp);
+                    //});
 
                     overrides?.Invoke(services);
                     services.AddHostedService<GitVersionApp>();
                 })
                 .UseConsoleLifetime();
+
+        //private static RootCommand BuildCommand(IServiceProvider serviceProvider)
+        //{
+        //    var rootCommand = ActivatorUtilities.GetServiceOrCreateInstance<GitVersionRootCommand>(serviceProvider);
+        //    return rootCommand;
+        //}
     }
 }

--- a/src/GitVersionExe/Program.cs
+++ b/src/GitVersionExe/Program.cs
@@ -53,6 +53,8 @@ namespace GitVersion
                     services.AddOptions<GitVersionOptions>()
                             .PostConfigure(a => a.Args = args);
 
+                    services.AddSingleton<GitVersionCommandExecutor>();
+
                     services.AddSingleton<GitVersionRootCommand>();
                     services.AddSingleton<CalculateCommand>();
                     //services.AddSingleton(sp =>

--- a/src/GitVersionExe/Properties/launchSettings.json
+++ b/src/GitVersionExe/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GitVersionExe": {
+      "commandName": "Project",
+      "commandLineArgs": "calculate --logging-method Console"
+    }
+  }
+}

--- a/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/src/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -33,8 +33,6 @@
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\GitVersionCore\GitVersionCore.csproj" />
-      <ProjectReference Include="..\GitVersionTask.MsBuild\GitVersionTask.MsBuild.csproj" />
-      <ProjectReference Include="..\GitVersionTask\GitVersionTask.csproj" />
     </ItemGroup>
     <ItemGroup>
         <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -24,7 +24,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\GitVersionTask.MsBuild\GitVersionTask.MsBuild.csproj" PrivateAssets="All" />
         <ProjectReference Include="..\GitVersionCore\GitVersionCore.csproj" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
As part of the refactoring discussed in https://github.com/GitTools/GitVersion/issues/2262

Adopting a new CLI parser library could really help simplify that stuff and give us a nice framework build / add commands around for V6.

To this end, I've got a quick spike up and running where I have got one command running: `gitversion calculate` using @arturcic 's fave CLI parser library: https://github.com/dotnet/command-line-api

## Description
- I unloaded the GitVersion.MsBuild task project. from the solution. I am not concerned with this for this spike.
- I removed logic to do with `remote repo's` - I figured users could clone down their own repo's and then run `gitversion calculate --normalize` on it. Or in a pinch we can add that command later.
- The only command implemented is `gitversion calculate` 
- You also get a free help screen and perhaps other features provided by the parsing library.

Help screen (auto created)

![image](https://user-images.githubusercontent.com/3176632/81449445-2faa1480-9178-11ea-8f29-f392c9a26765.png)

And here is the command working:

![image](https://user-images.githubusercontent.com/3176632/81449540-5cf6c280-9178-11ea-9769-ec08a4ed4f85.png)

I've done it in a way that commands can benefit from DI:

## Outline of pattern
Each command is registered for DI in `Program.cs`

```csharp
                    services.AddSingleton<GitVersionRootCommand>();
                    services.AddSingleton<CalculateCommand>();
```

A command looks like this:

```csharp
 public class CalculateCommand : Command
    {
        private readonly IGitVersionTool gitversionTool;
        private readonly Logging.IConsole console;

        public CalculateCommand(IGitVersionTool gitversionTool, Logging.IConsole console) : base("calculate", "Calculates version information from your git repository")
        {
            this.gitversionTool = gitversionTool;
            this.console = console;
            this.AddOption(new Option<bool>(
            "--normalize",
            "Attempt to mutate your git repository so gitversion has enough information (local branches, commit history etc) to calculate."));
            this.Handler = CommandHandler.Create<bool?>(ExecuteAsync);            
        }

        private async Task ExecuteAsync(bool? normalize)
        {
            if (normalize ?? false)
            {
                await Normalize();
            }

            var variables = this.gitversionTool.CalculateVersionVariables();
            console.WriteLine(variables.ToString());
        }

        private Task Normalize()
        {
            throw new NotImplementedException();
        }
    }

```

I tried to keep as much of everything else the same, but had to make some quick adjustments, to have the command actually executed.

## Motivation and Context
Gives us a way to structure commands, and a modular way to add new commands, backed by a parsing library that we don't have to maintain ourselves and offers more powerful features beyond the primary concern of gitversion. Establishing something like this will let us build out the command structure we need for V6 more easily.

## How Has This Been Tested?
I did enough to get the solution to compile and run one command with the new parser, just as a proof of concept. The changes I made were not thought about very much. I tried to do as little as possible, and made some on the spot decisions. I unloaded projects just to get it to run. The important thing is to try and show some pattern or example and discuss from there before we have to refactor the code base.
