### PR TITLE
#2578: Retry some file reads and writes to avoid 'file in use' on gitversion.json

### DIFF
--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -330,7 +330,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                     }
                     var remoteRefTipId = remoteTrackingReference.ReferenceTargetId;
                     log.Info($"Updating local ref '{localRef.Name.Canonical}' to point at {remoteRefTipId}.");
-                    repository.Refs.UpdateTarget(localRef, remoteRefTipId, log);
+                    new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, remoteRefTipId), maxRetries: 6).ExecuteAsync().Wait();
                     continue;
                 }
 
@@ -383,7 +383,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                 log.Info(isBranch ? $"Updating local branch {referenceName} to point at {repoTip}"
                     : $"Updating local branch {referenceName} to match ref {currentBranch}");
                 var localRef = repository.Refs[localCanonicalName];
-                repository.Refs.UpdateTarget(localRef, repoTipId, log);
+                new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, repoTipId), maxRetries: 6).ExecuteAsync().Wait();
             }
 
             repository.Checkout(localCanonicalName);

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -330,7 +330,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                     }
                     var remoteRefTipId = remoteTrackingReference.ReferenceTargetId;
                     log.Info($"Updating local ref '{localRef.Name.Canonical}' to point at {remoteRefTipId}.");
-                    new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, remoteRefTipId), maxRetries: 6).ExecuteAsync().Wait();
+                    new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, remoteRefTipId)).ExecuteAsync().Wait();
                     continue;
                 }
 
@@ -383,7 +383,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                 log.Info(isBranch ? $"Updating local branch {referenceName} to point at {repoTip}"
                     : $"Updating local branch {referenceName} to match ref {currentBranch}");
                 var localRef = repository.Refs[localCanonicalName];
-                new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, repoTipId), maxRetries: 6).ExecuteAsync().Wait();
+                new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => repository.Refs.UpdateTarget(localRef, repoTipId)).ExecuteAsync().Wait();
             }
 
             repository.Checkout(localCanonicalName);

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using GitVersion.Common;
 using GitVersion.Extensions;
+using GitVersion.Helpers;
 using GitVersion.Logging;
 using GitVersion.Model.Configuration;
 using Microsoft.Extensions.Options;
@@ -329,7 +330,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                     }
                     var remoteRefTipId = remoteTrackingReference.ReferenceTargetId;
                     log.Info($"Updating local ref '{localRef.Name.Canonical}' to point at {remoteRefTipId}.");
-                    repository.Refs.UpdateTarget(localRef, remoteRefTipId);
+                    repository.Refs.UpdateTarget(localRef, remoteRefTipId, log);
                     continue;
                 }
 
@@ -382,7 +383,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
                 log.Info(isBranch ? $"Updating local branch {referenceName} to point at {repoTip}"
                     : $"Updating local branch {referenceName} to match ref {currentBranch}");
                 var localRef = repository.Refs[localCanonicalName];
-                repository.Refs.UpdateTarget(localRef, repoTipId);
+                repository.Refs.UpdateTarget(localRef, repoTipId, log);
             }
 
             repository.Checkout(localCanonicalName);

--- a/src/GitVersion.Core/Core/ThreadSleep.cs
+++ b/src/GitVersion.Core/Core/ThreadSleep.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace GitVersion
 {
-    internal class ThreadSleep : IThreadSleep
+    public class ThreadSleep : IThreadSleep
     {
         public async Task SleepAsync(int milliseconds)
         {

--- a/src/GitVersion.Core/Git/IReferenceCollection.cs
+++ b/src/GitVersion.Core/Git/IReferenceCollection.cs
@@ -1,5 +1,3 @@
-using GitVersion.Logging;
-using System;
 using System.Collections.Generic;
 
 namespace GitVersion
@@ -13,10 +11,4 @@ namespace GitVersion
         IEnumerable<IReference> FromGlob(string prefix);
     }
 
-    public class LockedFileException : Exception
-    {
-        public LockedFileException(Exception inner) : base(inner.Message, inner)
-        {
-        }
-    }
 }

--- a/src/GitVersion.Core/Git/IReferenceCollection.cs
+++ b/src/GitVersion.Core/Git/IReferenceCollection.cs
@@ -1,4 +1,5 @@
 using GitVersion.Logging;
+using System;
 using System.Collections.Generic;
 
 namespace GitVersion
@@ -8,7 +9,14 @@ namespace GitVersion
         IReference Head { get; }
         IReference this[string name] { get; }
         void Add(string name, string canonicalRefNameOrObjectish, bool allowOverwrite = false);
-        void UpdateTarget(IReference directRef, IObjectId targetId, ILog log);
+        void UpdateTarget(IReference directRef, IObjectId targetId);
         IEnumerable<IReference> FromGlob(string prefix);
+    }
+
+    public class LockedFileException : Exception
+    {
+        public LockedFileException(Exception inner) : base(inner.Message, inner)
+        {
+        }
     }
 }

