### PR TITLE
Fixed SemVer regex (major number was optional) and added test

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
@@ -57,9 +57,10 @@ namespace GitVersion.Core.Tests
 
         [TestCase("someText")]
         [TestCase("some-T-ext")]
-        public void ValidateInvalidVersionParsing(string versionString)
+        [TestCase("v.1.2.3", "v")]
+        public void ValidateInvalidVersionParsing(string versionString, string tagPrefixRegex = null)
         {
-            Assert.IsFalse(SemanticVersion.TryParse(versionString, null, out _), "TryParse Result");
+            Assert.IsFalse(SemanticVersion.TryParse(versionString, tagPrefixRegex, out _), "TryParse Result");
         }
 
         [Test]

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -8,7 +8,7 @@ namespace GitVersion
         private static SemanticVersion Empty = new SemanticVersion();
 
         private static readonly Regex ParseSemVer = new Regex(
-            @"^(?<SemVer>(?<Major>\d+)?(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
+            @"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
             RegexOptions.Compiled);
 
         public int Major;


### PR DESCRIPTION
My changes in PR #2699 where causing an issue where the major number could be empty parsing a version string. This is now fixed and a new test which was red before my change is now green.

## Description
PR #2699 for the issue #2679 should make the minor number optional but made this for the major number, too. This is now fixed.

## Related Issue
 Input string was not in a correct format. on 5.6.10 

Fixes #2711

## Motivation and Context
Fixed a runtime exception (`System.FormatException: Input string was not in a correct format.`)

## How Has This Been Tested?
Tested by unit test and with the CLI. Both tests where failing without my changes and are now working.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
