### PR TITLE
GitRepository refactoring

### DIFF
--- a/src/GitVersion.LibGit2Sharp/Git/Branch.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Branch.cs
@@ -14,8 +14,16 @@ namespace GitVersion
         {
             innerBranch = branch;
             Name = new ReferenceName(branch.CanonicalName);
+
+            var commit = innerBranch.Tip;
+            Tip = commit is null ? null : new Commit(commit);
+
+            var commits = innerBranch.Commits;
+            Commits = commits is null ? null : new CommitCollection(commits);
         }
         public ReferenceName Name { get; }
+        public ICommit? Tip { get; }
+        public ICommitCollection? Commits { get; }
 
         public int CompareTo(IBranch other) => comparerHelper.Compare(this, other);
         public bool Equals(IBranch other) => equalityHelper.Equals(this, other);
@@ -23,24 +31,6 @@ namespace GitVersion
         public override int GetHashCode() => equalityHelper.GetHashCode(this);
         public override string ToString() => Name.ToString();
         public static implicit operator LibGit2Sharp.Branch(Branch d) => d.innerBranch;
-
-        public ICommit? Tip
-        {
-            get
-            {
-                var commit = innerBranch.Tip;
-                return commit is null ? null : new Commit(commit);
-            }
-        }
-
-        public ICommitCollection? Commits
-        {
-            get
-            {
-                var commits = innerBranch.Commits;
-                return commits is null ? null : new CommitCollection(commits);
-            }
-        }
 
         public bool IsDetachedHead => Name.Canonical.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
 

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -5,18 +5,17 @@ using GitVersion.Helpers;
 
 namespace GitVersion
 {
-    internal sealed class Commit : ICommit
+    internal sealed class Commit : GitObject, ICommit
     {
         private static readonly LambdaEqualityHelper<ICommit> equalityHelper = new(x => x.Id);
         private static readonly LambdaKeyComparer<ICommit, string> comparerHelper = new(x => x.Sha);
 
         private readonly LibGit2Sharp.Commit innerCommit;
 
-        internal Commit(LibGit2Sharp.Commit innerCommit)
+        internal Commit(LibGit2Sharp.Commit innerCommit) : base(innerCommit)
         {
             this.innerCommit = innerCommit;
             Parents = innerCommit.Parents.Select(parent => new Commit(parent));
-            Id = new ObjectId(innerCommit.Id);
             When = innerCommit.Committer.When;
         }
 
@@ -31,9 +30,7 @@ namespace GitVersion
         public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
 
         public IEnumerable<ICommit> Parents { get; }
-        public IObjectId Id { get; }
         public DateTimeOffset When { get; }
-        public string Sha => innerCommit.Sha;
 
         public string Message => innerCommit.Message;
     }

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -12,7 +12,13 @@ namespace GitVersion
 
         private readonly LibGit2Sharp.Commit innerCommit;
 
-        internal Commit(LibGit2Sharp.Commit innerCommit) => this.innerCommit = innerCommit;
+        internal Commit(LibGit2Sharp.Commit innerCommit)
+        {
+            this.innerCommit = innerCommit;
+            Parents = innerCommit.Parents.Select(parent => new Commit(parent));
+            Id = new ObjectId(innerCommit.Id);
+            When = innerCommit.Committer.When;
+        }
 
         public int CompareTo(ICommit other) => comparerHelper.Compare(this, other);
         public bool Equals(ICommit other) => equalityHelper.Equals(this, other);
@@ -24,13 +30,10 @@ namespace GitVersion
         }
         public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
 
-        public IEnumerable<ICommit> Parents => innerCommit.Parents.Select(parent => new Commit(parent));
-
+        public IEnumerable<ICommit> Parents { get; }
+        public IObjectId Id { get; }
+        public DateTimeOffset When { get; }
         public string Sha => innerCommit.Sha;
-
-        public IObjectId Id => new ObjectId(innerCommit.Id);
-
-        public DateTimeOffset When => innerCommit.Committer.When;
 
         public string Message => innerCommit.Message;
     }

