### PR TITLE
Docs: Describe configuration for using Conventional commits

### DIFF
--- a/docs/input/docs/more-info/version-increments.md
+++ b/docs/input/docs/more-info/version-increments.md
@@ -84,6 +84,20 @@ One thing to be aware of: If the current version is an alpha-version
 (eg from 0.2.0 to 0.3.0 instead of 1.0.0). Once the current version is greater
 than 1.0.0, bumping the major version works as expected.
 
+#### Conventional commit messages
+
+If you want to use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+standard, you can leverage this feature as follows:
+
+```yaml
+mode: MainLine # Only add this if you want every version to be created automatically on your main branch.
+major-version-bump-message: "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n.*\\n\\n.*BREAKING.*).*"
+minor-version-bump-message: "(feat)(\\([\\w\\s]*\\))?:"
+patch-version-bump-message: "(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:(.*\\n\\n.*\\n\\n.*BREAKING.*){0}"
+```
+
+This will ensure that your version gets bumped according to the commits you've created.
+
 ### GitVersion.yml
 
 The first is by setting the `next-version` property in the GitVersion.yml file.

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -46,6 +46,14 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Repository.MakeACommit("+semver:major");
 
             fixture.AssertFullSemver("2.0.0+2");
+
+            fixture.Repository.MakeACommit("+semver:patch");
+
+            fixture.AssertFullSemver("2.0.1+3");
+
+            fixture.Repository.MakeACommit("+semver:minor");
+
+            fixture.AssertFullSemver("2.1.0+3");
         }
 
         [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -36,6 +36,10 @@ namespace GitVersion.Core.Tests.IntegrationTests
         [Test]
         public void CanUseCommitMessagesToBumpVersion()
         {
+            var configuration = new Config
+            {
+                VersioningMode = GitVersion.VersionCalculation.VersioningMode.Mainline
+            };
             using var fixture = new EmptyRepositoryFixture();
             fixture.Repository.MakeACommit();
             fixture.MakeATaggedCommit("1.0.0");
@@ -49,11 +53,55 @@ namespace GitVersion.Core.Tests.IntegrationTests
 
             fixture.Repository.MakeACommit("+semver:patch");
 
-            fixture.AssertFullSemver("2.0.1+3");
+            fixture.AssertFullSemver("2.0.1", configuration);
 
             fixture.Repository.MakeACommit("+semver:minor");
 
-            fixture.AssertFullSemver("2.1.0+4");
+            fixture.AssertFullSemver("2.1.0", configuration);
+        }
+
+        [Test]
+        public void CanUseConventionalCommitsToBumpVersion()
+        {
+            var configuration = new Config
+            {
+                VersioningMode = GitVersion.VersionCalculation.VersioningMode.Mainline,
+
+                // For future debugging of this regex: https://regex101.com/r/UfzIwS/1
+                MajorVersionBumpMessage = "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n.*\\n\\n.*BREAKING.*).*",
+
+                // For future debugging of this regex: https://regex101.com/r/9ccNam/1
+                MinorVersionBumpMessage = "(feat)(\\([\\w\\s]*\\))?:",
+
+                // For future debugging of this regex: https://regex101.com/r/ALKccf/1
+                PatchVersionBumpMessage = "(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:(.*\\n\\n.*\\n\\n.*BREAKING.*){0}"
+            };
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.Repository.MakeACommit();
+            fixture.MakeATaggedCommit("1.0.0");
+
+            fixture.Repository.MakeACommit("feat(Api): Added some new endpoints");
+            fixture.AssertFullSemver("1.1.0", configuration);
+
+            // This tests if adding an exclamation mark after the type (breaking change) bumps the major version
+            fixture.Repository.MakeACommit("feat(Api)!: Changed existing API models");
+            fixture.AssertFullSemver("2.0.0", configuration);
+
+            // This tests if writing BREAKING CHANGE in the footer bumps the major version
+            fixture.Repository.MakeACommit("feat: Changed existing API models\n\nSome more descriptive text\n\nBREAKING CHANGE");
+            fixture.AssertFullSemver("3.0.0", configuration);
+
+            fixture.Repository.MakeACommit("chore: Cleaned up various things");
+            fixture.AssertFullSemver("3.0.1", configuration);
+
+            fixture.Repository.MakeACommit("chore: Cleaned up more various things");
+            fixture.AssertFullSemver("3.0.2", configuration);
+
+            fixture.Repository.MakeACommit("feat: Added some new functionality");
+            fixture.AssertFullSemver("3.1.0", configuration);
+
+            fixture.Repository.MakeACommit("feat: Added even more new functionality");
+            fixture.AssertFullSemver("3.2.0", configuration);
         }
 
         [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -36,10 +36,6 @@ namespace GitVersion.Core.Tests.IntegrationTests
         [Test]
         public void CanUseCommitMessagesToBumpVersion()
         {
-            var configuration = new Config
-            {
-                VersioningMode = GitVersion.VersionCalculation.VersioningMode.Mainline
-            };
             using var fixture = new EmptyRepositoryFixture();
             fixture.Repository.MakeACommit();
             fixture.MakeATaggedCommit("1.0.0");
@@ -50,14 +46,6 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Repository.MakeACommit("+semver:major");
 
             fixture.AssertFullSemver("2.0.0+2");
-
-            fixture.Repository.MakeACommit("+semver:patch");
-
-            fixture.AssertFullSemver("2.0.1", configuration);
-
-            fixture.Repository.MakeACommit("+semver:minor");
-
-            fixture.AssertFullSemver("2.1.0", configuration);
         }
 
         [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -53,7 +53,7 @@ namespace GitVersion.Core.Tests.IntegrationTests
 
             fixture.Repository.MakeACommit("+semver:minor");
 
-            fixture.AssertFullSemver("2.1.0+3");
+            fixture.AssertFullSemver("2.1.0+4");
         }
 
         [Test]


### PR DESCRIPTION
This change adds a chapter to the docs which describes how to configure GitVersion for using it with conventional commits

## Description
Using the `*-version-bump-message` configuration, I created some regex's which work for the [conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0/).

## Related Issue
Contributing guidelines didn't mention an open issue would be needed for documentation changes, do I need one?

## Motivation and Context
I've been a long time fan of this project (thanks guys! ❤), but since I started using conventional commits last year I've always struggled with keeping the configuration as simple as possible, at best this involved the use of GitVersion with several other tools chained together. This way I can finally use just a simple `GitVersion.yml` in my repo's and have my builds versioned accordingly.

I imagine there are others like me out there, so hopefully it will be of use to someone.

## How Has This Been Tested?
I added tests which test various conventional commit scenarios I could come up with.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