--- a/src/GitVersion.Core/Git/IReferenceCollection.cs
+++ b/src/GitVersion.Core/Git/IReferenceCollection.cs
@@ -1,3 +1,4 @@
+using GitVersion.Logging;
 using System.Collections.Generic;
 
 namespace GitVersion
@@ -7,7 +8,7 @@ namespace GitVersion
         IReference Head { get; }
         IReference this[string name] { get; }
         void Add(string name, string canonicalRefNameOrObjectish, bool allowOverwrite = false);
-        void UpdateTarget(IReference directRef, IObjectId targetId);
+        void UpdateTarget(IReference directRef, IObjectId targetId, ILog log);
         IEnumerable<IReference> FromGlob(string prefix);
     }
 }

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -8,6 +8,7 @@
         <PackageId>GitVersion.Core</PackageId>
         <Title>GitVersion</Title>
         <Description>Derives SemVer information from a repository following GitFlow or GitHubFlow. This is the Core library which both GitVersion cli and Task use allowing programatic usage of GitVersion.</Description>
+        
         <Product>$(AssemblyName)</Product>
     </PropertyGroup>
 

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -8,10 +8,15 @@
         <PackageId>GitVersion.Core</PackageId>
         <Title>GitVersion</Title>
         <Description>Derives SemVer information from a repository following GitFlow or GitHubFlow. This is the Core library which both GitVersion cli and Task use allowing programatic usage of GitVersion.</Description>
-
         <Product>$(AssemblyName)</Product>
     </PropertyGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>GitVersion.LibGit2Sharp</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+    
     <ItemGroup>
         <PackageReference Include="System.Net.Requests" Version="4.3.0" />
 

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -12,12 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>GitVersion.LibGit2Sharp</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
-    
-    <ItemGroup>
         <PackageReference Include="System.Net.Requests" Version="4.3.0" />
 
         <PackageReference Include="JetBrains.Annotations" Version="$(PackageVersion_JetBrainsAnnotations)" PrivateAssets="All" />

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -8,7 +8,7 @@
         <PackageId>GitVersion.Core</PackageId>
         <Title>GitVersion</Title>
         <Description>Derives SemVer information from a repository following GitFlow or GitHubFlow. This is the Core library which both GitVersion cli and Task use allowing programatic usage of GitVersion.</Description>
-        
+
         <Product>$(AssemblyName)</Product>
     </PropertyGroup>
 

--- a/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
+++ b/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
@@ -5,7 +5,7 @@ using GitVersion.Logging;
 
 namespace GitVersion.Helpers
 {
-    internal class OperationWithExponentialBackoff<T> : OperationWithExponentialBackoff<T, bool> where T : Exception
+    public class OperationWithExponentialBackoff<T> : OperationWithExponentialBackoff<T, bool> where T : Exception
     {
         public OperationWithExponentialBackoff(IThreadSleep threadSleep, ILog log, Action operation, int maxRetries = 5)
             : base(threadSleep, log, () => { operation(); return false; }, maxRetries)
@@ -18,7 +18,7 @@ namespace GitVersion.Helpers
 
 
     }
-    internal class OperationWithExponentialBackoff<T, Result> where T : Exception
+    public class OperationWithExponentialBackoff<T, Result> where T : Exception
     {
         private readonly IThreadSleep threadSleep;
         private readonly ILog log;

--- a/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
+++ b/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
@@ -31,7 +31,7 @@ namespace GitVersion.Helpers
                 throw new ArgumentOutOfRangeException(nameof(maxRetries));
 
             this.threadSleep = threadSleep ?? throw new ArgumentNullException(nameof(threadSleep));
-            this.log = log;
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.operation = operation;
             this.maxRetries = maxRetries;
         }

--- a/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
+++ b/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
@@ -11,11 +11,11 @@ namespace GitVersion.Helpers
             : base(threadSleep, log, () => { operation(); return false; }, maxRetries)
         {
         }
+
         public new Task ExecuteAsync()
         {
             return base.ExecuteAsync();
         }
-
 
     }
     public class OperationWithExponentialBackoff<T, Result> where T : Exception

