### PR TITLE
Prevent exeution of GenerateGitVersionInformation in XAML generated intermediate-projects

### DIFF
--- a/src/GitVersionTask/build/GitVersionTask.props
+++ b/src/GitVersionTask/build/GitVersionTask.props
@@ -27,6 +27,14 @@
 
         <!-- Property that enables GenerateGitVersionInformation -->
         <GenerateGitVersionInformation Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GenerateGitVersionInformation>
+        <!--
+          During XAML's "GenerateTemporaryTargetAssembly" a new project file is generated and compiled
+          which already contains the "GeneratedCodeFiles", i.e. GitVersionInformation.g.cs.
+          Then, when GenerateGitVersionInformation is called in this temp-build, the file is added another time, which results in an error at CSC.
+          Here we try to detect this situation and prevent GenerateGitVersionInformation from running.
+          (The global property "_TargetAssemblyProjectName" is injected by XAML's above-mentioned task)
+        -->
+        <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' And '$(_TargetAssemblyProjectName)' != '' ">false</GenerateGitVersionInformation>
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' ">true</GenerateGitVersionInformation>
 
         <!-- Property that enables GetVersion -->


### PR DESCRIPTION
## Description

During XAML'S build magic a temporary project may get generated and
build (target "GenerateTemporaryTargetAssembly"). The generated project
file already contains compile-items with the generated files from the
original project, this `GitVerstionInformation.g.cs` is listed. When the
GitVersion task now runs again, the file is added another time resulting
in an error of CSC.
This patch tries to detect this situation and prevent the execution of
GenerateGitVersionInformation by checking for a special property
injected by GenerateTemporaryTargetAssembly. Unfortunately this is not
documented and thus may change, see https://referencesource.microsoft.com/#PresentationBuildTasks/BuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs,163


## Related Issue
This should fix #2228

## How Has This Been Tested?
This patch was tested on top of the release v5.3.3 of GitVersionTask and solved the issue on a .NET Framework-4.7.2 solution, compiled with MSBuild 15 as well as VS2019 (aka MSBuild-16).

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
