### PR TITLE
Improve performance on untagged HEADs

### DIFF
--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -6,6 +6,7 @@ using GitVersion.Extensions;
 using GitVersion.Logging;
 using GitVersion.Model;
 using GitVersion.Model.Configuration;
+using GitVersion.VersionCalculation;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;

--- a/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
@@ -3,6 +3,7 @@ using GitTools.Testing;
 using GitVersion.Core.Tests.Helpers;
 using GitVersion.Core.Tests.IntegrationTests;
 using GitVersion.Logging;
+using GitVersion.VersionCalculation;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
@@ -13,11 +14,13 @@ namespace GitVersion.Core.Tests
     public class RepositoryStoreTests : TestBase
     {
         private readonly ILog log;
+        private readonly IIncrementStrategyFinder incrementStrategyFinder;
 
         public RepositoryStoreTests()
         {
             var sp = ConfigureServices();
             this.log = sp.GetService<ILog>();
+            this.incrementStrategyFinder = sp.GetService<IIncrementStrategyFinder>();
         }
 
         [Test]
@@ -62,7 +65,7 @@ namespace GitVersion.Core.Tests
 
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
-            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository, this.incrementStrategyFinder);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 
@@ -118,7 +121,7 @@ namespace GitVersion.Core.Tests
 
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
-            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository, this.incrementStrategyFinder);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 
@@ -193,7 +196,7 @@ namespace GitVersion.Core.Tests
             var develop = fixtureRepository.FindBranch("develop");
             var release = fixtureRepository.FindBranch("release-2.0.0");
 
-            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository, this.incrementStrategyFinder);
 
             var releaseBranchMergeBase = gitRepoMetadataProvider.FindMergeBase(release, develop);
 
@@ -210,7 +213,7 @@ namespace GitVersion.Core.Tests
         {
             using var fixture = new EmptyRepositoryFixture();
             var fixtureRepository = fixture.Repository.ToGitRepository();
-            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository);
+            var gitRepoMetadataProvider = new RepositoryStore(this.log, fixtureRepository, this.incrementStrategyFinder);
 
             Assert.Throws<ArgumentNullException>(() => gitRepoMetadataProvider.GetBranchesContainingCommit(null));
         }

--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -36,7 +36,7 @@ namespace GitVersion.Common
 
         SemanticVersion GetCurrentCommitTaggedVersion(ICommit? commit, EffectiveConfiguration config);
         SemanticVersion MaybeIncrement(BaseVersion baseVersion, GitVersionContext context);
-        IEnumerable<SemanticVersion?> GetVersionTagsOnBranch(IBranch branch, string? tagPrefixRegex);
+        IEnumerable<SemanticVersion> GetVersionTagsOnBranch(IBranch branch, string? tagPrefixRegex);
         IEnumerable<Tuple<ITag, SemanticVersion, ICommit>> GetValidVersionTags(string? tagPrefixRegex, DateTimeOffset? olderThan = null);
 
         bool IsCommitOnBranch(ICommit? baseVersionSource, IBranch branch, ICommit firstMatchingCommit);

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -20,11 +20,13 @@ namespace GitVersion
 
         private readonly ILog log;
         private readonly IGitRepository repository;
+        private readonly IIncrementStrategyFinder incrementStrategyFinder;
 
-        public RepositoryStore(ILog log, IGitRepository repository)
+        public RepositoryStore(ILog log, IGitRepository repository, IIncrementStrategyFinder incrementStrategyFinder)
         {
             this.log = log ?? throw new ArgumentNullException(nameof(log));
             this.repository = repository ?? throw new ArgumentNullException(nameof(log));
+            this.incrementStrategyFinder = incrementStrategyFinder ?? throw new ArgumentNullException(nameof(incrementStrategyFinder));
         }
 
         /// <summary>
@@ -351,7 +353,7 @@ namespace GitVersion
 
         public SemanticVersion MaybeIncrement(BaseVersion baseVersion, GitVersionContext context)
         {
-            var increment = IncrementStrategyFinder.DetermineIncrementedField(this.repository, context, baseVersion);
+            var increment = this.incrementStrategyFinder.DetermineIncrementedField(this.repository, context, baseVersion);
             return increment != null ? baseVersion.SemanticVersion.IncrementVersion(increment.Value) : baseVersion.SemanticVersion;
         }
 
@@ -409,7 +411,8 @@ namespace GitVersion
             return this.repository.Commits.QueryBy(filter);
         }
 
