### PR TITLE
Fix environment variable parsing for authentication

### DIFF
--- a/src/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/src/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -14,6 +14,7 @@ namespace GitVersionExe.Tests
     [TestFixture]
     public class ArgumentParserTests : TestBase
     {
+        private IEnvironment environment;
         private IArgumentParser argumentParser;
 
         [SetUp]
@@ -24,6 +25,7 @@ namespace GitVersionExe.Tests
                 services.AddSingleton<IArgumentParser, ArgumentParser>();
                 services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
             });
+            environment = sp.GetService<IEnvironment>();
             argumentParser = sp.GetService<IArgumentParser>();
         }
 
@@ -603,6 +605,38 @@ namespace GitVersionExe.Tests
                 var arguments = argumentParser.ParseArguments(command);
                 arguments.Verbosity.ShouldBe(expectedVerbosity);
             }
+        }
+
+        [Test]
+        public void EmptyArgumentsRemoteUsernameDefinedSetsUsername()
+        {
+            environment.SetEnvironmentVariable("GITVERSION_REMOTE_USERNAME", "value");
+            var arguments = argumentParser.ParseArguments(string.Empty);
+            arguments.Authentication.Username.ShouldBe("value");
+        }
+
+        [Test]
+        public void EmptyArgumentsRemotePasswordDefinedSetsPassword()
+        {
+            environment.SetEnvironmentVariable("GITVERSION_REMOTE_PASSWORD", "value");
+            var arguments = argumentParser.ParseArguments(string.Empty);
+            arguments.Authentication.Password.ShouldBe("value");
+        }
+
+        [Test]
+        public void ArbitraryArgumentsRemoteUsernameDefinedSetsUsername()
+        {
+            environment.SetEnvironmentVariable("GITVERSION_REMOTE_USERNAME", "value");
+            var arguments = argumentParser.ParseArguments("-nocache");
+            arguments.Authentication.Username.ShouldBe("value");
+        }
+
+        [Test]
+        public void ArbitraryArgumentsRemotePasswordDefinedSetsPassword()
+        {
+            environment.SetEnvironmentVariable("GITVERSION_REMOTE_PASSWORD", "value");
+            var arguments = argumentParser.ParseArguments("-nocache");
+            arguments.Authentication.Password.ShouldBe("value");
         }
     }
 }

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -46,6 +46,9 @@ namespace GitVersion
                 };
 
                 args.Output.Add(OutputType.Json);
+
+                AddAuthentication(args);
+
                 return args;
             }
 
@@ -133,7 +136,7 @@ namespace GitVersion
             var password = environment.GetEnvironmentVariable("GITVERSION_REMOTE_PASSWORD");
             if (!string.IsNullOrWhiteSpace(password))
             {
-                arguments.Authentication.Username = password;
+                arguments.Authentication.Password = password;
             }
         }
 


### PR DESCRIPTION
Fix an issue where GITVERSION_REMOTE_PASSWORD would overwrite the Username options intead of setting the Password option.

Also make sure authentication is set even if no other command line arguments are present.

## Description
Changed the one-liner where the assignation happens in ArgumentParser.cs. Pretty self-evident change. Relevant unit tests have been added.

While making this change, I realized that my tests failed when no other command line arguments were passed. I made sure to add authentication even in the case where no other command line arguments exist, and added relevant unit tests.

## Related Issue
Fixes #2276

## Motivation and Context
I need this to get GitVersion working in a GitLab CI build that needs authentication because it builds with Docker.

## How Has This Been Tested?
I have added 4 relevant unit tests.

## Checklist:

- [x] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.
- [n/a] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
