### PR TITLE
Additional options for command-line switch `/overrideconfig`.

### DIFF
--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -134,7 +134,7 @@ Following options are supported:
 
 Read more about [Configuration](docs/reference/configuration).
 
-It will not change config file 'GitVersion.yml'.
+Using `override-config` on the command line will not change the contents of the config file `GitVersion.yml`.
 
 ### Example: How to override configuration option 'tag-prefix' to use prefix 'custom'
 

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -99,15 +99,14 @@ gitversion init     Configuration utility for gitversion
 
 ## Override config
 
-`/overrideconfig [key=value]` will override appropriate key from 'GitVersion.yml'.
+`/overrideconfig [key=value]` will override appropriate `key` from 'GitVersion.yml'.
 
-Multiple options are separated by semicolon: `key1=value1;key2=value2`.
+To specify multiple options add multiple `/overrideconfig [key=value]` entries:
+`/overrideconfig key1=value1 /overrideconfig key2=value2`.
 
 To have **space characters** as a part of `value`, `value` has be enclosed with double quotes - `key="My value"`.
 
 Double quote character inside of the double quoted `value` has to be be escaped with a backslash '\\' - `key="My \"escaped-quotes\""`.
-
-If closing double-qoute character is missing, it will be implicitily added at the very end of the command line argument - `key="My Value;key2=2(")`.
 
 Following options are supported:
 1. `assembly-file-versioning-format`
@@ -151,6 +150,10 @@ Will pickup up environment variable `BUILD_NUMBER` or fallback to zero for assem
 `GitVersion.exe /output json /overrideconfig assembly-versioning-scheme=MajorMinor`
 
 Will use only major and minor version numbers for assembly version. Assembly build and revision numbers will be 0 (e.g. `1.2.0.0`)
+
+### Example: How to override multiple configuration options
+
+`GitVersion.exe /output json /overrideconfig tag-prefix=custom /overrideconfig assembly-versioning-scheme=MajorMinor`
 
 ### Example: How to override configuration option 'update-build-number'
 

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -131,7 +131,7 @@ Following options are supported:
 1. `tag-pre-release-weight`
 1. `update-build-number`
 
-Read more about [Configuration](docs/reference/configuration).
+Read more about [Configuration](/docs/reference/configuration).
 
 Using `override-config` on the command line will not change the contents of the config file `GitVersion.yml`.
 

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -99,9 +99,63 @@ gitversion init     Configuration utility for gitversion
 
 ## Override config
 
-`/overrideconfig [key=value]` will override appropriate key from
-`GitVersion.yml`.
+`/overrideconfig [key=value]` will override appropriate key from 'GitVersion.yml'.
 