--- a/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
@@ -19,7 +19,7 @@ namespace GitVersion
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public IEnumerable<ICommit> GetCommitsPriorTo(DateTimeOffset olderThan) => this.SkipWhile(c => c.When > olderThan);
-        public ICommitCollection QueryBy(CommitFilter commitFilter)
+        public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter)
         {
             static object? GetReacheableFrom(object item)
             {

--- a/src/GitVersion.LibGit2Sharp/Git/GitObject.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitObject.cs
@@ -1,0 +1,28 @@
+using GitVersion.Helpers;
+
+namespace GitVersion
+{
+    internal class GitObject : IGitObject
+    {
+        private static readonly LambdaEqualityHelper<IGitObject> equalityHelper = new(x => x.Id);
+        private static readonly LambdaKeyComparer<IGitObject, string> comparerHelper = new(x => x.Sha);
+
+        internal GitObject(LibGit2Sharp.GitObject innerGitObject)
+        {
+            Id = new ObjectId(innerGitObject.Id);
+            Sha = innerGitObject.Sha;
+        }
+
+        public int CompareTo(IGitObject other) => comparerHelper.Compare(this, other);
+        public bool Equals(IGitObject other) => equalityHelper.Equals(this, other);
+        public override bool Equals(object obj) => Equals((obj as IGitObject)!);
+        public override int GetHashCode() => equalityHelper.GetHashCode(this);
+        public override string ToString()
+        {
+            return Id.ToString(7);
+        }
+
+        public IObjectId Id { get; }
+        public string Sha { get; }
+    }
+}

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -7,7 +7,7 @@ using LibGit2Sharp.Handlers;
 
 namespace GitVersion
 {
-    internal sealed class GitRepository : IGitRepository
+    internal sealed class GitRepository : IMutatingGitRepository
     {
         private readonly ILog log;
         private Lazy<IRepository> repositoryLazy;

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -71,7 +71,6 @@ namespace GitVersion
         public bool IsHeadDetached => repositoryInstance.Info.IsHeadDetached;
 
         public IBranch Head => new Branch(repositoryInstance.Head);
-
         public ITagCollection Tags => new TagCollection(repositoryInstance.Tags);
         public IReferenceCollection Refs => new ReferenceCollection(repositoryInstance.Refs);
         public IBranchCollection Branches => new BranchCollection(repositoryInstance.Branches);

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -118,14 +118,15 @@ namespace GitVersion
 
             var reference = refs.First();
             var canonicalName = reference.CanonicalName;
+            var referenceName = ReferenceName.Parse(reference.CanonicalName);
             log.Info($"Found remote tip '{canonicalName}' pointing at the commit '{headTipSha}'.");
 
-            if (canonicalName.StartsWith("refs/tags"))
+            if (referenceName.IsTag)
             {
                 log.Info($"Checking out tag '{canonicalName}'");
                 Checkout(reference.Target.Sha);
             }
-            else if (canonicalName.StartsWith("refs/pull/") || canonicalName.StartsWith("refs/pull-requests/"))
+            else if (referenceName.IsPullRequest)
             {
                 var fakeBranchName = canonicalName.Replace("refs/pull/", "refs/heads/pull/").Replace("refs/pull-requests/", "refs/heads/pull-requests/");
 
@@ -153,15 +154,15 @@ namespace GitVersion
                 var message = ex.Message;
                 if (message.Contains("401"))
                 {
-                    throw new Exception("Unauthorized: Incorrect username/password");
+                    throw new Exception("Unauthorized: Incorrect username/password", ex);
                 }
                 if (message.Contains("403"))
                 {
-                    throw new Exception("Forbidden: Possibly Incorrect username/password");
+                    throw new Exception("Forbidden: Possibly Incorrect username/password", ex);
                 }
                 if (message.Contains("404"))
                 {
-                    throw new Exception("Not found: The repository was not found");
+                    throw new Exception("Not found: The repository was not found", ex);
                 }
 
                 throw new Exception("There was an unknown problem with the Git repository you provided", ex);

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using GitVersion.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GitVersion
@@ -82,12 +81,12 @@ namespace GitVersion
                 return gitVersionOptions.WorkingDirectory;
             }
 
-            var _dotGitDirectory = GitRepository.Discover(gitVersionOptions.WorkingDirectory);
+            var gitDirectory = GitRepository.Discover(gitVersionOptions.WorkingDirectory);
 
-            if (string.IsNullOrEmpty(_dotGitDirectory))
+            if (string.IsNullOrEmpty(gitDirectory))
                 throw new DirectoryNotFoundException("Cannot find the .git directory");
 
-            return new GitRepository(new NullLog(), _dotGitDirectory).WorkingDirectory;
+            return new GitRepository(gitDirectory).WorkingDirectory;
         }
 
         private string? GetGitRootPath()
@@ -102,7 +101,8 @@ namespace GitVersion
         {
             try
             {
-                return new GitRepository(new NullLog(), possiblePath).AnyMatchingRemote(targetUrl);
+                var gitRepository = new GitRepository(possiblePath);
+                return gitRepository.Remotes.Any(r => r.Url == targetUrl);
             }
             catch (Exception)
             {

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
@@ -1,0 +1,23 @@
+using GitVersion.Helpers;
+
+namespace GitVersion
+{
+    public class RefSpec : IRefSpec
+    {
+        private static readonly LambdaEqualityHelper<IRefSpec> equalityHelper = new(x => x.Specification);
+        private static readonly LambdaKeyComparer<IRefSpec, string> comparerHelper = new(x => x.Specification);
+
+        private readonly LibGit2Sharp.RefSpec innerRefSpec;
+
+        internal RefSpec(LibGit2Sharp.RefSpec refSpec) => innerRefSpec = refSpec;
+        public int CompareTo(IRefSpec other) => comparerHelper.Compare(this, other);
+        public bool Equals(IRefSpec other) => equalityHelper.Equals(this, other);
+        public override bool Equals(object obj) => Equals((obj as IRefSpec)!);
+        public override int GetHashCode() => equalityHelper.GetHashCode(this);
+        public override string ToString() => Specification;
+        public string Specification => innerRefSpec.Specification;
+        public RefSpecDirection Direction => (RefSpecDirection)innerRefSpec.Direction;
+        public string Source => innerRefSpec.Source;
+        public string Destination => innerRefSpec.Destination;
+    }
+}

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitVersion
+{
+    internal sealed class RefSpecCollection : IRefSpecCollection
+    {
+        private readonly LibGit2Sharp.RefSpecCollection innerCollection;
+        internal RefSpecCollection(LibGit2Sharp.RefSpecCollection collection) => innerCollection = collection;
+        public IEnumerator<IRefSpec> GetEnumerator()
+        {
+            return innerCollection.Select(tag => new RefSpec(tag)).GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/GitVersion.LibGit2Sharp/Git/Reference.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Reference.cs
@@ -15,8 +15,10 @@ namespace GitVersion
         {
             innerReference = reference;
             Name = new ReferenceName(reference.CanonicalName);
+            DirectReferenceTargetId = new ObjectId(directReference.Target.Id);
         }
         public ReferenceName Name { get; }
+        public IObjectId DirectReferenceTargetId { get; }
         public int CompareTo(IReference other) => comparerHelper.Compare(this, other);
         public override bool Equals(object obj) => Equals((obj as IReference)!);
         public bool Equals(IReference other) => equalityHelper.Equals(this, other);
@@ -24,7 +26,6 @@ namespace GitVersion
         public override string ToString() => Name.ToString();
         public string TargetIdentifier => innerReference.TargetIdentifier;
         public string DirectReferenceTargetIdentifier => directReference.TargetIdentifier;
-        public IObjectId DirectReferenceTargetId => new ObjectId(directReference.Target.Id);
         public static implicit operator LibGit2Sharp.Reference(Reference d) => d.innerReference;
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Reference.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Reference.cs
@@ -9,23 +9,23 @@ namespace GitVersion
         private static readonly LambdaKeyComparer<IReference, string> comparerHelper = new(x => x.Name.Canonical);
 
         internal readonly LibGit2Sharp.Reference innerReference;
-        private DirectReference directReference => innerReference.ResolveToDirectReference();
 
         internal Reference(LibGit2Sharp.Reference reference)
         {
             innerReference = reference;
             Name = new ReferenceName(reference.CanonicalName);
-            DirectReferenceTargetId = new ObjectId(directReference.Target.Id);
+
+            if (reference is DirectReference)
+                ReferenceTargetId = new ObjectId(reference.TargetIdentifier);
         }
         public ReferenceName Name { get; }
-        public IObjectId DirectReferenceTargetId { get; }
+        public IObjectId? ReferenceTargetId { get; }
         public int CompareTo(IReference other) => comparerHelper.Compare(this, other);
         public override bool Equals(object obj) => Equals((obj as IReference)!);
         public bool Equals(IReference other) => equalityHelper.Equals(this, other);
         public override int GetHashCode() => equalityHelper.GetHashCode(this);
         public override string ToString() => Name.ToString();
         public string TargetIdentifier => innerReference.TargetIdentifier;
-        public string DirectReferenceTargetIdentifier => directReference.TargetIdentifier;
         public static implicit operator LibGit2Sharp.Reference(Reference d) => d.innerReference;
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Remote.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Remote.cs
@@ -19,5 +19,6 @@ namespace GitVersion
         public override string ToString() => Name;
         public string Name => innerRemote.Name;
         public string RefSpecs => string.Join(", ", innerRemote.FetchRefSpecs.Select(r => r.Specification));
+        public string Url => innerRemote.Url;
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Remote.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Remote.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using GitVersion.Helpers;
 
@@ -18,7 +19,20 @@ namespace GitVersion
         public override int GetHashCode() => equalityHelper.GetHashCode(this);
         public override string ToString() => Name;
         public string Name => innerRemote.Name;
-        public string RefSpecs => string.Join(", ", innerRemote.FetchRefSpecs.Select(r => r.Specification));
         public string Url => innerRemote.Url;
+
+        public IEnumerable<IRefSpec> RefSpecs
+        {
+            get
+            {
+                var refSpecs = innerRemote.RefSpecs;
+                return refSpecs is null
+                    ? Enumerable.Empty<IRefSpec>()
+                    : new RefSpecCollection((LibGit2Sharp.RefSpecCollection)refSpecs);
+            }
+        }
+        public IEnumerable<IRefSpec> FetchRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Fetch);
+
+        public IEnumerable<IRefSpec> PushRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Push);
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
@@ -28,5 +28,9 @@ namespace GitVersion
         {
             innerCollection.Remove(remoteName);
         }
+        public void Update(string remoteName, string refSpec)
+        {
+            innerCollection.Update(remoteName, r => r.FetchRefSpecs.Add(refSpec));
+        }
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
@@ -23,5 +23,10 @@ namespace GitVersion
                 return remote is null ? null : new Remote(remote);
             }
         }
+
+        public void Remove(string remoteName)
+        {
+            innerCollection.Remove(remoteName);
+        }
     }
 }

--- a/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
+++ b/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
@@ -7,6 +7,7 @@ namespace GitVersion
         public void RegisterTypes(IServiceCollection services)
         {
             services.AddSingleton<IGitRepository, GitRepository>();
+            services.AddSingleton<IMutatingGitRepository, GitRepository>();
             services.AddSingleton<IGitRepositoryInfo, GitRepositoryInfo>();
         }
     }

--- a/src/GitVersionCore.Tests/Core/DynamicRepositoryTests.cs
+++ b/src/GitVersionCore.Tests/Core/DynamicRepositoryTests.cs
@@ -83,13 +83,13 @@ namespace GitVersionCore.Tests
             });
 
             var gitPreparer = sp.GetService<IGitPreparer>();
