### PR TITLE
Implemented the Dirty flag

### DIFF
--- a/docs/input/docs/more-info/variables.md
+++ b/docs/input/docs/more-info/variables.md
@@ -40,7 +40,7 @@ Running `GitVersion.exe` in your repo will show you what is available. For the
   "CommitsSinceVersionSource":1,
   "CommitsSinceVersionSourcePadded":"0001",
   "CommitDate":"2014-03-06",
-  "RepositoryDirtyFlag": ""
+  "UncommittedChanges": 0
 }
 ```
 

--- a/docs/input/docs/more-info/variables.md
+++ b/docs/input/docs/more-info/variables.md
@@ -39,7 +39,8 @@ Running `GitVersion.exe` in your repo will show you what is available. For the
   "VersionSourceSha":"950d2f830f5a2af12a6779a48d20dcbb02351f25",
   "CommitsSinceVersionSource":1,
   "CommitsSinceVersionSourcePadded":"0001",
-  "CommitDate":"2014-03-06"
+  "CommitDate":"2014-03-06",
+  "RepositoryDirtyFlag": ""
 }
 ```
 

--- a/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
@@ -148,7 +148,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
-        RepositoryDirtyFlag: 
+        UncommittedChanges: 0
         ";
 
             var stringBuilder = new StringBuilder();
@@ -209,6 +209,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
+        UncommittedChanges: 0
         ";
 
             using var fixture = new EmptyRepositoryFixture();
@@ -295,7 +296,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
-        RepositoryDirtyFlag: 
+        UncommittedChanges: 0 
         ";
 
             using var fixture = new EmptyRepositoryFixture();
@@ -359,7 +360,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
-        RepositoryDirtyFlag: 
+        UncommittedChanges: 0
         ";
 
             using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
@@ -148,6 +148,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
+        RepositoryDirtyFlag: 
         ";
 
             var stringBuilder = new StringBuilder();
@@ -294,6 +295,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
+        RepositoryDirtyFlag: 
         ";
 
             using var fixture = new EmptyRepositoryFixture();
@@ -357,6 +359,7 @@ namespace GitVersionCore.Tests
         CommitsSinceVersionSource: 19
         CommitsSinceVersionSourcePadded: 0019
         CommitDate: 2015-11-10
+        RepositoryDirtyFlag: 
         ";
 
             using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
@@ -14,12 +14,12 @@ namespace GitVersionCore.Tests.Helpers
             string weightedPreReleaseNumber = "", string informationalVersion = "", string commitDate = "",
             string nugetVersion = "", string nugetVersionV2 = "", string nugetPreReleaseTag = "",
             string nugetPreReleaseTagV2 = "", string versionSourceSha = "", string commitsSinceVersionSource = "",
-            string commitsSinceVersionSourcePadded = "") : base(
+            string commitsSinceVersionSourcePadded = "", string repositoryDirtyFlag = "") : base(
                 major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, escapedBranchName,
                 sha, shortSha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer,
                 assemblySemVer, assemblySemFileVer, preReleaseTag, weightedPreReleaseNumber, preReleaseTagWithDash,
                 preReleaseLabel, preReleaseNumber, informationalVersion, commitDate, nugetVersion, nugetVersionV2,
-                nugetPreReleaseTag, nugetPreReleaseTagV2, versionSourceSha, commitsSinceVersionSource, commitsSinceVersionSourcePadded)
+                nugetPreReleaseTag, nugetPreReleaseTagV2, versionSourceSha, commitsSinceVersionSource, commitsSinceVersionSourcePadded, repositoryDirtyFlag)
         {
         }
     }

--- a/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
@@ -14,12 +14,12 @@ namespace GitVersionCore.Tests.Helpers
             string weightedPreReleaseNumber = "", string informationalVersion = "", string commitDate = "",
             string nugetVersion = "", string nugetVersionV2 = "", string nugetPreReleaseTag = "",
             string nugetPreReleaseTagV2 = "", string versionSourceSha = "", string commitsSinceVersionSource = "",
-            string commitsSinceVersionSourcePadded = "", string repositoryDirtyFlag = "") : base(
+            string commitsSinceVersionSourcePadded = "", string uncommittedChanges = "") : base(
                 major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, escapedBranchName,
                 sha, shortSha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer,
                 assemblySemVer, assemblySemFileVer, preReleaseTag, weightedPreReleaseNumber, preReleaseTagWithDash,
                 preReleaseLabel, preReleaseNumber, informationalVersion, commitDate, nugetVersion, nugetVersionV2,
-                nugetPreReleaseTag, nugetPreReleaseTagV2, versionSourceSha, commitsSinceVersionSource, commitsSinceVersionSourcePadded, repositoryDirtyFlag)
+                nugetPreReleaseTag, nugetPreReleaseTagV2, versionSourceSha, commitsSinceVersionSource, commitsSinceVersionSourcePadded, uncommittedChanges)
         {
         }
     }

