### PR TITLE
Allow configuring the branch name extraction per branch.

### DIFF
--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -360,6 +360,14 @@ values, but here they are if you need to:
 This is the regex which is used to match the current branch to the correct
 branch configuration.
 
+### trim-regex
+
+This regex is used to capture the name to use for the branch when calculating
+the version tag. This regex is matched on the branch name. The first capture
+group is what defines the resulting name. By default (i.e. when not set), this
+is set to extract by using `{regex}(.*)` where `{regex}` is set from
+[above](#regex).
+
 ### source-branches
 
 Because git commits only refer to parent commits (not branches) GitVersion

--- a/src/GitVersionCore/Configuration/ConfigExtensions.cs
+++ b/src/GitVersionCore/Configuration/ConfigExtensions.cs
@@ -99,7 +99,7 @@ namespace GitVersion.Configuration
             return new EffectiveConfiguration(
                 assemblyVersioningScheme, assemblyFileVersioningScheme, assemblyInformationalFormat, assemblyVersioningFormat, assemblyFileVersioningFormat, versioningMode, gitTagPrefix,
                 tag, nextVersion, incrementStrategy,
-                currentBranchConfig.Regex,
+                currentBranchConfig.TrimRegex ?? $"{currentBranchConfig.Regex}(.*)",
                 preventIncrementForMergedBranchVersion,
                 tagNumberPattern, configuration.ContinuousDeploymentFallbackTag,
                 trackMergeTarget,
@@ -131,7 +131,7 @@ namespace GitVersion.Configuration
                 var branchName = branchNameOverride ?? branchFriendlyName;
                 if (!string.IsNullOrWhiteSpace(configuration.BranchPrefixToTrim))
                 {
-                    branchName = branchName.RegexReplace(configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                    branchName = branchName.RegexReplace(configuration.BranchPrefixToTrim, "$1", RegexOptions.IgnoreCase);
                 }
                 branchName = branchName.RegexReplace("[^a-zA-Z0-9-]", "-");
 

--- a/src/GitVersionCore/Model/Configuration/BranchConfig.cs
+++ b/src/GitVersionCore/Model/Configuration/BranchConfig.cs
@@ -26,6 +26,7 @@ namespace GitVersion.Model.Configuration
             CommitMessageIncrementing = branchConfiguration.CommitMessageIncrementing;
             TracksReleaseBranches = branchConfiguration.TracksReleaseBranches;
             Regex = branchConfiguration.Regex;
+            TrimRegex = branchConfiguration.TrimRegex;
             IsReleaseBranch = branchConfiguration.IsReleaseBranch;
             IsMainline = branchConfiguration.IsMainline;
             Name = branchConfiguration.Name;
@@ -60,6 +61,9 @@ namespace GitVersion.Model.Configuration
 
         [YamlMember(Alias = "regex")]
         public string Regex { get; set; }
+
+        [YamlMember(Alias = "trim-regex")]
+        public string TrimRegex { get; set; }
 
         [YamlMember(Alias = "source-branches")]
         public HashSet<string> SourceBranches { get; set; }
@@ -97,6 +101,7 @@ namespace GitVersion.Model.Configuration
             targetConfig.TrackMergeTarget = this.TrackMergeTarget ?? targetConfig.TrackMergeTarget;
             targetConfig.CommitMessageIncrementing = this.CommitMessageIncrementing ?? targetConfig.CommitMessageIncrementing;
             targetConfig.Regex = this.Regex ?? targetConfig.Regex;
+            targetConfig.TrimRegex = this.TrimRegex ?? targetConfig.TrimRegex;
             targetConfig.SourceBranches = this.SourceBranches ?? targetConfig.SourceBranches;
             targetConfig.IsSourceBranchFor = this.IsSourceBranchFor ?? targetConfig.IsSourceBranchFor;
             targetConfig.TracksReleaseBranches = this.TracksReleaseBranches ?? targetConfig.TracksReleaseBranches;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this change the branch name used for version tags can be configured via a regex.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This change resolves #2201.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As outlined in #2201 the branch name extraction was hardcoded to just trim everything a branch configuration's `regex` matched. With this change that behavior stays as is by default, but users can override the existing behavior by using a new setting called `trim-regex`. This regex is used to extract the part of a branch name to use.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`OtherBranchScenarios` has two new tests. One ensures the user can use the whole branch name altogether by specifying an empty regex, the other one confirms that only the captured part is used for the branch name for version tags.

This change is backwards compatible, as such all existing tests have been untouched and are still green.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
