### PR TITLE
Add nocache property to msbuild task

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -11,10 +11,12 @@
 
         <GitVersion_NoFetchEnabled Condition="$(GitVersion_NoFetchEnabled) == ''">false</GitVersion_NoFetchEnabled>
         <GitVersion_NoNormalizeEnabled Condition="$(GitVersion_NoNormalizeEnabled) == ''">false</GitVersion_NoNormalizeEnabled>
+        <GitVersion_NoCacheEnabled Condition="$(GitVersion_NoCacheEnabled) == ''">false</GitVersion_NoCacheEnabled>
 
         <GitVersion_ToolArgments>-output file -outputfile $(GitVersionOutputFile)</GitVersion_ToolArgments>
         <GitVersion_ToolArgments Condition=" '$(GitVersion_NoFetchEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nofetch</GitVersion_ToolArgments>
         <GitVersion_ToolArgments Condition=" '$(GitVersion_NoNormalizeEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nonormalize</GitVersion_ToolArgments>
+        <GitVersion_ToolArgments Condition=" '$(GitVersion_NoCacheEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nocache</GitVersion_ToolArgments>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Full' Or '$(MSBuildRuntimeType)' == 'Mono'">


### PR DESCRIPTION
## Description
Add `GitVersion_NoCacheEnabled` to support the nocache option for the msbuild task.

## Related Issue
None

## Motivation and Context
Our CI pipeline injects the build id for tracking purposes.
To do this, we configure GetVersion like this:
``` yaml
mode: Mainline
assembly-versioning-scheme: MajorMinorPatchTag
assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 0}'
assembly-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_BUILDID ?? 0}'
```
This works perfect for the first build on an agent.
If a commit is build twice on the same agent, the cache injects an old build id.
With this new option we can bypass the cache.

## How Has This Been Tested?
It isn't. Couldn't find any related (unit)test involving the `GitVersion_ToolArgments`
Please review carefully.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
