### PR TITLE
(GH-2456) Correctly assert version number for tagged commit

### DIFF
--- a/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
+++ b/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
@@ -15,6 +15,18 @@ namespace GitVersion.App.Tests
     public class TagCheckoutInBuildAgentTests
     {
         [Test]
+        public async Task VerifyTagCheckoutOnAzurePipelines()
+        {
+            var env = new Dictionary<string, string>
+            {
+                { AzurePipelines.EnvironmentVariableName, "true" },
+                { "BUILD_SOURCEBRANCH", "refs/tags/0.2.0" },
+            };
+
+            await VerifyTagCheckoutVersionIsCalculatedProperly(env);
+        }
+
+        [Test]
         public async Task VerifyTagCheckoutOnGitHubActions()
         {
             var env = new Dictionary<string, string>
@@ -23,6 +35,11 @@ namespace GitVersion.App.Tests
                 { "GITHUB_REF", "ref/tags/0.2.0" },
             };
 
+            await VerifyTagCheckoutVersionIsCalculatedProperly(env);
+        }
+
+        private static async Task VerifyTagCheckoutVersionIsCalculatedProperly(Dictionary<string, string> env)
+        {
             using var fixture = new EmptyRepositoryFixture();
             var remoteRepositoryPath = PathHelper.GetTempPath();
             RepositoryFixtureBase.Init(remoteRepositoryPath);

--- a/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
+++ b/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GitTools.Testing;
+using GitVersion.BuildAgents;
+using GitVersion.Core.Tests.Helpers;
+using LibGit2Sharp;
+using NUnit.Framework;
+using Shouldly;
+
+namespace GitVersion.App.Tests
+{
+    [TestFixture]
+    public class TagCheckoutInBuildAgentTests
+    {
+        [Test]
+        public async Task VerifyTagCheckoutOnGitHubActions()
+        {
+            var env = new Dictionary<string, string>
+            {
+                { GitHubActions.EnvironmentVariableName, "true" },
+                { "GITHUB_REF", "ref/tags/0.2.0" },
+            };
+
+            using var fixture = new EmptyRepositoryFixture();
+            var remoteRepositoryPath = PathHelper.GetTempPath();
+            RepositoryFixtureBase.Init(remoteRepositoryPath);
+            using (var remoteRepository = new Repository(remoteRepositoryPath))
+            {
+                remoteRepository.Config.Set("user.name", "Test");
+                remoteRepository.Config.Set("user.email", "test@email.com");
+                fixture.Repository.Network.Remotes.Add("origin", remoteRepositoryPath);
+                Console.WriteLine("Created git repository at {0}", remoteRepositoryPath);
+                remoteRepository.MakeATaggedCommit("0.1.0");
+                Commands.Checkout(remoteRepository, remoteRepository.CreateBranch("develop"));
+                remoteRepository.MakeACommit();
+                Commands.Checkout(remoteRepository, remoteRepository.CreateBranch("release/0.2.0"));
+                remoteRepository.MakeACommit();
+                Commands.Checkout(remoteRepository, TestBase.MainBranch);
+                remoteRepository.MergeNoFF("release/0.2.0", Generate.SignatureNow());
+                remoteRepository.MakeATaggedCommit("0.2.0");
+
+                Commands.Fetch((Repository)fixture.Repository, "origin", new string[0], new FetchOptions(), null);
+                Commands.Checkout(fixture.Repository, "0.2.0");
+            }
+
+            var programFixture = new ProgramFixture(fixture.RepositoryPath);
+            programFixture.WithEnv(env.ToArray());
+
+            var result = await programFixture.Run();
+
+            result.ExitCode.ShouldBe(0);
+            result.OutputVariables.FullSemVer.ShouldBe("0.2.0");
+
+            // Cleanup repository files
+            DirectoryHelper.DeleteDirectory(remoteRepositoryPath);
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -56,6 +56,7 @@ namespace GitVersion.VersionCalculation
             }
 
             var baseVersion = baseVersionCalculator.GetBaseVersion();
+            baseVersion.SemanticVersion.BuildMetaData = mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
             SemanticVersion semver;
             if (context.Configuration.VersioningMode == VersioningMode.Mainline)
             {
@@ -63,8 +64,15 @@ namespace GitVersion.VersionCalculation
             }
             else
             {
-                semver = PerformIncrement(baseVersion);
-                semver.BuildMetaData = mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
+                if (taggedSemanticVersion?.BuildMetaData == null || (taggedSemanticVersion.BuildMetaData.Sha != baseVersion.SemanticVersion.BuildMetaData.Sha))
+                {
+                    semver = PerformIncrement(baseVersion);
+                    semver.BuildMetaData = mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
+                }
+                else
+                {
+                    semver = baseVersion.SemanticVersion;
+                }
             }
 
             var hasPreReleaseTag = semver.PreReleaseTag.HasTag();


### PR DESCRIPTION
## Description

When running on a CI system, like GitHub Actions, when building a tagged commit, rather than asserting something like `0.2.0`, which is expected, GitVersion asserts a version number like `0.3.0-tags-0-2-0-0001`.  An example of this can be seen here:

https://github.com/cake-contrib/Cake.StrongNameSigner/runs/1779759425?check_suite_focus=true#step:5:217

A fix has been made to the code to only increment the semantic version number when on a tagged commit, if the current sha of the repository is different to the sha of the tagged semantic version.

This was discussed on a Twitch stream with @arturcic 

## Related Issue

#2456 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I have tested this code locally on my machine, and added unit tests to cover the code that has been changed.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