--- a/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
+++ b/src/GitVersion.Core/Helpers/OperationWithExponentialBackoff.cs
@@ -16,7 +16,6 @@ namespace GitVersion.Helpers
         {
             return base.ExecuteAsync();
         }
-
     }
     public class OperationWithExponentialBackoff<T, Result> where T : Exception
     {

--- a/src/GitVersion.Core/Model/Exceptions/LockedFileException.cs
+++ b/src/GitVersion.Core/Model/Exceptions/LockedFileException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GitVersion
+{
+    public class LockedFileException : Exception
+    {
+        public LockedFileException(Exception inner) : base(inner.Message, inner)
+        {
+        }
+    }
+}

--- a/src/GitVersion.Core/Model/VersionVariables.cs
+++ b/src/GitVersion.Core/Model/VersionVariables.cs
@@ -1,3 +1,5 @@
+using GitVersion.Helpers;
+using GitVersion.Logging;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GitVersion.Core/Model/VersionVariables.cs
+++ b/src/GitVersion.Core/Model/VersionVariables.cs
@@ -168,11 +168,9 @@ namespace GitVersion.OutputVariables
 
         public static VersionVariables FromFile(string filePath, IFileSystem fileSystem, ILog log)
         {
-            var retryOperation = new OperationWithExponentialBackoff<IOException, VersionVariables>(new ThreadSleep(), null, () => FromFileInternal(filePath, fileSystem));
-
+            var retryOperation = new OperationWithExponentialBackoff<IOException, VersionVariables>(new ThreadSleep(), log, () => FromFileInternal(filePath, fileSystem));
             var versionVariables = retryOperation.ExecuteAsync().Result;
             return versionVariables;
-
         }
         private static VersionVariables FromFileInternal(string filePath, IFileSystem fileSystem)
         {

--- a/src/GitVersion.Core/Model/VersionVariables.cs
+++ b/src/GitVersion.Core/Model/VersionVariables.cs
@@ -166,7 +166,7 @@ namespace GitVersion.OutputVariables
 
         public static VersionVariables FromFile(string filePath, IFileSystem fileSystem, ILog log)
         {
-            var retryOperation = new OperationWithExponentialBackoff<IOException, VersionVariables>(new ThreadSleep(), null, () => FromFileInternal(filePath, fileSystem), maxRetries: 6);
+            var retryOperation = new OperationWithExponentialBackoff<IOException, VersionVariables>(new ThreadSleep(), null, () => FromFileInternal(filePath, fileSystem));
 
             var versionVariables = retryOperation.ExecuteAsync().Result;
             return versionVariables;

--- a/src/GitVersion.Core/VersionCalculation/Cache/GitVersionCache.cs
+++ b/src/GitVersion.Core/VersionCalculation/Cache/GitVersionCache.cs
@@ -74,7 +74,7 @@ namespace GitVersion.VersionCalculation.Cache
                 {
                     try
                     {
-                        var loadedVariables = VersionVariables.FromFile(cacheFileName, fileSystem);
+                        var loadedVariables = VersionVariables.FromFile(cacheFileName, fileSystem, log);
                         return loadedVariables;
                     }
                     catch (Exception ex)

--- a/src/GitVersion.Core/VersionConverters/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Core/VersionConverters/OutputGenerator/OutputGenerator.cs
@@ -23,7 +23,7 @@ namespace GitVersion.VersionConverters.OutputGenerator
         public OutputGenerator(ICurrentBuildAgent buildAgent, IConsole console, ILog log, IFileSystem fileSystem, IOptions<GitVersionOptions> options)
         {
             this.console = console ?? throw new ArgumentNullException(nameof(console));
-            this.log = log;
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.buildAgent = buildAgent;

--- a/src/GitVersion.Core/VersionConverters/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Core/VersionConverters/OutputGenerator/OutputGenerator.cs
@@ -38,7 +38,7 @@ namespace GitVersion.VersionConverters.OutputGenerator
             }
             if (gitVersionOptions.Output.Contains(OutputType.File))
             {
-                var retryOperation = new OperationWithExponentialBackoff<IOException>(new ThreadSleep(), log, () => fileSystem.WriteAllText(context.OutputFile, variables.ToString()), maxRetries: 6);
+                var retryOperation = new OperationWithExponentialBackoff<IOException>(new ThreadSleep(), log, () => fileSystem.WriteAllText(context.OutputFile, variables.ToString()));
                 retryOperation.ExecuteAsync().Wait();
             }
             if (gitVersionOptions.Output.Contains(OutputType.Json))

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -58,7 +58,7 @@ namespace GitVersion
             {
                 var mergeBase = repositoryInstance.ObjectDatabase.FindMergeBase((Commit)commit, (Commit)otherCommit);
                 return new Commit(mergeBase);
-            }, 6).ExecuteAsync().Result;
+            }).ExecuteAsync().Result;
         }
 
         public int GetNumberOfUncommittedChanges()
