### PR TITLE
Fix TaggedCommitVersionStrategy performance problems

### DIFF
--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -37,7 +37,7 @@ namespace GitVersion.Common
         SemanticVersion GetCurrentCommitTaggedVersion(ICommit? commit, EffectiveConfiguration config);
         SemanticVersion MaybeIncrement(BaseVersion baseVersion, GitVersionContext context);
         IEnumerable<SemanticVersion?> GetVersionTagsOnBranch(IBranch branch, string? tagPrefixRegex);
-        IEnumerable<Tuple<ITag?, SemanticVersion?>> GetValidVersionTags(string? tagPrefixRegex, DateTimeOffset? olderThan = null);
+        IEnumerable<Tuple<ITag, SemanticVersion, ICommit>> GetValidVersionTags(string? tagPrefixRegex, DateTimeOffset? olderThan = null);
 
         bool IsCommitOnBranch(ICommit? baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
         VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context);

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -21,7 +21,8 @@ namespace GitVersion.VersionCalculation
 
         internal IEnumerable<BaseVersion> GetTaggedVersions(IBranch? currentBranch, DateTimeOffset? olderThan)
         {
-            if (currentBranch is null) return Enumerable.Empty<BaseVersion>();
+            if (currentBranch is null) 
+                return Enumerable.Empty<BaseVersion>();
             var versionTags = this.repositoryStore.GetValidVersionTags(Context.Configuration?.GitTagPrefix, olderThan);
             var versionTagsByCommit = versionTags.ToLookup(vt => vt.Item3.Id.Sha);
             var commitsOnBranch = currentBranch.Commits;

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TaggedCommitVersionStrategy.cs
@@ -21,7 +21,7 @@ namespace GitVersion.VersionCalculation
 
         internal IEnumerable<BaseVersion> GetTaggedVersions(IBranch? currentBranch, DateTimeOffset? olderThan)
         {
-            if (currentBranch is null) 
+            if (currentBranch is null)
                 return Enumerable.Empty<BaseVersion>();
             var versionTags = this.repositoryStore.GetValidVersionTags(Context.Configuration?.GitTagPrefix, olderThan);
             var versionTagsByCommit = versionTags.ToLookup(vt => vt.Item3.Id.Sha);


### PR DESCRIPTION
The problem was a branch commits x version tags nested loop that quickly
grew into the millions of iterations as the number of commits and/or
tags in a repo increased, even modestly.

Each iteration performed Git tag-to-commit resolution and GitVersion
commit object-to-object comparison, both of which take a little bit of
time and aren't particularly slow in isolation but which add up fast
when performed millions of times.

This is solved by doing a single pass over the tags, resolving each to a
commit only once; then using that to build a commit-to-tag lookup
(hashtable) keyed by commit SHA, eliminating the object comparisons; and
finally doing a single pass over the branch commits, looking up
associated tags from the hashtable by SHA, eliminating the nested loop.

Testing on a repo with ~20,000 commits and ~5,000 tags showed an overall
GitVersion run time reduction from over 2 minutes down to around 5
seconds.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
