### PR TITLE
Add failing test for missing source-branch config

### DIFF
--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.cs
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.cs
@@ -118,6 +118,21 @@ branches:
         }
 
         [Test]
+        public void SourceBranchesShouldExist()
+        {
+            const string text = @"
+branches:
+    bug:
+        regex: 'bug[/-]'
+        tag: bugfix
+        source-branches: [notconfigured]";
+            SetupConfigFileContent(text);
+            var ex = Should.Throw<ConfigurationException>(() => configProvider.Provide(repoPath));
+            ex.Message.ShouldBe($"Branch configuration 'bug' defines these 'source-branches' that are not configured: '[notconfigured]'{Environment.NewLine}" +
+                                "See https://gitversion.net/docs/configuration/ for more info");
+        }
+
+        [Test]
         public void CanProvideConfigForNewBranch()
         {
             const string text = @"

--- a/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using GitVersion.Extensions;
 using GitVersion.Model.Configuration;
 using GitVersion.VersionCalculation;
@@ -162,6 +163,10 @@ namespace GitVersion.Configuration
                 {
                     throw new ConfigurationException($"Branch configuration '{name}' is missing required configuration 'source-branches'{System.Environment.NewLine}" + "See https://gitversion.net/docs/configuration/ for more info");
                 }
+
+                var missingSourceBranches = sourceBranches.Where(sb => config.GetConfigForBranch(sb) == null).ToArray();
+                if (missingSourceBranches.Any())
+                    throw new ConfigurationException($"Branch configuration '{name}' defines these 'source-branches' that are not configured: '[{string.Join(",", missingSourceBranches)}]'{System.Environment.NewLine}" + "See https://gitversion.net/docs/configuration/ for more info");
             }
         }
 

--- a/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
@@ -164,7 +164,7 @@ namespace GitVersion.Configuration
                     throw new ConfigurationException($"Branch configuration '{name}' is missing required configuration 'source-branches'{System.Environment.NewLine}" + "See https://gitversion.net/docs/configuration/ for more info");
                 }
 
-                var missingSourceBranches = sourceBranches.Where(sb => config.GetConfigForBranch(sb) == null).ToArray();
+                var missingSourceBranches = sourceBranches.Where(sb => !config.Branches.ContainsKey(sb)).ToArray();
                 if (missingSourceBranches.Any())
                     throw new ConfigurationException($"Branch configuration '{name}' defines these 'source-branches' that are not configured: '[{string.Join(",", missingSourceBranches)}]'{System.Environment.NewLine}" + "See https://gitversion.net/docs/configuration/ for more info");
             }


### PR DESCRIPTION
## Description

We ran into a case where we added a source-branch that wasn't configured.
This ultimately led to a failure way down in the RepositoryMetadataProvider.
From the best I can tell this is due to having no `main` branch configuration.

```
    System.Collections.Generic.KeyNotFoundException: The given key 'main' was not present in the dictionary.
13:04:34
       at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
13:04:34
       at GitVersion.RepositoryMetadataProvider.<>c__DisplayClass33_0.<GetMergeCommitsForBranch>b__0(String sb) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 475
13:04:34
       at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
13:04:34
       at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
13:04:34
       at GitVersion.RepositoryMetadataProvider.<>c__DisplayClass33_0.<GetMergeCommitsForBranch>b__1(Branch b) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 480
13:04:34
       at System.Linq.Utilities.<>c__DisplayClass1_0`1.<CombinePredicates>b__0(TSource x)
13:04:34
       at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
13:04:34
       at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
13:04:34
       at System.Linq.OrderedEnumerable`1.ToList()
13:04:34
       at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
13:04:34
       at GitVersion.RepositoryMetadataProvider.GetMergeCommitsForBranch(Branch branch, Config configuration, IEnumerable`1 excludedBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 476
13:04:34
       at GitVersion.RepositoryMetadataProvider.FindCommitBranchWasBranchedFrom(Branch branch, Config configuration, Branch[] excludedBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 333
13:04:34
       at GitVersion.Configuration.BranchConfigurationCalculator.InheritBranchConfiguration(Branch targetBranch, BranchConfig branchConfiguration, Commit currentCommit, Config configuration, IList`1 excludedInheritBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Configuration\BranchConfigurationCalculator.cs:line 80
13:04:34
       at GitVersion.Configuration.BranchConfigurationCalculator.GetBranchConfiguration(Branch targetBranch, Commit currentCommit, Config configuration, IList`1 excludedInheritBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Configuration\BranchConfigurationCalculator.cs:line 48
```

## Related Issue

https://github.com/GitTools/GitVersion/issues/2349

## Motivation and Context

This will help other people discover misconfiguration early.

## How Has This Been Tested?

I'm depending on the failing test I've written.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
