### PR TITLE
Improve initialization of Language property

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <GitVersionOutputFile>$([MSBuild]::EnsureTrailingSlash($(BaseIntermediateOutputPath)))gitversion.json</GitVersionOutputFile>
 
-        <Language Condition=" '$(Language)' == '' ">C#</Language>
+        <Language Condition=" '$(Language)' == '' Or '$(DefaultLanguageSourceExtension)' == ''">C#</Language>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)/../</SolutionDir>
         <GitVersionPath Condition="'$(GitVersionPath)' == '' And '$(GitVersionUseSolutionDir)' == 'true'">$(SolutionDir)</GitVersionPath>
         <GitVersionPath Condition="'$(GitVersionPath)' == ''">$(MSBuildProjectDirectory)</GitVersionPath>


### PR DESCRIPTION
During regular builds MSBuild initializes `Language` to the language of the currently building project, e.g. C#. However, when
running some targets like `pack` this doesn't happen. Therefore GitVersion has to add a default value for `Language`. Unfortunately `Language` is also an environment variable that GNU gettext uses, so the `pack` target will fail on most Linux systems where that environment variable is set.

This change implements a fix by additionally checking `DefaultLanguageSourceExtension` which gets set by MSBuild at the
same time as `Language`. If that isn't set we can be pretty sure that `Language` didn't get set automatically by MSBuild and can set a default value.

This will cause existing builds to break IF they rely on being able to explicitly set `Language` to a value different from C#. However, I don't think this is a scenario that happens very often, and it can be easily worked around by setting the `DefaultLanguageSourceExtension` property to a non-empty value.

This fixes #2591.