@@ -91,7 +91,7 @@ namespace GitVersion
                 DiffTargets.Index | DiffTargets.WorkingDirectory);
 
                 return changes.Count;
-            }, 6).ExecuteAsync().Result;
+            }).ExecuteAsync().Result;
         }
         public void CreateBranchForPullRequestBranch(AuthenticationInfo auth)
         {
@@ -151,7 +151,7 @@ namespace GitVersion
                     var message = $"Remote tip '{canonicalName}' from remote '{remote.Url}' doesn't look like a valid pull request.";
                     throw new WarningException(message);
                 }
-            }, 6).ExecuteAsync().Wait();
+            }).ExecuteAsync().Wait();
         }
         public void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth)
         {
@@ -161,7 +161,7 @@ namespace GitVersion
                 {
                     var path = Repository.Clone(sourceUrl, workdirPath, GetCloneOptions(auth));
                     log.Info($"Returned path after repository clone: {path}");
-                }, 6).ExecuteAsync().Wait();
+                }).ExecuteAsync().Wait();
             }
             catch (LibGit2SharpException ex)
             {
@@ -184,12 +184,12 @@ namespace GitVersion
         }
         public void Checkout(string commitOrBranchSpec)
         {
-            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec), 6).ExecuteAsync().Wait();
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec)).ExecuteAsync().Wait();
         }
 
         public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage)
         {
-            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Fetch((Repository)repositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage), 6).ExecuteAsync().Wait();
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Fetch((Repository)repositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage)).ExecuteAsync().Wait();
         }
         internal static string Discover(string path) => Repository.Discover(path);
 

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GitVersion.Helpers;
 using GitVersion.Logging;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
@@ -53,101 +54,114 @@ namespace GitVersion
 
         public ICommit FindMergeBase(ICommit commit, ICommit otherCommit)
         {
-            var mergeBase = repositoryInstance.ObjectDatabase.FindMergeBase((Commit)commit, (Commit)otherCommit);
-            return new Commit(mergeBase);
+            return new OperationWithExponentialBackoff<LockedFileException, ICommit>(new ThreadSleep(), log, () =>
+            {
+                var mergeBase = repositoryInstance.ObjectDatabase.FindMergeBase((Commit)commit, (Commit)otherCommit);
+                return new Commit(mergeBase);
+            }, 6).ExecuteAsync().Result;
         }
