### PR TITLE
Allow special characters in Assembly InformationalVersion

### DIFF
--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -42,6 +42,7 @@ next-version: 1.0
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{InformationalVersion}'
+assembly-informational-is-semver: true
 mode: ContinuousDelivery
 increment: Inherit
 continuous-delivery-fallback-tag: ci
@@ -115,6 +116,13 @@ Follows the same formatting semantics as `assembly-file-versioning-format`.
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
+
+### assembly-informational-is-semver
+
+Controls whether `assembly-file-versioning-format` should follow semantic version allowed char-set or not.
+If set to `true` it will replace any special characters by a dash `-`.
+If set to `false` it will allow any special characters (unicode characters, spaces and symbols like `#@!?[]()$=-`).
+The default value is `true`.
 
 ### mode
 

--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -1,5 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
+assembly-informational-is-semver: true
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
 continuous-delivery-fallback-tag: ci

--- a/src/GitVersionCore.Tests/Helpers/TestEffectiveConfiguration.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestEffectiveConfiguration.cs
@@ -36,8 +36,10 @@ namespace GitVersionCore.Tests.Helpers
             bool tracksReleaseBranches = false,
             bool isRelease = false,
             string commitDateFormat = "yyyy-MM-dd",
-            bool updateBuildNumber = false) :
-            base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
+            bool updateBuildNumber = false,
+            bool assemblyInformationalIsSemver = true
+            ) :
+            base(assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyInformationalIsSemver, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch,
                     branchPrefixToTrim, preventIncrementForMergedBranchVersion, tagNumberPattern, continuousDeploymentFallbackTag,
                     trackMergeTarget,
                     majorMessage, minorMessage, patchMessage, noBumpMessage,

--- a/src/GitVersionCore.Tests/Model/CommitDateTests.cs
+++ b/src/GitVersionCore.Tests/Model/CommitDateTests.cs
@@ -28,7 +28,7 @@ namespace GitVersionCore.Tests
 
                                     },
                                     new EffectiveConfiguration(
-                                        AssemblyVersioningScheme.MajorMinorPatch, AssemblyFileVersioningScheme.MajorMinorPatch, "", "", "", VersioningMode.ContinuousDelivery, "", "", "", IncrementStrategy.Inherit,
+                                        AssemblyVersioningScheme.MajorMinorPatch, AssemblyFileVersioningScheme.MajorMinorPatch, "", true, "", "", VersioningMode.ContinuousDelivery, "", "", "", IncrementStrategy.Inherit,
                                         "", true, "", "", false, "", "", "", "", CommitMessageIncrementMode.Enabled, 4, 4, 4, Enumerable.Empty<IVersionFilter>(), false, true, format, false, 0, 0)
                                 );
 

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -17,7 +17,7 @@
   "AssemblySemVer":"1.2.3.0",
   "AssemblySemFileVer":"1.2.3.0",
   "FullSemVer":"1.2.3+5",
-  "InformationalVersion":"1.2.3+5.Branch.feature-123.Sha.commitShortSha",
+  "InformationalVersion":"1.2.3+5.Branch.feature/123.Sha.commitShortSha",
   "BranchName":"feature/123",
   "EscapedBranchName":"feature-123",
   "Sha":"commitSha",

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -17,7 +17,7 @@
   "AssemblySemVer":"1.2.3.0",
   "AssemblySemFileVer":"1.2.3.0",
   "FullSemVer":"1.2.3+5",
-  "InformationalVersion":"1.2.3+5.Branch.feature/123.Sha.commitShortSha",
+  "InformationalVersion":"1.2.3+5.Branch.feature-123.Sha.commitShortSha",
   "BranchName":"feature/123",
   "EscapedBranchName":"feature-123",
   "Sha":"commitSha",

--- a/src/GitVersionCore.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/VariableProviderTests.cs
@@ -312,7 +312,10 @@ namespace GitVersionCore.Tests
         {
             var semVer = new SemanticVersion();
             var textWithSpecialCharacters = @"+ -=#![]^&@$%:<>/\-çñáÁ统";
-            var config = new TestEffectiveConfiguration(assemblyInformationalFormat: $"Special characters: {textWithSpecialCharacters}");
+            var config = new TestEffectiveConfiguration(
+                assemblyInformationalFormat: $"Special characters: {textWithSpecialCharacters}",
+                assemblyInformationalIsSemver: false
+            );
 
             var vars = variableProvider.GetVariablesFor(semVer, config, false);
 

--- a/src/GitVersionCore.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/VariableProviderTests.cs
@@ -306,5 +306,17 @@ namespace GitVersionCore.Tests
 
             vars.ToString().ShouldMatchApproved(c => c.SubFolder("Approved"));
         }