--- a/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs
@@ -113,7 +113,7 @@ namespace GitVersionCore.Tests.IntegrationTests
                 File.Move(tempFile, repoFile);
                 File.WriteAllText(repoFile, "Hello world");
 
-                if(stageFile)
+                if (stageFile)
                     Commands.Stage(fixture.Repository, repoFile);
             }
 

--- a/src/GitVersionCore.Tests/Model/CommitDateTests.cs
+++ b/src/GitVersionCore.Tests/Model/CommitDateTests.cs
@@ -24,7 +24,7 @@ namespace GitVersionCore.Tests
             var formatValues = new SemanticVersionFormatValues(
                                     new SemanticVersion
                                     {
-                                        BuildMetaData = new SemanticVersionBuildMetaData("950d2f830f5a2af12a6779a48d20dcbb02351f25", 0, "master", "3139d4eeb044f46057693473eacc2655b3b27e7d", "3139d4eeb", new DateTimeOffset(date, TimeSpan.Zero)), // assume time zone is UTC
+                                        BuildMetaData = new SemanticVersionBuildMetaData("950d2f830f5a2af12a6779a48d20dcbb02351f25", 0, "master", "3139d4eeb044f46057693473eacc2655b3b27e7d", "3139d4eeb", new DateTimeOffset(date, TimeSpan.Zero), false), // assume time zone is UTC
 
                                     },
                                     new EffectiveConfiguration(

--- a/src/GitVersionCore.Tests/Model/CommitDateTests.cs
+++ b/src/GitVersionCore.Tests/Model/CommitDateTests.cs
@@ -24,7 +24,7 @@ namespace GitVersionCore.Tests
             var formatValues = new SemanticVersionFormatValues(
                                     new SemanticVersion
                                     {
-                                        BuildMetaData = new SemanticVersionBuildMetaData("950d2f830f5a2af12a6779a48d20dcbb02351f25", 0, "master", "3139d4eeb044f46057693473eacc2655b3b27e7d", "3139d4eeb", new DateTimeOffset(date, TimeSpan.Zero), false), // assume time zone is UTC
+                                        BuildMetaData = new SemanticVersionBuildMetaData("950d2f830f5a2af12a6779a48d20dcbb02351f25", 0, "master", "3139d4eeb044f46057693473eacc2655b3b27e7d", "3139d4eeb", new DateTimeOffset(date, TimeSpan.Zero), 0), // assume time zone is UTC
 
                                     },
                                     new EffectiveConfiguration(

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -29,6 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
-  "RepositoryDirtyFlag":"",
+  "UncommittedChanges":0,
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -29,5 +29,6 @@
   "VersionSourceSha":"versionSourceSha",
   "CommitsSinceVersionSource":5,
   "CommitsSinceVersionSourcePadded":"0005",
+  "RepositoryDirtyFlag":"",
   "CommitDate":"2014-03-06"
 }

--- a/src/GitVersionCore.Tests/VersionCalculation/JsonVersionBuilderTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/JsonVersionBuilderTests.cs
@@ -28,7 +28,7 @@ namespace GitVersionCore.Tests
                 Minor = 2,
                 Patch = 0,
                 PreReleaseTag = "unstable4",
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5, "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"))
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5, "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), false)
             };
 
             var config = new TestEffectiveConfiguration();

--- a/src/GitVersionCore.Tests/VersionCalculation/JsonVersionBuilderTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/JsonVersionBuilderTests.cs
@@ -28,7 +28,7 @@ namespace GitVersionCore.Tests
                 Minor = 2,
                 Patch = 0,
                 PreReleaseTag = "unstable4",
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5, "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), false)
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5, "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), 0)
             };
 
             var config = new TestEffectiveConfiguration();

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -19,7 +19,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void ShouldIncrementVersionBasedOnConfig()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, 0);
 
             var contextBuilder = new GitVersionContextBuilder();
 
@@ -43,7 +43,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void DoesNotIncrementWhenBaseVersionSaysNotTo()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, 0);
 
             var contextBuilder = new GitVersionContextBuilder();
 
@@ -68,7 +68,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void AppliesBranchPreReleaseTag()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 2, "develop", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 2, "develop", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, 0);
             var contextBuilder = new GitVersionContextBuilder();
 
             contextBuilder

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -19,7 +19,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void ShouldIncrementVersionBasedOnConfig()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
 
             var contextBuilder = new GitVersionContextBuilder();
 
@@ -43,7 +43,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void DoesNotIncrementWhenBaseVersionSaysNotTo()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 1, "master", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
 
             var contextBuilder = new GitVersionContextBuilder();
 
