### PR TITLE
Add global named mutex to prevent concurrent use

### DIFF
--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -57,7 +57,7 @@ namespace GitVersion
 
         private int RunGitVersionTool(GitVersionOptions gitVersionOptions)
         {
-            var mutexName = gitVersionOptions.WorkingDirectory.Replace("\\", "");
+            var mutexName = gitVersionOptions.WorkingDirectory.Replace(Path.DirectorySeparatorChar.ToString(), "");
             using var mutex = new Mutex(true, $@"Global\{mutexName}", out var acquired);
 
             try


### PR DESCRIPTION
When using GitVersion.MsBuild in multiple projects, you can get concurrent invocations of the GitVersion app. This can result in exceptions when normalization is run. This PR attempts to fix this problem by introducing a global mutex to ensure only a single instance of GitVersion is running at a time, per working directory.

## Description
I have added a named mutex in the `GitVersionExecutor.RunGitVersionTool` method, using the `WorkingDirectory` value as the name. Giving it a name along with the `Global\` prefix means that the mutex will be shared across all processes on the machine. 
This ensures that for a given working directory, only one instance of GitVersion will be executing at a time.

NOTE: Mutex names cannot have a backslash in them, so that is why I am removing them before using it as the name.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/GitTools/GitVersion/issues/1381
https://github.com/GitTools/GitVersion/issues/1031

## Motivation and Context
This change is required to prevent the various exceptions that can occur when the normalization process is run concurrently, which is likely to happen when more than one project in a solution is using GitVersion.MsBuild.

These errors include:
- `LibGit2Sharp.LockedFileException: failed to lock file`
- `LibGit2Sharp.NameConflictException: failed to write reference `

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
