### PR TITLE
Fix typos

### DIFF
--- a/docs/input/docs/build-server-support/build-server/teamcity.md
+++ b/docs/input/docs/build-server-support/build-server/teamcity.md
@@ -73,7 +73,7 @@ as msbuild/environmental variables to other build steps
 to the project called `GitVersion.NuGetVersion`. If many of your projects uses
 git-flow and SemVer you can add the parameter to the "root-project"
 (TeamCity 8.x+). You need a dummy param because GitVersion creates the variables
-at runtime, and you cannot reference a paramter which is not available
+at runtime, and you cannot reference a parameter which is not available
 statically. GitVersion will overwrite the dummy value
 * Then setup you nuget pack build set the "version" to `%GitVersion.NuGetVersion%`
 * If you do your pack in a build script then you can just use environmental

--- a/docs/input/docs/reference/intro-to-semver.md
+++ b/docs/input/docs/reference/intro-to-semver.md
@@ -18,12 +18,12 @@ SemVer introduces conventions about breaking changes into our version numbers so
 * `{major}` is only incremented if the release has breaking changes (includes bug fixes which have breaking behavioural changes
 * `{minor}` is incremented if the release has new non-breaking features
 * `{patch}` is incremented if the release only contains non-breaking bug fixes
-* `{tag}` is optional and denotes a pre-release of the version preceeding
+* `{tag}` is optional and denotes a pre-release of the version preceding
 * `{buildmetadata}` is optional and contains additional information about the version, but **does not affect** the semantic version preceding it.
 
 Only one number should be incremented per release, and all lower parts should be reset to 0 (if `{major}` is incremented, then `{minor}` and `{patch}` should become 0).
 
-For a more complete explaination check out [semver.org](http://semver.org) which is the official spec. Remember this is a brief introduction and does not cover all parts of semantic versioning, just the important parts to get started.
+For a more complete explanation check out [semver.org](http://semver.org) which is the official spec. Remember this is a brief introduction and does not cover all parts of semantic versioning, just the important parts to get started.
 
 ## SemVer in GitVersion
 GitVersion makes it easy to follow semantic versioning in your library by automatically calculating the next semantic version which your library/application is likely to use. In [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow/) the develop branch will bump the *minor* when master is tagged, while [GitHubFlow](https://guides.github.com/introduction/flow/) will bump the *patch*.

--- a/docs/input/docs/usage/command-line.md
+++ b/docs/input/docs/usage/command-line.md
@@ -85,7 +85,7 @@ This can be done for *.cs, *.vb and *.fs files.
 
 When requesting that GitVersion generate an assembly info file you are limited
 to only specifying a single `<filename>` within the `/updateassemblyinfo`
-switch, this is to prevent the creation of mulitple assembly info files with the
+switch, this is to prevent the creation of multiple assembly info files with the
 same assembly version attributes.  If this occurs your build will fail.
 
 ### Example: When AssemblyInfo.cs does not exist


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `docs/input/docs/build-server-support/build-server/teamcity.md`
- 2 typos in `docs/input/docs/reference/intro-to-semver.md`
- 1 typo in `docs/input/docs/usage/command-line.md`



Best! :robot: