### PR TITLE
Allow use of features and hotfixes with mainline mode

### DIFF
--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -178,6 +178,74 @@ namespace GitVersionCore.Tests.VersionCalculation
         }
 
         [Test]
+        public void MergeFeatureIntoMainlineWithMinorIncrement()
+        {
+            var config = new Config
+            {
+                VersioningMode = VersioningMode.Mainline,
+                Branches = new Dictionary<string, BranchConfig>()
+                {
+                    { "feature", new BranchConfig { Increment = IncrementStrategy.Minor } }
+                },
+                Ignore = new IgnoreConfig() { ShAs = new List<string>() },
+                MergeMessageFormats = new Dictionary<string, string>()
+            };
+
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.MakeACommit();
+            fixture.ApplyTag("1.0.0");
+            fixture.AssertFullSemver("1.0.0", config);
+
+            fixture.BranchTo("feature/foo");
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.1.0-foo.1", config);
+            fixture.ApplyTag("1.1.0-foo.1");
+
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo");
+            fixture.AssertFullSemver("1.1.0", config);
+        }
+
+        [Test]
+        public void MergeFeatureIntoMainlineWithMinorIncrementAndThenMergeHotfix()
+        {
+            var config = new Config
+            {
+                VersioningMode = VersioningMode.Mainline,
+                Branches = new Dictionary<string, BranchConfig>()
+                {
+                    { "feature", new BranchConfig { Increment = IncrementStrategy.Minor } }
+                },
+                Ignore = new IgnoreConfig() { ShAs = new List<string>() },
+                MergeMessageFormats = new Dictionary<string, string>()
+            };
+
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.MakeACommit();
+            fixture.ApplyTag("1.0.0");
+            fixture.AssertFullSemver("1.0.0", config);
+
+            fixture.BranchTo("feature/foo");
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.1.0-foo.1", config);
+            fixture.ApplyTag("1.1.0-foo.1");
+
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo");
+            fixture.AssertFullSemver("1.1.0", config);
+            fixture.ApplyTag("1.1.0");
+
+            fixture.BranchTo("hotfix/bar");
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.1.1-beta.1", config);
+            fixture.ApplyTag("1.1.1-beta.1");
+
+            fixture.Checkout("master");
+            fixture.MergeNoFF("hotfix/bar");
+            fixture.AssertFullSemver("1.1.1", config);
+        }
+
+        [Test]
         public void PreReleaseTagCanUseBranchNameVariable()
         {
             var config = new Config

--- a/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersionCore.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -155,6 +155,29 @@ namespace GitVersionCore.Tests.VersionCalculation
         }
 
         [Test]