@@ -68,7 +68,7 @@ namespace GitVersionCore.Tests.VersionCalculation
         [Test]
         public void AppliesBranchPreReleaseTag()
         {
-            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 2, "develop", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData("ef7d0d7e1e700f1c7c9fa01ea6791bb778a5c37c", 2, "develop", "b1a34edbd80e141f7cc046c074f109be7d022074", "b1a34e", DateTimeOffset.Now, false);
             var contextBuilder = new GitVersionContextBuilder();
 
             contextBuilder

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
@@ -26,10 +26,10 @@
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>
-  <?define RepositoryDirtyFlag=""?>
   <?define SemVer="1.2.3"?>
   <?define Sha="commitSha"?>
   <?define ShortSha="commitShortSha"?>
+  <?define UncommittedChanges="0"?>
   <?define VersionSourceSha="versionSourceSha"?>
   <?define WeightedPreReleaseNumber="0"?>
 </Include>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
@@ -26,6 +26,7 @@
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>
+  <?define RepositoryDirtyFlag=""?>
   <?define SemVer="1.2.3"?>
   <?define Sha="commitSha"?>
   <?define ShortSha="commitShortSha"?>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
@@ -26,10 +26,10 @@
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>
-  <?define RepositoryDirtyFlag=""?>
   <?define SemVer="1.2.3"?>
   <?define Sha="commitSha"?>
   <?define ShortSha="commitShortSha"?>
+  <?define UncommittedChanges="0"?>
   <?define VersionSourceSha="versionSourceSha"?>
   <?define WeightedPreReleaseNumber="0"?>
 </Include>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
@@ -26,6 +26,7 @@
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>
+  <?define RepositoryDirtyFlag=""?>
   <?define SemVer="1.2.3"?>
   <?define Sha="commitSha"?>
   <?define ShortSha="commitShortSha"?>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -58,5 +58,6 @@ static class GitVersionInformation
     public static string VersionSourceSha = "versionSourceSha";
     public static string CommitsSinceVersionSource = "5";
     public static string CommitsSinceVersionSourcePadded = "0005";
+    public static string RepositoryDirtyFlag = "";
     public static string CommitDate = "2014-03-06";
 }

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -58,6 +58,6 @@ static class GitVersionInformation
     public static string VersionSourceSha = "versionSourceSha";
     public static string CommitsSinceVersionSource = "5";
     public static string CommitsSinceVersionSourcePadded = "0005";
-    public static string RepositoryDirtyFlag = "";
+    public static string UncommittedChanges = "0";
     public static string CommitDate = "2014-03-06";
 }

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -60,5 +60,5 @@ type GitVersionInformation =
     static member VersionSourceSha = "versionSourceSha"
     static member CommitsSinceVersionSource = "5"
     static member CommitsSinceVersionSourcePadded = "0005"
-    static member RepositoryDirtyFlag = ""
+    static member UncommittedChanges = "0"
     static member CommitDate = "2014-03-06"

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -60,4 +60,5 @@ type GitVersionInformation =
     static member VersionSourceSha = "versionSourceSha"
     static member CommitsSinceVersionSource = "5"
     static member CommitsSinceVersionSourcePadded = "0005"
+    static member RepositoryDirtyFlag = ""
     static member CommitDate = "2014-03-06"

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -61,6 +61,7 @@ Namespace Global
         Public Shared VersionSourceSha As String = "versionSourceSha"
         Public Shared CommitsSinceVersionSource As String = "5"
         Public Shared CommitsSinceVersionSourcePadded As String = "0005"
+        Public Shared RepositoryDirtyFlag As String = ""
         Public Shared CommitDate As String = "2014-03-06"
     End Class
 

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -61,7 +61,7 @@ Namespace Global
         Public Shared VersionSourceSha As String = "versionSourceSha"
         Public Shared CommitsSinceVersionSource As String = "5"
         Public Shared CommitsSinceVersionSourcePadded As String = "0005"
-        Public Shared RepositoryDirtyFlag As String = ""
+        Public Shared UncommittedChanges As String = "0"
         Public Shared CommitDate As String = "2014-03-06"
     End Class
 

--- a/src/GitVersionCore.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
@@ -448,7 +448,7 @@ namespace GitVersionCore.Tests
             fileSystem = Substitute.For<IFileSystem>();
             var version = new SemanticVersion
             {
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now),
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, false),
                 Major = 2,
                 Minor = 3,
                 Patch = 1

--- a/src/GitVersionCore.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
@@ -448,7 +448,7 @@ namespace GitVersionCore.Tests
             fileSystem = Substitute.For<IFileSystem>();
             var version = new SemanticVersion
             {
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, false),
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, 0),
                 Major = 2,
                 Minor = 3,
                 Patch = 1

--- a/src/GitVersionCore.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
@@ -38,7 +38,7 @@ namespace GitVersionCore.Tests
                 Patch = 3,
                 PreReleaseTag = "unstable4",
                 BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5,
-                    "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), false)
+                    "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), 0)
             };
 
             var sp = ConfigureServices();

