### PR TITLE
System.InvalidOperationException: Sequence contains no elements exception fixed

### DIFF
--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -6,6 +6,7 @@ using GitVersion.Extensions;
 using GitVersion.Model.Configuration;
 using GitVersion.VersionCalculation;
 using GitVersionCore.Tests.Helpers;
+using GitVersionCore.Tests.IntegrationTests;
 using GitVersionCore.Tests.Mocks;
 using LibGit2Sharp;
 using Microsoft.Extensions.DependencyInjection;
@@ -213,6 +214,21 @@ namespace GitVersionCore.Tests.VersionCalculation
             fixture.Repository.Merge(fixture.Repository.FindBranch("feature/test"), Generate.SignatureNow());
 
             fixture.AssertFullSemver("0.1.0-beta.1+2", config);
+        }
+
+        [Test]
+        public void GetNextVersionOnNonMainlineBranchWithoutCommitsShouldWorkNormally()
+        {
+            var config = new Config
+            {
+                VersioningMode = VersioningMode.Mainline,
+                NextVersion = "1.0.0"
+            };
+
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.MakeACommit("initial commit");
+            fixture.BranchTo("feature/f1");
+            fixture.AssertFullSemver("1.0.0-f1.0", config);
         }
     }
 }

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -210,14 +210,17 @@ namespace GitVersion.VersionCalculation
             // detect forward merge and rewind mainlineTip to before it
             if (mergeBase == context.CurrentCommit && !mainlineCommitLog.Contains(mergeBase))
             {
-                var mainlineTipPrevious = mainlineTip.Parents.First();
-                var message = $"Detected forward merge at {mainlineTip}; rewinding mainline to previous commit {mainlineTipPrevious}";
+                var mainlineTipPrevious = mainlineTip.Parents.FirstOrDefault();
+                if (mainlineTipPrevious != null)
+                {
+                    var message = $"Detected forward merge at {mainlineTip}; rewinding mainline to previous commit {mainlineTipPrevious}";
 
-                log.Info(message);
+                    log.Info(message);
 
-                // re-do mergeBase detection before the forward merge
-                mergeBase = repositoryMetadataProvider.FindMergeBase(context.CurrentCommit, mainlineTipPrevious);
-                mainlineTip = GetEffectiveMainlineTip(mainlineCommitLog, mergeBase, mainlineTipPrevious);
+                    // re-do mergeBase detection before the forward merge
+                    mergeBase = repositoryMetadataProvider.FindMergeBase(context.CurrentCommit, mainlineTipPrevious);
+                    mainlineTip = GetEffectiveMainlineTip(mainlineCommitLog, mergeBase, mainlineTipPrevious);
+                }
             }
 
             return mergeBase;


### PR DESCRIPTION
System.InvalidOperationException: Sequence contains no elements exception fixed when mailineTip.Parent collection is empty
in MainlineVersionCalculator.FindMergeBaseBeforeForwardMerge method

<!--- Provide a general summary of your changes in the Title above -->

## Description
Following error occurs when running before first commit in non-mainline branch 

An unexpected error occurred:
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at GitVersion.VersionCalculation.MainlineVersionCalculator.FindMergeBaseBeforeForwardMerge(Commit baseVersionSource, Branch mainline, Commit& mainlineTip)
   at GitVersion.VersionCalculation.MainlineVersionCalculator.FindMainlineModeVersion(BaseVersion baseVersion)
   at GitVersion.VersionCalculation.NextVersionCalculator.FindVersion()
   at GitVersion.GitVersionTool.CalculateVersionVariables()
   at GitVersion.GitVersionExecutor.RunGitVersionTool(GitVersionOptions gitVersionOptions)

## Steps to reproduce

1) Create GitVersion.yml containing only one line:
mode: Mainline

2) Issue following commands from GitBash:
git init
git commit -m "initial commit" --allow-empty
git commit -b feature/f1
gitversion



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When using tool in mainline mode and running before first commit in non-mainline branch, exception occurs

## How Has This Been Tested?
Debugged in local environment, comparing official release behavior and fixed version.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
