### PR TITLE
Allow building from a detached tag, since there is no need to calculate the increment

### DIFF
--- a/src/GitVersionCore.Tests/IntegrationTests/TagCheckoutScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/TagCheckoutScenarios.cs
@@ -1,0 +1,32 @@
+﻿using GitTools.Testing;
+using NUnit.Framework;
+
+namespace GitVersionCore.Tests.IntegrationTests
+{
+    [TestFixture]
+    public class TagCheckoutScenarios
+    {
+        [Test]
+        public void GivenARepositoryWithSingleCommit()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            const string taggedVersion = "1.0.3";
+            fixture.Repository.MakeATaggedCommit(taggedVersion);
+            fixture.Checkout(taggedVersion);
+
+            fixture.AssertFullSemver(taggedVersion);
+        }
+
+        [Test]
+        public void GivenARepositoryWithSingleCommitAndSingleBranch()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            const string taggedVersion = "1.0.3";
+            fixture.Repository.MakeATaggedCommit(taggedVersion);
+            fixture.BranchTo("task1");
+            fixture.Checkout(taggedVersion);
+
+            fixture.AssertFullSemver(taggedVersion);
+        }
+    }
+}

--- a/src/GitVersionCore.Tests/IntegrationTests/TagCheckoutScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/TagCheckoutScenarios.cs
@@ -1,4 +1,4 @@
-﻿using GitTools.Testing;
+using GitTools.Testing;
 using NUnit.Framework;
 
 namespace GitVersionCore.Tests.IntegrationTests

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -35,7 +35,10 @@ namespace GitVersion.VersionCalculation
                 log.Info($"Current commit is tagged with version {context.CurrentCommitTaggedVersion}, " +
                          "version calculation is for metadata only.");
             }
-            EnsureHeadIsNotDetached(context);
+            else
+            {
+                EnsureHeadIsNotDetached(context);
+            }
 
             SemanticVersion taggedSemanticVersion = null;
 


### PR DESCRIPTION
## Description
Rejection of a detached head now only happens if no tag is available

## Related Issue
Fixes #2301 GitVersionTask fails when building from a tag

## Motivation and Context
Detached HEADs were always rejected, because a branch is needed to calculate the next version. But this is not required for tagged commits, since the version is directly derived from the tag.

## How Has This Been Tested?
```
git init
git commit --allow-empty -m "init"
git branch task1
git tag v0.2
git checkout v0.2
gitversion
```

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.