### PR TITLE
feat: handle spaces in exe path

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -6,7 +6,7 @@
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
     <Target Name="RunGitVersion">
-        <Exec Command="$(GitVersionFileExe) &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
+        <Exec Command="&quot;$(GitVersionFileExe)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
     <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">


### PR DESCRIPTION
feat: handle spaces in exe path

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added quotes to handle spaces in gitversion.exe path name

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
- nuget package cache is in .nuget folder inside user folder %USERPROFILE%
- in windows user folder can contain a space  

## How Has This Been Tested?
- locally, with "spaced" and "non spaced" folders in %USERPROFILE%

## Screenshots (if appropriate):

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