+        
+        [Test]
+        public void ProvidesVariableshWithCustomAssemblyInfoFormatSupportingAnySpecialCharcter()
+        {
+            var semVer = new SemanticVersion();
+            var textWithSpecialCharacters = @"+ -=#![]^&@$%:<>/\-çñáÁ统";
+            var config = new TestEffectiveConfiguration(assemblyInformationalFormat: $"Special characters: {textWithSpecialCharacters}");
+
+            var vars = variableProvider.GetVariablesFor(semVer, config, false);
+
+            vars.InformationalVersion.ShouldContain(textWithSpecialCharacters);
+        }
     }
 }

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -84,6 +84,7 @@ namespace GitVersion.Configuration
             var assemblyVersioningScheme = configuration.AssemblyVersioningScheme.Value;
             var assemblyFileVersioningScheme = configuration.AssemblyFileVersioningScheme.Value;
             var assemblyInformationalFormat = configuration.AssemblyInformationalFormat;
+            var assemblyInformationalIsSemver = configuration.AssemblyInformationalIsSemVer;
             var assemblyVersioningFormat = configuration.AssemblyVersioningFormat;
             var assemblyFileVersioningFormat = configuration.AssemblyFileVersioningFormat;
             var gitTagPrefix = configuration.TagPrefix;
@@ -97,7 +98,9 @@ namespace GitVersion.Configuration
 
             var commitMessageVersionBump = currentBranchConfig.CommitMessageIncrementing ?? configuration.CommitMessageIncrementing.Value;
             return new EffectiveConfiguration(
-                assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix,
+                assemblyVersioningScheme, assemblyFileVersioningScheme,
+                assemblyInformationalFormat, assemblyInformationalIsSemver,
+                assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix,
                 tag, nextVersion, incrementStrategy,
                 currentBranchConfig.Regex,
                 preventIncrementForMergedBranchVersion,

--- a/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
@@ -184,7 +184,8 @@ namespace GitVersion.Configuration
                 CommitsSinceVersionSourcePadding = 4,
                 CommitDateFormat = "yyyy-MM-dd",
                 UpdateBuildNumber = true,
-                TagPreReleaseWeight = DefaultTagPreReleaseWeight
+                TagPreReleaseWeight = DefaultTagPreReleaseWeight,
+                AssemblyInformationalIsSemVer = true
             };
 
             AddBranchConfig(Config.DevelopBranchKey,

--- a/src/GitVersionCore/Model/Configuration/Config.cs
+++ b/src/GitVersionCore/Model/Configuration/Config.cs
@@ -28,10 +28,13 @@ namespace GitVersion.Model.Configuration
 
         [YamlMember(Alias = "assembly-informational-format")]
         public string AssemblyInformationalFormat { get; set; }
+        
+        [YamlMember(Alias = "assembly-informational-is-semver")]
+        public bool AssemblyInformationalIsSemVer { get; set; }
 
         [YamlMember(Alias = "assembly-versioning-format")]
         public string AssemblyVersioningFormat { get; set; }
-
+        
         [YamlMember(Alias = "assembly-file-versioning-format")]
         public string AssemblyFileVersioningFormat { get; set; }
 

--- a/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersionCore/Model/Configuration/EffectiveConfiguration.cs
@@ -13,6 +13,7 @@ namespace GitVersion.Model.Configuration
             AssemblyVersioningScheme assemblyVersioningScheme,
             AssemblyFileVersioningScheme assemblyFileVersioningScheme,
             string assemblyInformationalFormat,
+            bool assemblyInformationalIsSemver,
             string assemblyVersioningFormat,
             string assemblyFileVersioningFormat,
             VersioningMode versioningMode, string gitTagPrefix,
@@ -36,11 +37,13 @@ namespace GitVersion.Model.Configuration
             string commitDateFormat,
             bool updateBuildNumber,
             int preReleaseWeight,
-            int tagPreReleaseWeight)
+            int tagPreReleaseWeight
+            )
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
             AssemblyFileVersioningScheme = assemblyFileVersioningScheme;
             AssemblyInformationalFormat = assemblyInformationalFormat;