-At the moment only `tag-prefix` option is supported. Read more about
-[Configuration](/docs/reference/configuration). It will not change config file
-`GitVersion.yml`.
+Multiple options are separated by semicolon: `key1=value1;key2=value2`.
+
+To have **space characters** as a part of `value`, `value` has be enclosed with double quotes - `key="My value"`.
+
+Double quote character inside of the double quoted `value` has to be be escaped with a backslash '\\' - `key="My \"escaped-quotes\""`.
+
+If closing double-qoute character is missing, it will be implicitily added at the very end of the command line argument - `key="My Value;key2=2(")`.
+
+Following options are supported:
+1. `assembly-file-versioning-format`
+1. `assembly-file-versioning-scheme`
+1. `assembly-informational-format`
+1. `assembly-versioning-format`
+1. `assembly-versioning-scheme`
+1. `build-metadata-padding`
+1. `commit-date-format`
+1. `commit-message-incrementing`
+1. `commits-since-version-source-padding`
+1. `continuous-delivery-fallback-tag`
+1. `increment`
+1. `legacy-semver-padding`
+1. `major-version-bump-message`
+1. `minor-version-bump-message`
+1. `mode`
+1. `next-version`
+1. `no-bump-message`
+1. `patch-version-bump-message`
+1. `tag-prefix`
+1. `tag-pre-release-weight`
+1. `update-build-number`
+
+Read more about [Configuration](docs/reference/configuration).
+
+It will not change config file 'GitVersion.yml'.
+
+### Example: How to override configuration option 'tag-prefix' to use prefix 'custom'
+
+`GitVersion.exe /output json /overrideconfig tag-prefix=custom`
+
+### Example: How to override configuration option 'assembly-versioning-format'
+
+`GitVersion.exe /output json /overrideconfig assembly-versioning-format="{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 0}"`
+
+Will pickup up environment variable `BUILD_NUMBER` or fallback to zero for assembly revision number.
+
+### Example: How to override configuration option 'assembly-versioning-scheme'
+
+`GitVersion.exe /output json /overrideconfig assembly-versioning-scheme=MajorMinor`
+
+Will use only major and minor version numbers for assembly version. Assembly build and revision numbers will be 0 (e.g. `1.2.0.0`)
+
+### Example: How to override configuration option 'update-build-number'
+
+`GitVersion.exe /output json /overrideconfig update-build-number=true`
+
+### Example: How to override configuration option 'next-version'
+
+`GitVersion.exe /output json /overrideconfig next-version=6`

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -394,7 +394,12 @@ namespace GitVersion.App.Tests
             };
             yield return new TestCaseData("assembly-versioning-scheme=WrongEnumValue")
             {
-                ExpectedResult = $"Could not parse /overrideconfig option: assembly-versioning-scheme=WrongEnumValue. Ensure that 'value' is valid for specified 'key' enumeration: {Environment.NewLine}MajorMinorPatchTag{Environment.NewLine}MajorMinorPatch{Environment.NewLine}MajorMinor{Environment.NewLine}Major{Environment.NewLine}None{Environment.NewLine}"
+                ExpectedResult = $"Could not parse /overrideconfig option: assembly-versioning-scheme=WrongEnumValue. Ensure that 'value' is valid for specified 'key' enumeration: {System.Environment.NewLine}" +
+                    $"MajorMinorPatchTag{System.Environment.NewLine}" +
+                    $"MajorMinorPatch{System.Environment.NewLine}" +
+                    $"MajorMinor{System.Environment.NewLine}" +
+                    $"Major{System.Environment.NewLine}" +
+                    $"None{System.Environment.NewLine}"
             };
         }
 

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -559,22 +559,22 @@ namespace GitVersion.App.Tests
         [TestCaseSource(nameof(OverrideconfigWithMultipleOptionsTestData))]
         public void OverrideconfigWithMultipleOptions(string options, Config expected)
         {
-            var arguments = argumentParser.ParseArguments($"/overrideconfig {options}");
+            var arguments = argumentParser.ParseArguments(options);
             arguments.OverrideConfig.ShouldBeEquivalentTo(expected);
         }
 
         private static IEnumerable<TestCaseData> OverrideconfigWithMultipleOptionsTestData()
         {
             yield return new TestCaseData(
-               "tag-prefix=sample;assembly-versioning-scheme=MajorMinor",
+               "/overrideconfig tag-prefix=sample /overrideconfig assembly-versioning-scheme=MajorMinor",
                new Config
                {
                    TagPrefix = "sample",
                    AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinor,
                }
-           );
+            );
             yield return new TestCaseData(
-                "tag-prefix=sample;assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\"",
+                "/overrideconfig tag-prefix=sample /overrideconfig assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\"",
                 new Config
                 {
                     TagPrefix = "sample",
@@ -582,7 +582,7 @@ namespace GitVersion.App.Tests
                 }
             );
             yield return new TestCaseData(
-                "tag-prefix=sample;assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\";update-build-number=true;assembly-versioning-scheme=MajorMinorPatchTag;mode=ContinuousDelivery;tag-pre-release-weight=4",
+                "/overrideconfig tag-prefix=sample /overrideconfig assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\" /overrideconfig update-build-number=true /overrideconfig assembly-versioning-scheme=MajorMinorPatchTag /overrideconfig mode=ContinuousDelivery /overrideconfig tag-pre-release-weight=4",
                 new Config
                 {
                     TagPrefix = "sample",

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -394,7 +394,7 @@ namespace GitVersion.App.Tests
             };
             yield return new TestCaseData("assembly-versioning-scheme=WrongEnumValue")
             {
-                ExpectedResult = "Could not parse /overrideconfig option: assembly-versioning-scheme=WrongEnumValue. Ensure that 'value' is valid for specified 'key' enumeration: \r\nMajorMinorPatchTag\r\nMajorMinorPatch\r\nMajorMinor\r\nMajor\r\nNone\r\n"
+                ExpectedResult = $"Could not parse /overrideconfig option: assembly-versioning-scheme=WrongEnumValue. Ensure that 'value' is valid for specified 'key' enumeration: {Environment.NewLine}MajorMinorPatchTag{Environment.NewLine}MajorMinorPatch{Environment.NewLine}MajorMinor{Environment.NewLine}Major{Environment.NewLine}None{Environment.NewLine}"
             };
         }
 

