### PR TITLE
Allows usage of Web SDK when updating project files

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -53,6 +53,25 @@ namespace GitVersionCore.Tests
         }
 
         [TestCase(@"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>
+")]
+        [Category(NoMono)]
+        [Description(NoMonoDescription)]
+        public void CanUpdateProjectFileWithStandardWebProjectFileXml(string xml)
+        {
+            using var projectFileUpdater = new ProjectFileUpdater(log, fileSystem);
+
+            var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+
+            canUpdate.ShouldBe(true);
+        }
+
+        [TestCase(@"
 <Project Sdk=""SomeOtherProject.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -102,11 +102,12 @@ namespace GitVersion.VersionConverters.AssemblyInfo
                 return false;
             }
 
-            var supportedSdk = "Microsoft.NET.Sdk";
+            var supportedSdks = new[] { "Microsoft.NET.Sdk", "Microsoft.NET.Sdk.Web" };
             var sdkAttribute = xmlRoot.Attribute("Sdk");
-            if (sdkAttribute == null || sdkAttribute.Value != supportedSdk)
+            if (sdkAttribute == null || !supportedSdks.Contains(sdkAttribute.Value))
             {
-                log.Warning($"Specified project file Sdk ({sdkAttribute?.Value}) is not supported, please ensure the project sdk is {supportedSdk}.");
+                var supportedSdkString = string.Join("|", supportedSdks);
+                log.Warning($"Specified project file Sdk ({sdkAttribute?.Value}) is not supported, please ensure the project sdk is of the following: {supportedSdkString}.");
                 return false;
             }
 


### PR DESCRIPTION
This addresses a use-case I missed in the previous feature. Ironically enough I was motivated to contribute here **specifically** to have Azure CI builds use GitVersion to update my web project, and I missed it. Meh.

## Description
Allows project file updating for Web SDK Projects

## Related Issue
Fixes https://github.com/GitTools/GitVersion/issues/2290

## Motivation and Context
I'd like to update my ASP.NET Core projects.

## How Has This Been Tested?
Added a test to ensure the `Microsoft.NET.Sdk.Web` was an allowed SDK

## Screenshots (if appropriate):
None. But you may have a picture of another one of my cats.
![image](https://user-images.githubusercontent.com/6847381/83049906-b59fd980-a019-11ea-8775-9084daf753ed.png)


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
