### PR TITLE
deterministically serialize number and string JSON output

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranch.approved.txt
@@ -6,7 +6,7 @@
   "PreReleaseTagWithDash": "",
   "PreReleaseLabel": "",
   "PreReleaseLabelWithDash": "",
-  "PreReleaseNumber": "",
+  "PreReleaseNumber": null,
   "WeightedPreReleaseNumber": 0,
   "BuildMetaData": 5,
   "BuildMetaDataPadded": "0005",

--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat.approved.txt
@@ -6,7 +6,7 @@
   "PreReleaseTagWithDash": "",
   "PreReleaseLabel": "",
   "PreReleaseLabelWithDash": "",
-  "PreReleaseNumber": "",
+  "PreReleaseNumber": null,
   "WeightedPreReleaseNumber": 0,
   "BuildMetaData": 5,
   "BuildMetaDataPadded": "0005",

--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeliveryModeForStable.approved.txt
@@ -6,7 +6,7 @@
   "PreReleaseTagWithDash": "",
   "PreReleaseLabel": "",
   "PreReleaseLabelWithDash": "",
-  "PreReleaseNumber": "",
+  "PreReleaseNumber": null,
   "WeightedPreReleaseNumber": 0,
   "BuildMetaData": 5,
   "BuildMetaDataPadded": "0005",

--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForPreRelease.approved.txt
@@ -8,7 +8,7 @@
   "PreReleaseLabelWithDash": "-unstable",
   "PreReleaseNumber": 8,
   "WeightedPreReleaseNumber": 8,
-  "BuildMetaData": "",
+  "BuildMetaData": null,
   "BuildMetaDataPadded": "",
   "FullBuildMetaData": "Branch.develop.Sha.commitSha",
   "MajorMinorPatch": "1.2.3",

--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStable.approved.txt
@@ -8,7 +8,7 @@
   "PreReleaseLabelWithDash": "-ci",
   "PreReleaseNumber": 5,
   "WeightedPreReleaseNumber": 5,
-  "BuildMetaData": "",
+  "BuildMetaData": null,
   "BuildMetaDataPadded": "",
   "FullBuildMetaData": "Branch.develop.Sha.commitSha",
   "MajorMinorPatch": "1.2.3",

--- a/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Approved/VariableProviderTests.ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged.approved.txt
@@ -6,7 +6,7 @@
   "PreReleaseTagWithDash": "",
   "PreReleaseLabel": "",
   "PreReleaseLabelWithDash": "",
-  "PreReleaseNumber": "",
+  "PreReleaseNumber": null,
   "WeightedPreReleaseNumber": 0,
   "BuildMetaData": 5,
   "BuildMetaDataPadded": "0005",

--- a/src/GitVersion.Core/Model/VersionVariablesJsonModel.cs
+++ b/src/GitVersion.Core/Model/VersionVariablesJsonModel.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace GitVersion.OutputVariables
+{
+    public class VersionVariablesJsonModel
+    {
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string Major { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string Minor { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string Patch { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string PreReleaseTag { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string PreReleaseTagWithDash { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string PreReleaseLabel { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string PreReleaseLabelWithDash { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string PreReleaseNumber { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string WeightedPreReleaseNumber { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string BuildMetaData { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string BuildMetaDataPadded { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string FullBuildMetaData { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string MajorMinorPatch { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string SemVer { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string LegacySemVer { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string LegacySemVerPadded { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string AssemblySemVer { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string AssemblySemFileVer { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string FullSemVer { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string InformationalVersion { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string BranchName { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string EscapedBranchName { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string Sha { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string ShortSha { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string NuGetVersionV2 { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string NuGetVersion { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string NuGetPreReleaseTagV2 { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string NuGetPreReleaseTag { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string VersionSourceSha { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string CommitsSinceVersionSource { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string CommitsSinceVersionSourcePadded { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonNumberConverter))]
+        public string UncommittedChanges { get; set; }
+        [JsonConverter(typeof(VersionVariablesJsonStringConverter))]
+        public string CommitDate { get; set; }
+    }
+}

--- a/src/GitVersion.Core/Model/VersionVariablesJsonNumberConverter.cs
+++ b/src/GitVersion.Core/Model/VersionVariablesJsonNumberConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace GitVersion.OutputVariables
+{
+    public class VersionVariablesJsonNumberConverter : JsonConverter<string>
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert == typeof(string);
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.Number && typeToConvert == typeof(string))
+                return reader.GetString() ?? "";
+
+            var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+            if (Utf8Parser.TryParse(span, out long number, out var bytesConsumed) && span.Length == bytesConsumed)
+                return number.ToString();
+
+            var data = reader.GetString();
+
+            throw new InvalidOperationException($"'{data}' is not a correct expected value!")
+            {
+                Source = nameof(VersionVariablesJsonNumberConverter)
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, [CanBeNull] string value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                writer.WriteNullValue();
+            }
+            else if (int.TryParse(value, out var number))
+            {
+                writer.WriteNumberValue(number);
+            }
+            else
+            {
+                throw new InvalidOperationException($"'{value}' is not a correct expected value!")
+                {
+                    Source = nameof(VersionVariablesJsonStringConverter)
+                };
+            }
+
+        }
+
+        public override bool HandleNull => true;
+
+        private static bool NotAPaddedNumber(string value) => value != null && (value == "0" || !value.StartsWith("0"));
+    }
+}

--- a/src/GitVersion.Core/Model/VersionVariablesJsonStringConverter.cs
+++ b/src/GitVersion.Core/Model/VersionVariablesJsonStringConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace GitVersion.OutputVariables
+{
+    public class VersionVariablesJsonStringConverter : JsonConverter<string>
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert == typeof(string);
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.Number && typeToConvert == typeof(string))
+                return reader.GetString() ?? "";
+
+            var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+            if (Utf8Parser.TryParse(span, out long number, out var bytesConsumed) && span.Length == bytesConsumed)
+                return number.ToString();
+
+            var data = reader.GetString();
+
+            throw new InvalidOperationException($"'{data}' is not a correct expected value!")
+            {
+                Source = nameof(VersionVariablesJsonStringConverter)
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, [CanBeNull] string value, JsonSerializerOptions options)
+        {
+            value ??= string.Empty;
+            writer.WriteStringValue(value);
+        }
+
+        public override bool HandleNull => true;
+
+        private static bool NotAPaddedNumber(string value) => value != null && (value == "0" || !value.StartsWith("0"));
+    }
+}


### PR DESCRIPTION
## Description
Deterministically serialize number and string JSON output.

## Related Issue
Fixes #1688 and fixes #2304.

## Motivation and Context
Ever since the introduction of the JsonOutputFormatter way back
in 2014 [1] all fields where serialized as JSON string. Except
for values looking like an int which where then serialized as JSON
numbers. This had some strange unpredictable side effects like
PreReleaseNumber being an empty JSON string instead of null
or a "2009069" ShortSha being formatted as a JSON number.

This change ensures all fields are serialized as JSON string
except Major, Minor, Patch, PreReleaseNumber,
WeightedPreReleaseNumber, CommitsSinceVersionSource and
UncommittedChanges which are now always serialized as JSON number.

Deserialisation remains the same as before for all fields so we
continue to accept both JSON string and JSON number formatted
values.

[1] https://github.com/GitTools/GitVersion/commit/f2daf607a1b6593bf4ce42626e7ee49eb19c3bc4#diff-fde1a8ff593c6ac2ad558a6f9bb512e0350db91343b185f9b2a00d1d6e848bc3


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change dos not require a change to the documentation (https://gitversion.net/docs/more-info/variables remains correct).
- [x] There was no need to update the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
