### PR TITLE
Fixing #2640 DisableGitVersionTask ineffective

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -5,7 +5,7 @@
     <UsingTask TaskName="WriteVersionInfoToBuildLog" AssemblyFile="$(GitVersionAssemblyFile)"/>
     <UsingTask TaskName="UpdateAssemblyInfo" AssemblyFile="$(GitVersionAssemblyFile)"/>
 
-    <Target Name="RunGitVersion">
+    <Target Name="RunGitVersion" Condition="'$(DisableGitVersionTask)' == 'false'">
         <Exec Command="$(GitVersionFileExe) &quot;$(MSBuildProjectDirectory)&quot; $(GitVersion_ToolArgments)" />
     </Target>
 
@@ -13,7 +13,7 @@
         <WriteVersionInfoToBuildLog SolutionDirectory="$(GitVersionPath)" VersionFile="$(GitVersionOutputFile)" />
     </Target>
 
-    <Target Name="GetVersion" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)">
+    <Target Name="GetVersion" DependsOnTargets="RunGitVersion" BeforeTargets="$(GitVersionTargetsBefore)" Condition="'$(DisableGitVersionTask)' == 'false'">
 
         <GetVersion SolutionDirectory="$(GitVersionPath)" VersionFile="$(GitVersionOutputFile)">
             <Output TaskParameter="Major" PropertyName="GitVersion_Major" />


### PR DESCRIPTION

## Description
Added condition cheking if DisableGitVersionTask == false in GetVersion and RunGitVersion targets

## Related Issue
Fixes #2640

## Motivation and Context
gitversion.exe is being called and fails in some cases despite DisableGitVersionTask is true

## How Has This Been Tested?
Tested manually if gitversion.exe is no longer called while DisableGitVersionTask is true

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
