### PR TITLE
(GH-2679) Support release branch naming with MAJOR SemVer number only

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
@@ -34,6 +34,8 @@ namespace GitVersion.Core.Tests
         [TestCase("v1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", Config.DefaultTagPrefix)]
         [TestCase("V1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", Config.DefaultTagPrefix)]
         [TestCase("version-1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", "version-")]
+        [TestCase("1", 1, 0, 0, null, null, null, null, null, null, "1.0.0", null)]
+        [TestCase("1.1", 1, 1, 0, null, null, null, null, null, null, "1.1.0", null)]
         public void ValidateVersionParsing(
             string versionString, int major, int minor, int patch, string tag, int? tagNumber, int? numberOfBuilds,
             string branchName, string sha, string otherMetaData, string fullFormattedVersionString, string tagPrefixRegex)

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -8,7 +8,7 @@ namespace GitVersion
         private static SemanticVersion Empty = new SemanticVersion();
 
         private static readonly Regex ParseSemVer = new Regex(
-            @"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
+            @"^(?<SemVer>(?<Major>\d+)?(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
             RegexOptions.Compiled);
 
         public int Major;


### PR DESCRIPTION
This is a PR for  #2679 (Support release branch naming with MAJOR SemVer number only)

## Description
Modified the regex for semantic versioning and added tests for the new possible version parsing.
It is now possible to parse just the major or the major and the minor version.

## Related Issue
Resolves #2679 (Support release branch naming with MAJOR SemVer number only)

## Motivation and Context
It is now possible to use release branches such as release/1 or release/1.1 and GitVersion will parse 1.0.0 or 1.1.0 for it.

## How Has This Been Tested?
There are two new test cases in the class SemanticVersionTests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