+            AssemblyInformationalIsSemver = assemblyInformationalIsSemver;
             AssemblyVersioningFormat = assemblyVersioningFormat;
             AssemblyFileVersioningFormat = assemblyFileVersioningFormat;
             VersioningMode = versioningMode;
@@ -78,6 +81,7 @@ namespace GitVersion.Model.Configuration
         public AssemblyVersioningScheme AssemblyVersioningScheme { get; private set; }
         public AssemblyFileVersioningScheme AssemblyFileVersioningScheme { get; private set; }
         public string AssemblyInformationalFormat { get; private set; }
+        public bool AssemblyInformationalIsSemver { get; private set; }
         public string AssemblyVersioningFormat { get; private set; }
         public string AssemblyFileVersioningFormat { get; private set; }
 

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -56,7 +56,8 @@ namespace GitVersion.VersionCalculation
 
             var semverFormatValues = new SemanticVersionFormatValues(semanticVersion, config);
 
-            var informationalVersion = CheckAndFormatString(config.AssemblyInformationalFormat, semverFormatValues, semverFormatValues.InformationalVersion, "AssemblyInformationalVersion", false);
+            var informationalVersion = CheckAndFormatString(config.AssemblyInformationalFormat, semverFormatValues, semverFormatValues.InformationalVersion, "AssemblyInformationalVersion",
+                replaceSpecialChars: config.AssemblyInformationalIsSemver);
 
             var assemblyFileSemVer = CheckAndFormatString(config.AssemblyFileVersioningFormat, semverFormatValues, semverFormatValues.AssemblyFileSemVer, "AssemblyFileVersioningFormat");
 

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -56,7 +56,7 @@ namespace GitVersion.VersionCalculation
 
             var semverFormatValues = new SemanticVersionFormatValues(semanticVersion, config);
 
-            var informationalVersion = CheckAndFormatString(config.AssemblyInformationalFormat, semverFormatValues, semverFormatValues.InformationalVersion, "AssemblyInformationalVersion");
+            var informationalVersion = CheckAndFormatString(config.AssemblyInformationalFormat, semverFormatValues, semverFormatValues.InformationalVersion, "AssemblyInformationalVersion", false);
 
             var assemblyFileSemVer = CheckAndFormatString(config.AssemblyFileVersioningFormat, semverFormatValues, semverFormatValues.AssemblyFileSemVer, "AssemblyFileVersioningFormat");
 
@@ -123,7 +123,7 @@ namespace GitVersion.VersionCalculation
             }
         }
 
-        private string CheckAndFormatString<T>(string formatString, T source, string defaultValue, string formatVarName)
+        private string CheckAndFormatString<T>(string formatString, T source, string defaultValue, string formatVarName, bool replaceSpecialChars = true)
         {
             string formattedString;
 
@@ -137,7 +137,10 @@ namespace GitVersion.VersionCalculation
 
                 try
                 {
-                    formattedString = formatString.FormatWith(source, environment).RegexReplace("[^0-9A-Za-z-.+]", "-");
+                    formattedString = formatString.FormatWith(source, environment);
+                    if (replaceSpecialChars) {
+                        formattedString = formattedString.RegexReplace("[^0-9A-Za-z-.+]", "-");
+                    }
                 }
                 catch (ArgumentException formex)
                 {


### PR DESCRIPTION
## Description
Allow any special character in Assembly InformationalVersion.
Added a parameter in the common function "CheckAndFormatString" to control whether or not special chars gets replaced.

### New in 2nd commit:
Added a new config parameter: `assembly-informational-is-semver` that is true by default to make this backwards compatible.
If set to false then it allows any character in  `assembly-informational-version`.

## Related Issue
https://github.com/GitTools/GitVersion/issues/2339
https://github.com/GitTools/GitVersion/issues/2199


## Motivation and Context
Allow any special character in Assembly InformationalVersion.
It is the only place we can add free long customized text describing anything we want and readable from dll/exe file properties.

## How Has This Been Tested?
Included a test.
Run all the test and got them passing.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
