### PR TITLE
Make Microsoft.Build.Utilities.Core package reference private

### DIFF
--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(PackageVersion_MsBuild)"/>
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(PackageVersion_MsBuild)" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.Win32.Registry" Version="$(PackageVersion_MicrosoftExtensions)" PrivateAssets="All"/>
         <PackageReference Include="System.Text.Json" Version="$(PackageVersion_MicrosoftJson)" PrivateAssets="All"/>
         <PackageReference Include="System.Text.Encodings.Web" Version="$(PackageVersion_MicrosoftJson)" PrivateAssets="All"/>


### PR DESCRIPTION
The Microsoft.Build.Utilities.Core package reference should be private to avoid leaking it into projects that use the GitVersion.MsBuild package.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #2642

## Motivation and Context
Without this change, anyone using GitVersion.MsBuild will end up with a reference to Microsoft.Build.Utilities.Core in their project as well, which is not something that the GitVersion.MsBuild package should be forcing on people.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
