### PR TITLE
Ammended dot net tool install instructions to include --version

### DIFF
--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -13,8 +13,9 @@ GitVersion can be installed as a [.NET global tool][dotnet-tool] under the name
 [`GitVersion.Tool`][tool] by executing the following in a terminal:
 
 ```shell
-dotnet tool install --global GitVersion.Tool
+dotnet tool install --global GitVersion.Tool --version x.x.x
 ```
+Where x.x.x is the version suggested here: https://www.nuget.org/packages/GitVersion.Tool/
 
 This should work on all operating systems supported by .NET Core.
 

--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -15,7 +15,9 @@ GitVersion can be installed as a [.NET global tool][dotnet-tool] under the name
 ```shell
 dotnet tool install --global GitVersion.Tool --version 5.*
 ```
-Where x.x.x is the version suggested here: https://www.nuget.org/packages/GitVersion.Tool/
+
+If you want to pin to a specific version of GitVersion, you can find the available
+versions of [`GitVersion.Tool` on NuGet](https://www.nuget.org/packages/GitVersion.Tool/).
 
 This should work on all operating systems supported by .NET Core.
 

--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -13,7 +13,7 @@ GitVersion can be installed as a [.NET global tool][dotnet-tool] under the name
 [`GitVersion.Tool`][tool] by executing the following in a terminal:
 
 ```shell
-dotnet tool install --global GitVersion.Tool --version x.x.x
+dotnet tool install --global GitVersion.Tool --version 5.*
 ```
 Where x.x.x is the version suggested here: https://www.nuget.org/packages/GitVersion.Tool/
 


### PR DESCRIPTION
As per https://www.nuget.org/packages/GitVersion.Tool/


## Description
I had difficulty installing gitversion on a private repo because of authfails, which were fixed by specifying the version number.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I had difficulty installing gitversion on a private repo because of authfails, which were fixed by specifying the version number.

## How Has This Been Tested?
The new command worked for me where the old one didn't

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11979650/130135424-ea2effc9-d727-46f4-90a2-8915a3b48c6c.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
