### PR TITLE
Fix for the wrong updateBuildNumber behavior

### DIFF
--- a/src/GitVersionCore.Tests/BuildAgents/BuildServerBaseTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/BuildServerBaseTests.cs
@@ -53,7 +53,7 @@ namespace GitVersionCore.Tests.BuildAgents
 
             writes = new List<string>();
             buildServer.WriteIntegration(writes.Add, variables, false);
-            writes.ShouldBeEmpty();
+            writes.ShouldNotContain(x => x.StartsWith("Executing GenerateSetVersionMessage for "));
         }
 
         private class BuildAgent : BuildAgentBase

--- a/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/GitHubActionsTests.cs
@@ -180,7 +180,7 @@ namespace GitVersionCore.Tests.BuildAgents
             // Act
             buildServer.WriteIntegration(s => { list.Add(s); }, vars, false);
 
-            list.ShouldBeEmpty();
+            list.ShouldNotContain(x => x.StartsWith("Executing GenerateSetVersionMessage for "));
         }
 
         [Test]

--- a/src/GitVersionCore/Core/BuildAgentBase.cs
+++ b/src/GitVersionCore/Core/BuildAgentBase.cs
@@ -30,13 +30,16 @@ namespace GitVersion
 
         public virtual void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
-            if (writer == null || !updateBuildNumber)
+            if (writer == null)
             {
                 return;
             }
 
-            writer($"Executing GenerateSetVersionMessage for '{GetType().Name}'.");
-            writer(GenerateSetVersionMessage(variables));
+            if (updateBuildNumber)
+            {
+                writer($"Executing GenerateSetVersionMessage for '{GetType().Name}'.");
+                writer(GenerateSetVersionMessage(variables));
+            }
             writer($"Executing GenerateBuildLogOutput for '{GetType().Name}'.");
             foreach (var buildParameter in GenerateBuildLogOutput(variables))
             {


### PR DESCRIPTION
When `updateBuildNumber` is set to false the Build Number is still be overwritten.

## Description
As discussed in #1770 the switch should result in a different behavior.

## Related Issue
#1457
#1770 

## Motivation and Context
The behavior was not implemented in the way it was intended. This should fix this.

## How Has This Been Tested?
Tested on my local machine and in my own Azure DevOps instance.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
