### PR TITLE
Update GitVersionTask.targets

### DIFF
--- a/src/GitVersionTask/build/GitVersionTask.targets
+++ b/src/GitVersionTask/build/GitVersionTask.targets
@@ -91,6 +91,7 @@
             <Output TaskParameter="FullSemVer" PropertyName="GitVersion_FullSemVer" />
             <Output TaskParameter="InformationalVersion" PropertyName="GitVersion_InformationalVersion" />
             <Output TaskParameter="BranchName" PropertyName="GitVersion_BranchName" />
+            <Output TaskParameter="EscapedBranchName" PropertyName="GitVersion_EscapedBranchName" />
             <Output TaskParameter="Sha" PropertyName="GitVersion_Sha" />
             <Output TaskParameter="NuGetVersionV2" PropertyName="GitVersion_NuGetVersionV2" />
             <Output TaskParameter="NuGetVersion" PropertyName="GitVersion_NuGetVersion" />
@@ -135,6 +136,7 @@
             <DefineConstants Condition=" '$(GitVersion_FullSemVer)' != '' ">GitVersion_FullSemVer=$(GitVersion_FullSemVer);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_InformationalVersion)' != '' ">GitVersion_InformationalVersion=$(GitVersion_InformationalVersion);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_BranchName)' != '' ">GitVersion_BranchName=$(GitVersion_BranchName);$(DefineConstants)</DefineConstants>
+            <DefineConstants Condition=" '$(GitVersion_EscapedBranchName)' != '' ">GitVersion_EscapedBranchName=$(GitVersion_EscapedBranchName);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_Sha)' != '' ">GitVersion_Sha=$(GitVersion_Sha);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_NuGetVersionV2)' != '' ">GitVersion_NuGetVersionV2=$(GitVersion_NuGetVersionV2);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_NuGetVersion)' != '' ">GitVersion_NuGetVersion=$(GitVersion_NuGetVersion);$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
Added GitVersion_EscapedBranchName

## Description
Output `EscapedBranchName` from the `GetVersion` task to a new property `GitVersion_EscapedBranchName`.

## Related Issue
Fixes #2398.

## Motivation and Context
New property https://github.com/GitTools/GitVersion/pull/2157 added.
It appears the line was just missed in the above pr. The change was made to [src/GitVersionTask.MsBuild/Tasks/GetVersion.cs](https://github.com/KiLLeRRaT/GitVersion/blob/eca4a2fc23592560f405b0c0f0ab401d8920df22/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs#L68) to add the output; exposing the property just wasn't updated in the target.

## How Has This Been Tested?
I tested by making the changing on my build machine in the nuget cache (`~\.nuget\packages\gitversiontask\5.3.7\build\GitVersionTask.targets`).
ReBuilt my project shoulded the new property was created.

## Screenshots (if appropriate):

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
