### PR TITLE
Escape $ symbols

### DIFF
--- a/docs/input/docs/build-server-support/build-server/continua.md
+++ b/docs/input/docs/build-server-support/build-server/continua.md
@@ -11,11 +11,11 @@ This guide assumes a few variables are present in the configuration. Note that
 this example uses `Catel` as repository name, but it should be replaced by the
 name of the repository where GitVersion is running against.
 
-* RepositoryBranchName => $Source.Catel.BranchName$
-* RepositoryCommitId => $Source.Catel.LatestChangeset.Id$
+* RepositoryBranchName => \$Source.Catel.BranchName\$
+* RepositoryCommitId => \$Source.Catel.LatestChangeset.Id\$
 * RepositoryName => Catel
-* RepositoryName => $Source.Catel.Path$
-* RepositoryUrl => $Source.Catel.Url$
+* RepositoryName => \$Source.Catel.Path\$
+* RepositoryUrl => \$Source.Catel.Url\$
 
 It also requires a few variables which will automatically be filled by
 GitVersion. The example below are just a few, any of the GitVersion variables


### PR DESCRIPTION
document contains unescaped $ symbols which makes them render incorrectly in html

## Description

Escape $ with \$

## Motivation and Context

Fix html rendering on this page 
https://gitversion.net/docs/build-server-support/build-server/continua

## How Has This Been Tested?

Only tested as markdown in github.. doesn't change the rendered output (but should for the docs). 

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
