### PR TITLE
Modified the VB.NET Template so that GitVersionInformation is in the Global namespace

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -8,40 +8,44 @@
 ' </auto-generated>
 '------------------------------------------------------------------------------
 
-<Global.System.Runtime.CompilerServices.CompilerGenerated()>
-<Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()>
-NotInheritable Class GitVersionInformation
-    Private Sub New()
-    End Sub
-    Public Shared Major As String = "1"
-    Public Shared Minor As String = "2"
-    Public Shared Patch As String = "3"
-    Public Shared PreReleaseTag As String = "unstable.4"
-    Public Shared PreReleaseTagWithDash As String = "-unstable.4"
-    Public Shared PreReleaseLabel As String = "unstable"
-    Public Shared PreReleaseNumber As String = "4"
-    Public Shared WeightedPreReleaseNumber As String = "4"
-    Public Shared BuildMetaData As String = "5"
-    Public Shared BuildMetaDataPadded As String = "0005"
-    Public Shared FullBuildMetaData As String = "5.Branch.feature1.Sha.commitSha"
-    Public Shared MajorMinorPatch As String = "1.2.3"
-    Public Shared SemVer As String = "1.2.3-unstable.4"
-    Public Shared LegacySemVer As String = "1.2.3-unstable4"
-    Public Shared LegacySemVerPadded As String = "1.2.3-unstable0004"
-    Public Shared AssemblySemVer As String = "1.2.3.0"
-    Public Shared AssemblySemFileVer As String = "1.2.3.0"
-    Public Shared FullSemVer As String = "1.2.3-unstable.4+5"
-    Public Shared InformationalVersion As String = "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha"
-    Public Shared BranchName As String = "feature1"
-    Public Shared EscapedBranchName As String = "feature1"
-    Public Shared Sha As String = "commitSha"
-    Public Shared ShortSha As String = "commitShortSha"
-    Public Shared NuGetVersionV2 As String = "1.2.3-unstable0004"
-    Public Shared NuGetVersion As String = "1.2.3-unstable0004"
-    Public Shared NuGetPreReleaseTagV2 As String = "unstable0004"
-    Public Shared NuGetPreReleaseTag As String = "unstable0004"
-    Public Shared VersionSourceSha As String = "versionSourceSha"
-    Public Shared CommitsSinceVersionSource As String = "5"
-    Public Shared CommitsSinceVersionSourcePadded As String = "0005"
-    Public Shared CommitDate As String = "2014-03-06"
-End Class
+Namespace Global
+
+    <Global.System.Runtime.CompilerServices.CompilerGenerated()>
+    <Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()>
+    NotInheritable Class GitVersionInformation
+        Private Sub New()
+        End Sub
+        Public Shared Major As String = "1"
+        Public Shared Minor As String = "2"
+        Public Shared Patch As String = "3"
+        Public Shared PreReleaseTag As String = "unstable.4"
+        Public Shared PreReleaseTagWithDash As String = "-unstable.4"
+        Public Shared PreReleaseLabel As String = "unstable"
+        Public Shared PreReleaseNumber As String = "4"
+        Public Shared WeightedPreReleaseNumber As String = "4"
+        Public Shared BuildMetaData As String = "5"
+        Public Shared BuildMetaDataPadded As String = "0005"
+        Public Shared FullBuildMetaData As String = "5.Branch.feature1.Sha.commitSha"
+        Public Shared MajorMinorPatch As String = "1.2.3"
+        Public Shared SemVer As String = "1.2.3-unstable.4"
+        Public Shared LegacySemVer As String = "1.2.3-unstable4"
+        Public Shared LegacySemVerPadded As String = "1.2.3-unstable0004"
+        Public Shared AssemblySemVer As String = "1.2.3.0"
+        Public Shared AssemblySemFileVer As String = "1.2.3.0"
+        Public Shared FullSemVer As String = "1.2.3-unstable.4+5"
+        Public Shared InformationalVersion As String = "1.2.3-unstable.4+5.Branch.feature1.Sha.commitSha"
+        Public Shared BranchName As String = "feature1"
+        Public Shared EscapedBranchName As String = "feature1"
+        Public Shared Sha As String = "commitSha"
+        Public Shared ShortSha As String = "commitShortSha"
+        Public Shared NuGetVersionV2 As String = "1.2.3-unstable0004"
+        Public Shared NuGetVersion As String = "1.2.3-unstable0004"
+        Public Shared NuGetPreReleaseTagV2 As String = "unstable0004"
+        Public Shared NuGetPreReleaseTag As String = "unstable0004"
+        Public Shared VersionSourceSha As String = "versionSourceSha"
+        Public Shared CommitsSinceVersionSource As String = "5"
+        Public Shared CommitsSinceVersionSourcePadded As String = "0005"
+        Public Shared CommitDate As String = "2014-03-06"
+    End Class
+
+End Namespace

