### PR TITLE
use NuGetVersion as a value for Version attribute in project file

### DIFF
--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -189,10 +189,10 @@ have the ability to create NuGet packages directly by using the `pack` target:
 `msbuild /t:pack`. The version is controlled by the MSBuild properties described
 above.
 
-GitVersionTask has the option to generate SemVer 2.0 compliant NuGet package
-versions by setting `UseFullSemVerForNuGet` to true in your project (this is off
-by default for compatibility). Some hosts, like MyGet, support SemVer 2.0
-package versions but older NuGet clients and nuget.org do not.
+GitVersionTask generates SemVer 2.0 compliant NuGet package versions by default.
+You can disable it by setting `UseFullSemVerForNuGet` to false in your project.
+Older NuGet clients do not support SemVer 2.0 package versions, but most of the
+modern hosts support it.
 
 #### Accessing variables in MSBuild
 

--- a/src/GitVersion.Core/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersion.Core/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -42,7 +42,7 @@ namespace GitVersion.VersionConverters.AssemblyInfo
             var assemblyVersion = variables.AssemblySemVer;
             var assemblyInfoVersion = variables.InformationalVersion;
             var assemblyFileVersion = variables.AssemblySemFileVer;
-            var packageVersion = variables.NuGetVersionV2;
+            var packageVersion = variables.NuGetVersion;
 
             foreach (var projectFile in projectFilesToUpdate)
             {

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -52,7 +52,7 @@
         </GetVersion>
 
         <PropertyGroup Condition=" '$(UpdateVersionProperties)' == 'true' ">
-            <Version>$(GitVersion_FullSemVer)</Version>
+            <Version>$(GitVersion_NuGetVersion)</Version>
             <VersionPrefix>$(GitVersion_MajorMinorPatch)</VersionPrefix>
             <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetPreReleaseTag)</VersionSuffix>
             <VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_PreReleaseTag)</VersionSuffix>


### PR DESCRIPTION
closes #2813 


@asbjornu, @arturcic, during implementation I had two questions:
1. As far as I see, https://github.com/GitTools/GitVersion/blob/55c56991b0f4889de0eceaf21df1187163e203a8/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs#L69-L71, NuGetVersion, and `NuGetVersionV2` return the same value. Is it make sense to mark `NuGetVersionV2` with the `Obsolete` attribute and remove it in the next major release?
2. [The documentation](https://github.com/GitTools/GitVersion/blob/main/docs/input/docs/usage/msbuild.md#nuget-packages) has mentioned that `UseFullSemVerForNuGet` is off by default, however, it's enabled by default https://github.com/GitTools/GitVersion/blob/55c56991b0f4889de0eceaf21df1187163e203a8/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props#L69

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
