### PR TITLE
Derive NoFetch argument from buildAgent field when GitVersion is invoked without any arguments

### DIFF
--- a/src/GitVersionExe.Tests/ArgumentParserOnBuildServerTests.cs
+++ b/src/GitVersionExe.Tests/ArgumentParserOnBuildServerTests.cs
@@ -1,0 +1,63 @@
+using System;
+using GitVersion;
+using GitVersion.OutputVariables;
+using GitVersionCore.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shouldly;
+
+namespace GitVersionExe.Tests
+{
+    [TestFixture]
+    public class ArgumentParserOnBuildServerTests : TestBase
+    {
+        private IArgumentParser argumentParser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var sp = ConfigureServices(services =>
+            {
+                services.AddSingleton<IArgumentParser, ArgumentParser>();
+                services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
+                services.AddSingleton<ICurrentBuildAgent, MockBuildAgent>();
+            });
+            argumentParser = sp.GetService<IArgumentParser>();
+        }
+
+        [Test]
+        public void EmptyOnFetchDisabledBuildServerMeansNoFetchIsTrue()
+        {
+            var arguments = argumentParser.ParseArguments("");
+            arguments.NoFetch.ShouldBe(true);
+        }
+
+        private class MockBuildAgent : ICurrentBuildAgent
+        {
+            public bool CanApplyToCurrentContext()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetCurrentBranch(bool usingDynamicRepos)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool PreventFetch()
+            {
+                return true;
+            }
+
+            public bool ShouldCleanUpRemotes()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/GitVersionExe/ArgumentParser.cs
+++ b/src/GitVersionExe/ArgumentParser.cs
@@ -49,6 +49,8 @@ namespace GitVersion
 
                 AddAuthentication(args);
 
+                args.NoFetch = buildAgent != null && buildAgent.PreventFetch();
+
                 return args;
             }
 


### PR DESCRIPTION
## Description
This will derive the `NoFetch` argument from the `buildAgent` field if `GitVersion` is invoked without any arguments.
It checks whether the `buildAgent` field is set and if so sets `NoFetch` to the result of its `PreventFetch` function (`false` otherwise). This is the same behavior that is applied when `GitVersion` is invoked with at least one argument (which not necessarily needs to be the `NoFetch` argument).

## Related Issue
[https://github.com/GitTools/GitVersion/issues/2439](https://github.com/GitTools/GitVersion/issues/2439)

## Motivation and Context
I think the default for the `NoFetch` argument should be the same no matter whether `GitVersion` is being invoked without any parameters at all or one or more (unrelated) parameters. An equal solution has previously been applied for the `AddAuthentication` function which in earlier versions also was called only when `GitVersion`was invoked with at least one argument.

## How Has This Been Tested?
I added a test class that is similar to the `ArgumentParserTests` class but replaced the `argumentParser` field with an instance that contains a mock build agent. The only test here calls `ParseArguments` without anys arguments and checks afterwards whether `NoFetch` is `true` (which is the return of the mocks `PreventFetch` function).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. 
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 16 tests in GitVersionTask.Tests fail when running as netcoreapp2.1 but these also failed before I implemented this fix so these should not be related to this pr
