### PR TITLE
RFC regarding the calculation of Base Versions

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
@@ -228,11 +228,11 @@ public class DevelopScenarios : TestBase
         fixture.Checkout("develop");
         fixture.MergeNoFF("release/1.2.0");
         fixture.MakeACommit("commit in develop - 6");
-        fixture.AssertFullSemver("1.3.0-alpha.9");
+        fixture.AssertFullSemver("1.3.0-alpha.6");
         fixture.SequenceDiagram.Destroy("release/1.2.0");
         fixture.Repository.Branches.Remove("release/1.2.0");
 
-        const string expectedFullSemVer = "1.3.0-alpha.9";
+        const string expectedFullSemVer = "1.3.0-alpha.6";
         fixture.AssertFullSemver(expectedFullSemVer, config);
     }
 
@@ -260,11 +260,11 @@ public class DevelopScenarios : TestBase
         fixture.MakeACommit("commit in develop - 2");
         fixture.AssertFullSemver("1.3.0-alpha.1");
         fixture.MergeNoFF("release/1.2.0");
-        fixture.AssertFullSemver("1.3.0-alpha.5");
+        fixture.AssertFullSemver("1.3.0-alpha.2");
         fixture.SequenceDiagram.Destroy("release/1.2.0");
         fixture.Repository.Branches.Remove("release/1.2.0");
 
-        const string expectedFullSemVer = "1.3.0-alpha.5";
+        const string expectedFullSemVer = "1.3.0-alpha.2";
         fixture.AssertFullSemver(expectedFullSemVer, config);
     }
 
@@ -317,16 +317,16 @@ public class DevelopScenarios : TestBase
         fixture.MergeNoFF(ReleaseBranch);
 
         // Version numbers will still be correct when the release branch is around.
-        fixture.AssertFullSemver("1.2.0-alpha.6");
-        fixture.AssertFullSemver("1.2.0-alpha.6", config);
+        fixture.AssertFullSemver("1.2.0-alpha.3");
+        fixture.AssertFullSemver("1.2.0-alpha.3", config);
 
         var versionSourceBeforeReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
 
         fixture.Repository.Branches.Remove(ReleaseBranch);
         var versionSourceAfterReleaseBranchIsRemoved = fixture.GetVersion(config).Sha;
         Assert.AreEqual(versionSourceBeforeReleaseBranchIsRemoved, versionSourceAfterReleaseBranchIsRemoved);
-        fixture.AssertFullSemver("1.2.0-alpha.6");
-        fixture.AssertFullSemver("1.2.0-alpha.6", config);
+        fixture.AssertFullSemver("1.2.0-alpha.3");
+        fixture.AssertFullSemver("1.2.0-alpha.3", config);
 
         config.Branches = new Dictionary<string, BranchConfig>
         {
@@ -374,7 +374,7 @@ public class DevelopScenarios : TestBase
         fixture.Repository.MakeCommits(2);
         fixture.MergeNoFF(ReleaseBranch);
         fixture.Repository.Branches.Remove(ReleaseBranch);
-        fixture.AssertFullSemver("1.2.0-alpha.6", config);
+        fixture.AssertFullSemver("1.2.0-alpha.3", config);
 
         // Create hotfix for defects found in release/1.1.0
         const string HotfixBranch = "hotfix/1.1.1";
@@ -391,11 +391,11 @@ public class DevelopScenarios : TestBase
         fixture.Checkout("develop");
         // Simulate some work done on develop while the hotfix branch was open.
         fixture.Repository.MakeCommits(3);
-        fixture.AssertFullSemver("1.2.0-alpha.9", config);
+        fixture.AssertFullSemver("1.2.0-alpha.6", config);
         fixture.Repository.MergeNoFF(HotfixBranch);
-        fixture.AssertFullSemver("1.2.0-alpha.19", config);
+        fixture.AssertFullSemver("1.2.0-alpha.10", config);
 
         fixture.Repository.Branches.Remove(HotfixBranch);
-        fixture.AssertFullSemver("1.2.0-alpha.19", config);
+        fixture.AssertFullSemver("1.2.0-alpha.10", config);
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamples.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamples.cs
@@ -155,7 +155,7 @@ public class DocumentationSamples : TestBase
 
         // Not 0 for commit count as we can't know the increment rules of the merged branch
         fixture.Checkout("develop");
-        fixture.AssertFullSemver("1.4.0-alpha.4");
+        fixture.AssertFullSemver("1.4.0-alpha.2");
         Console.WriteLine(fixture.SequenceDiagram.GetDiagram());
     }
 
