### PR TITLE
GitVersion.MsBuild: Handle paths with spaces

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -6,7 +6,7 @@
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
     <Target Name="RunGitVersion">
-        <Exec Command="$(GitVersionFileExe) $(MSBuildProjectDirectory) $(GitVersion_ToolArgments)" />
+        <Exec Command="&quot;$(GitVersionFileExe)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
     <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -6,7 +6,7 @@
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
     <Target Name="RunGitVersion">
-        <Exec Command="&quot;$(GitVersionFileExe)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
+        <Exec Command="$(GitVersionFileExe) &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
     <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">


### PR DESCRIPTION
Update GitVersion.MsBuild.targets file to properly handle project folders ~~as well as NuGet package folders~~ which contain spaces.

## Description
Encapsulated path references in `&quot;` to enable proper parsing of paths which contain spaces. This applies to project folders ~~as well as local NuGet Packages folders~~.

## Related Issue
#2540 

## Motivation and Context
Can process paths containing spaces.

## How Has This Been Tested?
Manually modified the file GitVersion.MsBuild.targets inside the NuGet Packages folder.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
