### PR TITLE
use tag branch name even when the branch has no namespace fixes #2201

### DIFF
--- a/src/GitVersion.Core/Configuration/ConfigExtensions.cs
+++ b/src/GitVersion.Core/Configuration/ConfigExtensions.cs
@@ -131,7 +131,8 @@ namespace GitVersion.Configuration
                 var branchName = branchNameOverride ?? branchFriendlyName;
                 if (!string.IsNullOrWhiteSpace(configuration.BranchPrefixToTrim))
                 {
-                    branchName = branchName.RegexReplace(configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                    var branchNameTrimmed = branchName.RegexReplace(configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                    branchName = string.IsNullOrEmpty(branchNameTrimmed) ? branchName : branchNameTrimmed;
                 }
                 branchName = branchName.RegexReplace("[^a-zA-Z0-9-]", "-");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As suggested in #2201 this fix uses the untrimmed branchname if a trim of the namespace prefix has resulted in an empty tag name, for branches with non namespaces eg 'somebranch" (https://github.com/GitTools/GitVersion/issues/2201#issuecomment-815983599)

## Related Issue
Resolves #2201 

## Motivation and Context
To allow prerelease tags for branches which aren't namespaced

## How Has This Been Tested?
via a new unit test for the scenario(s), old ones are already covered.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
