### PR TITLE
Target .net 5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        targetFramework: [ 3.1 ]
+        targetFramework: [ 3.1, 5.0 ]
         distro: [ alpine.3.12-x64, centos.7-x64, debian.9-x64, debian.10-x64, ubuntu.16.04-x64, ubuntu.18.04-x64, ubuntu.20.04-x64 ]
       fail-fast: false
 
@@ -233,7 +233,7 @@ jobs:
     strategy:
       matrix:
         os: [linux]
-        targetFramework: [ 3.1 ]
+        targetFramework: [ 3.1, 5.0 ]
         distro: [ alpine.3.12-x64, centos.7-x64, debian.9-x64, debian.10-x64, ubuntu.16.04-x64, ubuntu.18.04-x64, ubuntu.20.04-x64 ]
       fail-fast: false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ stages:
       name: Linux
       vmImage: 'ubuntu-latest'
       distros: [ alpine.3.12-x64, centos.7-x64, debian.9-x64, debian.10-x64, ubuntu.16.04-x64, ubuntu.18.04-x64, ubuntu.20.04-x64 ]
-      dotnetVersions: [ '3.1' ]
+      dotnetVersions: [ 3.1, 5.0 ]
 
 - stage: Artifact_Windows_Test
   displayName: 'Artifacts Windows test'
@@ -83,7 +83,7 @@ stages:
       name: Linux
       vmImage: 'ubuntu-latest'
       distros: [ alpine.3.12-x64, centos.7-x64, debian.9-x64, debian.10-x64, ubuntu.16.04-x64, ubuntu.18.04-x64, ubuntu.20.04-x64 ]
-      dotnetVersions: [ '3.1' ]
+      dotnetVersions: [ 3.1, 5.0 ]
 
 - stage: Publish
   displayName: 'Publish'

--- a/build/artifacts-test.cake
+++ b/build/artifacts-test.cake
@@ -132,7 +132,7 @@ Task("Artifacts-MsBuildFull-Test")
     var nugetSource = MakeAbsolute(parameters.Paths.Directories.NugetRoot).FullPath;
 
     Information("\nTesting msbuild task with dotnet build (for .net core)\n");