--- a/src/GitVersionCore/VersionConverters/GitVersionInfo/GitVersionInfoGenerator.cs
+++ b/src/GitVersionCore/VersionConverters/GitVersionInfo/GitVersionInfoGenerator.cs
@@ -36,8 +36,9 @@ namespace GitVersion.VersionConverters.GitVersionInfo
             var fileExtension = Path.GetExtension(filePath);
             var template = templateManager.GetTemplateFor(fileExtension);
             var addFormat = templateManager.GetAddFormatFor(fileExtension);
+            var indentation = GetIndentation(fileExtension);
 
-            var members = string.Join(System.Environment.NewLine, variables.Select(v => string.Format("    " + addFormat, v.Key, v.Value)));
+            var members = string.Join(System.Environment.NewLine, variables.Select(v => string.Format(indentation + addFormat, v.Key, v.Value)));
 
             var fileContents = string.Format(template, members);
 
@@ -49,6 +50,15 @@ namespace GitVersion.VersionConverters.GitVersionInfo
 
         public void Dispose()
         {
+        }
+
+        // Because The VB-generated class is included in a namespace declaration,
+        // the properties must be offsetted by 2 tabs.
+        // Whereas in the C# and F# cases, 1 tab is enough.
+        private static string GetIndentation(string fileExtension)
+        {
+            var tabs = fileExtension.ToLowerInvariant().EndsWith("vb") ? 2 : 1;
+            return new string(' ', tabs * 4);
         }
     }
 }

--- a/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.vb
+++ b/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.vb
@@ -8,10 +8,14 @@
 ' </auto-generated>
 '------------------------------------------------------------------------------
 
-<Global.System.Runtime.CompilerServices.CompilerGenerated()>
-<Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()>
-NotInheritable Class GitVersionInformation
-    Private Sub New()
-    End Sub
+Namespace Global
+
+    <Global.System.Runtime.CompilerServices.CompilerGenerated()>
+    <Global.System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage()>
+    NotInheritable Class GitVersionInformation
+        Private Sub New()
+        End Sub
 {0}
-End Class
+    End Class
+
+End Namespace


### PR DESCRIPTION
## Description

* Modified the VB template so that the resulting class is part of the global namespace
* Tweaked a bit `GitVersionInfoGenerator.cs` so that it uses different tab lengths for the VB case and the F#/C# cases (this is simply a cosmetic change so that VB output formatting is correct).
* Modified `msbuild-task.md` in the documentation so that:
  * It does not try to find `GitVersionInformation` in the assembly's default namespace but in the global namespace
  * It works with F# generated classes (properties vs fields).

## Related Issue

Fixes #2310

## Motivation and Context

Now, the VB version of `GitVersionInformation` belongs to the `Global` namespace in the same way as its F# and C# counterparts.

## How Has This Been Tested?

* Fixed the units tests
* Double-checked with ILSpy that the resutling class is indeed part of the global namespace. Here is what it looks like when decompiled with ILSpy:

```csharp
// GitVersionInformation
using System.Diagnostics.CodeAnalysis;
using System.Runtime.CompilerServices;

[CompilerGenerated]
[ExcludeFromCodeCoverage]
internal sealed class GitVersionInformation
{
	public static string Major = "1";

	public static string Minor = "2";

	public static string Patch = "3";

	public static string PreReleaseTag = "unstable.4";

       ...

	public static string CommitsSinceVersionSourcePadded = "0005";

	public static string CommitDate = "2014-03-06";

	private GitVersionInformation()
	{
	}
}
```

![image](https://user-images.githubusercontent.com/79333/83971603-7c4e5000-a8dc-11ea-8fa1-b972cc26433f.png)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