-        public VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context) => IncrementStrategyFinder.DetermineIncrementedField(this.repository, context, baseVersion);
+        public VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context) =>
+            this.incrementStrategyFinder.DetermineIncrementedField(this.repository, context, baseVersion);
 
         public bool IsCommitOnBranch(ICommit? baseVersionSource, IBranch branch, ICommit firstMatchingCommit)
         {

--- a/src/GitVersion.Core/Extensions/DictionaryExtensions.cs
+++ b/src/GitVersion.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace GitVersion.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, Func<TValue> getValue)
+        {
+            if (dict is null) throw new ArgumentNullException(nameof(dict));
+            if (getValue is null) throw new ArgumentNullException(nameof(getValue));
+            if (!dict.TryGetValue(key, out TValue value))
+            {
+                value = getValue();
+                dict.Add(key, value);
+            }
+            return value;
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/Abstractions/IIncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/Abstractions/IIncrementStrategyFinder.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace GitVersion.VersionCalculation
+{
+    public interface IIncrementStrategyFinder
+    {
+        VersionField? DetermineIncrementedField(IGitRepository repository, GitVersionContext context, BaseVersion baseVersion);
+        VersionField? GetIncrementForCommits(GitVersionContext context, IEnumerable<ICommit> commits);
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/CommitMessageIncrementMode.cs
+++ b/src/GitVersion.Core/VersionCalculation/CommitMessageIncrementMode.cs
@@ -1,0 +1,9 @@
+namespace GitVersion.VersionCalculation
+{
+    public enum CommitMessageIncrementMode
+    {
+        Enabled,
+        Disabled,
+        MergeMessageOnly
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -7,13 +7,6 @@ using GitVersion.Extensions;
 
 namespace GitVersion.VersionCalculation
 {
-    public enum CommitMessageIncrementMode
-    {
-        Enabled,
-        Disabled,
-        MergeMessageOnly
-    }
-
     public class IncrementStrategyFinder : IIncrementStrategyFinder
     {
         public const string DefaultMajorPattern = @"\+semver:\s?(breaking|major)";

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -123,7 +123,7 @@ namespace GitVersion.VersionCalculation
 
             var lastTag = this.repositoryStore
                 .GetVersionTagsOnBranch(context.CurrentBranch!, context.Configuration?.GitTagPrefix)
-                .FirstOrDefault(v => v?.PreReleaseTag?.Name?.IsEquivalentTo(tagToUse) == true);
+                .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(tagToUse) == true);
 
             if (lastTag != null &&
                 MajorMinorPatchEqual(lastTag, semanticVersion) &&

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculationModule.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculationModule.cs
@@ -13,6 +13,7 @@ namespace GitVersion.VersionCalculation
             services.AddSingleton<IBaseVersionCalculator, BaseVersionCalculator>();
             services.AddSingleton<IMainlineVersionCalculator, MainlineVersionCalculator>();
             services.AddSingleton<INextVersionCalculator, NextVersionCalculator>();
+            services.AddSingleton<IIncrementStrategyFinder, IncrementStrategyFinder>();
         }
     }
 }


### PR DESCRIPTION
## Introduction
My previous PR #2800 improved GitVersion performance when HEAD is already tagged as a release.  This PR continues where that left off and improves performance when it isn't.

## Measurements
A real-world Git repo containing ~20,000 commits and ~5,000 release tags was used to measure progress during this work.  Run times cited here and in commit messages are for Debug builds running under a debugger/profiler on my two-year-old Thinkpad.  Release builds running standalone are somewhat faster in absolute terms, but the relative performance improvements are the same.

## Overall Results
This PR brings GitVersion run times on an untagged HEAD from over 3 minutes down to 20-25 seconds.

## Description of Changes
Our starting run time is just over 3 minutes.

First I make `IncrementStrategyFinder` non-static, make the relevant members non-static, and register it in the IOC container as a singleton following the established pattern.  This is so I can add some targeted caching later, also following the established pattern.

Next I add a `DictionaryExtensions` class following the established pattern, with a `GetOrAdd()` method to be used later to implement caches.

Next I implement the first optimisation, a cache of commit message analysis results in `IncrementStrategyFinder`.  This is a relatively expensive operation -- up to 4 regex executions -- and is often done repeatedly for the same commits from different code paths higher up the call stack.

This halves our run time down to a minute and a half.

The second optimisation is in `RepositoryStore`, where I convert an exponential nested loop in `GetVersionTagsOnBranch()` to a lookup+linear iteration.  (This is similar to what was done in my previous PR #2800).

This cuts run time by a further 60-70%, taking us down to around 30 seconds.

The final optimisation is back in `IncrementStrategyFinder` in `GetIntermediateCommits()` and is essentially another nested loop conversion, but instead of a lookup directly to the final result(s), it's an index (by arbitrary commit sha) into the (cached) sequence of all commits from start to HEAD, which we then use to yield the subsequence from _that_ commit to HEAD on-the-cheap using an `ArraySegment`.

This knocks another 30% or so off the run time, bringing us down to a final time of around 20 seconds.