--- a/src/GitVersionCore.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
@@ -38,7 +38,7 @@ namespace GitVersionCore.Tests
                 Patch = 3,
                 PreReleaseTag = "unstable4",
                 BuildMetaData = new SemanticVersionBuildMetaData("versionSourceSha", 5,
-                    "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"))
+                    "feature1", "commitSha", "commitShortSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z"), false)
             };
 
             var sp = ConfigureServices();

--- a/src/GitVersionCore.Tests/VersionConverters/InformationalVersionBuilderTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/InformationalVersionBuilderTests.cs
@@ -30,7 +30,7 @@ namespace GitVersionCore.Tests
                 Minor = minor,
                 Patch = patch,
                 PreReleaseTag = tag,
-                BuildMetaData = new SemanticVersionBuildMetaData(versionSourceSha, commitsSinceTag, branchName, sha, shortSha, DateTimeOffset.MinValue),
+                BuildMetaData = new SemanticVersionBuildMetaData(versionSourceSha, commitsSinceTag, branchName, sha, shortSha, DateTimeOffset.MinValue, false),
             };
             var informationalVersion = semanticVersion.ToString("i");
 

--- a/src/GitVersionCore.Tests/VersionConverters/InformationalVersionBuilderTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/InformationalVersionBuilderTests.cs
@@ -30,7 +30,7 @@ namespace GitVersionCore.Tests
                 Minor = minor,
                 Patch = patch,
                 PreReleaseTag = tag,
-                BuildMetaData = new SemanticVersionBuildMetaData(versionSourceSha, commitsSinceTag, branchName, sha, shortSha, DateTimeOffset.MinValue, false),
+                BuildMetaData = new SemanticVersionBuildMetaData(versionSourceSha, commitsSinceTag, branchName, sha, shortSha, DateTimeOffset.MinValue, 0),
             };
             var informationalVersion = semanticVersion.ToString("i");
 

--- a/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -334,7 +334,7 @@ namespace GitVersionCore.Tests
             fileSystem = Substitute.For<IFileSystem>();
             var version = new SemanticVersion
             {
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, false),
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, 0),
                 Major = 2,
                 Minor = 3,
                 Patch = 1

--- a/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersionCore.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -334,7 +334,7 @@ namespace GitVersionCore.Tests
             fileSystem = Substitute.For<IFileSystem>();
             var version = new SemanticVersion
             {
-                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now),
+                BuildMetaData = new SemanticVersionBuildMetaData("versionSourceHash", 3, "foo", "hash", "shortHash", DateTimeOffset.Now, false),
                 Major = 2,
                 Minor = 3,
                 Patch = 1

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
@@ -44,6 +44,6 @@ namespace GitVersion.Common
         string ShortenObjectId(GitObject commit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);
 
-        bool HasUncommittedChanges();
+        int GetNumberOfUncommittedChanges();
     }
 }

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
@@ -43,5 +43,7 @@ namespace GitVersion.Common
         bool GetMatchingCommitBranch(Commit baseVersionSource, Branch branch, Commit firstMatchingCommit);
         string ShortenObjectId(GitObject commit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);
+
+        bool HasUncommitedChanges();
     }
 }

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
@@ -44,6 +44,6 @@ namespace GitVersion.Common
         string ShortenObjectId(GitObject commit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);
 
-        bool HasUncommitedChanges();
+        bool HasUncommittedChanges();
     }
 }

--- a/src/GitVersionCore/Core/GitVersionContextFactory.cs
+++ b/src/GitVersionCore/Core/GitVersionContextFactory.cs
@@ -46,7 +46,7 @@ namespace GitVersion
             var currentBranchConfig = branchConfigurationCalculator.GetBranchConfiguration(currentBranch, currentCommit, configuration);
             var effectiveConfiguration = configuration.CalculateEffectiveConfiguration(currentBranchConfig);
             var currentCommitTaggedVersion = repositoryMetadataProvider.GetCurrentCommitTaggedVersion(currentCommit, effectiveConfiguration);
-            var hasUncommittedChanges = repositoryMetadataProvider.HasUncommitedChanges();
+            var hasUncommittedChanges = repositoryMetadataProvider.HasUncommittedChanges();
 
             return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion, hasUncommittedChanges);
         }

--- a/src/GitVersionCore/Core/GitVersionContextFactory.cs
+++ b/src/GitVersionCore/Core/GitVersionContextFactory.cs
@@ -46,9 +46,9 @@ namespace GitVersion
             var currentBranchConfig = branchConfigurationCalculator.GetBranchConfiguration(currentBranch, currentCommit, configuration);
             var effectiveConfiguration = configuration.CalculateEffectiveConfiguration(currentBranchConfig);
             var currentCommitTaggedVersion = repositoryMetadataProvider.GetCurrentCommitTaggedVersion(currentCommit, effectiveConfiguration);
-            var hasUncommittedChanges = repositoryMetadataProvider.HasUncommittedChanges();
+            var numberOfUncommittedChanges = repositoryMetadataProvider.GetNumberOfUncommittedChanges();
 