--- a/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
+++ b/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
@@ -110,7 +110,7 @@ namespace GitVersionExe.Tests
         }
 
         [TestCaseSource(nameof(UnquoteTextTestData))]
-        public string UnquoteTextTextTests(string input)
+        public string UnquoteTextTests(string input)
         {
             return QuotedStringHelpers.UnquoteText(input);
         }

--- a/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
+++ b/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
@@ -21,7 +21,7 @@ namespace GitVersionExe.Tests
             };
             yield return new TestCaseData("one two three", ' ')
             {
-                ExpectedResult = new []{ "one", "two", "three" }
+                ExpectedResult = new[] { "one", "two", "three" }
             };
             yield return new TestCaseData("one \"two three\"", ' ')
             {

--- a/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
+++ b/src/GitVersion.App.Tests/QuotedStringHelpersTests.cs
@@ -1,0 +1,130 @@
+using GitVersion;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace GitVersionExe.Tests
+{
+    [TestFixture]
+    public class QuotedStringHelpersTests
+    {
+        [TestCaseSource(nameof(SplitUnquotedTestData))]
+        public string[] SplitUnquotedTests(string input, char splitChar)
+        {
+            return QuotedStringHelpers.SplitUnquoted(input, splitChar);
+        }
+
+        private static IEnumerable<TestCaseData> SplitUnquotedTestData()
+        {
+            yield return new TestCaseData(null, ' ')
+            {
+                ExpectedResult = System.Array.Empty<string>()
+            };
+            yield return new TestCaseData("one two three", ' ')
+            {
+                ExpectedResult = new []{ "one", "two", "three" }
+            };
+            yield return new TestCaseData("one \"two three\"", ' ')
+            {
+                ExpectedResult = new[] { "one", "\"two three\"" }
+            };
+            yield return new TestCaseData("one \"two three", ' ')
+            {
+                ExpectedResult = new[] { "one", "\"two three" }
+            };
+            yield return new TestCaseData("/overrideconfig tag-prefix=Sample", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/overrideconfig",
+                    "tag-prefix=Sample"
+                }
+            };
+            yield return new TestCaseData("/overrideconfig tag-prefix=Sample 2", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/overrideconfig",
+                    "tag-prefix=Sample",
+                    "2"
+                }
+            };
+            yield return new TestCaseData("/overrideconfig tag-prefix=\"Sample 2\"", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/overrideconfig",
+                    "tag-prefix=\"Sample 2\""
+                }
+            };
+            yield return new TestCaseData("/overrideconfig tag-prefix=\"Sample \\\"quoted\\\"\"", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/overrideconfig",
+                    "tag-prefix=\"Sample \\\"quoted\\\"\""
+                }
+            };
+            yield return new TestCaseData("/overrideconfig tag-prefix=sample;assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\"", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/overrideconfig",
+                    "tag-prefix=sample;assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\""
+                }
+            };
+            yield return new TestCaseData("tag-prefix=sample;assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\"", ';')
+            {
+                ExpectedResult = new[]
+                {
+                    "tag-prefix=sample",
+                    "assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\""
+                }
+            };
+            yield return new TestCaseData("assembly-versioning-format=\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\"", '=')
+            {
+                ExpectedResult = new[]
+                {
+                    "assembly-versioning-format",
+                    "\"{Major}.{Minor}.{Patch}.{env:CI_JOB_ID ?? 0}\""
+                }
+            };
+        }
+
+        [TestCaseSource(nameof(RemoveEmptyEntriesTestData))]
+        public string[] SplitUnquotedRemovesEmptyEntries(string input, char splitChar)
+        {
+            return QuotedStringHelpers.SplitUnquoted(input, splitChar);
+        }
+
+        private static IEnumerable<TestCaseData> RemoveEmptyEntriesTestData()
+        {
+            yield return new TestCaseData(" /switch1 value1  /switch2 ", ' ')
+            {
+                ExpectedResult = new[]
+                {
+                    "/switch1",
+                    "value1",
+                    "/switch2"
+                }
+            };
+        }
+
+        [TestCaseSource(nameof(UnquoteTextTestData))]
+        public string UnquoteTextTextTests(string input)
+        {
+            return QuotedStringHelpers.UnquoteText(input);
+        }
+
+        private static IEnumerable<TestCaseData> UnquoteTextTestData()
+        {
+            yield return new TestCaseData("\"sample\"")
+            {
+                ExpectedResult = "sample"
+            };
+            yield return new TestCaseData("\"escaped \\\"quote\"")
+            {
+                ExpectedResult = "escaped \"quote"
+            };
+        }
+    }
+}

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -7,7 +7,6 @@ using GitVersion.BuildAgents;
 using GitVersion.Extensions;
 using GitVersion.Logging;
 using GitVersion.Model;
