### PR TITLE
CA1810: Initialize reference type static fields inline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -172,3 +172,6 @@ dotnet_diagnostic.CA1822.severity = warning
 
 # CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.CA2208.severity = warning
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = warning

--- a/src/GitVersion.Core/Extensions/StringExtensions.cs
+++ b/src/GitVersion.Core/Extensions/StringExtensions.cs
@@ -9,24 +9,8 @@ namespace GitVersion.Extensions
 {
     public static class StringExtensions
     {
-        private static readonly string[] Trues;
-        private static readonly string[] Falses;
-
-
-        static StringExtensions()
-        {
-            Trues = new[]
-            {
-                "1",
-                "true"
-            };
-
-            Falses = new[]
-            {
-                "0",
-                "false"
-            };
-        }
+        private static readonly string[] Trues = new[] { "1", "true" };
+        private static readonly string[] Falses = new[] { "0", "false" };
 
         public static bool IsTrue(this string value) => Trues.Contains(value, StringComparer.OrdinalIgnoreCase);
 

--- a/src/GitVersion.Core/Logging/Disposable.cs
+++ b/src/GitVersion.Core/Logging/Disposable.cs
@@ -4,11 +4,9 @@ namespace GitVersion.Logging
 {
     public static class Disposable
     {
-        static Disposable() => Empty = Create(() => { });
-
         public static IDisposable Create(Action disposer) => new AnonymousDisposable(disposer);
 
-        public static readonly IDisposable Empty;
+        public static readonly IDisposable Empty = Create(() => { });
 
         private sealed class AnonymousDisposable : IDisposable
         {

--- a/src/GitVersion.MsBuild/Helpers/FileHelper.cs
+++ b/src/GitVersion.MsBuild/Helpers/FileHelper.cs
@@ -15,12 +15,12 @@ namespace GitVersion.MsBuild
             { ".vb", VisualBasicFileContainsVersionAttribute }
         };
 
-        public static string TempPath;
+        public static string TempPath = MakeAndGetTempPath();
 
-        static FileHelper()
+        private static string MakeAndGetTempPath()
         {
-            TempPath = Path.Combine(Path.GetTempPath(), "GitVersionTask");
             Directory.CreateDirectory(TempPath);
+            return Path.Combine(Path.GetTempPath(), "GitVersionTask");
         }
 
         public static void DeleteTempFiles()

--- a/src/GitVersion.MsBuild/Helpers/FileHelper.cs
+++ b/src/GitVersion.MsBuild/Helpers/FileHelper.cs
@@ -15,12 +15,13 @@ namespace GitVersion.MsBuild
             { ".vb", VisualBasicFileContainsVersionAttribute }
         };
 
-        public static string TempPath = MakeAndGetTempPath();
+        public static readonly string TempPath = MakeAndGetTempPath();
 
         private static string MakeAndGetTempPath()
         {
-            Directory.CreateDirectory(TempPath);
-            return Path.Combine(Path.GetTempPath(), "GitVersionTask");
+            var tempPath = Path.Combine(Path.GetTempPath(), "GitVersionTask");
+            Directory.CreateDirectory(tempPath);
+            return tempPath;
         }
 
         public static void DeleteTempFiles()


### PR DESCRIPTION
Enable CA1810 analyzer as warning level and fix found issues.

The idea behind this analyzer is to improve performance by preventing some extra calls caused by a static constructor.