### PR TITLE
Encourage writing RepositoryFixture tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,21 @@ A clear and concise description of what the bug is.
 <!-- Not obligatory, but suggest a fix or reason for the bug -->
 
 ## Steps to Reproduce
-<!-- Provide a link to a live example, or an unambiguous set of steps to -->
-<!-- reproduce this bug. Include code to reproduce, if relevant -->
+<!--
+If you are able to write your bug or scenario up as a `RepositoryFixture` test
+and submit a pull-request with it, it is going to increase the likelyhood of
+the bug being fixed.
+
+It will both make it easier to understand what you are trying to achieve, how
+GitVersion deviates from this expectation and to start debugging the problem. It
+will also make it easier for you to fix the problem yourself. Please look at the
+following example for how such a test can look like:
+
+https://github.com/GitTools/GitVersion/blob/251645f08802ea9dc401d5b2f2d681e8f8adf626/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs#L13-L32
+
+Otherwise, please provide a link to a live example, or an unambiguous set of
+steps to reproduce this bug.
+-->
 
 ## Context
 <!-- How has this bug affected you? What were you trying to accomplish? -->

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -11,7 +11,8 @@ assignees: ''
 A clear and concise description of what the bug is or a link to it
 
 ## Test code
-```
+
+```csharp
 using var fixture = new EmptyRepositoryFixture();
 fixture.Repository.MakeACommit();
 fixture.BranchTo("develop");

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,24 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
 
 ## Detailed Description
-<!--- Provide a detailed description of the change or addition you are proposing -->
+<!---
+Provide a detailed description of the change or addition you are proposing.
+
+If you are able to write your feature or scenario up as a `RepositoryFixture`
+test and submit a pull-request with it, it is going to increase the likelyhood
+of the feature being implemented.
+
+It will both make it easier to understand what you are trying to achieve, how
+GitVersion deviates from this expectation and to start debugging the problem. It
+will also make it easier for you to implement the feature yourself. Please look
+at the following example for how such a test can look like:
+
+https://github.com/GitTools/GitVersion/blob/251645f08802ea9dc401d5b2f2d681e8f8adf626/src/GitVersionCore.Tests/IntegrationTests/MasterScenarios.cs#L13-L32
+-->
 
 ## Context
 <!--- Why is this change important to you? How would you use it? -->


### PR DESCRIPTION
I think it's a good idea to encourage writing `RepositoryFixture` tests in the bug and feature request templates.

## Description
Add text to the bug and feature request templates encouraging the submission of `RepositoryFixture` tests so contributors are made aware of their existence and can see how easy they are to write.

## Motivation and Context
`RepositoryFixture` tests are a great, precise, canonical way to describe the behavior expected from GitVersion.