-            gitPreparer.Prepare();
+            gitPreparer?.Prepare();
 
             var gitVersionCalculator = sp.GetService<IGitVersionCalculateTool>();
 
-            var versionVariables = gitVersionCalculator.CalculateVersionVariables();
+            var versionVariables = gitVersionCalculator?.CalculateVersionVariables();
 
-            Assert.AreEqual(expectedFullSemVer, versionVariables.FullSemVer);
+            Assert.AreEqual(expectedFullSemVer, versionVariables?.FullSemVer);
         }
     }
 }

--- a/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersionCore.Tests/Core/GitVersionExecutorTests.cs
@@ -27,7 +27,6 @@ namespace GitVersionCore.Tests
         private IFileSystem fileSystem;
         private ILog log;
         private IGitVersionCache gitVersionCache;
-        private IGitPreparer gitPreparer;
         private IServiceProvider sp;
 
         [Test]
@@ -470,27 +469,6 @@ namespace GitVersionCore.Tests
         }
 
         [Test]
-        public void DynamicRepositoriesShouldNotErrorWithFailedToFindGitDirectory()
-        {
-            using var fixture = new EmptyRepositoryFixture();
-            fixture.Repository.MakeACommit();
-
-            var gitVersionOptions = new GitVersionOptions
-            {
-                WorkingDirectory = fixture.RepositoryPath,
-                RepositoryInfo =
-                {
-                    TargetUrl = "https://github.com/GitTools/GitVersion.git",
-                    TargetBranch = "refs/head/master"
-                }
-            };
-
-            var gitVersionCalculator = GetGitVersionCalculator(gitVersionOptions, repository: fixture.Repository.ToGitRepository());
-            gitPreparer.Prepare();
-            gitVersionCalculator.CalculateVersionVariables();
-        }
-
-        [Test]
         public void GetDotGitDirectoryNoWorktree()
         {
             using var fixture = new EmptyRepositoryFixture();
@@ -577,7 +555,6 @@ namespace GitVersionCore.Tests
             fileSystem = sp.GetService<IFileSystem>();
             log = sp.GetService<ILog>();
             gitVersionCache = sp.GetService<IGitVersionCache>();
-            gitPreparer = sp.GetService<IGitPreparer>();
 
             return sp.GetService<IGitVersionCalculateTool>();
         }

