### PR TITLE
Add PreReleaseLabelWithDash variable

### DIFF
--- a/docs/input/docs/more-info/variables.md
+++ b/docs/input/docs/more-info/variables.md
@@ -15,6 +15,7 @@ Running `GitVersion.exe` in your repo will show you what is available. For the
   "PreReleaseTag":"beta.1",
   "PreReleaseTagWithDash":"-beta.1",
   "PreReleaseLabel":"beta",
+  "PreReleaseLabelWithDash":"-beta",
   "PreReleaseNumber":1,
   "WeightedPreReleaseNumber":1001,
   "BuildMetaData":1,

--- a/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
@@ -123,6 +123,7 @@ namespace GitVersionCore.Tests
         PreReleaseTag: test.19
         PreReleaseTagWithDash: -test.19
         PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
         PreReleaseNumber: 19
         WeightedPreReleaseNumber: 19
         BuildMetaData:
@@ -186,6 +187,7 @@ namespace GitVersionCore.Tests
         PreReleaseTag: test.19
         PreReleaseTagWithDash: -test.19
         PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
         PreReleaseNumber: 19
         BuildMetaData:
         BuildMetaDataPadded:
@@ -271,6 +273,7 @@ namespace GitVersionCore.Tests
         PreReleaseTag: test.19
         PreReleaseTagWithDash: -test.19
         PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
         PreReleaseNumber: 19
         WeightedPreReleaseNumber: 19
         BuildMetaData:
@@ -335,6 +338,7 @@ namespace GitVersionCore.Tests
         PreReleaseTag: test.19
         PreReleaseTagWithDash: -test.19
         PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
         PreReleaseNumber: 19
         WeightedPreReleaseNumber: 19
         BuildMetaData:

--- a/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
+++ b/src/GitVersionCore.Tests/Helpers/TestableVersionVariables.cs
@@ -10,7 +10,7 @@ namespace GitVersionCore.Tests.Helpers
             string escapedBranchName = "", string sha = "", string shortSha = "", string majorMinorPatch = "",
             string semVer = "", string legacySemVer = "", string legacySemVerPadded = "", string fullSemVer = "",
             string assemblySemVer = "", string assemblySemFileVer = "", string preReleaseTag = "",
-            string preReleaseTagWithDash = "", string preReleaseLabel = "", string preReleaseNumber = "",
+            string preReleaseTagWithDash = "", string preReleaseLabel = "", string preReleaseLabelWithDash = "", string preReleaseNumber = "",
             string weightedPreReleaseNumber = "", string informationalVersion = "", string commitDate = "",
             string nugetVersion = "", string nugetVersionV2 = "", string nugetPreReleaseTag = "",
             string nugetPreReleaseTagV2 = "", string versionSourceSha = "", string commitsSinceVersionSource = "",
@@ -18,7 +18,7 @@ namespace GitVersionCore.Tests.Helpers
                 major, minor, patch, buildMetaData, buildMetaDataPadded, fullBuildMetaData, branchName, escapedBranchName,
                 sha, shortSha, majorMinorPatch, semVer, legacySemVer, legacySemVerPadded, fullSemVer,
                 assemblySemVer, assemblySemFileVer, preReleaseTag, weightedPreReleaseNumber, preReleaseTagWithDash,
-                preReleaseLabel, preReleaseNumber, informationalVersion, commitDate, nugetVersion, nugetVersionV2,
+                preReleaseLabel, preReleaseLabelWithDash, preReleaseNumber, informationalVersion, commitDate, nugetVersion, nugetVersionV2,
                 nugetPreReleaseTag, nugetPreReleaseTagV2, versionSourceSha, commitsSinceVersionSource, commitsSinceVersionSourcePadded, uncommittedChanges)
         {
         }

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/JsonVersionBuilderTests.Json.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"unstable.4",
   "PreReleaseTagWithDash":"-unstable.4",
   "PreReleaseLabel":"unstable",
+  "PreReleaseLabelWithDash":"-unstable",
   "PreReleaseNumber":4,
   "WeightedPreReleaseNumber":4,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
+  "PreReleaseLabelWithDash":"",
   "PreReleaseNumber":"",
   "WeightedPreReleaseNumber":0,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
+  "PreReleaseLabelWithDash":"",
   "PreReleaseNumber":"",
   "WeightedPreReleaseNumber":0,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreRelease.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"unstable.4",
   "PreReleaseTagWithDash":"-unstable.4",
   "PreReleaseLabel":"unstable",
+  "PreReleaseLabelWithDash":"-unstable",
   "PreReleaseNumber":4,
   "WeightedPreReleaseNumber":4,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"unstable.4",
   "PreReleaseTagWithDash":"-unstable.4",
   "PreReleaseLabel":"unstable",
+  "PreReleaseLabelWithDash":"-unstable",
   "PreReleaseNumber":4,
   "WeightedPreReleaseNumber":4,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
