### PR TITLE
Document installation as .NET global tool

### DIFF
--- a/docs/input/docs/usage/command-line.md
+++ b/docs/input/docs/usage/command-line.md
@@ -5,7 +5,7 @@ Title: Command Line
 
 If you want a command line version installed on your machine then you can use
 [Chocolatey](http://chocolatey.org) or [Homebrew](https://brew.sh/) to install
-GitVersion.
+GitVersion, or you can install it as a .NET global tool.
 
 :::{.alert .alert-info}
 **Hint**
@@ -36,6 +36,23 @@ brew install gitversion
 Switches are available with `gitversion --help`. Even though the documentation
 uses a slash `/` for all switches, you need to use a dash `-` instead, since `/`
 is interpreted as a root path on POSIX based operating systems.
+
+## .NET Global Tool
+
+To install GitVersion as a [.NET global tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-global-tool), type:
+
+```shell
+dotnet tool install -g GitVersion.Tool
+```
+
+To invoke GitVersion as a .NET global tool you need to write
+`dotnet gitversion` or `dotnet-gitversion` instead of `GitVersion.exe`.
+
+Switches are available with `dotnet gitversion -help`
+
+## Mono
+
+To use on mac or linux with Mono, install `mono-complete` then just run `mono GitVersion.exe`
 
 ## Output
 
@@ -133,7 +150,3 @@ To support integration with WiX projects, use `GitVersion.exe /updatewixversionf
 All the [variables](../more-info/variables) are written to
 `GitVersion_WixVersion.wxi` under the current working directory and can be
 referenced in the WiX project files.
-
-## Mono
-
-To use on mac or linux, install `mono-complete` then just run `mono GitVersion.exe`


### PR DESCRIPTION
Added documentation on how to install GitVersion.Tool as a .NET global tool. (Second attempt.)

## Description
Added a section to document the installation of GitVersion.Tool as a .NET global tool.

Moved the section about Mono up as it is yet another alternative to run GitVersion on mac
or linux.

## Related Issue
Closes #2584.

## Motivation and Context
The installation as a .NET global tool was not documented.

## How Has This Been Tested?
Ran doc preview.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