--- a/src/GitVersionCore.Tests/Core/RepositoryStoreTests.cs
+++ b/src/GitVersionCore.Tests/Core/RepositoryStoreTests.cs
@@ -11,11 +11,11 @@ using Shouldly;
 namespace GitVersionCore.Tests
 {
     [TestFixture]
-    public class RepositoryMetadataProviderTests : TestBase
+    public class RepositoryStoreTests : TestBase
     {
         private readonly ILog log;
 
-        public RepositoryMetadataProviderTests()
+        public RepositoryStoreTests()
         {
             var sp = ConfigureServices();
             log = sp.GetService<ILog>();
@@ -63,7 +63,7 @@ namespace GitVersionCore.Tests
 
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
-            var gitRepoMetadataProvider = new RepositoryMetadataProvider(log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(log, fixtureRepository);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 
@@ -119,7 +119,7 @@ namespace GitVersionCore.Tests
 
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
-            var gitRepoMetadataProvider = new RepositoryMetadataProvider(log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(log, fixtureRepository);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 
@@ -194,7 +194,7 @@ namespace GitVersionCore.Tests
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
 
-            var gitRepoMetadataProvider = new RepositoryMetadataProvider(log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(log, fixtureRepository);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 

--- a/src/GitVersionCore/Core/Abstractions/IGitPreparer.cs
+++ b/src/GitVersionCore/Core/Abstractions/IGitPreparer.cs
@@ -3,5 +3,6 @@ namespace GitVersion
     public interface IGitPreparer
     {
         void Prepare();
+        void EnsureLocalBranchExistsForCurrentBranch(IRemote remote, string currentBranch);
     }
 }

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryMetadataProvider.cs
@@ -40,7 +40,6 @@ namespace GitVersion.Common
         IEnumerable<Tuple<ITag, SemanticVersion>> GetValidVersionTags(string tagPrefixRegex, DateTimeOffset? olderThan = null);
 
         bool GetMatchingCommitBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
-        string ShortenObjectId(ICommit commit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);
 
         int GetNumberOfUncommittedChanges();

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryStore.cs
@@ -5,7 +5,7 @@ using GitVersion.VersionCalculation;
 
 namespace GitVersion.Common
 {
-    public interface IRepositoryMetadataProvider
+    public interface IRepositoryStore
     {
         /// <summary>
         /// Find the merge base of the two branches, i.e. the best common ancestor of the two branches' tips.

--- a/src/GitVersionCore/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersionCore/Core/Abstractions/IRepositoryStore.cs
@@ -39,7 +39,7 @@ namespace GitVersion.Common
         IEnumerable<SemanticVersion> GetVersionTagsOnBranch(IBranch branch, string tagPrefixRegex);
         IEnumerable<Tuple<ITag, SemanticVersion>> GetValidVersionTags(string tagPrefixRegex, DateTimeOffset? olderThan = null);
 
-        bool GetMatchingCommitBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
+        bool IsCommitOnBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);
 
         int GetNumberOfUncommittedChanges();

--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -16,20 +16,20 @@ namespace GitVersion
         private readonly IMutatingGitRepository repository;
         private readonly IOptions<GitVersionOptions> options;
         private readonly IGitRepositoryInfo repositoryInfo;
-        private readonly IRepositoryMetadataProvider repositoryMetadataProvider;
+        private readonly IRepositoryStore repositoryStore;
         private readonly ICurrentBuildAgent buildAgent;
 
         private const string DefaultRemoteName = "origin";
 
         public GitPreparer(ILog log, IEnvironment environment, ICurrentBuildAgent buildAgent, IOptions<GitVersionOptions> options,
-            IMutatingGitRepository repository, IGitRepositoryInfo repositoryInfo, IRepositoryMetadataProvider repositoryMetadataProvider)
+            IMutatingGitRepository repository, IGitRepositoryInfo repositoryInfo, IRepositoryStore repositoryStore)
         {
             this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
             this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.repositoryInfo = repositoryInfo ?? throw new ArgumentNullException(nameof(repositoryInfo));
-            this.repositoryMetadataProvider = repositoryMetadataProvider ?? throw new ArgumentNullException(nameof(repositoryMetadataProvider));
+            this.repositoryStore = repositoryStore ?? throw new ArgumentNullException(nameof(repositoryStore));
             this.buildAgent = buildAgent;
         }
 
@@ -184,7 +184,7 @@ namespace GitVersion
                 EnsureLocalBranchExistsForCurrentBranch(remote, currentBranchName);
                 CreateOrUpdateLocalBranchesFromRemoteTrackingOnes(remote.Name);
 
-                var currentBranch = repositoryMetadataProvider.FindBranch(currentBranchName);
+                var currentBranch = repositoryStore.FindBranch(currentBranchName);
                 // Bug fix for https://github.com/GitTools/GitVersion/issues/1754, head maybe have been changed
                 // if this is a dynamic repository. But only allow this in case the branches are different (branch switch)
                 if (expectedSha != repository.Head.Tip.Sha &&

--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -322,19 +322,19 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                 if (repo.Refs.Any(x => x.Name.Equals(referenceName)))
                 {
                     var localRef = repo.Refs[localCanonicalName];
-                    if (localRef.DirectReferenceTargetIdentifier == remoteTrackingReference.DirectReferenceTargetIdentifier)
+                    if (localRef.TargetIdentifier == remoteTrackingReference.TargetIdentifier)
                     {
                         log.Info($"Skipping update of '{remoteTrackingReference.Name.Canonical}' as it already matches the remote ref.");
                         continue;
                     }
-                    var remoteRefTipId = remoteTrackingReference.DirectReferenceTargetId;
+                    var remoteRefTipId = remoteTrackingReference.ReferenceTargetId;
                     log.Info($"Updating local ref '{localRef.Name.Canonical}' to point at {remoteRefTipId}.");
                     repo.Refs.UpdateTarget(localRef, remoteRefTipId);
                     continue;
                 }
 
                 log.Info($"Creating local branch from remote tracking '{remoteTrackingReference.Name.Canonical}'.");
-                repo.Refs.Add(localCanonicalName, remoteTrackingReference.DirectReferenceTargetIdentifier, true);
+                repo.Refs.Add(localCanonicalName, remoteTrackingReference.TargetIdentifier, true);
 
                 var branch = repo.Branches[branchName];
                 repo.Branches.UpdateTrackedBranch(branch, remoteTrackingReferenceName);

--- a/src/GitVersionCore/Core/GitPreparer.cs
+++ b/src/GitVersionCore/Core/GitPreparer.cs
@@ -176,7 +176,8 @@ namespace GitVersion
                 }
                 else
                 {
-                    log.Info($"Fetching from remote '{remote.Name}' using the following refspecs: {remote.RefSpecs}.");
+                    var refSpecs = string.Join(", ", remote.FetchRefSpecs.Select(r => r.Specification));
+                    log.Info($"Fetching from remote '{remote.Name}' using the following refspecs: {refSpecs}.");
                     repository.Fetch(remote.Name, Enumerable.Empty<string>(), authentication, null);
                 }
 

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -94,11 +94,6 @@ namespace GitVersion
             }
         }
 
-        public ICommit FindMergeBase(ICommit commit, ICommit mainlineTip)
-        {
-            return repository.FindMergeBase(commit, mainlineTip);
-        }
-
         public ICommit GetCurrentCommit(IBranch currentBranch, string commitId)
         {
             ICommit currentCommit = null;
@@ -501,6 +496,8 @@ namespace GitVersion
 
             return commitCollection.FirstOrDefault(c => c.Parents.Contains(findMergeBase));
         }
+
+        public ICommit FindMergeBase(ICommit commit, ICommit mainlineTip) => repository.FindMergeBase(commit, mainlineTip);
 
         public int GetNumberOfUncommittedChanges() => repository.GetNumberOfUncommittedChanges();
     }

--- a/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
+++ b/src/GitVersionCore/Core/RepositoryMetadataProvider.cs
@@ -423,11 +423,6 @@ namespace GitVersion
             return repository.Commits.QueryBy(filter);
         }
 
-        public string ShortenObjectId(ICommit commit)
-        {
-            return repository.ShortenObjectId(commit);
-        }
-
         public VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context)
         {
             return IncrementStrategyFinder.DetermineIncrementedField(repository, context, baseVersion);

--- a/src/GitVersionCore/Core/RepositoryStore.cs
+++ b/src/GitVersionCore/Core/RepositoryStore.cs
@@ -10,7 +10,7 @@ using GitVersion.VersionCalculation;
 
 namespace GitVersion
 {
-    public class RepositoryMetadataProvider : IRepositoryMetadataProvider
+    public class RepositoryStore : IRepositoryStore
     {
         private readonly Dictionary<IBranch, List<BranchCommit>> mergeBaseCommitsCache = new();
         private readonly Dictionary<Tuple<IBranch, IBranch>, ICommit> mergeBaseCache = new();
@@ -20,7 +20,7 @@ namespace GitVersion
         private readonly ILog log;
         private readonly IGitRepository repository;
 
-        public RepositoryMetadataProvider(ILog log, IGitRepository repository)
+        public RepositoryStore(ILog log, IGitRepository repository)
         {
             this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.repository = repository ?? throw new ArgumentNullException(nameof(log));

--- a/src/GitVersionCore/Core/RepositoryStore.cs
+++ b/src/GitVersionCore/Core/RepositoryStore.cs
@@ -423,7 +423,7 @@ namespace GitVersion
             return IncrementStrategyFinder.DetermineIncrementedField(repository, context, baseVersion);
         }
 
-        public bool GetMatchingCommitBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit)
+        public bool IsCommitOnBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit)
         {
             var filter = new CommitFilter
             {

--- a/src/GitVersionCore/Git/ICommit.cs
+++ b/src/GitVersionCore/Git/ICommit.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 
 namespace GitVersion
 {
-    public interface ICommit : IEquatable<ICommit>, IComparable<ICommit>
+    public interface ICommit : IEquatable<ICommit>, IComparable<ICommit>, IGitObject
     {
         IEnumerable<ICommit> Parents { get; }
-        string Sha { get; }
-        IObjectId Id { get; }
         DateTimeOffset When { get; }
         string Message { get; }
     }

--- a/src/GitVersionCore/Git/ICommitCollection.cs
+++ b/src/GitVersionCore/Git/ICommitCollection.cs
@@ -6,6 +6,6 @@ namespace GitVersion
     public interface ICommitCollection : IEnumerable<ICommit>
     {
         IEnumerable<ICommit> GetCommitsPriorTo(DateTimeOffset olderThan);
-        ICommitCollection QueryBy(CommitFilter commitFilter);
+        IEnumerable<ICommit> QueryBy(CommitFilter commitFilter);
     }
 }

--- a/src/GitVersionCore/Git/IGitObject.cs
+++ b/src/GitVersionCore/Git/IGitObject.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GitVersion
+{
+    public interface IGitObject : IEquatable<IGitObject>, IComparable<IGitObject>
+    {
+        IObjectId Id { get; }
+        string Sha { get; }
+    }
+}

--- a/src/GitVersionCore/Git/IGitRepository.cs
+++ b/src/GitVersionCore/Git/IGitRepository.cs
@@ -16,16 +16,13 @@ namespace GitVersion
         IRemoteCollection Remotes { get; }
 
         int GetNumberOfUncommittedChanges();
-        string ShortenObjectId(ICommit commit);
 
-        void CleanupDuplicateOrigin(string remoteName);
         IRemote EnsureOnlyOneRemoteIsDefined();
         ICommit FindMergeBase(ICommit commit, ICommit otherCommit);
+        void CreateBranchForPullRequestBranch(AuthenticationInfo auth);
 
         void Checkout(string commitOrBranchSpec);
-        void Checkout(IBranch branch);
         void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage);
-        void CreateBranchForPullRequestBranch(AuthenticationInfo auth);
-        string Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth);
+        void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth);
     }
 }

