### PR TITLE
CommitsSinceVersionSource should not decrease upon merging a release branch into develop

### DIFF
--- a/docs/input/docs/configuration.md
+++ b/docs/input/docs/configuration.md
@@ -202,7 +202,7 @@ set to `4`, which will pad the `CommitsSinceVersionSource` value of `1` to
 ### tag-pre-release-weight
 
 The pre-release weight in case of tagged commits. If the value is not set in the configuration, a default weight of 60000 is used instead. If the `WeightedPreReleaseNumber` [variable](./more-info/variables) is 0 and this parameter is set, its value is used. This helps if your branching model is GitFlow and the last release build, which is often tagged, can utilise this parameter to produce a monotonically increasing build number.
- 
+
 ### commit-message-incrementing
 
 Sets whether it should be possible to increment the version with special syntax
@@ -462,7 +462,10 @@ Same as for the [global configuration, explained above](#increment).
 
 When `release-2.0.0` is merged into master, we want master to build `2.0.0`. If
 `release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
-prevents incrementing after a versioned branch is merged
+prevents incrementing after a versioned branch is merged.
+
+In a GitFlow-based repository, setting this option can have implications on the `CommitsSinceVersionSource` output variable. It can rule
+out a potentially better version source proposed by the `MergeMessageBaseVersionStrategy`. For more details and an in-depth analysis, please see the discussion [here](https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037).
 
 ### tag-number-pattern
 

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -329,7 +329,6 @@ namespace GitVersionCore.Tests.IntegrationTests
             fixture.AssertFullSemver("1.2.0-alpha.6");
             fixture.AssertFullSemver("1.2.0-alpha.6", config);
 
-            
             config.Branches = new Dictionary<string, BranchConfig>
             {
                 { "develop", new BranchConfig { PreventIncrementOfMergedBranchVersion = true } },

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -303,9 +303,7 @@ namespace GitVersionCore.Tests.IntegrationTests
             fixture.MakeACommit();
             fixture.BranchTo("develop");
             fixture.MakeATaggedCommit("1.0.0");
-            fixture.Repository.MakeCommits(10);
-
-            fixture.AssertFullSemver("1.1.0-alpha.10", config);
+            fixture.Repository.MakeCommits(1);
 
             // Create a release branch and make some commits
             fixture.BranchTo(ReleaseBranch);
@@ -317,12 +315,12 @@ namespace GitVersionCore.Tests.IntegrationTests
             fixture.ApplyTag("v1.1.0");
             fixture.Checkout("develop");
             // Simulate some work done on develop while the release branch was open.
-            fixture.Repository.MakeCommits(10);
+            fixture.Repository.MakeCommits(2);
             fixture.MergeNoFF(ReleaseBranch);
 
             // Version numbers will still be correct when the release branch is around.
-            fixture.AssertFullSemver("1.2.0-alpha.14");
-            fixture.AssertFullSemver("1.2.0-alpha.14", config);
+            fixture.AssertFullSemver("1.2.0-alpha.6");
+            fixture.AssertFullSemver("1.2.0-alpha.6", config);
 
             var versionSourceBeforeReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
 
@@ -330,8 +328,8 @@ namespace GitVersionCore.Tests.IntegrationTests
             fixture.Repository.Branches.Remove(ReleaseBranch);
             var versionSourceAfterReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
             Assert.AreEqual(versionSourceBeforeReleaseBranchIsRemoved, versionSourceAfterReleaseBranchIsRemoved);
-            fixture.AssertFullSemver("1.2.0-alpha.14");
-            fixture.AssertFullSemver("1.2.0-alpha.14", config);
+            fixture.AssertFullSemver("1.2.0-alpha.6");
+            fixture.AssertFullSemver("1.2.0-alpha.6", config);
         }
     }
 }

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -324,8 +324,12 @@ namespace GitVersionCore.Tests.IntegrationTests
             fixture.AssertFullSemver("1.2.0-alpha.14");
             fixture.AssertFullSemver("1.2.0-alpha.14", config);
 
+            var versionSourceBeforeReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
+
             // Removing the release branch and calculating the version with the config exhibits the problem.
             fixture.Repository.Branches.Remove(ReleaseBranch);
+            var versionSourceAfterReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
+            Assert.AreEqual(versionSourceBeforeReleaseBranchIsRemoved, versionSourceAfterReleaseBranchIsRemoved);
             fixture.AssertFullSemver("1.2.0-alpha.14");
             fixture.AssertFullSemver("1.2.0-alpha.14", config);
         }

--- a/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersionCore.Tests/IntegrationTests/DevelopScenarios.cs
@@ -286,15 +286,14 @@ namespace GitVersionCore.Tests.IntegrationTests
         }
 
         [Test]
-        public void WhenPreventIncrementOfMergedBranchVersionIsSetToTrueCommitsSinceVersionSourceShouldNotGoDownWhenMergingReleaseToDevelop()
+        public void WhenPreventIncrementOfMergedBranchVersionIsSetToFalseCommitsSinceVersionSourceShouldNotGoDownWhenMergingReleaseToDevelop()
         {
-            // Simulate the configuration used in production.
             var config = new Config
             {
                 VersioningMode = VersioningMode.ContinuousDeployment,
                 Branches = new Dictionary<string, BranchConfig>
                 {
-                    { "develop", new BranchConfig { PreventIncrementOfMergedBranchVersion = true } },
+                    { "develop", new BranchConfig { PreventIncrementOfMergedBranchVersion = false } },
                 }
             };
 
@@ -324,12 +323,18 @@ namespace GitVersionCore.Tests.IntegrationTests
 
             var versionSourceBeforeReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
 
-            // Removing the release branch and calculating the version with the config exhibits the problem.
             fixture.Repository.Branches.Remove(ReleaseBranch);
             var versionSourceAfterReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
             Assert.AreEqual(versionSourceBeforeReleaseBranchIsRemoved, versionSourceAfterReleaseBranchIsRemoved);
             fixture.AssertFullSemver("1.2.0-alpha.6");
             fixture.AssertFullSemver("1.2.0-alpha.6", config);
+
+            
+            config.Branches = new Dictionary<string, BranchConfig>
+            {
+                { "develop", new BranchConfig { PreventIncrementOfMergedBranchVersion = true } },
+            };
+            fixture.AssertFullSemver("1.2.0-alpha.3", config);
         }
     }
 }


### PR DESCRIPTION
`CommitsSinceVersionSource` decreases when a release branch is merged to develop and `PreventIncrementOfMergedBranchVersion` is set to `true`.

For now I have added a minimalistic testcase, exhibiting the problem defined in issue #2505. 