### PR TITLE
Add test for the version argument

### DIFF
--- a/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
@@ -53,6 +53,18 @@ namespace GitVersion.App.Tests
         }
 
         [Test]
+        public void VersionArgumentReturnsVersionNumber()
+        {
+            using var fixture = new EmptyRepositoryFixture();
+            fixture.MakeACommit();
+
+            var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, arguments: " -version", logToFile: false);
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBe("1.0.0");
+        }
+
+        [Test]
         public void WorkingDirectoryWithoutGitFolderFailsWithInformativeMessage()
         {
             var result = GitVersionHelper.ExecuteIn(System.Environment.SystemDirectory, arguments: null, logToFile: false);


### PR DESCRIPTION
The GitVersion executable currently returns `1.0.0` when invoked with the `-version` argument. We have no tests for this, so this PR adds such a test. We need to figure out how to return the proper version number, though.

## Description

The version numbering of our assemblies has suddenly stopped working and we need to fix it. This PR adds a test to ensure that `-version` does not return `1.0.0`, but we still need to figure out how to fix the problem.

## Motivation and Context

Returning `1.0.0` as GitVersion's version number is a bug and needs to be fixed.

## How Has This Been Tested?

I added a test that provokes the problem, but I have not yet made any attempt fixing the problem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