-            return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion, hasUncommittedChanges);
+            return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion, numberOfUncommittedChanges);
         }
     }
 }

--- a/src/GitVersionCore/Core/GitVersionContextFactory.cs
+++ b/src/GitVersionCore/Core/GitVersionContextFactory.cs
@@ -46,8 +46,9 @@ namespace GitVersion
             var currentBranchConfig = branchConfigurationCalculator.GetBranchConfiguration(currentBranch, currentCommit, configuration);
             var effectiveConfiguration = configuration.CalculateEffectiveConfiguration(currentBranchConfig);
             var currentCommitTaggedVersion = repositoryMetadataProvider.GetCurrentCommitTaggedVersion(currentCommit, effectiveConfiguration);
+            var hasUncommittedChanges = repositoryMetadataProvider.HasUncommitedChanges();
 
-            return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion);
+            return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion, hasUncommittedChanges);
         }
     }
 }

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -516,7 +516,7 @@ namespace GitVersion
                     return status.Untracked.Count() + status.Staged.Count();
 
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     return Int32.MaxValue;  // this should be somewhat puzzling to see,
                                             // so we may have reached our goal to show that

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -500,7 +500,7 @@ namespace GitVersion
             return branchMergeBases;
         }
 
-        public bool HasUncommitedChanges()
+        public bool HasUncommittedChanges()
         {
             // check if we have a branch tip at all to behave properly with empty repos
             // => return that we have actually uncomitted changes because we are apparently

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -500,19 +500,35 @@ namespace GitVersion
             return branchMergeBases;
         }
 
-        public bool HasUncommittedChanges()
+        public int GetNumberOfUncommittedChanges()
         {
             // check if we have a branch tip at all to behave properly with empty repos
             // => return that we have actually uncomitted changes because we are apparently
             // running GitVersion on something which lives inside this brand new repo _/\Ö/\_
             if (repository.Head?.Tip == null || repository.Diff == null)
-                return true;
+            {
+                // this is a somewhat cumbersome way of figuring out the number of changes in the repo
+                // which is more expensive than to use the Diff as it gathers more info, but
+                // we can't use the other method when we are dealing with a new/empty repo
+                try
+                {
+                    var status = repository.RetrieveStatus();
+                    return status.Untracked.Count() + status.Staged.Count();
+
+                }
+                catch(Exception)
+                {
+                    return Int32.MaxValue;  // this should be somewhat puzzling to see,
+                                            // so we may have reached our goal to show that
+                                            // that repo is really "Dirty"...
+                }
+            }
 
             // gets all changes of the last commit vs Staging area and WT
             var changes = repository.Diff.Compare<TreeChanges>(repository.Head.Tip.Tree,
                                                   DiffTargets.Index | DiffTargets.WorkingDirectory);
 
-            return changes.Count > 0;
+            return changes.Count;
         }
 
         private class MergeBaseData

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -500,6 +500,21 @@ namespace GitVersion
             return branchMergeBases;
         }
 
+        public bool HasUncommitedChanges()
+        {
+            // check if we have a branch tip at all to behave properly with empty repos
+            // => return that we have actually uncomitted changes because we are apparently
+            // running GitVersion on something which lives inside this brand new repo _/\Ö/\_
+            if (repository.Head?.Tip == null || repository.Diff == null)
+                return true;
+
+            // gets all changes of the last commit vs Staging area and WT
+            var changes = repository.Diff.Compare<TreeChanges>(repository.Head.Tip.Tree,
+                                                  DiffTargets.Index | DiffTargets.WorkingDirectory);
+
+            return changes.Count > 0;
+        }
+
         private class MergeBaseData
         {
             public Commit MergeBase { get; }

--- a/src/GitVersionCore/Model/GitVersionContext.cs
+++ b/src/GitVersionCore/Model/GitVersionContext.cs
@@ -19,12 +19,14 @@ namespace GitVersion
         public Commit CurrentCommit { get; }
         public bool IsCurrentCommitTagged => CurrentCommitTaggedVersion != null;
 
+        public bool HasUncommittedChanges { get; }
+
         public GitVersionContext()
         {
         }
 
         public GitVersionContext(Branch currentBranch, Commit currentCommit,
-            Config configuration, EffectiveConfiguration effectiveConfiguration, SemanticVersion currentCommitTaggedVersion)
+            Config configuration, EffectiveConfiguration effectiveConfiguration, SemanticVersion currentCommitTaggedVersion, bool hasUncommmittedChanges)
         {
             CurrentCommit = currentCommit;
             CurrentBranch = currentBranch;
@@ -33,6 +35,8 @@ namespace GitVersion
             Configuration = effectiveConfiguration;
 
             CurrentCommitTaggedVersion = currentCommitTaggedVersion;
+
+            HasUncommittedChanges = hasUncommmittedChanges;
         }
     }
 }

