### PR TITLE
Failing test for merge of remote main with local main in mainline mode

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -445,9 +445,9 @@ namespace GitVersion.Core.Tests.IntegrationTests
             local.AssertFullSemver("1.0.1", config);
             remote.AssertFullSemver("1.0.3", config);
 
-            Commands.Pull((Repository)local.Repository, Generate.SignatureNow(), new PullOptions
+            Commands.Pull((Repository)local.Repository, Generate.SignatureNow(), new PullOptions()
             {
-                MergeOptions = new MergeOptions
+                MergeOptions = new MergeOptions()
                 {
                     FastForwardStrategy = FastForwardStrategy.NoFastForward
                 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -445,7 +445,16 @@ namespace GitVersion.Core.Tests.IntegrationTests
             local.AssertFullSemver("1.0.1", config);
             remote.AssertFullSemver("1.0.3", config);
 
-            Commands.Pull((Repository)local.Repository, Generate.SignatureNow(), new PullOptions());
+            Commands.Pull((Repository)local.Repository, Generate.SignatureNow(), new PullOptions
+            {
+                MergeOptions = new MergeOptions
+                {
+                    FastForwardStrategy = FastForwardStrategy.NoFastForward
+                }
+            });
+
+            var latestCommitMessage = local.Repository.Head.Tip.Message;
+            Assert.That(latestCommitMessage, Does.StartWith("Merge branch 'main' of "));
 
             // There are 5 commits including the merge commit.
             // Since all of them were in their 'main' branch, they should all be counted.

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -427,6 +427,32 @@ namespace GitVersion.Core.Tests.IntegrationTests
         }
 
         [Test]
+        public void VerifyMergeRemoteMainIncrementsAllCommits()
+        {
+            using var remote = new EmptyRepositoryFixture();
+
+            remote.Repository.MakeACommit("1");
+            remote.MakeATaggedCommit("1.0.0");
+
+            using var local = remote.CloneRepository();
+
+            local.Repository.MakeACommit("l.1");
+
+            remote.Repository.MakeACommit("r.1");
+            remote.Repository.MakeACommit("r.2");
+            remote.Repository.MakeACommit("r.3");
+
+            local.AssertFullSemver("1.0.1", config);
+            remote.AssertFullSemver("1.0.3", config);
+
+            Commands.Pull((Repository)local.Repository, Generate.SignatureNow(), new PullOptions());
+
+            // There are 5 commits including the merge commit.
+            // Since all of them were in their 'main' branch, they should all be counted.
+            local.AssertFullSemver("1.0.5", config);
+        }
+
+        [Test]
         public void VerifyIncrementConfigIsHonoured()
         {
             var minorIncrementConfig = new Config


### PR DESCRIPTION
Added test asserting that merging changes on remote main with change in local main should increment semver for all commits in both remote and local main.

## Related Issue
#2739 

## Motivation and Context
In order to avoid several commits creating the same semver.

## How Has This Been Tested?
It is a failing thest for a bug report.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
