### PR TITLE
Fix calculation of version and branch when using git worktree

### DIFF
--- a/src/GitVersionCore.Tests/Extensions/GitToolsTestingExtensions.cs
+++ b/src/GitVersionCore.Tests/Extensions/GitToolsTestingExtensions.cs
@@ -29,7 +29,7 @@ namespace GitVersionCore.Tests
 
             var options = Options.Create(new GitVersionOptions
             {
-                WorkingDirectory = repository.GetRepositoryDirectory(),
+                WorkingDirectory = repository.Info.WorkingDirectory,
                 ConfigInfo = { OverrideConfig = configuration },
                 RepositoryInfo =
                 {

--- a/src/GitVersionCore.Tests/IntegrationTests/WorktreeScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/WorktreeScenarios.cs
@@ -1,0 +1,35 @@
+using GitTools.Testing;
+using LibGit2Sharp;
+using NUnit.Framework;
+using System.IO;
+using GitVersionCore.Tests.Helpers;
+
+namespace GitVersionCore.Tests.IntegrationTests
+{
+
+    [TestFixture]
+    public class WorktreeScenarios : TestBase
+    {
+
+        [Test]
+        [Category("NoMono")]
+        [Description("LibGit2Sharp fails here when running under Mono")]
+        public void UseWorktreeRepositoryForVersion()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            var repoDir = new DirectoryInfo(fixture.RepositoryPath);
+            var worktreePath = Path.Combine(repoDir.Parent.FullName, $"{repoDir.Name}-v1");
+
+            fixture.Repository.MakeATaggedCommit("v1.0.0");
+            var branchV1 = fixture.Repository.CreateBranch("support/1.0");
+
+            fixture.Repository.MakeATaggedCommit("v2.0.0");
+            fixture.AssertFullSemver("2.0.0");
+
+            fixture.Repository.Worktrees.Add(branchV1.CanonicalName, "1.0", worktreePath, false);
+            using var worktreeFixture = new LocalRepositoryFixture(new Repository(worktreePath));
+            worktreeFixture.AssertFullSemver("1.0.0");
+        }
+
+    }
+}

--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -87,9 +87,7 @@ namespace GitVersion
         private void CleanupDuplicateOrigin()
         {
             var remoteToKeep = DefaultRemoteName;
-
-            var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
-            using var repo = new Repository(isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory);
+            using var repo = new Repository(options.Value.GitRootPath);
 
             // check that we have a remote that matches defaultRemoteName if not take the first remote
             if (!repo.Network.Remotes.Any(remote => remote.Name.Equals(DefaultRemoteName, StringComparison.InvariantCultureIgnoreCase)))

--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -88,7 +88,8 @@ namespace GitVersion
         {
             var remoteToKeep = DefaultRemoteName;
 
-            using var repo = new Repository(options.Value.DotGitDirectory);
+            var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
+            using var repo = new Repository(isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory);
 
             // check that we have a remote that matches defaultRemoteName if not take the first remote
             if (!repo.Network.Remotes.Any(remote => remote.Name.Equals(DefaultRemoteName, StringComparison.InvariantCultureIgnoreCase)))

--- a/src/GitVersionCore/Core/GitRepository.cs
+++ b/src/GitVersionCore/Core/GitRepository.cs
@@ -11,11 +11,7 @@ namespace GitVersion
         private IRepository repositoryInstance => repositoryLazy.Value;
 
         public GitRepository(IOptions<GitVersionOptions> options)
-            : this(() =>
-            {
-                var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
-                return isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory;
-            })
+            : this(() => options.Value.GitRootPath)
         {
         }
 

--- a/src/GitVersionCore/Core/GitRepository.cs
+++ b/src/GitVersionCore/Core/GitRepository.cs
@@ -11,13 +11,17 @@ namespace GitVersion
         private IRepository repositoryInstance => repositoryLazy.Value;
 
         public GitRepository(IOptions<GitVersionOptions> options)
-            : this(() => options.Value.DotGitDirectory)
+            : this(() =>
+            {
+                var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
+                return isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory;
+            })
         {
         }
 
-        public GitRepository(Func<string> getDotGitDirectory)
+        public GitRepository(Func<string> getGitRootDirectory)
         {
-            repositoryLazy = new Lazy<IRepository>(() => new Repository(getDotGitDirectory()));
+            repositoryLazy = new Lazy<IRepository>(() => new Repository(getGitRootDirectory()));
             Commands = new GitRepositoryCommands(repositoryLazy);
         }
 

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -183,10 +183,12 @@ namespace GitVersion
                 {
                     // In the case where HEAD is not the desired branch, try to find the branch with matching name
                     desiredBranch = repository.Branches?
-                        .SingleOrDefault(b =>
+                        .Where(b =>
                             b.CanonicalName.IsEquivalentTo(targetBranch) ||
                             b.FriendlyName.IsEquivalentTo(targetBranch) ||
-                            b.NameWithoutRemote().IsEquivalentTo(targetBranch));
+                            b.NameWithoutRemote().IsEquivalentTo(targetBranch))
+                        .OrderBy(b => b.IsRemote)
+                        .FirstOrDefault();
 
                     // Failsafe in case the specified branch is invalid
                     desiredBranch ??= repository.Head;

--- a/src/GitVersionCore/Extensions/GitVersionOptionsExtensions.cs
+++ b/src/GitVersionCore/Extensions/GitVersionOptionsExtensions.cs
@@ -38,6 +38,14 @@ namespace GitVersion.Extensions
             return repository.Info.WorkingDirectory;
         }
 
+        public static string GetGitRootPath(this GitVersionOptions options)
+        {
+            var isDynamicRepo = !string.IsNullOrWhiteSpace(options.DynamicGitRepositoryPath);
+            var rootDirectory = isDynamicRepo ? options.DotGitDirectory : options.ProjectRootDirectory;
+
+            return rootDirectory;
+        }
+
         public static string GetDynamicGitRepositoryPath(this GitVersionOptions gitVersionOptions)
         {
             if (string.IsNullOrWhiteSpace(gitVersionOptions.RepositoryInfo.TargetUrl)) return null;

--- a/src/GitVersionCore/Model/GitVersionOptions.cs
+++ b/src/GitVersionCore/Model/GitVersionOptions.cs
@@ -11,12 +11,14 @@ namespace GitVersion
         private Lazy<string> dotGitDirectory;
         private Lazy<string> projectRootDirectory;
         private Lazy<string> dynamicGitRepositoryPath;
+        private Lazy<string> gitRootPath;
 
         public GitVersionOptions()
         {
             dotGitDirectory = new Lazy<string>(this.GetDotGitDirectory);
             projectRootDirectory = new Lazy<string>(this.GetProjectRootDirectory);
             dynamicGitRepositoryPath = new Lazy<string>(this.GetDynamicGitRepositoryPath);
+            gitRootPath = new Lazy<string>(this.GetGitRootPath);
         }
 
         public string WorkingDirectory { get; set; }
@@ -24,6 +26,7 @@ namespace GitVersion
         public string DotGitDirectory => dotGitDirectory.Value;
         public string ProjectRootDirectory => projectRootDirectory.Value;
         public string DynamicGitRepositoryPath => dynamicGitRepositoryPath.Value;
+        public string GitRootPath => gitRootPath.Value;
 
         public AssemblyInfoData AssemblyInfo { get; } = new AssemblyInfoData();
         public AuthenticationInfo Authentication { get; } = new AuthenticationInfo();

--- a/src/GitVersionCore/VersionCalculation/Cache/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/VersionCalculation/Cache/GitVersionCacheKeyFactory.cs
@@ -141,7 +141,8 @@ namespace GitVersion.VersionCalculation.Cache
 
         private string GetRepositorySnapshotHash()
         {
-            using var repo = new Repository(options.Value.DotGitDirectory);
+            var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
+            using var repo = new Repository(isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory);
 
             var head = repo.Head;
             if (head.Tip == null)

--- a/src/GitVersionCore/VersionCalculation/Cache/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersionCore/VersionCalculation/Cache/GitVersionCacheKeyFactory.cs
@@ -141,8 +141,7 @@ namespace GitVersion.VersionCalculation.Cache
 
         private string GetRepositorySnapshotHash()
         {
-            var isDynamicRepo = !string.IsNullOrWhiteSpace(options.Value.DynamicGitRepositoryPath);
-            using var repo = new Repository(isDynamicRepo ? options.Value.DotGitDirectory : options.Value.ProjectRootDirectory);
+            using var repo = new Repository(options.Value.GitRootPath);
 
             var head = repo.Head;
             if (head.Tip == null)


### PR DESCRIPTION
## Description

This PR fixes the calculation of the version and branch when using git worktree. This fixes #2165.

## Related Issue

#2165 

This PR re-uses the tests from and enhances #1848 

## Motivation and Context


## How Has This Been Tested?

```
git init testgv
cd testgv
git commit -m "Initial commit" --allow-empty
git tag v1.0 -m "v1.0"
git worktree add ../testgv2
cd ../testgv2
git commit -m "Commit on other branch
+semver:major" --allow-empty
```

When run with an unpatched version of `gitversion` this will output

```
...
  "FullSemVer":"1.0.0",
  "InformationalVersion":"1.0.0+Branch.master.Sha.1cb7c58dd04425f3a6aabe7431bf9f78061548f4",
  "BranchName":"master",
...
```

with these changes the output is:

```
...
  "FullSemVer":"2.0.0-testgv2.1+1",
  "InformationalVersion":"2.0.0-testgv2.1+1.Branch.testgv2.Sha.222d9fdef4732e7a3800f7b1964437a8e11e2d5d",
  "BranchName":"testgv2",
...
```

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (that were passing previously).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gittools/gitversion/2281)
<!-- Reviewable:end -->
