### PR TITLE
Adds CodeBuild support for builds that are not initiated via a webhook

### DIFF
--- a/src/GitVersionCore.Tests/BuildAgents/CodeBuildTests.cs
+++ b/src/GitVersionCore.Tests/BuildAgents/CodeBuildTests.cs
@@ -31,16 +31,30 @@ namespace GitVersionCore.Tests.BuildAgents
         }
 
         [Test]
-        public void CorrectlyIdentifiesCodeBuildPresence()
+        public void CorrectlyIdentifiesCodeBuildPresenceFromSourceVersion()
         {
-            environment.SetEnvironmentVariable(CodeBuild.EnvironmentVariableName, "a value");
+            environment.SetEnvironmentVariable(CodeBuild.SourceVersionEnvironmentVariableName, "a value");
             buildServer.CanApplyToCurrentContext().ShouldBe(true);
         }
 
         [Test]
-        public void PicksUpBranchNameFromEnvironment()
+        public void PicksUpBranchNameFromEnvironmentFromSourceVersion()
         {
-            environment.SetEnvironmentVariable(CodeBuild.EnvironmentVariableName, "refs/heads/master");
+            environment.SetEnvironmentVariable(CodeBuild.SourceVersionEnvironmentVariableName, "refs/heads/master");
+            buildServer.GetCurrentBranch(false).ShouldBe("refs/heads/master");
+        }
+
+        [Test]
+        public void CorrectlyIdentifiesCodeBuildPresenceFromWebHook()
+        {
+            environment.SetEnvironmentVariable(CodeBuild.WebHookEnvironmentVariableName, "a value");
+            buildServer.CanApplyToCurrentContext().ShouldBe(true);
+        }
+
+        [Test]
+        public void PicksUpBranchNameFromEnvironmentFromWebHook()
+        {
+            environment.SetEnvironmentVariable(CodeBuild.WebHookEnvironmentVariableName, "refs/heads/master");
             buildServer.GetCurrentBranch(false).ShouldBe("refs/heads/master");
         }
 

--- a/src/GitVersionCore/BuildAgents/CodeBuild.cs
+++ b/src/GitVersionCore/BuildAgents/CodeBuild.cs
@@ -8,7 +8,8 @@ namespace GitVersion.BuildAgents
     public sealed class CodeBuild : BuildAgentBase
     {
         private string file;
-        public const string EnvironmentVariableName = "CODEBUILD_WEBHOOK_HEAD_REF";
+        public const string WebHookEnvironmentVariableName = "CODEBUILD_WEBHOOK_HEAD_REF";
+        public const string SourceVersionEnvironmentVariableName = "CODEBUILD_SOURCE_VERSION";
 
         public CodeBuild(IEnvironment environment, ILog log) : base(environment, log)
         {
@@ -20,7 +21,7 @@ namespace GitVersion.BuildAgents
             file = propertiesFileName;
         }
 
-        protected override string EnvironmentVariable { get; } = EnvironmentVariableName;
+        protected override string EnvironmentVariable => throw new InvalidOperationException();
 
         public override string GenerateSetVersionMessage(VersionVariables variables)
         {
@@ -37,7 +38,15 @@ namespace GitVersion.BuildAgents
 
         public override string GetCurrentBranch(bool usingDynamicRepos)
         {
-            return Environment.GetEnvironmentVariable(EnvironmentVariableName);
+
+            var currentBranch = Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName);
+
+            if (string.IsNullOrEmpty(currentBranch))
+            {
+                return Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName);
+            }
+
+            return currentBranch;
         }
 
         public override void WriteIntegration(Action<string> writer, VersionVariables variables, bool updateBuildNumber = true)
@@ -48,5 +57,8 @@ namespace GitVersion.BuildAgents
         }
 
         public override bool PreventFetch() => true;
+
+        public override bool CanApplyToCurrentContext()
+            => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName)) || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName));
     }
 }

--- a/src/GitVersionCore/BuildAgents/CodeBuild.cs
+++ b/src/GitVersionCore/BuildAgents/CodeBuild.cs
@@ -21,7 +21,7 @@ namespace GitVersion.BuildAgents
             file = propertiesFileName;
         }
 
-        protected override string EnvironmentVariable => throw new InvalidOperationException();
+        protected override string EnvironmentVariable => throw new NotSupportedException($"Accessing {nameof(EnvironmentVariable)} is not supported as {nameof(CodeBuild)} supports two environment variables for branch names.");
 
         public override string GenerateSetVersionMessage(VersionVariables variables)
         {

--- a/src/GitVersionExe.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersionExe.Tests/PullRequestInBuildAgentTest.cs
@@ -38,7 +38,7 @@ namespace GitVersionExe.Tests
         {
             var env = new Dictionary<string, string>
             {
-                { CodeBuild.EnvironmentVariableName, PullRequestBranchName },
+                { CodeBuild.WebHookEnvironmentVariableName, PullRequestBranchName },
             };
             await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
         }


### PR DESCRIPTION
The current CodeBuild support only supports retrieving the branch when a build has been initiated via a webhook, mainly GitHub.  There are other use cases when a this environment variable will not be populated, and branch name is available via the `CODEBUILD_SOURCE_VERSION` variable.  This PR updates the CodeBuild agent to also check this environment variable.

This does result in a difference from the other build agents, as this involves 2 possible environment variables.

## Description
Updates the CodeBuild agent to check the `CODEBUILD_SOURCE_VERSION` if the value from `CODEBUILD_WEBHOOK_BASE_REF` is null or empty.  Overloads the base class so it no longer uses the `EnvironmentVariable` property, as there are 2 variables to be checked.  Throws an exception if the property is accessed

## Motivation and Context
We want to use GItVersion within CodeBuild from builds initiated from Jenkins that are initiated via webhook

## How Has This Been Tested?
Added additional unit tests and confirmed they pass

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