+  "PreReleaseLabelWithDash":"",
   "PreReleaseNumber":"",
   "WeightedPreReleaseNumber":0,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"unstable.8",
   "PreReleaseTagWithDash":"-unstable.8",
   "PreReleaseLabel":"unstable",
+  "PreReleaseLabelWithDash":"-unstable",
   "PreReleaseNumber":8,
   "WeightedPreReleaseNumber":8,
   "BuildMetaData":"",

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"ci.5",
   "PreReleaseTagWithDash":"-ci.5",
   "PreReleaseLabel":"ci",
+  "PreReleaseLabelWithDash":"-ci",
   "PreReleaseNumber":5,
   "WeightedPreReleaseNumber":5,
   "BuildMetaData":"",

--- a/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersionCore.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -5,6 +5,7 @@
   "PreReleaseTag":"",
   "PreReleaseTagWithDash":"",
   "PreReleaseLabel":"",
+  "PreReleaseLabelWithDash":"",
   "PreReleaseNumber":"",
   "WeightedPreReleaseNumber":0,
   "BuildMetaData":5,

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFile.approved.txt
@@ -23,6 +23,7 @@
   <?define NuGetVersionV2="1.2.3"?>
   <?define Patch="3"?>
   <?define PreReleaseLabel=""?>
+  <?define PreReleaseLabelWithDash=""?>
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/WixFileTests.UpdateWixVersionFileWhenFileAlreadyExists.approved.txt
@@ -23,6 +23,7 @@
   <?define NuGetVersionV2="1.2.3"?>
   <?define Patch="3"?>
   <?define PreReleaseLabel=""?>
+  <?define PreReleaseLabelWithDash=""?>
   <?define PreReleaseNumber=""?>
   <?define PreReleaseTag=""?>
   <?define PreReleaseTagWithDash=""?>

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/cs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -34,6 +34,7 @@ static class GitVersionInformation
     public static string PreReleaseTag = "unstable.4";
     public static string PreReleaseTagWithDash = "-unstable.4";
     public static string PreReleaseLabel = "unstable";
+    public static string PreReleaseLabelWithDash = "-unstable";
     public static string PreReleaseNumber = "4";
     public static string WeightedPreReleaseNumber = "4";
     public static string BuildMetaData = "5";

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/fs/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -36,6 +36,7 @@ type GitVersionInformation =
     static member PreReleaseTag = "unstable.4"
     static member PreReleaseTagWithDash = "-unstable.4"
     static member PreReleaseLabel = "unstable"
+    static member PreReleaseLabelWithDash = "-unstable"
     static member PreReleaseNumber = "4"
     static member WeightedPreReleaseNumber = "4"
     static member BuildMetaData = "5"

--- a/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
+++ b/src/GitVersionCore.Tests/VersionConverters/Approved/vb/GitVersionInfoGeneratorTests.ShouldCreateFile.approved.txt
@@ -37,6 +37,7 @@ Namespace Global
         Public Shared PreReleaseTag As String = "unstable.4"
         Public Shared PreReleaseTagWithDash As String = "-unstable.4"
         Public Shared PreReleaseLabel As String = "unstable"
+        Public Shared PreReleaseLabelWithDash As String = "-unstable"
         Public Shared PreReleaseNumber As String = "4"
         Public Shared WeightedPreReleaseNumber As String = "4"
         Public Shared BuildMetaData As String = "5"

--- a/src/GitVersionCore/Model/VersionVariables.cs
+++ b/src/GitVersionCore/Model/VersionVariables.cs
@@ -31,6 +31,7 @@ namespace GitVersion.OutputVariables
                                 string preReleaseTag,
                                 string preReleaseTagWithDash,
                                 string preReleaseLabel,
+                                string preReleaseLabelWithDash,
                                 string preReleaseNumber,
                                 string weightedPreReleaseNumber,
                                 string informationalVersion,
@@ -64,6 +65,7 @@ namespace GitVersion.OutputVariables
             PreReleaseTag = preReleaseTag;
             PreReleaseTagWithDash = preReleaseTagWithDash;
             PreReleaseLabel = preReleaseLabel;
+            PreReleaseLabelWithDash = preReleaseLabelWithDash;
             PreReleaseNumber = preReleaseNumber;
             WeightedPreReleaseNumber = weightedPreReleaseNumber;
             InformationalVersion = informationalVersion;
@@ -84,6 +86,7 @@ namespace GitVersion.OutputVariables
         public string PreReleaseTag { get; }
         public string PreReleaseTagWithDash { get; }
         public string PreReleaseLabel { get; }
+        public string PreReleaseLabelWithDash { get; }
         public string PreReleaseNumber { get; }
         public string WeightedPreReleaseNumber { get; }
         public string BuildMetaData { get; }

--- a/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersionCore/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -28,6 +28,8 @@ namespace GitVersion
 
         public string PreReleaseLabel => semver.PreReleaseTag.HasTag() ? semver.PreReleaseTag.Name : null;
 
