### PR TITLE
Replace int.Parse() with int.TryParse() to avoid exceptions caused by overflowing values in tags

### DIFF
--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -191,7 +191,7 @@ namespace GitVersion
                 Major = major,
                 Minor = minor,
                 Patch = patch,
-                PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
+                PreReleaseTag = SemanticVersionPreReleaseTag.TryParse(parsed.Groups["Tag"].Value),
                 BuildMetaData = semanticVersionBuildMetaData
             };
 

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -6,6 +6,7 @@ namespace GitVersion
     public class SemanticVersion : IFormattable, IComparable<SemanticVersion>
     {
         private static SemanticVersion Empty = new SemanticVersion();
+
         private static readonly Regex ParseSemVer = new Regex(
             @"^(?<SemVer>(?<Major>\d+)?(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
             RegexOptions.Compiled);
@@ -196,8 +197,6 @@ namespace GitVersion
 
             return true;
         }
-
-
 
         public int CompareTo(SemanticVersion value)
         {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -6,7 +6,6 @@ namespace GitVersion
     public class SemanticVersion : IFormattable, IComparable<SemanticVersion>
     {
         private static SemanticVersion Empty = new SemanticVersion();
-
         private static readonly Regex ParseSemVer = new Regex(
             @"^(?<SemVer>(?<Major>\d+)?(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
             RegexOptions.Compiled);
@@ -147,10 +146,10 @@ namespace GitVersion
         public static bool TryParse(string version, string tagPrefixRegex, out SemanticVersion semanticVersion)
         {
             var match = Regex.Match(version, $"^({tagPrefixRegex})?(?<version>.*)$");
+            semanticVersion = null;
 
             if (!match.Success)
             {
-                semanticVersion = null;
                 return false;
             }
 
@@ -159,7 +158,6 @@ namespace GitVersion
 
             if (!parsed.Success)
             {
-                semanticVersion = null;
                 return false;
             }
 
@@ -167,36 +165,39 @@ namespace GitVersion
             var fourthPart = parsed.Groups["FourthPart"];
             if (fourthPart.Success && semanticVersionBuildMetaData.CommitsSinceTag == null)
             {
-                semanticVersionBuildMetaData.CommitsSinceTag = int.Parse(fourthPart.Value);
+                semanticVersionBuildMetaData.CommitsSinceTag = Int32.Parse(fourthPart.Value);
             }
 
-            try
+            int major = 0, minor = 0, patch = 0;
+
+            if (!parsed.Groups["Major"].Success || !Int32.TryParse(parsed.Groups["Major"].Value, out major))
             {
-                semanticVersion = new SemanticVersion
-                {
-                    Major = int.Parse(parsed.Groups["Major"].Value),
-                    Minor = parsed.Groups["Minor"].Success ? int.Parse(parsed.Groups["Minor"].Value) : 0,
-                    Patch = parsed.Groups["Patch"].Success ? int.Parse(parsed.Groups["Patch"].Value) : 0,
-                    PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
-                    BuildMetaData = semanticVersionBuildMetaData
-                };
+                return false;
             }
-            catch (Exception exception)
+
+            if (parsed.Groups["Minor"].Success && !Int32.TryParse(parsed.Groups["Minor"].Value, out minor))
             {
-                if (exception is FormatException || exception is OverflowException)
-                {
-                    Console.Error.WriteLine("Failed to Parse Tag:");
-                    Console.Error.WriteLine(exception.Message);
-
-                    semanticVersion = null;
-                    return false;
-                }
-
-                throw exception;
+                return false;
             }
+            
+            if (parsed.Groups["Patch"].Success && !Int32.TryParse(parsed.Groups["Patch"].Value, out patch))
+            {
+                return false;
+            }
+
+            semanticVersion = new SemanticVersion
+            {
+                Major = major,
+                Minor = minor,
+                Patch = patch,
+                PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
+                BuildMetaData = semanticVersionBuildMetaData
+            };
 
             return true;
         }
+
+
 
         public int CompareTo(SemanticVersion value)
         {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -180,7 +180,8 @@ namespace GitVersion
                     PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
                     BuildMetaData = semanticVersionBuildMetaData
                 };
-            } catch(Exception exception)
+            }
+            catch (Exception exception)
             {
                 if (exception is FormatException || exception is OverflowException)
                 {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -180,7 +180,7 @@ namespace GitVersion
             {
                 return false;
             }
-            
+
             if (parsed.Groups["Patch"].Success && !Int32.TryParse(parsed.Groups["Patch"].Value, out patch))
             {
                 return false;

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -170,14 +170,29 @@ namespace GitVersion
                 semanticVersionBuildMetaData.CommitsSinceTag = int.Parse(fourthPart.Value);
             }
 
-            semanticVersion = new SemanticVersion
+            try
             {
-                Major = int.Parse(parsed.Groups["Major"].Value),
-                Minor = parsed.Groups["Minor"].Success ? int.Parse(parsed.Groups["Minor"].Value) : 0,
-                Patch = parsed.Groups["Patch"].Success ? int.Parse(parsed.Groups["Patch"].Value) : 0,
-                PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
-                BuildMetaData = semanticVersionBuildMetaData
-            };
+                semanticVersion = new SemanticVersion
+                {
+                    Major = int.Parse(parsed.Groups["Major"].Value),
+                    Minor = parsed.Groups["Minor"].Success ? int.Parse(parsed.Groups["Minor"].Value) : 0,
+                    Patch = parsed.Groups["Patch"].Success ? int.Parse(parsed.Groups["Patch"].Value) : 0,
+                    PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
+                    BuildMetaData = semanticVersionBuildMetaData
+                };
+            } catch(Exception exception)
+            {
+                if (exception is FormatException || exception is OverflowException)
+                {
+                    Console.Error.WriteLine("Failed to Parse Tag:");
+                    Console.Error.WriteLine(exception.Message);
+
+                    semanticVersion = null;
+                    return false;
+                }
+
+                throw exception;
+            }
 
             return true;
         }

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
@@ -103,7 +103,8 @@ namespace GitVersion
             }
 
             var value = match.Groups["name"].Value;