-    var frameworks = new[] { parameters.CoreFxVersion31 };
+    var frameworks = new[] { parameters.CoreFxVersion31, parameters.NetVersion50 };
     foreach(var framework in frameworks)
     {
         var dotnetCoreMsBuildSettings = new DotNetCoreMSBuildSettings();

--- a/build/artifacts-test.cake
+++ b/build/artifacts-test.cake
@@ -113,6 +113,8 @@ Task("Artifacts-MsBuildCore-Test")
 
         if (targetframework == "3.1") {
             targetframework = $"netcoreapp{targetframework}";
+        } else if (targetframework == "5.0") {
+            targetframework = $"net{targetframework}";
         }
 
         var cmd = $"-file {rootPrefix}/scripts/Test-MsBuildCore.ps1 -version {version} -repoPath {rootPrefix}/repo/tests/integration/core -nugetPath {rootPrefix}/nuget -targetframework {targetframework}";

--- a/build/pack.cake
+++ b/build/pack.cake
@@ -141,7 +141,7 @@ DirectoryPath PackPrepareNative(ICakeContext context, BuildParameters parameters
 
     var settings = new DotNetCorePublishSettings
     {
-        Framework = parameters.CoreFxVersion31,
+        Framework = parameters.NetVersion50,
         Runtime = runtime,
         NoRestore = false,
         Configuration = parameters.Configuration,
@@ -151,9 +151,7 @@ DirectoryPath PackPrepareNative(ICakeContext context, BuildParameters parameters
 
     settings.ArgumentCustomization =
         arg => arg
-        .Append("/p:PublishSingleFile=true")
-        .Append("/p:PublishTrimmed=true")
-        .Append("/p:IncludeSymbolsInSingleFile=true");
+        .Append("/p:PublishSingleFile=true");
 
     context.DotNetCorePublish("./src/GitVersionExe/GitVersionExe.csproj", settings);
 

--- a/build/test.cake
+++ b/build/test.cake
@@ -5,7 +5,7 @@ Task("UnitTest")
     .IsDependentOn("Build")
     .Does<BuildParameters>((parameters) =>
 {
-    var frameworks = new[] { parameters.CoreFxVersion31, parameters.FullFxVersion48 };
+    var frameworks = new[] { parameters.CoreFxVersion31, parameters.FullFxVersion48, parameters.NetVersion50 };
     var testResultsPath = parameters.Paths.Directories.TestResultsOutput;
 
     foreach(var framework in frameworks)
@@ -39,7 +39,7 @@ Task("UnitTest")
                     Exclude = new List<string> { "[GitVersion*.Tests]*" }
                 };
 
-                if (string.Equals(framework, parameters.FullFxVersion48)) 
+                if (string.Equals(framework, parameters.FullFxVersion48))
                 {
                     if (IsRunningOnUnix()) {
                         settings.Filter = "TestCategory!=NoMono";
@@ -47,7 +47,7 @@ Task("UnitTest")
                         settings.Filter = "TestCategory!=NoNet48";
                     }
                 }
-                
+
                 DotNetCoreTest(project.FullPath, settings, coverletSettings);
             });
         }

--- a/build/utils/artifacts.cake
+++ b/build/utils/artifacts.cake
@@ -100,7 +100,7 @@ public class DockerImages
 
     public static DockerImages GetDockerImages(ICakeContext context, BuildParameters parameters)
     {
-        var versions =  new[] { "3.1" };
+        var versions =  new[] { "3.1", "5.0" };
         var distros  = parameters.DockerDistros;
 
         var dockerImages =

--- a/build/utils/docker.cake
+++ b/build/utils/docker.cake
@@ -150,7 +150,7 @@ string[] GetDockerTags(DockerImage dockerImage, BuildParameters parameters) {
         $"{name}:{parameters.Version.SemVersion}-{distro}-{targetframework}",
     };
 
-    if (distro == "debian.10-x64" && targetframework == parameters.CoreFxVersion31) {
+    if (distro == "debian.10-x64" && targetframework == parameters.NetVersion50) {
         tags.AddRange(new[] {
             $"{name}:{parameters.Version.Version}",
             $"{name}:{parameters.Version.SemVersion}",

--- a/build/utils/parameters.cake
+++ b/build/utils/parameters.cake
@@ -11,6 +11,7 @@ public class BuildParameters
     public const string MainRepoOwner = "gittools";
     public const string MainRepoName = "GitVersion";
     public string CoreFxVersion31 { get; private set; }  = "netcoreapp3.1";
+    public string NetVersion50 { get; private set; }  = "net5.0";
     public string FullFxVersion48 { get; private set; }  = "net48";
 
     public string DockerDistro { get; private set; }

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net48;netcoreapp3.1;net5.0</TargetFrameworks>
 
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -26,6 +26,11 @@
         <GitVersionAssemblyFile>$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <GitVersionFileExe>dotnet $(MSBuildThisFileDirectory)net5.0/gitversion.dll</GitVersionFileExe>
+        <GitVersionAssemblyFile>$(MSBuildThisFileDirectory)net5.0/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
+    </PropertyGroup>
+
     <PropertyGroup>
         <DisableGitVersionTask Condition=" '$(DisableGitVersionTask)' == '' ">false</DisableGitVersionTask>
 

--- a/src/GitVersion.MsBuild/nuget-files.props
+++ b/src/GitVersion.MsBuild/nuget-files.props
@@ -3,8 +3,10 @@
     <PropertyGroup>
         <PublishTask_net48>../GitVersionExe/bin/$(Configuration)/net48</PublishTask_net48>
         <PublishTask_netcore31>../GitVersionExe/bin/$(Configuration)/netcoreapp3.1/publish</PublishTask_netcore31>
+        <PublishTask_net50>../GitVersionExe/bin/$(Configuration)/net5.0/publish</PublishTask_net50>
         <Target_net48>tools/net48</Target_net48>
         <Target_netcore31>tools/netcoreapp3.1</Target_netcore31>
+        <Target_net50>tools/net5.0</Target_net50>
     </PropertyGroup>
     <ItemGroup Condition="$(IsPackaging) != ''">
         <None Include="msbuild/tools/*.*"                                        Pack="true" PackagePath="tools" />
@@ -13,8 +15,10 @@
 
         <None Include="$(PublishTask_net48)/**/*"                                Pack="true" PackagePath="$(Target_net48)" />
         <None Include="$(PublishTask_netcore31)/**/*"                            Pack="true" PackagePath="$(Target_netcore31)" />
+        <None Include="$(PublishTask_net50)/**/*"                                Pack="true" PackagePath="$(Target_net50)" />
 
         <None Include="bin/$(Configuration)/netstandard2.0/GitVersion.MsBuild.*" Pack="true" PackagePath="$(Target_net48)" />
         <None Include="bin/$(Configuration)/netstandard2.0/GitVersion.MsBuild.*" Pack="true" PackagePath="$(Target_netcore31)" />
+        <None Include="bin/$(Configuration)/netstandard2.0/GitVersion.MsBuild.*" Pack="true" PackagePath="$(Target_net50)" />
     </ItemGroup>
 </Project>

--- a/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/src/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net48;netcoreapp3.1;net5.0</TargetFrameworks>
 
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>

--- a/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/src/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net48;netcoreapp3.1;net5.0</TargetFrameworks>
 
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/src/GitVersionExe/GitVersionExe.csproj
+++ b/src/GitVersionExe/GitVersionExe.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <RootNamespace>GitVersion</RootNamespace>
         <AssemblyName>gitversion</AssemblyName>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DocumentationFile>bin\$(Configuration)\GitVersion.xml</DocumentationFile>


### PR DESCRIPTION
Continuation of #2452 

This one has support for .net 5.0. Added additional artifacts tests on new linux distros (alpine and ubuntu 20.04) - thanks to the latest libgit2sharp preview package.  