--- a/src/GitVersionCore/Git/IGitRepository.cs
+++ b/src/GitVersionCore/Git/IGitRepository.cs
@@ -15,23 +15,12 @@ namespace GitVersion
         ICommitCollection Commits { get; }
         IRemoteCollection Remotes { get; }
 
-        IGitRepository CreateNew(string gitRootPath);
-
         int GetNumberOfUncommittedChanges();
         string ShortenObjectId(ICommit commit);
 
-        void CleanupDuplicateOrigin(string gitRootPath, string remoteName);
-        bool GetMatchingCommitBranch(ICommit baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
+        void CleanupDuplicateOrigin(string remoteName);
         IRemote EnsureOnlyOneRemoteIsDefined();
         ICommit FindMergeBase(ICommit commit, ICommit otherCommit);
-        ICommit GetBaseVersionSource(ICommit currentBranchTip);
-        ICommit GetForwardMerge(ICommit commitToFindCommonBase, ICommit findMergeBase);
-
-        IEnumerable<ICommit> GetCommitsReacheableFrom(ICommit commit, IBranch branch);
-        IEnumerable<ICommit> GetMergeBaseCommits(ICommit mergeCommit, ICommit mergedHead, ICommit findMergeBase);
-        IEnumerable<ICommit> GetMainlineCommitLog(ICommit baseVersionSource, ICommit mainlineTip);
-        IEnumerable<ICommit> GetCommitsReacheableFromHead(ICommit headCommit);
-        IEnumerable<ICommit> GetCommitLog(ICommit baseVersionSource, ICommit currentCommit);
 
         void Checkout(string commitOrBranchSpec);
         void Checkout(IBranch branch);

--- a/src/GitVersionCore/Git/IGitRepository.cs
+++ b/src/GitVersionCore/Git/IGitRepository.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
-
 namespace GitVersion
 {
-    public interface IGitRepository : IDisposable
+    public interface IGitRepository
     {
         string Path { get; }
         string WorkingDirectory { get; }
@@ -17,10 +14,5 @@ namespace GitVersion
 
         ICommit FindMergeBase(ICommit commit, ICommit otherCommit);
         int GetNumberOfUncommittedChanges();
-        void CreateBranchForPullRequestBranch(AuthenticationInfo auth);
-
-        void Checkout(string commitOrBranchSpec);
-        void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage);
-        void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth);
     }
 }

--- a/src/GitVersionCore/Git/IGitRepository.cs
+++ b/src/GitVersionCore/Git/IGitRepository.cs
@@ -15,10 +15,8 @@ namespace GitVersion
         ICommitCollection Commits { get; }
         IRemoteCollection Remotes { get; }
 
-        int GetNumberOfUncommittedChanges();
-
-        IRemote EnsureOnlyOneRemoteIsDefined();
         ICommit FindMergeBase(ICommit commit, ICommit otherCommit);
+        int GetNumberOfUncommittedChanges();
         void CreateBranchForPullRequestBranch(AuthenticationInfo auth);
 
         void Checkout(string commitOrBranchSpec);

