### PR TITLE
docs: Rec. adding/disabling "GenerateAssemblyFileVersion" in .NET project

### DIFF
--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -50,6 +50,14 @@ The next thing you need to do is to remove the `Assembly*Version` attributes fro
 your `Properties\AssemblyInfo.cs` files. This puts GitVersion.MsBuild in charge of
 versioning your assemblies.
 
+For SDK-style projects, add the following properties set to `false`:
+```
+    <!-- GitVersion DotNet SDK Compatibility -->
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+```
+
 ### Done!
 
 The setup process is now complete and GitVersion.MsBuild should be working its magic,

--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -51,7 +51,8 @@ your `Properties\AssemblyInfo.cs` files. This puts GitVersion.MsBuild in charge 
 versioning your assemblies.
 
 For SDK-style projects, add the following properties set to `false`:
-```
+
+```xml
     <!-- GitVersion DotNet SDK Compatibility -->
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In DotNet SDK-style projects, several properties that determine if the compiler will generate AssemblyInfo are default to `true`.
These lead to the build tools creating their own AssemblyInfo.g.cs which conflicts with GitVersion.

1. I'm unsure which header this should go under. Suggestions are welcome.
2. I didn't have much time to test them, but I can confirm that adding these to my project resolved certain build errors. Those errors were caused by the build tools generating an AssemblyInfo.g.cs that overwrote or conflicted with GitVersion's generated AssemblyInfo.g.cs.
3. I may be difficult to contact during the next week, but I'll try to check here frequently.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
