### PR TITLE
Avoid set-env environment warning during build log generation

### DIFF
--- a/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
@@ -97,7 +97,7 @@ namespace GitVersionCore.Tests.BuildAgents
         }
 
         [TestCase("Something", "1.0.0",
-            "::set-env name=GitVersion_Something::1.0.0")]
+            "\"GitVersion_Something=1.0.0\" >> $GITHUB_ENV")]
         public void GetSetParameterMessage(string key, string value, string expectedResult)
         {
             // Assert
@@ -141,7 +141,7 @@ namespace GitVersionCore.Tests.BuildAgents
                 "Executing GenerateSetVersionMessage for 'GitHubActions'.",
                 "",
                 "Executing GenerateBuildLogOutput for 'GitHubActions'.",
-                "::set-env name=GitVersion_Major::1.0.0"
+                "\"GitVersion_Major=1.0.0\" >> $GITHUB_ENV"
             };
 
             string.Join(Environment.NewLine, list)

--- a/src/GitVersionCore/BuildAgents/GitHubActions.cs
+++ b/src/GitVersionCore/BuildAgents/GitHubActions.cs
@@ -23,9 +23,9 @@ namespace GitVersion.BuildAgents
 
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
-            // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-environment-variable-set-env
+            // https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
             // Example
-            // echo "::set-env name=action_state::yellow"
+            // echo "name=action_state::yellow >> $GITHUB_ENV"
 
             if (!string.IsNullOrWhiteSpace(value))
             {
@@ -33,7 +33,7 @@ namespace GitVersion.BuildAgents
 
                 return new[]
                 {
-                    $"::set-env name={key}::{value}"
+                    $"\"{key}={value}\" >> $GITHUB_ENV"
                 };
             }
 


### PR DESCRIPTION
GitHub Actions is deprecating set-env and add-path commands as outlined by

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Therefore starting from version 2.273.5 of the runner `GenerateBuildLogOutput` outputs

![image](https://user-images.githubusercontent.com/174258/95555485-27e5e900-0a12-11eb-9ca4-cff84ea77886.png)

Environment files should be used instead

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

## Description

see above

## Related Issue

Fixes #2421 and GitTools/actions#213.
## Motivation and Context



## How Has This Been Tested?

No, I edited the file online and did not try to build and intermediate package to a private feed and then use that in my code. We should be able though to see the impact on the build on this project. I'll update the screenshots as soon as this compiles

## Screenshots (if appropriate):

Also happens on the build of this project, see

![image](https://user-images.githubusercontent.com/174258/95556016-eace2680-0a12-11eb-877c-33ae9fa17597.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
