### PR TITLE
docs: improved regex for conventional commit docs

### DIFF
--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -92,9 +92,9 @@ standard, you can leverage this feature as follows:
 
 ```yaml
 mode: MainLine # Only add this if you want every version to be created automatically on your main branch.
-major-version-bump-message: "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n.*\\n\\n.*BREAKING.*).*"
-minor-version-bump-message: "(feat)(\\([\\w\\s]*\\))?:"
-patch-version-bump-message: "(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:(.*\\n\\n.*\\n\\n.*BREAKING.*){0}"
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s]*\\))?:"
+patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"
 ```
 
 This will ensure that your version gets bumped according to the commits you've created.

--- a/src/GitTools.Testing/GitTestExtensions.cs
+++ b/src/GitTools.Testing/GitTestExtensions.cs
@@ -50,7 +50,7 @@ namespace GitTools.Testing
 
             Commands.Stage(repository, randomFile);
 
-            return repository.Commit($"Test Commit for file '{relativeFileName}' - {commitMessage}",
+            return repository.Commit(commitMessage ?? $"Test Commit for file '{relativeFileName}'",
                 Generate.SignatureNow(), Generate.SignatureNow());
         }
 


### PR DESCRIPTION
Recent documentation updated to show how to use GitVersion with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/.) notation has a few gaps.  This PR is just an incremental improvement.

## Description
- Updated regex expressions to support more cases.
- Additional test scenarios to support.

## Related Issue
Partial feature implementation discussed in this [this PR](https://github.com/GitTools/GitVersion/pull/2553) and  [this issue (closed)](https://github.com/GitTools/GitVersion/issues/2395)

## Motivation and Context
Current docs are incomplete and regex is not consistent with Conventional Commits in some cases.

## How Has This Been Tested?
Updated existing tests, replacing with `TestCase` scenarios for isolation and brevity.
Ran all unit tests in solution successfully.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