+
         public int GetNumberOfUncommittedChanges()
         {
-            // check if we have a branch tip at all to behave properly with empty repos
-            // => return that we have actually uncomitted changes because we are apparently
-            // running GitVersion on something which lives inside this brand new repo _/\Ö/\_
-            if (repositoryInstance.Head?.Tip == null || repositoryInstance.Diff == null)
+            return new OperationWithExponentialBackoff<LibGit2Sharp.LockedFileException, int>(new ThreadSleep(), log, () =>
             {
-                // this is a somewhat cumbersome way of figuring out the number of changes in the repo
-                // which is more expensive than to use the Diff as it gathers more info, but
-                // we can't use the other method when we are dealing with a new/empty repo
-                try
+                // check if we have a branch tip at all to behave properly with empty repos
+                // => return that we have actually uncomitted changes because we are apparently
+                // running GitVersion on something which lives inside this brand new repo _/\Ö/\_
+                if (repositoryInstance.Head?.Tip == null || repositoryInstance.Diff == null)
                 {
-                    var status = repositoryInstance.RetrieveStatus();
-                    return status.Untracked.Count() + status.Staged.Count();
+                    // this is a somewhat cumbersome way of figuring out the number of changes in the repo
+                    // which is more expensive than to use the Diff as it gathers more info, but
+                    // we can't use the other method when we are dealing with a new/empty repo
+                    try
+                    {
+                        var status = repositoryInstance.RetrieveStatus();
+                        return status.Untracked.Count() + status.Staged.Count();
+                    }
+                    catch (Exception)
+                    {
+                        return int.MaxValue; // this should be somewhat puzzling to see,
+                                             // so we may have reached our goal to show that
+                                             // that repo is really "Dirty"...
+                    }
                 }
-                catch (Exception)
-                {
-                    return int.MaxValue; // this should be somewhat puzzling to see,
-                    // so we may have reached our goal to show that
-                    // that repo is really "Dirty"...
-                }
-            }
 
-            // gets all changes of the last commit vs Staging area and WT
-            var changes = repositoryInstance.Diff.Compare<TreeChanges>(repositoryInstance.Head.Tip.Tree,
+                // gets all changes of the last commit vs Staging area and WT
+                var changes = repositoryInstance.Diff.Compare<TreeChanges>(repositoryInstance.Head.Tip.Tree,
                 DiffTargets.Index | DiffTargets.WorkingDirectory);
 
-            return changes.Count;
+                return changes.Count;
+            }, 6).ExecuteAsync().Result;
         }
         public void CreateBranchForPullRequestBranch(AuthenticationInfo auth)
         {
-            var network = repositoryInstance.Network;
-            var remote = network.Remotes.Single();
-
-            log.Info("Fetching remote refs to see if there is a pull request ref");
-            var credentialsProvider = GetCredentialsProvider(auth);
-            var remoteTips = (credentialsProvider != null
-                    ? network.ListReferences(remote, credentialsProvider)
-                    : network.ListReferences(remote))
-                .Select(r => r.ResolveToDirectReference()).ToList();
-
-            log.Info($"Remote Refs:{System.Environment.NewLine}" + string.Join(System.Environment.NewLine, remoteTips.Select(r => r.CanonicalName)));
-
-            var headTipSha = Head.Tip?.Sha;
-
-            var refs = remoteTips.Where(r => r.TargetIdentifier == headTipSha).ToList();
-
-            if (refs.Count == 0)
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () =>
             {
-                var message = $"Couldn't find any remote tips from remote '{remote.Url}' pointing at the commit '{headTipSha}'.";
-                throw new WarningException(message);
-            }
+                var network = repositoryInstance.Network;
+                var remote = network.Remotes.Single();
 
-            if (refs.Count > 1)
-            {
-                var names = string.Join(", ", refs.Select(r => r.CanonicalName));
-                var message = $"Found more than one remote tip from remote '{remote.Url}' pointing at the commit '{headTipSha}'. Unable to determine which one to use ({names}).";
-                throw new WarningException(message);
-            }
+                log.Info("Fetching remote refs to see if there is a pull request ref");
+                var credentialsProvider = GetCredentialsProvider(auth);
+                var remoteTips = (credentialsProvider != null
+                        ? network.ListReferences(remote, credentialsProvider)
+                        : network.ListReferences(remote))
+                    .Select(r => r.ResolveToDirectReference()).ToList();
 
-            var reference = refs.First();
-            var canonicalName = reference.CanonicalName;
-            var referenceName = ReferenceName.Parse(reference.CanonicalName);
-            log.Info($"Found remote tip '{canonicalName}' pointing at the commit '{headTipSha}'.");
+                log.Info($"Remote Refs:{System.Environment.NewLine}" + string.Join(System.Environment.NewLine, remoteTips.Select(r => r.CanonicalName)));
 
-            if (referenceName.IsTag)
-            {
-                log.Info($"Checking out tag '{canonicalName}'");
-                Checkout(reference.Target.Sha);
-            }
-            else if (referenceName.IsPullRequest)
-            {
-                var fakeBranchName = canonicalName.Replace("refs/pull/", "refs/heads/pull/").Replace("refs/pull-requests/", "refs/heads/pull-requests/");
+                var headTipSha = Head.Tip?.Sha;
 
-                log.Info($"Creating fake local branch '{fakeBranchName}'.");
-                Refs.Add(fakeBranchName, headTipSha);
+                var refs = remoteTips.Where(r => r.TargetIdentifier == headTipSha).ToList();
 
-                log.Info($"Checking local branch '{fakeBranchName}' out.");
-                Checkout(fakeBranchName);
-            }
-            else
-            {
-                var message = $"Remote tip '{canonicalName}' from remote '{remote.Url}' doesn't look like a valid pull request.";
-                throw new WarningException(message);
-            }
+                if (refs.Count == 0)
+                {
+                    var message = $"Couldn't find any remote tips from remote '{remote.Url}' pointing at the commit '{headTipSha}'.";
+                    throw new WarningException(message);
+                }
+
+                if (refs.Count > 1)
+                {
+                    var names = string.Join(", ", refs.Select(r => r.CanonicalName));
+                    var message = $"Found more than one remote tip from remote '{remote.Url}' pointing at the commit '{headTipSha}'. Unable to determine which one to use ({names}).";
+                    throw new WarningException(message);
+                }
+
+                var reference = refs.First();
+                var canonicalName = reference.CanonicalName;
+                var referenceName = ReferenceName.Parse(reference.CanonicalName);
+                log.Info($"Found remote tip '{canonicalName}' pointing at the commit '{headTipSha}'.");
+
+                if (referenceName.IsTag)
+                {
+                    log.Info($"Checking out tag '{canonicalName}'");
+                    Checkout(reference.Target.Sha);
+                }
+                else if (referenceName.IsPullRequest)
+                {
+                    var fakeBranchName = canonicalName.Replace("refs/pull/", "refs/heads/pull/").Replace("refs/pull-requests/", "refs/heads/pull-requests/");
+
+                    log.Info($"Creating fake local branch '{fakeBranchName}'.");
+                    Refs.Add(fakeBranchName, headTipSha);
+
+                    log.Info($"Checking local branch '{fakeBranchName}' out.");
+                    Checkout(fakeBranchName);
+                }
+                else
+                {
+                    var message = $"Remote tip '{canonicalName}' from remote '{remote.Url}' doesn't look like a valid pull request.";
+                    throw new WarningException(message);
+                }
+            }, 6).ExecuteAsync().Wait();
         }
         public void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth)
         {
             try
             {
-                var path = Repository.Clone(sourceUrl, workdirPath, GetCloneOptions(auth));
-                log.Info($"Returned path after repository clone: {path}");
+                new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () =>
+                {
+                    var path = Repository.Clone(sourceUrl, workdirPath, GetCloneOptions(auth));
+                    log.Info($"Returned path after repository clone: {path}");
+                }, 6).ExecuteAsync().Wait();
             }
             catch (LibGit2SharpException ex)
             {
@@ -168,9 +182,15 @@ namespace GitVersion
                 throw new Exception("There was an unknown problem with the Git repository you provided", ex);
             }
         }
