### PR TITLE
Use .git directory for mutex name

### DIFF
--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -58,7 +58,7 @@ namespace GitVersion
         private int RunGitVersionTool(GitVersionOptions gitVersionOptions)
         {
             var mutexName = repositoryInfo.DotGitDirectory.Replace(Path.DirectorySeparatorChar.ToString(), "");
-            using var mutex = new Mutex(true, $@"Global\{mutexName}", out var acquired);
+            using var mutex = new Mutex(true, $@"Global\gitversion{mutexName}", out var acquired);
 
             try
             {

--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -57,7 +57,7 @@ namespace GitVersion
 
         private int RunGitVersionTool(GitVersionOptions gitVersionOptions)
         {
-            var mutexName = gitVersionOptions.WorkingDirectory.Replace(Path.DirectorySeparatorChar.ToString(), "");
+            var mutexName = repositoryInfo.DotGitDirectory.Replace(Path.DirectorySeparatorChar.ToString(), "");
             using var mutex = new Mutex(true, $@"Global\{mutexName}", out var acquired);
 
             try


### PR DESCRIPTION
Follow-up PR to #2669 to fix the mutex name. Based on the [command line documentation](https://gitversion.net/docs/usage/cli/arguments) and my initial investigation of the code, I thought `WorkingDirectory` would be  the actual git working directory, but that turns out to not be true.

Instead, I've switched to using `IGitRepositoryInfo.DotGitDirectory`, which should always be pointing at the same location for all projects in a solution.

If there are projects that have different `DotGitDirectory` values in a solution, then that would mean they are operating on completely different repos, but that likely means you have something misconfigured in your solution anyway. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/GitTools/GitVersion/pull/2669

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