--- a/src/GitVersionCore/Model/GitVersionContext.cs
+++ b/src/GitVersionCore/Model/GitVersionContext.cs
@@ -19,14 +19,14 @@ namespace GitVersion
         public Commit CurrentCommit { get; }
         public bool IsCurrentCommitTagged => CurrentCommitTaggedVersion != null;
 
-        public bool HasUncommittedChanges { get; }
+        public int NumberOfUncommittedChanges { get; }
 
         public GitVersionContext()
         {
         }
 
         public GitVersionContext(Branch currentBranch, Commit currentCommit,
-            Config configuration, EffectiveConfiguration effectiveConfiguration, SemanticVersion currentCommitTaggedVersion, bool hasUncommmittedChanges)
+            Config configuration, EffectiveConfiguration effectiveConfiguration, SemanticVersion currentCommitTaggedVersion, int numberOfUncommittedChanges)
         {
             CurrentCommit = currentCommit;
             CurrentBranch = currentBranch;
@@ -36,7 +36,7 @@ namespace GitVersion
 
             CurrentCommitTaggedVersion = currentCommitTaggedVersion;
 
-            HasUncommittedChanges = hasUncommmittedChanges;
+            NumberOfUncommittedChanges = numberOfUncommittedChanges;
         }
     }
 }

--- a/src/GitVersionCore/Model/VersionVariables.cs
+++ b/src/GitVersionCore/Model/VersionVariables.cs
@@ -42,7 +42,7 @@ namespace GitVersion.OutputVariables
                                 string versionSourceSha,
                                 string commitsSinceVersionSource,
                                 string commitsSinceVersionSourcePadded,
-                                string repositoryDirtyFlag)
+                                string uncommittedChanges)
         {
             Major = major;
             Minor = minor;
@@ -75,7 +75,7 @@ namespace GitVersion.OutputVariables
             VersionSourceSha = versionSourceSha;
             CommitsSinceVersionSource = commitsSinceVersionSource;
             CommitsSinceVersionSourcePadded = commitsSinceVersionSourcePadded;
-            RepositoryDirtyFlag = repositoryDirtyFlag;
+            UncommittedChanges = uncommittedChanges;
         }
 
         public string Major { get; }
@@ -109,7 +109,7 @@ namespace GitVersion.OutputVariables
         public string CommitsSinceVersionSource { get; }
         public string CommitsSinceVersionSourcePadded { get; }
 
-        public string RepositoryDirtyFlag { get; }
+        public string UncommittedChanges { get; }
 
         [ReflectionIgnore]
         public static IEnumerable<string> AvailableVariables

--- a/src/GitVersionCore/Model/VersionVariables.cs
+++ b/src/GitVersionCore/Model/VersionVariables.cs
@@ -41,7 +41,8 @@ namespace GitVersion.OutputVariables
                                 string nugetPreReleaseTagV2,
                                 string versionSourceSha,
                                 string commitsSinceVersionSource,
-                                string commitsSinceVersionSourcePadded)
+                                string commitsSinceVersionSourcePadded,
+                                string repositoryDirtyFlag)
         {
             Major = major;
             Minor = minor;
@@ -74,6 +75,7 @@ namespace GitVersion.OutputVariables
             VersionSourceSha = versionSourceSha;
             CommitsSinceVersionSource = commitsSinceVersionSource;
             CommitsSinceVersionSourcePadded = commitsSinceVersionSourcePadded;
+            RepositoryDirtyFlag = repositoryDirtyFlag;
         }
 
         public string Major { get; }
@@ -106,6 +108,8 @@ namespace GitVersion.OutputVariables
         public string VersionSourceSha { get; }
         public string CommitsSinceVersionSource { get; }
         public string CommitsSinceVersionSourcePadded { get; }
+
+        public string RepositoryDirtyFlag { get; }
 
         [ReflectionIgnore]
         public static IEnumerable<string> AvailableVariables

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -97,7 +97,8 @@ namespace GitVersion.VersionCalculation
                 context.CurrentBranch.FriendlyName,
                 context.CurrentCommit.Sha,
                 shortSha,
-                context.CurrentCommit.When());
+                context.CurrentCommit.When(),
+                context.HasUncommittedChanges);
         }
 
 

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -98,7 +98,7 @@ namespace GitVersion.VersionCalculation
                 context.CurrentCommit.Sha,
                 shortSha,
                 context.CurrentCommit.When(),
-                context.HasUncommittedChanges);
+                context.NumberOfUncommittedChanges);
         }
 
 

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
@@ -21,12 +21,13 @@ namespace GitVersion
         public DateTimeOffset CommitDate;
         public string VersionSourceSha;
         public int CommitsSinceVersionSource;
+        public bool HasUncomittedChanges;
 
         public SemanticVersionBuildMetaData()
         {
         }
 
