### PR TITLE
Ensure parameter names matches interfaces definitions

### DIFF
--- a/src/GitVersion.Core.Tests/Helpers/TestFileSystem.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestFileSystem.cs
@@ -47,11 +47,11 @@ namespace GitVersion.Core.Tests.Helpers
             this.fileSystem.Remove(fullPath);
         }
 
-        public string ReadAllText(string file)
+        public string ReadAllText(string path)
         {
-            var path = Path.GetFullPath(file);
-            if (!this.fileSystem.TryGetValue(path, out var content))
-                throw new FileNotFoundException($"The file '{path}' was not found", path);
+            var fullPath = Path.GetFullPath(path);
+            if (!this.fileSystem.TryGetValue(fullPath, out var content))
+                throw new FileNotFoundException($"The file '{fullPath}' was not found", fullPath);
 
             var encoding = EncodingHelper.DetectEncoding(content) ?? Encoding.UTF8;
             return encoding.GetString(content);
@@ -76,35 +76,35 @@ namespace GitVersion.Core.Tests.Helpers
 
         public Stream OpenWrite(string path) => new TestStream(path, this);
 
-        public Stream OpenRead(string file)
+        public Stream OpenRead(string path)
         {
-            var path = Path.GetFullPath(file);
-            if (this.fileSystem.ContainsKey(path))
+            var fullPath = Path.GetFullPath(path);
+            if (this.fileSystem.ContainsKey(fullPath))
             {
-                var content = this.fileSystem[path];
+                var content = this.fileSystem[fullPath];
                 return new MemoryStream(content);
             }
 
-            throw new FileNotFoundException("File not found.", path);
+            throw new FileNotFoundException("File not found.", fullPath);
         }
 
-        public void CreateDirectory(string directory)
+        public void CreateDirectory(string path)
         {
-            var path = Path.GetFullPath(directory);
-            if (this.fileSystem.ContainsKey(path))
+            var fullPath = Path.GetFullPath(path);
+            if (this.fileSystem.ContainsKey(fullPath))
             {
-                this.fileSystem[path] = Array.Empty<byte>();
+                this.fileSystem[fullPath] = Array.Empty<byte>();
             }
             else
             {
-                this.fileSystem.Add(path, Array.Empty<byte>());
+                this.fileSystem.Add(fullPath, Array.Empty<byte>());
             }
         }
 
-        public bool DirectoryExists(string directory)
+        public bool DirectoryExists(string path)
         {
-            var path = Path.GetFullPath(directory);
-            return this.fileSystem.ContainsKey(path);
+            var fullPath = Path.GetFullPath(path);
+            return this.fileSystem.ContainsKey(fullPath);
         }
 
         public long GetLastDirectoryWrite(string path) => 1;

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -28,6 +28,6 @@ namespace GitVersion
 
         public IReference? Head => this["HEAD"];
 
-        public IEnumerable<IReference> FromGlob(string pattern) => this.innerCollection.FromGlob(pattern).Select(reference => new Reference(reference));
+        public IEnumerable<IReference> FromGlob(string prefix) => this.innerCollection.FromGlob(prefix).Select(reference => new Reference(reference));
     }
 }

--- a/src/GitVersion.MsBuild.Tests/Mocks/MockEngine.cs
+++ b/src/GitVersion.MsBuild.Tests/Mocks/MockEngine.cs
@@ -24,33 +24,33 @@ namespace GitVersion.MsBuild.Tests.Mocks
 
         public bool IsRunningMultipleNodes { get; set; }
 
-        public void LogErrorEvent(BuildErrorEventArgs eventArgs)
+        public void LogErrorEvent(BuildErrorEventArgs e)
         {
-            Console.WriteLine(EventArgsFormatting.FormatEventMessage(eventArgs));
-            this.log.AppendLine(EventArgsFormatting.FormatEventMessage(eventArgs));
+            Console.WriteLine(EventArgsFormatting.FormatEventMessage(e));
+            this.log.AppendLine(EventArgsFormatting.FormatEventMessage(e));
             ++Errors;
         }
 
-        public void LogWarningEvent(BuildWarningEventArgs eventArgs)
+        public void LogWarningEvent(BuildWarningEventArgs e)
         {
-            Console.WriteLine(EventArgsFormatting.FormatEventMessage(eventArgs));
-            this.log.AppendLine(EventArgsFormatting.FormatEventMessage(eventArgs));
+            Console.WriteLine(EventArgsFormatting.FormatEventMessage(e));
+            this.log.AppendLine(EventArgsFormatting.FormatEventMessage(e));
             ++Warnings;
         }
 
-        public void LogCustomEvent(CustomBuildEventArgs eventArgs)
+        public void LogCustomEvent(CustomBuildEventArgs e)
         {
-            Console.WriteLine(eventArgs.Message);
-            this.log.AppendLine(eventArgs.Message);
+            Console.WriteLine(e.Message);
+            this.log.AppendLine(e.Message);
         }
 
-        public void LogMessageEvent(BuildMessageEventArgs eventArgs)
+        public void LogMessageEvent(BuildMessageEventArgs e)
         {
             // Only if the message is above the minimum importance should we record the log message
-            if (eventArgs.Importance <= MinimumMessageImportance)
+            if (e.Importance <= MinimumMessageImportance)
             {
-                Console.WriteLine(eventArgs.Message);
-                this.log.AppendLine(eventArgs.Message);
+                Console.WriteLine(e.Message);
+                this.log.AppendLine(e.Message);
                 ++Messages;
             }
         }
@@ -100,9 +100,9 @@ namespace GitVersion.MsBuild.Tests.Mocks
             string[] projectFileNames,
             string[] targetNames,
             IDictionary[] globalProperties,
-            IList<string>[] undefineProperties,
+            IList<string>[] removeGlobalProperties,
             string[] toolsVersion,
-            bool includeTargetOutputs) => new(false, null);
+            bool returnTargetOutputs) => new(false, null);
 
         public void Yield()
         {


### PR DESCRIPTION
It is generally a good practice to keep the parent (interface or class) parameter name rather than changing them in a child implementation.