+        public string PreReleaseLabelWithDash => semver.PreReleaseTag.HasTag() ? "-" + semver.PreReleaseTag.Name : null;
+
         public string PreReleaseNumber => semver.PreReleaseTag.HasTag() ? semver.PreReleaseTag.Number.ToString() : null;
 
         public string WeightedPreReleaseNumber => GetWeightedPreReleaseNumber();

--- a/src/GitVersionCore/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersionCore/VersionCalculation/VariableProvider.cs
@@ -83,6 +83,7 @@ namespace GitVersion.VersionCalculation
                 semverFormatValues.PreReleaseTag,
                 semverFormatValues.PreReleaseTagWithDash,
                 semverFormatValues.PreReleaseLabel,
+                semverFormatValues.PreReleaseLabelWithDash,
                 semverFormatValues.PreReleaseNumber,
                 semverFormatValues.WeightedPreReleaseNumber,
                 informationalVersion,

--- a/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
+++ b/src/GitVersionTask.MsBuild/Tasks/GetVersion.cs
@@ -23,6 +23,9 @@ namespace GitVersion.MSBuildTask.Tasks
         public string PreReleaseLabel { get; set; }
 
         [Output]
+        public string PreReleaseLabelWithDash { get; set; }
+
+        [Output]
         public string PreReleaseNumber { get; set; }
 
         [Output]

--- a/src/GitVersionTask/build/GitVersionTask.targets
+++ b/src/GitVersionTask/build/GitVersionTask.targets
@@ -78,6 +78,7 @@
             <Output TaskParameter="PreReleaseTag" PropertyName="GitVersion_PreReleaseTag" />
             <Output TaskParameter="PreReleaseTagWithDash" PropertyName="GitVersion_PreReleaseTagWithDash" />
             <Output TaskParameter="PreReleaseLabel" PropertyName="GitVersion_PreReleaseLabel" />
+            <Output TaskParameter="PreReleaseLabelWithDash" PropertyName="GitVersion_PreReleaseLabelWithDash" />
             <Output TaskParameter="PreReleaseNumber" PropertyName="GitVersion_PreReleaseNumber" />
             <Output TaskParameter="WeightedPreReleaseNumber" PropertyName="GitVersion_WeightedPreReleaseNumber" />
             <Output TaskParameter="BuildMetaData" PropertyName="GitVersion_BuildMetaData" />
@@ -124,6 +125,7 @@
             <DefineConstants Condition=" '$(GitVersion_PreReleaseTag)' != '' ">GitVersion_PreReleaseTag=$(GitVersion_PreReleaseTag);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseTagWithDash)' != '' ">GitVersion_PreReleaseTagWithDash=$(GitVersion_PreReleaseTagWithDash);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseLabel)' != '' ">GitVersion_PreReleaseLabel=$(GitVersion_PreReleaseLabel);$(DefineConstants)</DefineConstants>
+            <DefineConstants Condition=" '$(GitVersion_PreReleaseLabelWithDash)' != '' ">GitVersion_PreReleaseLabelWithDash=$(GitVersion_PreReleaseLabeWithDashl);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseNumber)' != '' ">GitVersion_PreReleaseNumber=$(GitVersion_PreReleaseNumber);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_WeightedPreReleaseNumber)' != '' ">GitVersion_WeightedPreReleaseNumber=$(GitVersion_WeightedPreReleaseNumber);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_BuildMetaData)' != '' ">GitVersion_BuildMetaData=$(GitVersion_BuildMetaData);$(DefineConstants)</DefineConstants>

--- a/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
+++ b/src/GitVersionTask/buildMultiTargeting/GitVersionTask.targets
@@ -35,6 +35,7 @@
             <Output TaskParameter="PreReleaseTag" PropertyName="GitVersion_PreReleaseTag" />
             <Output TaskParameter="PreReleaseTagWithDash" PropertyName="GitVersion_PreReleaseTagWithDash" />
             <Output TaskParameter="PreReleaseLabel" PropertyName="GitVersion_PreReleaseLabel" />
+            <Output TaskParameter="PreReleaseLabelWithDash" PropertyName="GitVersion_PreReleaseLabelWithDash" />
             <Output TaskParameter="PreReleaseNumber" PropertyName="GitVersion_PreReleaseNumber" />
             <Output TaskParameter="BuildMetaData" PropertyName="GitVersion_BuildMetaData" />
             <Output TaskParameter="BuildMetaDataPadded" PropertyName="GitVersion_BuildMetaDataPadded" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This will add new variable **PreReleaseLabelWithDash** similar to **PreReleaseTagWithDash**

GitVersion.PreReleaseLabel: alpha
GitVersion.PreReleaseLabelWithDash: -alpha

## Related Issue
Seems to be that we have old, already closed, issue #1069  

## Motivation and Context
I need that :)

## How Has This Been Tested?
Similar to **PreReleaseTagWithDash**

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