-        public SemanticVersionBuildMetaData(string versionSourceSha, int? commitsSinceTag, string branch, string commitSha, string commitShortSha, DateTimeOffset commitDate, string otherMetadata = null)
+        public SemanticVersionBuildMetaData(string versionSourceSha, int? commitsSinceTag, string branch, string commitSha, string commitShortSha, DateTimeOffset commitDate, bool hasUncommitedChanges, string otherMetadata = null)
         {
             Sha = commitSha;
             ShortSha = commitShortSha;
@@ -36,6 +37,7 @@ namespace GitVersion
             OtherMetaData = otherMetadata;
             VersionSourceSha = versionSourceSha;
             CommitsSinceVersionSource = commitsSinceTag ?? 0;
+            HasUncomittedChanges = hasUncommitedChanges;
         }
 
         public SemanticVersionBuildMetaData(SemanticVersionBuildMetaData buildMetaData)
@@ -48,6 +50,7 @@ namespace GitVersion
             OtherMetaData = buildMetaData.OtherMetaData;
             VersionSourceSha = buildMetaData.VersionSourceSha;
             CommitsSinceVersionSource = buildMetaData.CommitsSinceVersionSource;
+            HasUncomittedChanges = buildMetaData.HasUncomittedChanges;
         }
 
         public override bool Equals(object obj)
@@ -156,6 +159,9 @@ namespace GitVersion
 
             if (parsed.Groups["Other"].Success && !string.IsNullOrEmpty(parsed.Groups["Other"].Value))
                 semanticVersionBuildMetaData.OtherMetaData = parsed.Groups["Other"].Value.TrimStart('.');
+
+            // note: not super beautiful, but it might be "good enough" for this end (?)
+            semanticVersionBuildMetaData.HasUncomittedChanges = semanticVersionBuildMetaData.OtherMetaData == "Dirty"; 
 
             return semanticVersionBuildMetaData;
         }

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
@@ -161,7 +161,7 @@ namespace GitVersion
                 semanticVersionBuildMetaData.OtherMetaData = parsed.Groups["Other"].Value.TrimStart('.');
 
             // note: not super beautiful, but it might be "good enough" for this end (?)
-            semanticVersionBuildMetaData.HasUncomittedChanges = semanticVersionBuildMetaData.OtherMetaData == "Dirty"; 
+            semanticVersionBuildMetaData.HasUncomittedChanges = semanticVersionBuildMetaData.OtherMetaData == "Dirty";
 
             return semanticVersionBuildMetaData;
         }

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
@@ -21,13 +21,13 @@ namespace GitVersion
         public DateTimeOffset CommitDate;
         public string VersionSourceSha;
         public int CommitsSinceVersionSource;
-        public bool HasUncomittedChanges;
+        public int UncommittedChanges;
 
         public SemanticVersionBuildMetaData()
         {
         }
 
-        public SemanticVersionBuildMetaData(string versionSourceSha, int? commitsSinceTag, string branch, string commitSha, string commitShortSha, DateTimeOffset commitDate, bool hasUncommitedChanges, string otherMetadata = null)
+        public SemanticVersionBuildMetaData(string versionSourceSha, int? commitsSinceTag, string branch, string commitSha, string commitShortSha, DateTimeOffset commitDate, int numbeerOfUncommitedChanges, string otherMetadata = null)
         {
             Sha = commitSha;
             ShortSha = commitShortSha;
@@ -37,7 +37,7 @@ namespace GitVersion
             OtherMetaData = otherMetadata;
             VersionSourceSha = versionSourceSha;
             CommitsSinceVersionSource = commitsSinceTag ?? 0;
-            HasUncomittedChanges = hasUncommitedChanges;
+            UncommittedChanges = numbeerOfUncommitedChanges;
         }
 
         public SemanticVersionBuildMetaData(SemanticVersionBuildMetaData buildMetaData)
@@ -50,7 +50,7 @@ namespace GitVersion
             OtherMetaData = buildMetaData.OtherMetaData;
             VersionSourceSha = buildMetaData.VersionSourceSha;
             CommitsSinceVersionSource = buildMetaData.CommitsSinceVersionSource;
-            HasUncomittedChanges = buildMetaData.HasUncomittedChanges;
+            UncommittedChanges = buildMetaData.UncommittedChanges;
         }
 
         public override bool Equals(object obj)
@@ -159,9 +159,6 @@ namespace GitVersion
 
             if (parsed.Groups["Other"].Success && !string.IsNullOrEmpty(parsed.Groups["Other"].Value))
                 semanticVersionBuildMetaData.OtherMetaData = parsed.Groups["Other"].Value.TrimStart('.');