+        public void MergeFeatureIntoMainline()
+        {
+            var config = new Config
+            {
+                VersioningMode = VersioningMode.Mainline
+            };
+
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.MakeACommit();
+            fixture.ApplyTag("1.0.0");
+            fixture.AssertFullSemver("1.0.0", config);
+
+            fixture.BranchTo("feature/foo");
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.0.1-foo.1", config);
+            fixture.ApplyTag("1.0.1-foo.1");
+
+            fixture.Checkout("master");
+            fixture.MergeNoFF("feature/foo");
+            fixture.AssertFullSemver("1.0.1", config);
+        }
+
+        [Test]
         public void PreReleaseTagCanUseBranchNameVariable()
         {
             var config = new Config

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -61,18 +61,14 @@ namespace GitVersion.VersionCalculation
 
                 FixTheBaseVersionSourceOfMergeMessageStrategyIfReleaseBranchWasMergedAndDeleted(baseVersions);
 
-                Versions maxVersion;
                 if (context.Configuration.VersioningMode == VersioningMode.Mainline)
                 {
-                    maxVersion = baseVersions
+                    baseVersions = baseVersions
                         .Where(b => !b.IncrementedVersion.PreReleaseTag.HasTag())
-                        .Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
-                }
-                else
-                {
-                    maxVersion = baseVersions.Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
+                        .ToList();
                 }
 
+                var maxVersion = baseVersions.Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
                 var matchingVersionsOnceIncremented = baseVersions
                     .Where(b => b.Version.BaseVersionSource != null && b.IncrementedVersion == maxVersion.IncrementedVersion)
                     .ToList();

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -60,7 +60,19 @@ namespace GitVersion.VersionCalculation
                     .ToList();
 
                 FixTheBaseVersionSourceOfMergeMessageStrategyIfReleaseBranchWasMergedAndDeleted(baseVersions);
-                var maxVersion = baseVersions.Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
+
+                Versions maxVersion;
+                if (context.Configuration.VersioningMode == VersioningMode.Mainline)
+                {
+                    maxVersion = baseVersions
+                        .Where(b => !b.IncrementedVersion.PreReleaseTag.HasTag())
+                        .Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
+                }
+                else
+                {
+                    maxVersion = baseVersions.Aggregate((v1, v2) => v1.IncrementedVersion > v2.IncrementedVersion ? v1 : v2);
+                }
+
                 var matchingVersionsOnceIncremented = baseVersions
                     .Where(b => b.Version.BaseVersionSource != null && b.IncrementedVersion == maxVersion.IncrementedVersion)
                     .ToList();


### PR DESCRIPTION
See #2479 for detailed description of issue.

This PR allows the use of feature/hotfix branch pre-release builds when using mainline mode. Previously this was throwing an exception with message "Mainline development mode doesn't yet support pre-release tags on master". This would occur after the following steps:

- master has 1.0.0
- feature branch from master
- commit to feature branch -> 1.1.0-alpha.1 (correct)
- merge feature into master -> Exception "Mainline development mode doesn't yet support pre-release tags on master" as it's trying to tag master with 1.1.0-alpha.2 rather than 1.1.0.

## Description
After getting the base versions in `BaseVersionCalculator.GetBaseVersion()`, check if the configured versioning mode is mainline, if it is then filter out pre-release versions from `baseVersions` list before proceeding.

## Related Issue
#2479

## Motivation and Context
I'm trying to achieve the following:

Versioning NuGet packages using GitVersion. I do not intend to use develop or release branches because it's just overkill for me and my team and would frankly just be a waste of time and effort.

We want to be able to use master as our released branch. Versions on the master branch will always be format {major}.{minor}.{patch}. We would like to use feature branches for new functionality and would like feature branches to also trigger package builds but of a pre-release format such as {major}.{minor}.{patch}-{tag}.{number}. Feature branches merged into master would increment the minor version automatically. Finally, we would like to use hotfix branches for bug fixes. Hotfixes builds would have the same pre-release format as feature branches but when they're merged into master, they'd increment the patch version.

I have tried using both Mainline and Continuous Deployment modes to achieve this but both have failed me so far. I might just be doing something wrong so please advise as to whether this is possible and how.

The [documentation](https://gitversion.readthedocs.io/en/latest/input/docs/reference/versioning-modes/mainline-development/) shows that my desired outcome should indeed be possible with mainline mode, however this does not seem to be the case in reality.

The documentation contains a graphic which begins like this:

![image](https://user-images.githubusercontent.com/16683916/102403486-3b976800-3fde-11eb-88ff-19ea3a3fd6a4.png)

Firstly, this shows that a feature branch has been tagged with **1.0.1-foo.1+1.** The current mainline functionality creates a tag with name **1.0.1-foo.1** (missing the +1). Is this documentation just old? Has the +1 part been removed now?

Secondly, the diagram shows that once the feature branch is merged into master, master is then tagged with 1.0.1 (same issue with +2). This is not the case, GitVersion outputs version **1.0.1-foo.2** for me.

## How Has This Been Tested?
Added new tests to cover new scenarios and also ensured all existing tests still pass successfully.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