@@ -211,7 +211,7 @@ public class DocumentationSamples : TestBase
 
         // Not 0 for commit count as we can't know the increment rules of the merged branch
         fixture.Checkout("develop");
-        fixture.AssertFullSemver("2.1.0-alpha.4");
+        fixture.AssertFullSemver("2.1.0-alpha.2");
         Console.WriteLine(fixture.SequenceDiagram.GetDiagram());
     }
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -41,16 +41,16 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Checkout(developBranch);
             fixture.MergeNoFF(release1Branch);
             fixture.Repository.Branches.Remove(fixture.Repository.Branches[release1Branch]);
-            fixture.AssertFullSemver("1.2.0-alpha.2");
+            fixture.AssertFullSemver("1.2.0-alpha.1");
 
             // Feature 2
             fixture.BranchTo(feature2Branch);
             fixture.MakeACommit("added feature 2");
-            fixture.AssertFullSemver("1.2.0-f2.1+3");
+            fixture.AssertFullSemver("1.2.0-f2.1+2");
             fixture.Checkout(developBranch);
             fixture.MergeNoFF(feature2Branch);
             fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature2Branch]);
-            fixture.AssertFullSemver("1.2.0-alpha.4");
+            fixture.AssertFullSemver("1.2.0-alpha.3");
 
             // Release 1.2.0
             fixture.BranchTo(release2Branch);
@@ -64,13 +64,13 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Checkout(developBranch);
             fixture.MergeNoFF(release2Branch);
             fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
-            fixture.AssertFullSemver("1.3.0-alpha.2");
+            fixture.AssertFullSemver("1.3.0-alpha.1");
 
             // Hotfix
             fixture.Checkout(MainBranch);
             fixture.BranchTo(hotfixBranch);
             fixture.MakeACommit("added hotfix");
-            fixture.AssertFullSemver("1.2.1-beta.1+7");
+            fixture.AssertFullSemver("1.2.1-beta.1+1");
             fixture.Checkout(MainBranch);
             fixture.MergeNoFF(hotfixBranch);
             fixture.AssertFullSemver("1.2.1+2");
@@ -79,7 +79,7 @@ namespace GitVersion.Core.Tests.IntegrationTests
             fixture.Checkout(developBranch);
             fixture.MergeNoFF(hotfixBranch);
             fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
-            fixture.AssertFullSemver("1.3.0-alpha.9");
+            fixture.AssertFullSemver("1.3.0-alpha.3");
         }
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -48,12 +48,12 @@ public class ReleaseBranchScenarios : TestBase
         // Merge to develop
         fixture.Checkout("develop");
         fixture.Repository.MergeNoFF("release/1.0.0");
-        fixture.AssertFullSemver("1.1.0-alpha.2");
+        fixture.AssertFullSemver("1.1.0-alpha.1");
 
         fixture.Repository.MakeACommit();
         fixture.Repository.Branches.Remove("release/1.0.0");
 
-        fixture.AssertFullSemver("1.1.0-alpha.3");
+        fixture.AssertFullSemver("1.1.0-alpha.2");
     }
 
     [Test]
@@ -184,7 +184,7 @@ public class ReleaseBranchScenarios : TestBase
     }
 
     [Test]
