### PR TITLE
Ensure optional args are passed to base

### DIFF
--- a/src/GitVersion.Core/BuildAgents/CodeBuild.cs
+++ b/src/GitVersion.Core/BuildAgents/CodeBuild.cs
@@ -40,7 +40,7 @@ namespace GitVersion.BuildAgents
 
         public override void WriteIntegration(Action<string?> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
-            base.WriteIntegration(writer, variables);
+            base.WriteIntegration(writer, variables, updateBuildNumber);
             writer($"Outputting variables to '{this.file}' ... ");
             File.WriteAllLines(this.file, GenerateBuildLogOutput(variables));
         }

--- a/src/GitVersion.Core/BuildAgents/GitLabCi.cs
+++ b/src/GitVersion.Core/BuildAgents/GitLabCi.cs
@@ -30,7 +30,7 @@ namespace GitVersion.BuildAgents
 
         public override void WriteIntegration(Action<string?> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
-            base.WriteIntegration(writer, variables);
+            base.WriteIntegration(writer, variables, updateBuildNumber);
             writer($"Outputting variables to '{this.file}' ... ");
             WriteVariablesFile(variables);
         }

--- a/src/GitVersion.Core/BuildAgents/Jenkins.cs
+++ b/src/GitVersion.Core/BuildAgents/Jenkins.cs
@@ -40,7 +40,7 @@ namespace GitVersion.BuildAgents
 
         public override void WriteIntegration(Action<string?> writer, VersionVariables variables, bool updateBuildNumber = true)
         {
-            base.WriteIntegration(writer, variables);
+            base.WriteIntegration(writer, variables, updateBuildNumber);
             writer($"Outputting variables to '{this.file}' ... ");
             WriteVariablesFile(variables);
         }


### PR DESCRIPTION
In a couple of places, methods with optional args were not passing them to the base call, this PR fixes this incorrect behavior.