### PR TITLE
#if'ed the definition of ExcludeFromCodeCoverageAttribute depending o…

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -8,6 +8,22 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+#if NET20 || NET35 || NETCOREAPP1_0 || NETCOREAPP1_1 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5 || NETSTANDARD1_6
+namespace System.Diagnostics.CodeAnalysis
+{
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Event,
+        Inherited = false, AllowMultiple = false)]
+    internal sealed class ExcludeFromCodeCoverageAttribute : global::System.Attribute { }
+}
+#endif
+
 [global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 static class GitVersionInformation

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -8,6 +8,22 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+#if NET20 || NET35 || NETCOREAPP1_0 || NETCOREAPP1_1 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5 || NETSTANDARD1_6
+namespace System.Diagnostics.CodeAnalysis
+
+[<Sealed>]
+[<global.System.AttributeUsage(
+    global.System.AttributeTargets.Assembly ||| 
+    global.System.AttributeTargets.Class ||| 
+    global.System.AttributeTargets.Struct ||| 
+    global.System.AttributeTargets.Constructor ||| 
+    global.System.AttributeTargets.Method ||| 
+    global.System.AttributeTargets.Property ||| 
+    global.System.AttributeTargets.Event, 
+    Inherited = false, AllowMultiple = false)>]
+type ExcludeFromCodeCoverageAttribute() = inherit global.System.Attribute()
+#endif
+
 namespace global
 
 [<AbstractClass; Sealed>]

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -8,6 +8,22 @@
 ' </auto-generated>
 '------------------------------------------------------------------------------
 
+#If NET20 OrElse NET35 OrElse NETCOREAPP1_0 OrElse NETCOREAPP1_1 OrElse NETSTANDARD1_0 OrElse NETSTANDARD1_1 OrElse NETSTANDARD1_2 OrElse NETSTANDARD1_3 OrElse NETSTANDARD1_4 OrElse NETSTANDARD1_5 OrElse NETSTANDARD1_6 Then
+Namespace Global.System.Diagnostics.CodeAnalysis
+    <Global.System.AttributeUsage(
+        Global.System.AttributeTargets.Assembly Or
+        Global.System.AttributeTargets.Class Or
+        Global.System.AttributeTargets.Struct Or
+        Global.System.AttributeTargets.Constructor Or
+        Global.System.AttributeTargets.Method Or
+        Global.System.AttributeTargets.Property Or
+        Global.System.AttributeTargets.Event, Inherited:=False, AllowMultiple:=False)>
+    Friend NotInheritable Class ExcludeFromCodeCoverageAttribute
+        Inherits Global.System.Attribute
+    End Class
+End Namespace
+#End If
+
 Namespace Global
 
     <Global.System.Runtime.CompilerServices.CompilerGenerated()>

--- a/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.cs
+++ b/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.cs
@@ -8,6 +8,22 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+#if NET20 || NET35 || NETCOREAPP1_0 || NETCOREAPP1_1 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5 || NETSTANDARD1_6
+namespace System.Diagnostics.CodeAnalysis
+{{
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Event,
+        Inherited = false, AllowMultiple = false)]
+    internal sealed class ExcludeFromCodeCoverageAttribute : global::System.Attribute {{ }}
+}}
+#endif
+
 [global::System.Runtime.CompilerServices.CompilerGenerated]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 static class GitVersionInformation

--- a/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.fs
+++ b/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.fs
@@ -8,6 +8,22 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+#if NET20 || NET35 || NETCOREAPP1_0 || NETCOREAPP1_1 || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2 || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5 || NETSTANDARD1_6
+namespace System.Diagnostics.CodeAnalysis
+
+[<Sealed>]
+[<global.System.AttributeUsage(
+    global.System.AttributeTargets.Assembly ||| 
+    global.System.AttributeTargets.Class ||| 
+    global.System.AttributeTargets.Struct ||| 
+    global.System.AttributeTargets.Constructor ||| 
+    global.System.AttributeTargets.Method ||| 
+    global.System.AttributeTargets.Property ||| 
+    global.System.AttributeTargets.Event, 
+    Inherited = false, AllowMultiple = false)>]
+type ExcludeFromCodeCoverageAttribute() = inherit global.System.Attribute()
+#endif
+
 namespace global
 
 [<AbstractClass; Sealed>]

--- a/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.vb
+++ b/src/GitVersionCore/VersionConverters/GitVersionInfo/Templates/GitVersionInformation.vb
@@ -8,6 +8,22 @@
 ' </auto-generated>
 '------------------------------------------------------------------------------
 
+#If NET20 OrElse NET35 OrElse NETCOREAPP1_0 OrElse NETCOREAPP1_1 OrElse NETSTANDARD1_0 OrElse NETSTANDARD1_1 OrElse NETSTANDARD1_2 OrElse NETSTANDARD1_3 OrElse NETSTANDARD1_4 OrElse NETSTANDARD1_5 OrElse NETSTANDARD1_6 Then
+Namespace Global.System.Diagnostics.CodeAnalysis
+    <Global.System.AttributeUsage(
+        Global.System.AttributeTargets.Assembly Or
+        Global.System.AttributeTargets.Class Or
+        Global.System.AttributeTargets.Struct Or
+        Global.System.AttributeTargets.Constructor Or
+        Global.System.AttributeTargets.Method Or
+        Global.System.AttributeTargets.Property Or
+        Global.System.AttributeTargets.Event, Inherited:=False, AllowMultiple:=False)>
+    Friend NotInheritable Class ExcludeFromCodeCoverageAttribute
+        Inherits Global.System.Attribute
+    End Class
+End Namespace
+#End If
+
 Namespace Global
 
     <Global.System.Runtime.CompilerServices.CompilerGenerated()>


### PR DESCRIPTION
…n the target framework

The `ExcludeFromCodeCoverageAttribute` is not supported on some older .NET framework targets:
* Classic framework < v4.0
* .NET Core < v2.0
* .NET Standard < 2.0

In order for projects targeting some of these frameworks to be able to use GitVersion,  `ExcludeFromCodeCoverageAttribute` needs to be defined conditionally when targeting these frameworks.

This is exactly what this PR does. 

This PR fixes #2330.

I used a side-project to ensure my changes were correct (see https://github.com/odalet/GitVersionTests). Unfortunately I wasn't able to enforce these tests with proper unit tests (I think it is not a trivial task to be able to ensure correct compilation of projects across all framework x language combinations).

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