-        public void Checkout(string commitOrBranchSpec) => Commands.Checkout(repositoryInstance, commitOrBranchSpec);
-        public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage) =>
-            Commands.Fetch((Repository)repositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage);
+        public void Checkout(string commitOrBranchSpec)
+        {
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec) , 6).ExecuteAsync().Wait();
+        }
+
+        public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage)
+        {
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Fetch((Repository)repositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage), 6).ExecuteAsync().Wait();
+        }
         internal static string Discover(string path) => Repository.Discover(path);
 
         private static FetchOptions GetFetchOptions(AuthenticationInfo auth)

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -81,8 +81,8 @@ namespace GitVersion
                     catch (Exception)
                     {
                         return int.MaxValue; // this should be somewhat puzzling to see,
-                                             // so we may have reached our goal to show that
-                                             // that repo is really "Dirty"...
+                        // so we may have reached our goal to show that
+                        // that repo is really "Dirty"...
                     }
                 }
 
@@ -184,7 +184,7 @@ namespace GitVersion
         }
         public void Checkout(string commitOrBranchSpec)
         {
-            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec) , 6).ExecuteAsync().Wait();
+            new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec), 6).ExecuteAsync().Wait();
         }
 
         public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage)

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -60,7 +60,6 @@ namespace GitVersion
                 return new Commit(mergeBase);
             }).ExecuteAsync().Result;
         }
-
         public int GetNumberOfUncommittedChanges()
         {
             return new OperationWithExponentialBackoff<LibGit2Sharp.LockedFileException, int>(new ThreadSleep(), log, () =>
@@ -68,7 +67,6 @@ namespace GitVersion
                 return GetNumberOfUncommittedChangesInternal();
             }).ExecuteAsync().Result;
         }
-
         private int GetNumberOfUncommittedChangesInternal()
         {
             // check if we have a branch tip at all to behave properly with empty repos
@@ -87,18 +85,17 @@ namespace GitVersion
                 catch (Exception)
                 {
                     return int.MaxValue; // this should be somewhat puzzling to see,
-                                         // so we may have reached our goal to show that
-                                         // that repo is really "Dirty"...
+                    // so we may have reached our goal to show that
+                    // that repo is really "Dirty"...
                 }
             }
 
             // gets all changes of the last commit vs Staging area and WT
             var changes = repositoryInstance.Diff.Compare<TreeChanges>(repositoryInstance.Head.Tip.Tree,
-            DiffTargets.Index | DiffTargets.WorkingDirectory);
+                DiffTargets.Index | DiffTargets.WorkingDirectory);
 
             return changes.Count;
         }