-using GitVersion.Model.Configuration;
 using GitVersion.OutputVariables;
 
 namespace GitVersion

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -298,7 +298,7 @@ namespace GitVersion
 
             if (name.IsSwitch("overrideconfig"))
             {
-                ParseOverrideConfig(arguments, value);
+                ParseOverrideConfig(arguments, values);
                 return true;
             }
 
@@ -422,19 +422,15 @@ namespace GitVersion
             }
         }
 
-        private static void ParseOverrideConfig(Arguments arguments, string value)
+        private static void ParseOverrideConfig(Arguments arguments, string[] values)
         {
-            // TODO: Split valu with regex so that double quotes are taken in consideration as well as escaped double quotes.
-            var keyValueOptions = QuotedStringHelpers.SplitUnquoted(value, ';');
-            if (keyValueOptions.Length == 0)
-            {
+            if (values == null || values.Length == 0)
                 return;
-            }
 
             var parser = new OverrideConfigOptionParser();
 
             // key=value
-            foreach (var keyValueOption in keyValueOptions)
+            foreach (var keyValueOption in values)
             {
                 var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
                 if (keyAndValue.Length != 2)

--- a/src/GitVersion.App/OverrideConfigOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigOptionParser.cs
@@ -1,0 +1,114 @@
+using GitVersion.Model.Configuration;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace GitVersion
+{
+    internal class OverrideConfigOptionParser
+    {
+        private static readonly Lazy<ILookup<string, PropertyInfo>> _lazySupportedProperties =
+            new Lazy<ILookup<string, PropertyInfo>>(GetSupportedProperties, true);
+
+        private Lazy<Config> _lazyConfig = new Lazy<Config>();
+
+        internal ILookup<string, PropertyInfo> SupportedProperties => _lazySupportedProperties.Value;
+
+        /// <summary>
+        /// Dynamically creates <see cref="ILookup{string, PropertyInfo}"/> of
+        /// <see cref="Config"/> properties supported as a part of command line '/overrideconfig' option.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// Lookup keys are created from <see cref="YamlDotNet.Serialization.YamlMemberAttribute"/> to match 'GitVersion.yml'
+        /// options as close as possible.
+        /// </remarks>
+        private static ILookup<string, PropertyInfo> GetSupportedProperties()
+        {
+            return typeof(Config).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(
+                    pi => IsSupportedPropertyType(pi.PropertyType)
+                        && pi.CanWrite
+                        && pi.GetCustomAttributes(typeof(YamlDotNet.Serialization.YamlMemberAttribute), false).Length > 0
+                )
+                .ToLookup(
+                    pi => (pi.GetCustomAttributes(typeof(YamlDotNet.Serialization.YamlMemberAttribute), false)[0] as YamlDotNet.Serialization.YamlMemberAttribute).Alias,
+                    pi => pi
+                );
+        }
+
+        /// <summary>
+        /// Checks if property <see cref="Type"/> of <see cref="Config"/>
+        /// is supported as a part of command line '/overrideconfig' option.
+        /// </summary>
+        /// <param name="propertyType">Type we want to check.</param>
+        /// <returns>True, if type is supported.</returns>
+        /// <remarks>Only simple types are supported</remarks>
+        private static bool IsSupportedPropertyType(Type propertyType)
+        {
+            Type unwrappedType = Nullable.GetUnderlyingType(propertyType);
+            if (unwrappedType == null)
+                unwrappedType = propertyType;
+
+            return unwrappedType == typeof(string)
+                || unwrappedType.IsEnum
+                || unwrappedType == typeof(int)
+                || unwrappedType == typeof(bool);
+        }
+
+        internal void SetValue(string key, string value)
+        {
+            if (!SupportedProperties.Contains(key))
+                return;
+
+            var unwrappedText = QuotedStringHelpers.UnquoteText(value);
+            foreach (var pi in SupportedProperties[key])
+            {
+                Type unwrapped = Nullable.GetUnderlyingType(pi.PropertyType);
+                if (unwrapped == null)
+                    unwrapped = pi.PropertyType;
+
+                if (unwrapped == typeof(string))
+                    pi.SetValue(_lazyConfig.Value, unwrappedText);
+                else if (unwrapped.IsEnum)
+                {
+                    try
+                    { 
+                        var parsedEnum = Enum.Parse(unwrapped, unwrappedText);
+                        pi.SetValue(_lazyConfig.Value, parsedEnum);
+                    }
+                    catch (ArgumentException)
+                    {
+                        var sb = new System.Text.StringBuilder();
+
+                        sb.Append($"Could not parse /overrideconfig option: {key}={value}.");
+                        sb.AppendLine(" Ensure that 'value' is valid for specified 'key' enumeration: ");
+                        foreach (var name in Enum.GetNames(unwrapped))
+                            sb.AppendLine(name);
+
+                        throw new WarningException(sb.ToString());
+                    }
+                }
+                else if (unwrapped == typeof(int))
+                {
+                    if (int.TryParse(unwrappedText, out int parsedInt))
+                        pi.SetValue(_lazyConfig.Value, parsedInt);
+                    else
+                        throw new WarningException($"Could not parse /overrideconfig option: {key}={value}. Ensure that 'value' is valid integer number.");
+                }
+                else if (unwrapped == typeof(bool))
+                {
+                    if (bool.TryParse(unwrappedText, out bool parsedBool))
+                        pi.SetValue(_lazyConfig.Value, parsedBool);
+                    else
+                        throw new WarningException($"Could not parse /overrideconfig option: {key}={value}. Ensure that 'value' is 'true' or 'false'.");
+                }
+            }
+        }
+
+        internal Config GetConfig()
+        {
+            return _lazyConfig.IsValueCreated ? _lazyConfig.Value : null;
+        }
+    }
+}

--- a/src/GitVersion.App/OverrideConfigOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigOptionParser.cs
@@ -15,7 +15,7 @@ namespace GitVersion
         internal ILookup<string, PropertyInfo> SupportedProperties => _lazySupportedProperties.Value;
 
         /// <summary>
-        /// Dynamically creates <see cref="ILookup{string, PropertyInfo}"/> of
+        /// Dynamically creates <see cref="System.Linq.ILookup{TKey, TElement}"/> of
         /// <see cref="Config"/> properties supported as a part of command line '/overrideconfig' option.
         /// </summary>
         /// <returns></returns>

--- a/src/GitVersion.App/OverrideConfigOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigOptionParser.cs
@@ -73,7 +73,7 @@ namespace GitVersion
                 else if (unwrapped.IsEnum)
                 {
                     try
-                    { 
+                    {
                         var parsedEnum = Enum.Parse(unwrapped, unwrappedText);
                         pi.SetValue(_lazyConfig.Value, parsedEnum);
                     }

--- a/src/GitVersion.App/QuotedStringHelpers.cs
+++ b/src/GitVersion.App/QuotedStringHelpers.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GitVersion
+{
+    public static class QuotedStringHelpers
+    {
+        /// <summary>
+        /// Splits input string based on split-character, ignoring split-character in
+        /// quoted part of the string.
+        /// </summary>
+        /// <param name="input">String we want to split.</param>
+        /// <param name="splitChar">Character used for splitting.</param>
+        /// <returns>Array of splitted string parts</returns>
+        /// <remarks>
+        /// If there is opening quotes character without closing quotes,
+        /// closing quotes are implicitly assumed at the end of the input string.
+        /// </remarks>
+        /// <example>
+        /// "one two three" -> {"one", "two",  "three"}
+        /// "one \"two three\"" -> {"one", "\"two three\""}
+        /// "one \"two three" -> {"one", "\"two three"} // implicit closing quote.
+        /// </example>
+        public static string[] SplitUnquoted(string input, char splitChar)
+        {
+            if (input == null)
+                return System.Array.Empty<string>();
+
+            var splitted = new List<string>();
+            bool isPreviousCharBackslash = false;
+            bool isInsideQuotes = false;
+
+            int startIndex = 0;
+            for (int i = 0; i < input.Length; i++)
+            {
+                char current = input[i];
+                switch (current)
+                {
+                    case '"':
+                        if (!isPreviousCharBackslash)
+                            isInsideQuotes = !isInsideQuotes;
+                        break;
+                    default:
+                        if (current == splitChar && !isInsideQuotes)
+                        {
+                            splitted.Add(input.Substring(startIndex, i - startIndex));
+                            startIndex = i + 1;
+                        }
+                        break;
+                }
+                isPreviousCharBackslash = current == '\\';
+            }
+
+            splitted.Add(input.Substring(startIndex, input.Length - startIndex));
+
+            return splitted.Where(argument => !string.IsNullOrEmpty(argument)).ToArray();
+        }
+
+        /// <summary>
+        /// Removes enclosing quotes around input string and unescapes quote characters
+        /// inside of string.
+        /// </summary>
+        /// <param name="input">Input string to unescape.</param>
+        /// <returns>Unescaped string.</returns>
+        /// <example>
+        /// "\"one \\\"two\\\"\"" -> "one \"two\""
+        /// </example>
+        public static string UnquoteText(string input)
+        {
+            var sb = new StringBuilder(input);
+
+            if (sb[0] == '"')
+                sb.Remove(0, 1);
+
+            if (sb[sb.Length - 1] == '"' && sb[sb.Length - 2] != '\\')
+                sb.Remove(sb.Length - 1, 1);
+
+            sb.Replace("\\\"", "\""); // unescape quotes.
+
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
All 'Gitversion.yml` options with simple property type (string, enum, int, bool) are now supported - 21 in total.

<!--- Provide a general summary of your changes in the Title above -->

## Description
As discussed in issue #2485 I've added support for all writeable properties from `GitVersion.Model.Configuration.Config` class (effectively `Gitversion.yml`) which have simple type (string, Enum, int, bool and their nullable counterparts).

Implementation uses Reflection to parse which properties fit criteria and uses "aliases" for property names provided by `YamlMemberAttribute`'s `Alias` value.

Following `/overrideconfig` options are supported:
1. `assembly-file-versioning-format`
1. `assembly-file-versioning-scheme`
1. `assembly-informational-format`
1. `assembly-versioning-format`
1. `assembly-versioning-scheme`
1. `build-metadata-padding`
1. `commit-date-format`
1. `commit-message-incrementing`
1. `commits-since-version-source-padding`
1. `continuous-delivery-fallback-tag`
1. `increment`
1. `legacy-semver-padding`
1. `major-version-bump-message`
1. `minor-version-bump-message`
1. `mode`
1. `next-version`
1. `no-bump-message`
1. `patch-version-bump-message`
1. `tag-prefix`
1. `tag-pre-release-weight`
1. `update-build-number`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Support 'assembly-versioning-format' option as a part of '/overrideconfig' command line parameter #2485

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In CI environment (GitLab, TeamCity), it makes sense that some of the customizations to the gitversion configuration can be overridden via command line. That allows for applying global changes (for example different assembly-versioning style) on company level, via shared CI build script template, instead of committing same configuration option to every single repository separately in `Gitversion.yml` files.

Since `tag-prefix` option has already been supported, I requested `assembly-versioning-format`, but instead agreed with @asbjornu that it is better make `/overrideconfig` option-parity with `Gitversion.yml` - to the extent that it is possible/reasonable , due to differences in (de)serialization fidelity between `yml` files and command-line arguments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code is unit-tested for all currently available `/overrideconfig` options, common errors (wrong key, wrong value, format errors) and setting of multiple options at once.
In addition, I manually tested in windows console as well for couple of common options.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