-    public void MainVersioningContinuousCorrectlyAfterMergingReleaseBranch()
+    public void MainVersioningContinuesCorrectlyAfterMergingReleaseBranch()
     {
         using var fixture = new EmptyRepositoryFixture();
         fixture.Repository.MakeATaggedCommit("1.0.3");
@@ -199,6 +199,30 @@ public class ReleaseBranchScenarios : TestBase
         fixture.Repository.ApplyTag("2.0.0");
         fixture.Repository.MakeCommits(1);
         fixture.AssertFullSemver("2.0.1+1");
+    }
+
+    [Test]
+    public void MainVersioningContinuesCountingAfterMergingTheSameReleaseBranchMultipleTimes()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.3");
+        fixture.Repository.MakeCommits(1);
+        fixture.Repository.CreateBranch("release/2.0.0");
+        fixture.Checkout("release/2.0.0");
+        fixture.Repository.MakeCommits(4);
+        fixture.Checkout(MainBranch);
+        fixture.Repository.MergeNoFF("release/2.0.0", Generate.SignatureNow());
+
+        fixture.AssertFullSemver("2.0.0+0");
+
+        fixture.Checkout("release/2.0.0");
+        fixture.Repository.MakeCommits(3);
+        fixture.Checkout(MainBranch);
+        fixture.Repository.MergeNoFF("release/2.0.0", Generate.SignatureNow());
+
+        fixture.AssertFullSemver("2.0.0+4");
+        fixture.Repository.MakeCommits(1);
+        fixture.AssertFullSemver("2.0.0+5");
     }
 
     [Test]
@@ -434,7 +458,7 @@ public class ReleaseBranchScenarios : TestBase
     }
 
     [Test]
-    public void CommitBeetweenMergeReleaseToDevelopShouldNotResetCount()
+    public void CommitBetweenMergeReleaseToDevelopShouldNotResetCount()
     {
         var config = new Config
         {

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -75,7 +75,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
                     {
                         if (baseVersion != null)
                         {
-                            log.Info($" - {BaseVersionToString(baseVersion)}");
+                            this.log.Info($" - {BaseVersionToString(baseVersion)}");
                         }
                     }
 

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -89,7 +89,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
 
                     maxVersion = matchingVersionsOnceIncremented.Aggregate(CompareVersions);
                     baseVersionWithOldestSource = maxVersion.Version;
-                    log.Info($"Taking oldest source for commit counting : {BaseVersionToString(baseVersionWithOldestSource)}");
+                    this.log.Info($"Taking oldest source for commit counting : {BaseVersionToString(baseVersionWithOldestSource)}");
                 }
                 else
                 {

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -83,7 +83,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
 
                     if (tagVersions.Count > 0)
                     {
-                        log.Info("As there are Git tags, the other sources will be discarded");
+                        this.log.Info("As there are Git tags, the other sources will be discarded");
                         matchingVersionsOnceIncremented = tagVersions;
                     }
 

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -69,8 +69,8 @@ public class BaseVersionCalculator : IBaseVersionCalculator
                         return versions1.Version.BaseVersionSource.When < version2.Version.BaseVersionSource.When ? versions1 : version2;
                     }
 
-                    log.Info($"Found multiple base versions which will produce the same SemVer ({maxVersion.IncrementedVersion})");
-                    log.Info($"Here are the different source candidate for commit counting : ");
+                    this.log.Info($"Found multiple base versions which will produce the same SemVer ({maxVersion.IncrementedVersion})");
+                    this.log.Info($"Here are the different source candidate for commit counting : ");
                     foreach (var baseVersion in matchingVersionsOnceIncremented.Select(b => b.Version))
                     {
                         if (baseVersion != null)

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -95,7 +95,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
                 {
                     maxVersion = matchingVersionsOnceIncremented.First();
                     baseVersionWithOldestSource = maxVersion.Version;
-                    log.Info(
+                    this.log.Info(
                         $"Found a base versions which will produce the following SemVer ({maxVersion.IncrementedVersion}), " +
                         $"with the following source for commit counting : {BaseVersionToString(baseVersionWithOldestSource)}"
                     );

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -121,7 +121,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
                 baseVersionWithOldestSource.BaseVersionSource,
                 maxVersion.Version.BranchNameOverride);
 
-            log.Info($"Base version used: {calculatedBase}");
+            this.log.Info($"Base version used: {calculatedBase}");
 
             return calculatedBase;
         }


### PR DESCRIPTION
Dear Reviewers,

Please take a look at the discussion here : https://github.com/GitTools/GitVersion/issues/2798

TL;DR : I'm proposing we use the `BaseVersionSource` of `Tags` before `MergeMessage`, if there are any.

I think there might be implications I am not foreseeing and would like your input on this proposition.

## Related Issue

Resolves #2798.
Related to #1526.
Fixes #2394.

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
