### PR TITLE
Allow custom assembly attributes; only override version attributes.

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -37,7 +37,9 @@
         <!-- Property that enables UpdateAssemblyInfo. -->
         <UpdateAssemblyInfo Condition=" '$(DisableGitVersionTask)' == 'true' ">false</UpdateAssemblyInfo>
         <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == '' ">true</UpdateAssemblyInfo>
-        <GenerateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == 'true' ">false</GenerateAssemblyInfo>
+        <GenerateAssemblyFileVersionAttribute Condition=" '$(UpdateAssemblyInfo)' == 'true' ">false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute Condition=" '$(UpdateAssemblyInfo)' == 'true' ">false</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateAssemblyVersionAttribute Condition=" '$(UpdateAssemblyInfo)' == 'true' ">false</GenerateAssemblyVersionAttribute>
 
         <!-- Property that enables GenerateGitVersionInformation -->
         <GenerateGitVersionInformation Condition=" '$(DisableGitVersionTask)' == 'true' ">false</GenerateGitVersionInformation>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this change users of GitVersion.MsBuild are able to set assembly attributes without having to disable GitVersion's assembly information update target.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This resolves #2501.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
GitVersion.MsBuild was disabling an MSBuild property that various MSBuild SDKs utilize to automatically generate the assembly info file. Instead of disabling it altogether this change ensures that only the version attributes are disabled for automatic generation. GitVersion.MsBuild will then "inject" its own version information, without changing (or removing) any other assembly attribute information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been manually adjusting the changed files in my local NuGet cache.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
