### PR TITLE
Added support for project type Microsoft.NET.Sdk.WindowsDesktop.

### DIFF
--- a/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -72,6 +72,25 @@ namespace GitVersionCore.Tests
         }
 
         [TestCase(@"
+<Project Sdk=""Microsoft.NET.Sdk.WindowsDesktop"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+</Project>
+")]
+        [Category(NoMono)]
+        [Description(NoMonoDescription)]
+        public void CanUpdateProjectFileWithStandardDesktopProjectFileXml(string xml)
+        {
+            using var projectFileUpdater = new ProjectFileUpdater(log, fileSystem);
+
+            var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+
+            canUpdate.ShouldBe(true);
+        }
+
+        [TestCase(@"
 <Project Sdk=""SomeOtherProject.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersionCore/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -111,7 +111,7 @@ namespace GitVersion.VersionConverters.AssemblyInfo
                 return false;
             }
 
-            var supportedSdks = new[] { "Microsoft.NET.Sdk", "Microsoft.NET.Sdk.Web" };
+            var supportedSdks = new[] { "Microsoft.NET.Sdk", "Microsoft.NET.Sdk.Web", "Microsoft.NET.Sdk.WindowsDesktop" };
             var sdkAttribute = xmlRoot.Attribute("Sdk");
             if (sdkAttribute == null || !supportedSdks.Contains(sdkAttribute.Value))
             {


### PR DESCRIPTION
I've added a check so that WindowsDesktop projects can be accepted. They are in the same format as the Microsoft.NET.Sdk.
I've added a unit test to match the existing ones as well.