-            var number = match.Groups["number"].Success ? int.Parse(match.Groups["number"].Value) : (int?)null;
+            var number = (match.Groups["number"].Success && int.TryParse(match.Groups["number"].Value, out int parsedNumber)) ? (int?)parsedNumber : null;
+
             if (value.EndsWith("-"))
                 return new SemanticVersionPreReleaseTag(preReleaseTag, null);
 

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
@@ -84,10 +84,10 @@ namespace GitVersion
 
         public static implicit operator SemanticVersionPreReleaseTag(string preReleaseTag)
         {
-            return Parse(preReleaseTag);
+            return TryParse(preReleaseTag);
         }
 
-        public static SemanticVersionPreReleaseTag Parse(string preReleaseTag)
+        public static SemanticVersionPreReleaseTag TryParse(string preReleaseTag)
         {
             if (string.IsNullOrEmpty(preReleaseTag))
             {


### PR DESCRIPTION
Replace int.Parse() with int.TryParse() This is to prevent the tool failing with an overflowing value.

## Description
If a tag has a suffix which is a numeric value larger than a 32bit int then gitversion fails with an Overflow error.
Whilst the tag can be ignore by using the `tag-prefix` config It would be preferable if it didn't fall over when it encounters such a tag.

## Related Issue
 #2390

## Motivation and Context
We have some tags in our repository which are suffixed with a timestamp value (created by another build process).
We have used the `tag-prefix` config to ignore these, but without it gitversion falls over with an Int32 Overflow exception.

## How Has This Been Tested?
<currently testing>

## Screenshots (if appropriate):

## Checklist:

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. ( Will add if this change is deemed acceptable)
- [X ] All new and existing tests passed.