--- a/src/GitVersionCore/Git/IMutatingGitRepository.cs
+++ b/src/GitVersionCore/Git/IMutatingGitRepository.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace GitVersion
+{
+    public interface IMutatingGitRepository : IGitRepository
+    {
+        void CreateBranchForPullRequestBranch(AuthenticationInfo auth);
+        void Checkout(string commitOrBranchSpec);
+        void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage);
+        void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth);
+    }
+}

--- a/src/GitVersionCore/Git/IRefSpec.cs
+++ b/src/GitVersionCore/Git/IRefSpec.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace GitVersion
+{
+    public interface IRefSpec : IEquatable<IRefSpec>, IComparable<IRefSpec>
+    {
+        string Specification { get; }
+        RefSpecDirection Direction { get; }
+        string Source { get; }
+        string Destination { get; }
+    }
+
+    public enum RefSpecDirection
+    {
+        Fetch,
+        Push
+    }
+}

--- a/src/GitVersionCore/Git/IRefSpec.cs
+++ b/src/GitVersionCore/Git/IRefSpec.cs
@@ -9,10 +9,4 @@ namespace GitVersion
         string Source { get; }
         string Destination { get; }
     }
-
-    public enum RefSpecDirection
-    {
-        Fetch,
-        Push
-    }
 }

--- a/src/GitVersionCore/Git/IRefSpecCollection.cs
+++ b/src/GitVersionCore/Git/IRefSpecCollection.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace GitVersion
+{
+    public interface IRefSpecCollection : IEnumerable<IRefSpec>
+    {
+    }
+}

--- a/src/GitVersionCore/Git/IReference.cs
+++ b/src/GitVersionCore/Git/IReference.cs
@@ -5,7 +5,6 @@ namespace GitVersion
     public interface IReference : IEquatable<IReference>, IComparable<IReference>, INamedReference
     {
         string TargetIdentifier { get; }
-        string DirectReferenceTargetIdentifier { get; }
-        IObjectId DirectReferenceTargetId { get; }
+        IObjectId ReferenceTargetId { get; }
     }
 }

--- a/src/GitVersionCore/Git/IRemote.cs
+++ b/src/GitVersionCore/Git/IRemote.cs
@@ -6,5 +6,6 @@ namespace GitVersion
     {
         string Name { get; }
         string RefSpecs { get; }
+        string Url { get; }
     }
 }

--- a/src/GitVersionCore/Git/IRemote.cs
+++ b/src/GitVersionCore/Git/IRemote.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Collections.Generic;
 
 namespace GitVersion
 {
     public interface IRemote : IEquatable<IRemote>, IComparable<IRemote>
     {
         string Name { get; }
-        string RefSpecs { get; }
         string Url { get; }
+
+        IEnumerable<IRefSpec> RefSpecs { get; }
+        IEnumerable<IRefSpec> FetchRefSpecs { get; }
+        IEnumerable<IRefSpec> PushRefSpecs { get; }
     }
 }

--- a/src/GitVersionCore/Git/IRemoteCollection.cs
+++ b/src/GitVersionCore/Git/IRemoteCollection.cs
@@ -6,5 +6,6 @@ namespace GitVersion
     {
         IRemote this[string name] { get; }
         void Remove(string remoteName);
+        void Update(string remoteName, string refSpec);
     }
 }

--- a/src/GitVersionCore/Git/IRemoteCollection.cs
+++ b/src/GitVersionCore/Git/IRemoteCollection.cs
@@ -5,5 +5,6 @@ namespace GitVersion
     public interface IRemoteCollection : IEnumerable<IRemote>
     {
         IRemote this[string name] { get; }
+        void Remove(string remoteName);
     }
 }

--- a/src/GitVersionCore/Git/RefSpecDirection.cs
+++ b/src/GitVersionCore/Git/RefSpecDirection.cs
@@ -1,0 +1,8 @@
+namespace GitVersion
+{
+    public enum RefSpecDirection
+    {
+        Fetch,
+        Push
+    }
+}

--- a/src/GitVersionCore/Git/ReferenceName.cs
+++ b/src/GitVersionCore/Git/ReferenceName.cs
@@ -11,19 +11,28 @@ namespace GitVersion
         private const string LocalBranchPrefix = "refs/heads/";
         private const string RemoteTrackingBranchPrefix = "refs/remotes/";
         private const string TagPrefix = "refs/tags/";
+        private const string PullRequestPrefix1 = "refs/pull/";
+        private const string PullRequestPrefix2 = "refs/pull-requests/";
 
         public ReferenceName(string canonical)
         {
             Canonical = canonical ?? throw new ArgumentNullException(nameof(canonical));
             Friendly = Shorten();
             WithoutRemote = RemoveRemote();
+
+            IsBranch = IsPrefixedBy(Canonical, LocalBranchPrefix);
+            IsRemoteBranch = IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix);
+            IsTag = IsPrefixedBy(Canonical, TagPrefix);
+            IsPullRequest = IsPrefixedBy(Canonical, PullRequestPrefix1) || IsPrefixedBy(Canonical, PullRequestPrefix2);
         }
 
         public static ReferenceName Parse(string canonicalName)
         {
             if (IsPrefixedBy(canonicalName, LocalBranchPrefix)
                 || IsPrefixedBy(canonicalName, RemoteTrackingBranchPrefix)
-                || IsPrefixedBy(canonicalName, TagPrefix))
+                || IsPrefixedBy(canonicalName, TagPrefix)
+                || IsPrefixedBy(canonicalName, PullRequestPrefix1)
+                || IsPrefixedBy(canonicalName, PullRequestPrefix2))
             {
                 return new ReferenceName(canonicalName);
             }
@@ -32,6 +41,10 @@ namespace GitVersion
         public string Canonical { get; }
         public string Friendly { get; }
         public string WithoutRemote { get; }
+        public bool IsBranch { get; }
+        public bool IsRemoteBranch { get; }
+        public bool IsTag { get; }
+        public bool IsPullRequest { get; }
 
         public bool Equals(ReferenceName other) => equalityHelper.Equals(this, other);
         public int CompareTo(ReferenceName other) => comparerHelper.Compare(this, other);

--- a/src/GitVersionCore/GitVersionCoreModule.cs
+++ b/src/GitVersionCore/GitVersionCoreModule.cs
@@ -44,7 +44,7 @@ namespace GitVersion
 
             services.AddSingleton<IBuildAgentResolver, BuildAgentResolver>();
             services.AddSingleton<IGitPreparer, GitPreparer>();
