### PR TITLE
For GitHub Actions, outgoing env vars need to be written to $GITHUV_ENV file

### DIFF
--- a/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
@@ -107,23 +107,17 @@ namespace GitVersionCore.Tests.BuildAgents
             result.ShouldBe("refs/pull/1/merge");
         }
 
-        [TestCase("Something", "1.0.0",
-            "Writing \"GitVersion_Something=1.0.0\" to the file at $GITHUB_ENV", "GitVersion_Something=1.0.0")]
-        public void GetSetParameterMessage(string key, string value, string expectedResult, string expectedFileResult)
+        [Test]
+        public void GetSetParameterMessage()
         {
             // Assert
             environment.GetEnvironmentVariable("GitVersion_Something").ShouldBeNullOrWhiteSpace();
 
             // Act
-            var result = buildServer.GenerateSetParameterMessage(key, value);
+            var result = buildServer.GenerateSetParameterMessage("GitVersion_Something", "1.0.0");
 
             // Assert
-            result.ShouldContain(s => true, 1);
-            result.ShouldBeEquivalentTo(new[] { expectedResult });
-            var resultLines = File.ReadAllLines(githubSetEnvironmentTempFilePath);
-            resultLines.ShouldContain(s => true, 1);
-            resultLines.ShouldBeEquivalentTo(new[] { expectedFileResult });
-
+            result.ShouldContain(s => true, 0);
         }
 
         [Test]
@@ -156,11 +150,20 @@ namespace GitVersionCore.Tests.BuildAgents
                 "Executing GenerateSetVersionMessage for 'GitHubActions'.",
                 "",
                 "Executing GenerateBuildLogOutput for 'GitHubActions'.",
-                "Writing \"GitVersion_Major=1.0.0\" to the file at $GITHUB_ENV"
+                "Writing version variables to $GITHUB_ENV file for 'GitHubActions'."
             };
 
             string.Join(Environment.NewLine, list)
                 .ShouldBe(string.Join(Environment.NewLine, expected));
+
+            var expectedFileContents = new List<string>
+            {
+                "GitVersion_Major=1.0.0"
+            };
+
+            var actualFileContents = File.ReadAllLines(githubSetEnvironmentTempFilePath);
+
+            actualFileContents.ShouldBe(expectedFileContents);
         }
 
         [Test]

--- a/src/GitVersionCore/BuildAgents/GitHubActions.cs
+++ b/src/GitVersionCore/BuildAgents/GitHubActions.cs
@@ -1,7 +1,6 @@
 using GitVersion.Logging;
 using GitVersion.OutputVariables;
 using System.IO;
-using System.Text;
 
 namespace GitVersion.BuildAgents
 {
@@ -11,12 +10,10 @@ namespace GitVersion.BuildAgents
 
         public GitHubActions(IEnvironment environment, ILog log) : base(environment, log)
         {
-            this.environment = environment;
         }
 
         public const string EnvironmentVariableName = "GITHUB_ACTIONS";
         public const string GitHubSetEnvTempFileEnvironmentVariableName = "GITHUB_ENV";
-        private readonly IEnvironment environment;
 
         protected override string EnvironmentVariable { get; } = EnvironmentVariableName;
 
@@ -47,7 +44,7 @@ namespace GitVersion.BuildAgents
                 return;
             }
 
