### PR TITLE
Quote GitVersionFileExe for profile paths with spaces.

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -18,13 +18,13 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Full' Or '$(MSBuildRuntimeType)' == 'Mono'">
-        <GitVersionFileExe>$(MSBuildThisFileDirectory)net48/gitversion.exe</GitVersionFileExe>
-        <GitVersionAssemblyFile>$(MSBuildThisFileDirectory)net48/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
+        <GitVersionFileExe>&quot;$(MSBuildThisFileDirectory)net48/gitversion.exe&quot;</GitVersionFileExe>
+        <GitVersionAssemblyFile>&quot;$(MSBuildThisFileDirectory)net48/GitVersion.MsBuild.dll&quot;</GitVersionAssemblyFile>
     </PropertyGroup>
 
     <PropertyGroup>
         <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$(MSBuildThisFileDirectory)netcoreapp3.1/gitversion.dll&quot;</GitVersionFileExe>
-        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
+        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">&quot;$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll&quot;</GitVersionAssemblyFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -19,12 +19,12 @@
 
     <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Full' Or '$(MSBuildRuntimeType)' == 'Mono'">
         <GitVersionFileExe>&quot;$(MSBuildThisFileDirectory)net48/gitversion.exe&quot;</GitVersionFileExe>
-        <GitVersionAssemblyFile>&quot;$(MSBuildThisFileDirectory)net48/GitVersion.MsBuild.dll&quot;</GitVersionAssemblyFile>
+        <GitVersionAssemblyFile>$(MSBuildThisFileDirectory)net48/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
 
     <PropertyGroup>
         <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$(MSBuildThisFileDirectory)netcoreapp3.1/gitversion.dll&quot;</GitVersionFileExe>
-        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">&quot;$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll&quot;</GitVersionAssemblyFile>
+        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$(MSBuildThisFileDirectory)netcoreapp3.1/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -6,7 +6,7 @@
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
     <Target Name="RunGitVersion">
-        <Exec Command="&quot;$(GitVersionFileExe)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
+        <Exec Command="$(GitVersionFileExe) &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
     <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -6,7 +6,7 @@
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
     <Target Name="RunGitVersion">
-        <Exec Command="$(GitVersionFileExe) &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
+        <Exec Command="&quot;$(GitVersionFileExe)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
     <Target Name="WriteVersionInfoToBuildLog" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="$(WriteVersionInfoToBuildLog) == 'true'">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GitVersion.MsBuild 5.6.4 breaks my build because my profile directory includes spaces in it.

```text
Rebuild started...
1>------ Rebuild All started: Project: TestProject.CLI, Configuration: Release Any CPU ------
1>'C:\Users\abc' is not recognized as an internal or external command,
1>operable program or batch file.
1>C:\Users\abc 123\.nuget\packages\gitversion.msbuild\5.6.4\tools\GitVersion.MsBuild.targets(9,9): error MSB3073: The command "C:\Users\abc 123\.nuget\packages\gitversion.msbuild\5.6.4\tools\net48/gitversion.exe "c:\Builds\git.repos\TestProject.CLI\TestProject.CLI" -output file -outputfile obj\gitversion.json" exited with code 9009.
1>Done building project "TestProject.CLI.csproj" -- FAILED.
========== Rebuild All: 0 succeeded, 1 failed, 0 skipped ==========
```

## Related Issue
Fixes #2555 Fixes #2540 #2541 (Duplicate of #2558)

## Motivation and Context
It solves profile paths with spaces because my username on my machine has spaces.

## How Has This Been Tested?
Manually modified the file GitVersion.MsBuild.targets inside the NuGet Packages folder.

* Tested with Visual Studio 2019
* Tested with `dotnet build`

## Screenshots (if appropriate):
Hmm... 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