-            services.AddSingleton<IRepositoryMetadataProvider, RepositoryMetadataProvider>();
+            services.AddSingleton<IRepositoryStore, RepositoryStore>();
 
             services.AddSingleton<IOutputGenerator, OutputGenerator>();
             services.AddSingleton<IGitVersionInfoGenerator, GitVersionInfoGenerator>();

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -10,15 +10,15 @@ namespace GitVersion.VersionCalculation
     public class BaseVersionCalculator : IBaseVersionCalculator
     {
         private readonly ILog log;
-        private readonly IRepositoryMetadataProvider repositoryMetadataProvider;
+        private readonly IRepositoryStore repositoryStore;
         private readonly IVersionStrategy[] strategies;
         private readonly Lazy<GitVersionContext> versionContext;
         private GitVersionContext context => versionContext.Value;
 
-        public BaseVersionCalculator(ILog log, IRepositoryMetadataProvider repositoryMetadataProvider, Lazy<GitVersionContext> versionContext, IEnumerable<IVersionStrategy> strategies)
+        public BaseVersionCalculator(ILog log, IRepositoryStore repositoryStore, Lazy<GitVersionContext> versionContext, IEnumerable<IVersionStrategy> strategies)
         {
             this.log = log ?? throw new ArgumentNullException(nameof(log));
-            this.repositoryMetadataProvider = repositoryMetadataProvider ?? throw new ArgumentNullException(nameof(repositoryMetadataProvider));
+            this.repositoryStore = repositoryStore ?? throw new ArgumentNullException(nameof(repositoryStore));
             this.strategies = strategies?.ToArray() ?? Array.Empty<IVersionStrategy>();
             this.versionContext = versionContext ?? throw new ArgumentNullException(nameof(versionContext));
         }
@@ -37,7 +37,7 @@ namespace GitVersion.VersionCalculation
                 var versions = allVersions
                     .Select(baseVersion => new Versions
                     {
-                        IncrementedVersion = repositoryMetadataProvider.MaybeIncrement(baseVersion, context),
+                        IncrementedVersion = repositoryStore.MaybeIncrement(baseVersion, context),
                         Version = baseVersion
                     })
                     .ToList();
@@ -125,7 +125,7 @@ namespace GitVersion.VersionCalculation
                         baseVersion.Version.Source,
                         baseVersion.Version.ShouldIncrement,
                         baseVersion.Version.SemanticVersion,
-                        repositoryMetadataProvider.FindMergeBase(parents[0], parents[1]),
+                        repositoryStore.FindMergeBase(parents[0], parents[1]),
                         baseVersion.Version.BranchNameOverride);
                 }
             }
