### PR TITLE
Fix expected-actual order in test assert

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -580,7 +580,7 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Checkout("release-2.0.0");
 
             var variables = fixture.GetVersion(config);
-            Assert.AreEqual(variables.AssemblySemFileVer, "2.0.0.1001");
+            Assert.AreEqual("2.0.0.1001", variables.AssemblySemFileVer);
         }
 
         [Test]
@@ -599,7 +599,7 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Repository.CreateBranch("release-2.0.0");
             fixture.Checkout("release-2.0.0");
             var variables = fixture.GetVersion(config);
-            Assert.AreEqual(variables.AssemblySemFileVer, "2.0.0.30001");
+            Assert.AreEqual("2.0.0.30001", variables.AssemblySemFileVer);
         }
 
         /// <summary>

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -69,7 +69,7 @@ namespace GitVersion
             if (string.IsNullOrEmpty(gitDirectory))
                 throw new DirectoryNotFoundException("Cannot find the .git directory");
 
-            return gitDirectory is null ? null : gitDirectory.Contains(Path.Combine(".git", "worktrees"))
+            return gitDirectory?.Contains(Path.Combine(".git", "worktrees")) == true
                 ? Directory.GetParent(Directory.GetParent(gitDirectory).FullName).FullName
                 : gitDirectory;
         }


### PR DESCRIPTION
I haven't created a ticket for this PR (let me know if you want one).

In two places of the codebase, the `expected` and `actual` arguments were mixed which would cause confusion in case of a failing test.