-            var gitHubSetEnvFilePath = environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
+            var gitHubSetEnvFilePath = this.Environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
 
             if (gitHubSetEnvFilePath != null)
             {

--- a/src/GitVersionCore/BuildAgents/GitHubActions.cs
+++ b/src/GitVersionCore/BuildAgents/GitHubActions.cs
@@ -1,5 +1,7 @@
 using GitVersion.Logging;
 using GitVersion.OutputVariables;
+using System.IO;
+using System.Text;
 
 namespace GitVersion.BuildAgents
 {
@@ -9,9 +11,13 @@ namespace GitVersion.BuildAgents
 
         public GitHubActions(IEnvironment environment, ILog log) : base(environment, log)
         {
+            this.environment = environment;
         }
 
         public const string EnvironmentVariableName = "GITHUB_ACTIONS";
+        public const string GitHubSetEnvTempFileEnvironmentVariableName = "GITHUB_ENV";
+        private readonly IEnvironment environment;
+
         protected override string EnvironmentVariable { get; } = EnvironmentVariableName;
 
         public override string GenerateSetVersionMessage(VersionVariables variables)
@@ -24,16 +30,31 @@ namespace GitVersion.BuildAgents
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
             // https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
-            // Example
-            // echo "name=action_state::yellow >> $GITHUB_ENV"
+            // However it's important that GitHub Actions does not parse the log output. The outgoing environment variables must be
+            // written to a temporary file (identified by the $GITHUB_ENV environment variable, which changes for every step in a workflow)
+            // which is then parsed. That file must also be UTF-8 or it will fail.
 
             if (!string.IsNullOrWhiteSpace(value))
             {
-                var key = $"GitVersion_{name}";
+                var gitHubSetEnvFilePath = environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
+                var assignment = $"GitVersion_{name}={value}";
+
+                if (gitHubSetEnvFilePath != null)
+                {
+                    using (var streamWriter = File.AppendText(gitHubSetEnvFilePath)) // Already uses UTF-8 as required by GitHub
+                    {
+                        streamWriter.WriteLine(assignment);
+                    }
+
+                    return new[]
+                    {
+                        $"Writing \"{assignment}\" to the file at ${GitHubSetEnvTempFileEnvironmentVariableName}"
+                    };
+                }
 
                 return new[]
                 {
-                    $"\"{key}={value}\" >> $GITHUB_ENV"
+                    $"Unable to write \"{assignment}\" to ${GitHubSetEnvTempFileEnvironmentVariableName} because the environment variable is not set."
                 };
             }
 

--- a/src/GitVersionCore/BuildAgents/GitHubActions.cs
+++ b/src/GitVersionCore/BuildAgents/GitHubActions.cs
@@ -29,36 +29,44 @@ namespace GitVersion.BuildAgents
 
         public override string[] GenerateSetParameterMessage(string name, string value)
         {
-            // https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
-            // However it's important that GitHub Actions does not parse the log output. The outgoing environment variables must be
-            // written to a temporary file (identified by the $GITHUB_ENV environment variable, which changes for every step in a workflow)
-            // which is then parsed. That file must also be UTF-8 or it will fail.
-
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                var gitHubSetEnvFilePath = environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
-                var assignment = $"GitVersion_{name}={value}";
-
-                if (gitHubSetEnvFilePath != null)
-                {
-                    using (var streamWriter = File.AppendText(gitHubSetEnvFilePath)) // Already uses UTF-8 as required by GitHub
-                    {
-                        streamWriter.WriteLine(assignment);
-                    }
-
-                    return new[]
-                    {
-                        $"Writing \"{assignment}\" to the file at ${GitHubSetEnvTempFileEnvironmentVariableName}"
-                    };
-                }
-
-                return new[]
-                {
-                    $"Unable to write \"{assignment}\" to ${GitHubSetEnvTempFileEnvironmentVariableName} because the environment variable is not set."
-                };
-            }
+            // There is no equivalent function in GitHub Actions.
 
             return new string[0];
+        }
+
+        public override void WriteIntegration(System.Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
+        {
+            base.WriteIntegration(writer, variables, updateBuildNumber);
+
+            // https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
+            // The outgoing environment variables must be written to a temporary file (identified by the $GITHUB_ENV environment
+            // variable, which changes for every step in a workflow) which is then parsed. That file must also be UTF-8 or it will fail.
+
+            if (writer == null || !updateBuildNumber)
+            {
+                return;
+            }
+
+            var gitHubSetEnvFilePath = environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
+
+            if (gitHubSetEnvFilePath != null)
+            {
+                writer($"Writing version variables to $GITHUB_ENV file for '{GetType().Name}'.");
+                using (var streamWriter = File.AppendText(gitHubSetEnvFilePath)) // Already uses UTF-8 as required by GitHub
+                {
+                    foreach (var variable in variables)
+                    {
+                        if (!string.IsNullOrEmpty(variable.Value))
+                        {
+                            streamWriter.WriteLine($"GitVersion_{variable.Key}={variable.Value}");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                writer($"Unable to write GitVersion variables to ${GitHubSetEnvTempFileEnvironmentVariableName} because the environment variable is not set.");
+            }
         }
 
         public override string GetCurrentBranch(bool usingDynamicRepos)


### PR DESCRIPTION
It turns out https://github.com/GitTools/GitVersion/pull/2422 was an incorrect implementation of GitHub Actions' new way of exporting environment variables from a workflow step. GitHub Actions does not parse environment variables out of the log output. It generates a temporary file, which is different for every step of a workflow, that it identifies using the $GITHUB_ENV environment variable. You need to write each key as `{NAME}={VALUE}` to that temp file. GitHub Actions then parses _that_ file and then (I believe) disposes of it before the next step starts.

So while https://github.com/GitTools/GitVersion/pull/2422 still resulted in a correctly built binary, the exported environment variables essentially disappeared from any later step, making it impossible to do things like deploy prerelease builds to one environment and production builds to a different one.

## Description
* Identify file path from GITHUB_ENV value
* Output key=value pairs to file
* Change log output to indicate values are being written to file, to erase confusion that they are parsed from log output
* If GITHUB_ACTIONS is set but GITHUB_ENV is missing, log a warning message

## Related Issue
* Fixes https://github.com/GitTools/GitVersion/issues/2449
* Bug introduced in https://github.com/GitTools/GitVersion/pull/2422

## Motivation and Context
Regression in behavior previously working in GitHub Actions

## How Has This Been Tested?
* Updated unit tests for GitHub Actions to provide a temporary file in GITHUB_ENV and assert its contents are written correctly.
* All unit tests run successfully.
* Though I'd like to generate a package and test on my target project, I'm getting errors executing build.ps1.

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
