### PR TITLE
Add Version element to project file updater

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Xml.Linq;
 using GitVersion;
 using GitVersion.Extensions;
 using GitVersion.Logging;
@@ -12,6 +9,9 @@ using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
+using System;
+using System.IO;
+using System.Xml.Linq;
 
 namespace GitVersionCore.Tests
 {
@@ -298,6 +298,7 @@ namespace GitVersionCore.Tests
     <AssemblyVersion>2.3.1.0</AssemblyVersion>
     <FileVersion>2.3.1.0</FileVersion>
     <InformationalVersion>2.3.1+3.Branch.foo.Sha.hash</InformationalVersion>
+    <Version>2.3.1</Version>
   </PropertyGroup>
 </Project>";
                 var transformedXml = fs.ReadAllText(fileName);

--- a/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -56,6 +56,8 @@ namespace GitVersion.VersionConverters.AssemblyInfo
                     continue;
                 }
 
+                log.Debug($"Update file: {localProjectFile}");
+
                 var backupProjectFile = localProjectFile + ".bak";
                 fileSystem.Copy(localProjectFile, backupProjectFile, true);
 

--- a/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -1,10 +1,10 @@
+using GitVersion.Logging;
+using GitVersion.OutputVariables;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using GitVersion.Logging;
-using GitVersion.OutputVariables;
 
 namespace GitVersion.VersionConverters.AssemblyInfo
 {
@@ -17,6 +17,7 @@ namespace GitVersion.VersionConverters.AssemblyInfo
         internal const string AssemblyVersionElement = "AssemblyVersion";
         internal const string FileVersionElement = "FileVersion";
         internal const string InformationalVersionElement = "InformationalVersion";
+        internal const string VersionElement = "Version";
 
         private readonly List<Action> restoreBackupTasks = new List<Action>();
         private readonly List<Action> cleanupBackupTasks = new List<Action>();
@@ -40,6 +41,7 @@ namespace GitVersion.VersionConverters.AssemblyInfo
             var assemblyVersion = variables.AssemblySemVer;
             var assemblyInfoVersion = variables.InformationalVersion;
             var assemblyFileVersion = variables.AssemblySemFileVer;
+            var packageVersion = variables.NuGetVersionV2;
 
             foreach (var projectFile in projectFilesToUpdate)
             {
@@ -82,6 +84,11 @@ namespace GitVersion.VersionConverters.AssemblyInfo
                 if (!string.IsNullOrWhiteSpace(assemblyInfoVersion))
                 {
                     UpdateProjectVersionElement(fileXml, InformationalVersionElement, assemblyInfoVersion);
+                }
+
+                if (!string.IsNullOrWhiteSpace(packageVersion))
+                {
+                    UpdateProjectVersionElement(fileXml, VersionElement, packageVersion);
                 }
 
                 var outputXmlString = fileXml.ToString();


### PR DESCRIPTION
Add Version element to project file updater.

## Description
Extends the `ProjectFileUpdater` class with the `Version` element handling and adds debug logging.

## Related Issue
Fixes #2359

## Motivation and Context
Expected behavior on naming a NuGet package in a DevOps pipeline.

## How Has This Been Tested?
Unit Test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.