-
         public void CreateBranchForPullRequestBranch(AuthenticationInfo auth)
         {
             new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () =>
@@ -106,7 +103,6 @@ namespace GitVersion
                 CreateBranchForPullRequestBranchInternal(auth);
             }).ExecuteAsync().Wait();
         }
-
         private void CreateBranchForPullRequestBranchInternal(AuthenticationInfo auth)
         {
             var network = repositoryInstance.Network;
@@ -164,7 +160,6 @@ namespace GitVersion
                 throw new WarningException(message);
             }
         }
-
         public void Clone(string sourceUrl, string workdirPath, AuthenticationInfo auth)
         {
             try
@@ -198,7 +193,6 @@ namespace GitVersion
         {
             new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Checkout(repositoryInstance, commitOrBranchSpec)).ExecuteAsync().Wait();
         }
-
         public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string logMessage)
         {
             new OperationWithExponentialBackoff<LockedFileException>(new ThreadSleep(), log, () => Commands.Fetch((Repository)repositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage)).ExecuteAsync().Wait();

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -21,15 +21,10 @@ namespace GitVersion
 
         public void UpdateTarget(IReference directRef, IObjectId targetId)
         {
-            try
+            RepositoryExtensions.RunSafe(() =>
             {
                 innerCollection.UpdateTarget((Reference)directRef, (ObjectId)targetId);
-            }
-            catch (LibGit2Sharp.LockedFileException ex)
-            {
-                // Wrap this exception so that callers that want to catch it don't need to take a dependency on LibGit2Sharp.
-                throw new LockedFileException(ex);
-            }
+            });
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -1,3 +1,5 @@
+using GitVersion.Helpers;
+using GitVersion.Logging;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,9 +21,9 @@ namespace GitVersion
             innerCollection.Add(name, canonicalRefNameOrObjectish, allowOverwrite);
         }
 
-        public void UpdateTarget(IReference directRef, IObjectId targetId)
+        public void UpdateTarget(IReference directRef, IObjectId targetId, ILog log)
         {
-            innerCollection.UpdateTarget((Reference)directRef, (ObjectId)targetId);
+            new OperationWithExponentialBackoff<LibGit2Sharp.LockedFileException>(new ThreadSleep(), log, () => innerCollection.UpdateTarget((Reference)directRef, (ObjectId)targetId), maxRetries: 6).ExecuteAsync().Wait();
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/GitVersion.LibGit2Sharp/RepositoryExtensions.cs
+++ b/src/GitVersion.LibGit2Sharp/RepositoryExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using LibGit2Sharp;
 using Microsoft.Extensions.Options;
 
@@ -7,5 +8,31 @@ namespace GitVersion
     {
         public static IGitRepository ToGitRepository(this IRepository repository) => new GitRepository(repository);
         public static IGitRepositoryInfo ToGitRepositoryInfo(IOptions<GitVersionOptions> options) => new GitRepositoryInfo(options);
+
+        public static void RunSafe(Action operation)
+        {
+            try
+            {
+                operation();
+            }
+            catch (LibGit2Sharp.LockedFileException ex)
+            {
+                // Wrap this exception so that callers that want to catch it don't need to take a dependency on LibGit2Sharp.
+                throw new LockedFileException(ex);
+            }
+        }
+
+        public static T RunSafe<T>(Func<T> operation)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (LibGit2Sharp.LockedFileException ex)
+            {
+                // Wrap this exception so that callers that want to catch it don't need to take a dependency on LibGit2Sharp.
+                throw new LockedFileException(ex);
+            }
+        }
     }
 }

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using GitVersion.Logging;
 using GitVersion.MsBuild.Tasks;
 using GitVersion.OutputVariables;
 using Microsoft.Extensions.Options;
