### PR TITLE
add main to the master branch regex in the default configuration

### DIFF
--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -283,7 +283,7 @@ upgrade.
 ```yaml
 branches:
   master:
-    regex: ^master|main$
+    regex: ^master$|^main$
     mode: ContinuousDelivery
     tag: ''
     increment: Patch

--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -283,7 +283,7 @@ upgrade.
 ```yaml
 branches:
   master:
-    regex: ^master
+    regex: ^master|main$
     mode: ContinuousDelivery
     tag: ''
     increment: Patch

--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -31,7 +31,7 @@ branches:
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
-    regex: ^master$
+    regex: ^master|main$
     source-branches:
     - develop
     - release

--- a/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersionCore.Tests/Configuration/ConfigProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -31,7 +31,7 @@ branches:
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
-    regex: ^master|main$
+    regex: ^master$|^main$
     source-branches:
     - develop
     - release

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -60,25 +60,25 @@ namespace GitVersionCore.Tests.IntegrationTests
         [Test]
         public void AllowHavingMainInsteadOfMaster()
         {
-            var config = new Config();
-            config.Branches.Add("master", new BranchConfig
-            {
-                Regex = "main",
-                VersioningMode = VersioningMode.ContinuousDelivery,
-                Tag = "useBranchName",
-                Increment = IncrementStrategy.Patch,
-                PreventIncrementOfMergedBranchVersion = true,
-                TrackMergeTarget = false,
-                SourceBranches = new HashSet<string>()
-            });
-
             using var fixture = new EmptyRepositoryFixture();
             fixture.Repository.MakeACommit();
             Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
             Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("main"));
             fixture.Repository.Branches.Remove(fixture.Repository.Branches["master"]);
 
-            fixture.AssertFullSemver("0.1.0-1+0", config);
+            fixture.AssertFullSemver("0.1.0+0");
+        }
+
+        [Test]
+        public void AllowHavingVariantsStartingWithMain()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.Repository.MakeACommit();
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.MakeACommit();
+            Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("mainfix"));
+
+            fixture.AssertFullSemver("1.0.1-mainfix.1+1");
         }
 
         [Test]

--- a/src/GitVersionCore/Model/Configuration/Config.cs
+++ b/src/GitVersionCore/Model/Configuration/Config.cs
@@ -115,7 +115,7 @@ namespace GitVersion.Model.Configuration
         public const string HotfixBranchRegex = "^hotfix(es)?[/-]";
         public const string SupportBranchRegex = "^support[/-]";
         public const string DevelopBranchRegex = "^dev(elop)?(ment)?$";
-        public const string MasterBranchRegex = "^master|main$";
+        public const string MasterBranchRegex = "^master$|^main$";
         public const string MasterBranchKey = "master";
         public const string ReleaseBranchKey = "release";
         public const string FeatureBranchKey = "feature";

--- a/src/GitVersionCore/Model/Configuration/Config.cs
+++ b/src/GitVersionCore/Model/Configuration/Config.cs
@@ -115,7 +115,7 @@ namespace GitVersion.Model.Configuration
         public const string HotfixBranchRegex = "^hotfix(es)?[/-]";
         public const string SupportBranchRegex = "^support[/-]";
         public const string DevelopBranchRegex = "^dev(elop)?(ment)?$";
-        public const string MasterBranchRegex = "^master$";
+        public const string MasterBranchRegex = "^master|main$";
         public const string MasterBranchKey = "master";
         public const string ReleaseBranchKey = "release";
         public const string FeatureBranchKey = "feature";


### PR DESCRIPTION
As many more organizations (including [GitHub](https://twitter.com/natfriedman/status/1271253144442253312)) and repositories are moving towards naming their default branch `main` instead of `master`, it would be useful to include this naming in the default configuration.

## Description
Change the default regex for master branches from `^master$` to `^master|main$`.

## Related Issue
Fixes #2366.

## Motivation and Context
Our organization is making this change and many of our repos use GitVersion. We could make custom configurations for all these repositories, but that is yet another configuration file to maintain and distribute. As this is a movement that is gaining popularity across the board, it would be useful to have this baked into GitVersion and not require a custom configuration.

`main` seems to be the general consensus from the community as the preferred alternative to `master`. It also seems to be the preferred name of the [developer who chose the original names](https://twitter.com/xpasky/status/1271477451756056577).

## How Has This Been Tested?
~I attempted to test this locally but was unable to figure out how to build the project. I attempted to build it in a docker image but my changes were not there. I would appreciate help on this.~
I wasn't able to package it locally still, but I was able to get the project working and ran the tests that were breaking in GitHub. Much easier than making a commit to test.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