@@ -134,7 +134,7 @@ namespace GitVersion.VersionCalculation
         private bool ReleaseBranchExistsInRepo()
         {
             var releaseBranchConfig = context.FullConfiguration.GetReleaseBranchConfig();
-            var releaseBranches = repositoryMetadataProvider.GetReleaseBranches(releaseBranchConfig);
+            var releaseBranches = repositoryStore.GetReleaseBranches(releaseBranchConfig);
             return releaseBranches.Any();
         }
 

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/FallbackVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/FallbackVersionStrategy.cs
@@ -11,11 +11,11 @@ namespace GitVersion.VersionCalculation
     /// </summary>
     public class FallbackVersionStrategy : VersionStrategyBase
     {
-        private readonly IRepositoryMetadataProvider repositoryMetadataProvider;
+        private readonly IRepositoryStore repositoryStore;
 
-        public FallbackVersionStrategy(IRepositoryMetadataProvider repositoryMetadataProvider, Lazy<GitVersionContext> versionContext) : base(versionContext)
+        public FallbackVersionStrategy(IRepositoryStore repositoryStore, Lazy<GitVersionContext> versionContext) : base(versionContext)
         {
-            this.repositoryMetadataProvider = repositoryMetadataProvider;
+            this.repositoryStore = repositoryStore;
         }
         public override IEnumerable<BaseVersion> GetVersions()
         {
@@ -25,7 +25,7 @@ namespace GitVersion.VersionCalculation
                 throw new GitVersionException("No commits found on the current branch.");
             }
 
-            var baseVersionSource = repositoryMetadataProvider.GetBaseVersionSource(currentBranchTip);
+            var baseVersionSource = repositoryStore.GetBaseVersionSource(currentBranchTip);
 
             yield return new BaseVersion("Fallback base version", false, new SemanticVersion(minor: 1), baseVersionSource, null);
         }

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -12,11 +12,11 @@ namespace GitVersion.VersionCalculation
     /// </summary>
     public class TaggedCommitVersionStrategy : VersionStrategyBase
     {
-        private readonly IRepositoryMetadataProvider repositoryMetadataProvider;
+        private readonly IRepositoryStore repositoryStore;
 
-        public TaggedCommitVersionStrategy(IRepositoryMetadataProvider repositoryMetadataProvider, Lazy<GitVersionContext> versionContext) : base(versionContext)
+        public TaggedCommitVersionStrategy(IRepositoryStore repositoryStore, Lazy<GitVersionContext> versionContext) : base(versionContext)
         {
-            this.repositoryMetadataProvider = repositoryMetadataProvider ?? throw new ArgumentNullException(nameof(repositoryMetadataProvider));
+            this.repositoryStore = repositoryStore ?? throw new ArgumentNullException(nameof(repositoryStore));
         }
 
         public override IEnumerable<BaseVersion> GetVersions()
@@ -26,7 +26,7 @@ namespace GitVersion.VersionCalculation
 
         internal IEnumerable<BaseVersion> GetTaggedVersions(IBranch currentBranch, DateTimeOffset? olderThan)
         {
-            var allTags = repositoryMetadataProvider.GetValidVersionTags(Context.Configuration.GitTagPrefix, olderThan);
+            var allTags = repositoryStore.GetValidVersionTags(Context.Configuration.GitTagPrefix, olderThan);
 
             var taggedCommits = currentBranch
                 .Commits

--- a/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchNameVersionStrategy.cs
@@ -13,11 +13,11 @@ namespace GitVersion.VersionCalculation
     /// </summary>
     public class VersionInBranchNameVersionStrategy : VersionStrategyBase
     {
-        private IRepositoryMetadataProvider repositoryMetadataProvider;
+        private IRepositoryStore repositoryStore;
 
-        public VersionInBranchNameVersionStrategy(IRepositoryMetadataProvider repositoryMetadataProvider, Lazy<GitVersionContext> versionContext) : base(versionContext)
+        public VersionInBranchNameVersionStrategy(IRepositoryStore repositoryStore, Lazy<GitVersionContext> versionContext) : base(versionContext)
         {
-            this.repositoryMetadataProvider = repositoryMetadataProvider ?? throw new ArgumentNullException(nameof(repositoryMetadataProvider));
+            this.repositoryStore = repositoryStore ?? throw new ArgumentNullException(nameof(repositoryStore));
         }
 
         public override IEnumerable<BaseVersion> GetVersions()
@@ -38,7 +38,7 @@ namespace GitVersion.VersionCalculation
             var versionInBranch = GetVersionInBranch(branchName, tagPrefixRegex);
             if (versionInBranch != null)
             {
-                var commitBranchWasBranchedFrom = repositoryMetadataProvider.FindCommitBranchWasBranchedFrom(currentBranch, Context.FullConfiguration);
+                var commitBranchWasBranchedFrom = repositoryStore.FindCommitBranchWasBranchedFrom(currentBranch, Context.FullConfiguration);
                 var branchNameOverride = branchName.RegexReplace("[-/]" + versionInBranch.Item1, string.Empty);
                 yield return new BaseVersion("Version in branch name", false, versionInBranch.Item2, commitBranchWasBranchedFrom.Commit, branchNameOverride);
             }

--- a/src/GitVersionCore/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersionCore/VersionCalculation/IncrementStrategyFinder.cs
@@ -105,11 +105,11 @@ namespace GitVersion
         {
             if (baseCommit == null) yield break;
 
-            IEnumerable<ICommit> commitCache = intermediateCommitCache;
+            var commitCache = intermediateCommitCache;
 
             if (commitCache == null || !Equals(commitCache.LastOrDefault(), headCommit))
             {
-                commitCache = repo.GetCommitsReacheableFromHead(headCommit);
+                commitCache = GetCommitsReacheableFromHead(repo, headCommit).ToList();
                 intermediateCommitCache = commitCache;
             }
 
@@ -130,6 +130,17 @@ namespace GitVersion
             if (patchRegex.IsMatch(message)) return VersionField.Patch;
             if (none.IsMatch(message)) return VersionField.None;
             return null;
+        }
+
+        private static IEnumerable<ICommit> GetCommitsReacheableFromHead(IGitRepository repo, ICommit headCommit)
+        {
+            var filter = new CommitFilter
+            {
+                IncludeReachableFrom = headCommit,
+                SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse
+            };
+
+            return repo.Commits.QueryBy(filter);
         }
     }
 }

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -89,7 +89,7 @@ namespace GitVersion.VersionCalculation
             var commitsSinceTag = commitLog.Count();
             log.Info($"{commitsSinceTag} commits found between {baseVersionSource} and {context.CurrentCommit}");
 
-            var shortSha = repositoryMetadataProvider.ShortenObjectId(context.CurrentCommit);
+            var shortSha = context.CurrentCommit.Id.ToString(7);
             return new SemanticVersionBuildMetaData(
                 baseVersionSource.Sha,
                 commitsSinceTag,

--- a/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/MainlineVersionCalculator.cs
@@ -147,7 +147,7 @@ namespace GitVersion.VersionCalculation
             }
 
             // prefer a branch on which the merge base was a direct commit, if there is such a branch
-            var firstMatchingCommitBranch = possibleMainlineBranches.FirstOrDefault(b => repositoryStore.GetMatchingCommitBranch(baseVersionSource, b, firstMatchingCommit));
+            var firstMatchingCommitBranch = possibleMainlineBranches.FirstOrDefault(b => repositoryStore.IsCommitOnBranch(baseVersionSource, b, firstMatchingCommit));
             if (firstMatchingCommitBranch != null)
             {
                 var message = string.Format(

--- a/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -12,18 +12,18 @@ namespace GitVersion.VersionCalculation
         private readonly ILog log;
         private readonly IBaseVersionCalculator baseVersionCalculator;
         private readonly IMainlineVersionCalculator mainlineVersionCalculator;
-        private readonly IRepositoryMetadataProvider repositoryMetadataProvider;
+        private readonly IRepositoryStore repositoryStore;
         private readonly Lazy<GitVersionContext> versionContext;
         private GitVersionContext context => versionContext.Value;
 
         public NextVersionCalculator(ILog log, IBaseVersionCalculator baseVersionCalculator,
-            IMainlineVersionCalculator mainlineVersionCalculator, IRepositoryMetadataProvider repositoryMetadataProvider,
+            IMainlineVersionCalculator mainlineVersionCalculator, IRepositoryStore repositoryStore,
             Lazy<GitVersionContext> versionContext)
         {
             this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.baseVersionCalculator = baseVersionCalculator ?? throw new ArgumentNullException(nameof(baseVersionCalculator));
             this.mainlineVersionCalculator = mainlineVersionCalculator ?? throw new ArgumentNullException(nameof(mainlineVersionCalculator));
-            this.repositoryMetadataProvider = repositoryMetadataProvider ?? throw new ArgumentNullException(nameof(repositoryMetadataProvider));
+            this.repositoryStore = repositoryStore ?? throw new ArgumentNullException(nameof(repositoryStore));
             this.versionContext = versionContext ?? throw new ArgumentNullException(nameof(versionContext));
         }
 
@@ -95,7 +95,7 @@ namespace GitVersion.VersionCalculation
         private SemanticVersion PerformIncrement(BaseVersion baseVersion)
         {
             var semver = baseVersion.SemanticVersion;
-            var increment = repositoryMetadataProvider.DetermineIncrementedField(baseVersion, context);
+            var increment = repositoryStore.DetermineIncrementedField(baseVersion, context);
             if (increment != null)
             {
                 semver = semver.IncrementVersion(increment.Value);
@@ -110,7 +110,7 @@ namespace GitVersion.VersionCalculation
 
             int? number = null;
 
-            var lastTag = repositoryMetadataProvider
+            var lastTag = repositoryStore
                 .GetVersionTagsOnBranch(context.CurrentBranch, context.Configuration.GitTagPrefix)
                 .FirstOrDefault(v => v.PreReleaseTag.Name.IsEquivalentTo(tagToUse));
 


### PR DESCRIPTION
In this PR I have moved the code from `GitRepository` to `RepositoryMetadataProvider` and `GitPreparer`, and kept the `GitRepository` as a thin layer on top of the libgit2sharp. It now exposes only the Collections of commits, branches, references, tags, the head. All the other methods were moved to `RepositoryMetadataProvider` and some to `GitPreparer`. Renamed `RepositoryMetadataProvider` to `RepositoryStore` (shorter and it's kind of a store, maybe we need a better name for this).

I also made the `IGitRepository` expose its properties for quering the git for needed information, and the methods that were mutating were moved to `IMutatingGitRepository` that extends  `IGitRepository`.  `IMutatingGitRepository` is used only by `GitPreparer`, as only this class is mutating the git repository.

The dependencies now look like:
`IRepositoryStore -> IGitRepository` (read only), where the `IGitRepository` is only exposing the collections and `IRepositoryStore` is actually the store

`IGitPreparer -> IMutatingGitRepository` (read/write) - where `IMutatingGitRepository` expose methods for clone, checkout, and so on.

