### PR TITLE
Added simple fix for mergemessageformats override

### DIFF
--- a/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
+++ b/src/GitVersionCore/Configuration/ConfigurationBuilder.cs
@@ -60,7 +60,7 @@ namespace GitVersion.Configuration
             targetConfig.CommitMessageIncrementing = overrideConfig.CommitMessageIncrementing ?? targetConfig.CommitMessageIncrementing;
             targetConfig.Increment = overrideConfig.Increment ?? targetConfig.Increment;
             targetConfig.CommitDateFormat = overrideConfig.CommitDateFormat ?? targetConfig.CommitDateFormat;
-            targetConfig.MergeMessageFormats = overrideConfig.MergeMessageFormats ?? targetConfig.MergeMessageFormats;
+            targetConfig.MergeMessageFormats = overrideConfig.MergeMessageFormats.Any() ? overrideConfig.MergeMessageFormats : targetConfig.MergeMessageFormats;
             targetConfig.UpdateBuildNumber = overrideConfig.UpdateBuildNumber ?? targetConfig.UpdateBuildNumber;
 
             if (overrideConfig.Ignore != null && !overrideConfig.Ignore.IsEmpty)


### PR DESCRIPTION
Quick hotfix for issue #2371. When you set your own custom merge-message-formats it will get overwritten when applying gitversion.
Running the gitversion /showConfig will just show a emtpy dictionary again :
commit-date-format: yyyy-MM-dd merge-message-formats: {} update-build-number: true

## Description
Quick fix in ConfigurationBuilder by instead of checking only for the MergeMessageFormats to be null, actually checking if it has any values. 
Proper resolution still needed, because this will not actually merge the two dictionaries.

## Related Issue
Issue #2371

## Motivation and Context
See the issue for more details. This will now solve the situation that custom formats are not applied.

## How Has This Been Tested?
Ran all the unittests, using it in own build server environment.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