-
-            // note: not super beautiful, but it might be "good enough" for this end (?)
-            semanticVersionBuildMetaData.HasUncomittedChanges = semanticVersionBuildMetaData.OtherMetaData == "Dirty";
 
             return semanticVersionBuildMetaData;
         }

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -83,7 +83,7 @@ namespace GitVersion
 
         public string CommitsSinceVersionSourcePadded => semver.BuildMetaData.CommitsSinceVersionSource.ToString(CultureInfo.InvariantCulture).PadLeft(config.CommitsSinceVersionSourcePadding, '0');
 
-        public string HasUncommitedChanges => semver.BuildMetaData.HasUncomittedChanges ? "Dirty" : null;
+        public string HasUncommittedChanges => semver.BuildMetaData.HasUncomittedChanges ? "Dirty" : null;
 
         private String GetWeightedPreReleaseNumber()
         {

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -83,6 +83,8 @@ namespace GitVersion
 
         public string CommitsSinceVersionSourcePadded => semver.BuildMetaData.CommitsSinceVersionSource.ToString(CultureInfo.InvariantCulture).PadLeft(config.CommitsSinceVersionSourcePadding, '0');
 
+        public string HasUncommitedChanges => semver.BuildMetaData.HasUncomittedChanges ? "Dirty" : null;
+
         private String GetWeightedPreReleaseNumber()
         {
             var weightedPreReleaseNumber =

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -83,7 +83,7 @@ namespace GitVersion
 
         public string CommitsSinceVersionSourcePadded => semver.BuildMetaData.CommitsSinceVersionSource.ToString(CultureInfo.InvariantCulture).PadLeft(config.CommitsSinceVersionSourcePadding, '0');
 
-        public string HasUncommittedChanges => semver.BuildMetaData.HasUncomittedChanges ? "Dirty" : null;
+        public string UncommittedChanges => semver.BuildMetaData.UncommittedChanges.ToString(CultureInfo.InvariantCulture);
 
         private String GetWeightedPreReleaseNumber()
         {

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -94,7 +94,7 @@ namespace GitVersion.VersionCalculation
                 semverFormatValues.VersionSourceSha,
                 semverFormatValues.CommitsSinceVersionSource,
                 semverFormatValues.CommitsSinceVersionSourcePadded,
-                semverFormatValues.HasUncommittedChanges);
+                semverFormatValues.UncommittedChanges);
 
             return variables;
         }

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -93,7 +93,8 @@ namespace GitVersion.VersionCalculation
                 semverFormatValues.NuGetPreReleaseTagV2,
                 semverFormatValues.VersionSourceSha,
                 semverFormatValues.CommitsSinceVersionSource,
-                semverFormatValues.CommitsSinceVersionSourcePadded);
+                semverFormatValues.CommitsSinceVersionSourcePadded,
+                semverFormatValues.HasUncommitedChanges);
 
             return variables;
         }

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -94,7 +94,7 @@ namespace GitVersion.VersionCalculation
                 semverFormatValues.VersionSourceSha,
                 semverFormatValues.CommitsSinceVersionSource,
                 semverFormatValues.CommitsSinceVersionSourcePadded,
-                semverFormatValues.HasUncommitedChanges);
+                semverFormatValues.HasUncommittedChanges);
 
             return variables;
         }

--- a/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
@@ -99,7 +99,7 @@ namespace GitVersion.MSBuildTask.Tasks
 
 
         [Output]
-        public string RepositoryDirtyFlag { get; set; }
+        public string UncommittedChanges { get; set; }
 
         protected override bool OnExecute() => TaskProxy.GetVersion(this);
     }

--- a/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
@@ -97,6 +97,10 @@ namespace GitVersion.MSBuildTask.Tasks
         [Output]
         public string CommitsSinceVersionSourcePadded { get; set; }
 
+
+        [Output]
+        public string RepositoryDirtyFlag { get; set; }
+
         protected override bool OnExecute() => TaskProxy.GetVersion(this);
     }
 }

--- a/src/GitVersionTask/GitVersionTask.csproj
+++ b/src/GitVersionTask/GitVersionTask.csproj
@@ -9,6 +9,7 @@
         <Description>Stamps an assembly with git information based on SemVer.</Description>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Have been replacing a bunch of usages of the deprected Fody.Stamp with GitVersion lately and found that we need the "Dirty" flag as some others (see #1198). Just got ahead and implemented it.

Hope it'll meet the required project standards ;)

## Description
Added a variable ```RepositoryDirtyFlag``` which is either ```null``` or ```Dirty``` to be able to add that suffix to my version strings.

## Related Issue
As mentioned above: #1198 

## Motivation and Context


## How Has This Been Tested?
I added four test cases which test the behavior of the dirty flag in ```/src/GitVersionCore.Tests/IntegrationTests/OtherScenarios.cs```. 

It should be set when there's any non-ignored change vs the HEAD of the repo (that includes staged files). 

Other than that I had to change a some other test cases which work on the outputed data to make them work again

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project. (hope so :))
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (I had a bug in a subset of the tests for the netcoreapp2.1 build which seemed to be related to some specifics on my env)
