### PR TITLE
Fix path separator and quotation issues in MSBuild task

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -2,7 +2,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <GitVersionOutputFile>$(BaseIntermediateOutputPath)/gitversion.json</GitVersionOutputFile>
+        <GitVersionOutputFile>$([MSBuild]::EnsureTrailingSlash($(BaseIntermediateOutputPath)))gitversion.json</GitVersionOutputFile>
 
         <Language Condition=" '$(Language)' == '' ">C#</Language>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)/../</SolutionDir>
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major $(MSBuildThisFileDirectory)netcoreapp3.1/gitversion.dll</GitVersionFileExe>
+        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$(MSBuildThisFileDirectory)netcoreapp3.1/gitversion.dll&quot;</GitVersionFileExe>
         <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
 


### PR DESCRIPTION
## Description
There are several issues with the MSBuild task when it runs on file paths being different from usual situations.

## Related Issue
Fixes #2534

## Motivation and Context
The MSBuild task should be more reliable when it comes to uncommon project paths.

## How Has This Been Tested?
I could not find any automated tests covering MSBuild scripts, so I simply patched my local cache of the package with the fixed .props file to see if that solves the issues I had. I doubt this is enough but I have no idea what more could be done on that.

## Screenshots (if appropriate):
N/A
## Checklist:
- [x] ~~My code follows the code style of this project.~~ Actually no code was changed
- [x] ~~My change requires a change to the documentation.~~ No
- [x] ~~I have updated the documentation accordingly.~~
- [x] ~~I have added tests to cover my changes.~~ I did not find automated tests for the .props/.targets portion. If I missed something here, let me know and I will reopen this task
- [x] All ~~new and~~ existing tests passed.