@@ -9,20 +10,22 @@ namespace GitVersion.MsBuild
     public class GitVersionTaskExecutor : IGitVersionTaskExecutor
     {
         private readonly IFileSystem fileSystem;
+        private readonly ILog log;
         private readonly IGitVersionOutputTool gitVersionOutputTool;
         private readonly IOptions<GitVersionOptions> options;
         private VersionVariables versionVariables;
 
-        public GitVersionTaskExecutor(IFileSystem fileSystem, IGitVersionOutputTool gitVersionOutputTool, IOptions<GitVersionOptions> options)
+        public GitVersionTaskExecutor(IFileSystem fileSystem, IGitVersionOutputTool gitVersionOutputTool, IOptions<GitVersionOptions> options, ILog log)
         {
             this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+            this.log = log;
             this.gitVersionOutputTool = gitVersionOutputTool ?? throw new ArgumentNullException(nameof(gitVersionOutputTool));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         public void GetVersion(GetVersion task)
         {
-            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
+            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem, log);
             var outputType = typeof(GetVersion);
             foreach (var variable in versionVariables)
             {
@@ -32,7 +35,7 @@ namespace GitVersion.MsBuild
 
         public void UpdateAssemblyInfo(UpdateAssemblyInfo task)
         {
-            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
+            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem, log);
             FileHelper.DeleteTempFiles();
             if (task.CompileFiles != null) FileHelper.CheckForInvalidFiles(task.CompileFiles, task.ProjectFile);
 
@@ -50,7 +53,7 @@ namespace GitVersion.MsBuild
 
         public void GenerateGitVersionInformation(GenerateGitVersionInformation task)
         {
-            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
+            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem, log);
             var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "GitVersionInformation");
             task.GitVersionInformationFilePath = Path.Combine(fileWriteInfo.WorkingDirectory, fileWriteInfo.FileName);
 
@@ -62,7 +65,7 @@ namespace GitVersion.MsBuild
 
         public void WriteVersionInfoToBuildLog(WriteVersionInfoToBuildLog task)
         {
-            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
+            versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem, log);
             gitVersionOutputTool.OutputVariables(versionVariables, false);
         }
     }

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -18,7 +18,7 @@ namespace GitVersion.MsBuild
         public GitVersionTaskExecutor(IFileSystem fileSystem, IGitVersionOutputTool gitVersionOutputTool, IOptions<GitVersionOptions> options, ILog log)
         {
             this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-            this.log = log;
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.gitVersionOutputTool = gitVersionOutputTool ?? throw new ArgumentNullException(nameof(gitVersionOutputTool));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
         }

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -72,7 +72,7 @@
             <DefineConstants Condition=" '$(GitVersion_PreReleaseTag)' != '' ">GitVersion_PreReleaseTag=$(GitVersion_PreReleaseTag);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseTagWithDash)' != '' ">GitVersion_PreReleaseTagWithDash=$(GitVersion_PreReleaseTagWithDash);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseLabel)' != '' ">GitVersion_PreReleaseLabel=$(GitVersion_PreReleaseLabel);$(DefineConstants)</DefineConstants>
-            <DefineConstants Condition=" '$(GitVersion_PreReleaseLabelWithDash)' != '' ">GitVersion_PreReleaseLabelWithDash=$(GitVersion_PreReleaseLabelWithDash);$(DefineConstants)</DefineConstants>
+            <DefineConstants Condition=" '$(GitVersion_PreReleaseLabelWithDash)' != '' ">GitVersion_PreReleaseLabelWithDash=$(GitVersion_PreReleaseLabeWithDashl);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_PreReleaseNumber)' != '' ">GitVersion_PreReleaseNumber=$(GitVersion_PreReleaseNumber);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_WeightedPreReleaseNumber)' != '' ">GitVersion_WeightedPreReleaseNumber=$(GitVersion_WeightedPreReleaseNumber);$(DefineConstants)</DefineConstants>
             <DefineConstants Condition=" '$(GitVersion_BuildMetaData)' != '' ">GitVersion_BuildMetaData=$(GitVersion_BuildMetaData);$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
## Description
Retry some file reads and writes to avoid 'file in use' on gitversion.json. Up to 6 attempts will be made on any IO exception, with exponential back-off between retries. The contentious operations typically write and read the entire gitversion.json file and tend to be sub-second on typical systems.

Also retry LibGit2Sharp.LockedFileException failures on some GIT operations.

## Related Issue
Closes #2578.
Mitigates #1031.

## Motivation and Context
With multi-targeted projects and solutions with many projects, there is read/write contention on the gitversion.json files, resulting in intermittent failures. See linked issue for one repro.

## How Has This Been Tested?
Used in local builds on our repos. Reproduced failures like this, and confirmed the fix eliminates them. https://github.com/TRUMPF-IoT/cdePlugins/pull/23/checks?check_run_id=1827871101.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
