### PR TITLE
[Docs] Recommend disabling GenerateAssemblyFileVersionAttribute MSBuild prop

### DIFF
--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -51,6 +51,14 @@ The next thing you need to do is to remove the `Assembly*Version` attributes fro
 your `Properties\AssemblyInfo.cs` files. This puts GitVersion.MsBuild in charge of
 versioning your assemblies.
 
+For SDK-style projects, add the following properties set to `false`:
+```
+    <!-- GitVersion DotNet SDK Compatibility -->
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+```
+
 ### Done!
 
 The setup process is now complete and GitVersion.MsBuild should be working its magic,

--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -51,13 +51,14 @@ The next thing you need to do is to remove the `Assembly*Version` attributes fro
 your `Properties\AssemblyInfo.cs` files. This puts GitVersion.MsBuild in charge of
 versioning your assemblies.
 
-For SDK-style projects, add the following properties set to `false`:
+DotNet SDK-style projects will generate Assembly Version info along with other
+Assembly Info in a 'projectname.AssemblyInfo.cs' file, conflicting with GitVersion.
+So, you will need to edit your project. Add [GenerateAssemblyFileVersionAttribute](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generateassemblyfileversionattribute)
+under the first PropertyGroup and set it to `false`:
 
 ```xml
-    <!-- GitVersion DotNet SDK Compatibility -->
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+<!-- GitVersion DotNet SDK Compatibility -->
+<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
 ```
 
 ### Done!

--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -52,7 +52,8 @@ your `Properties\AssemblyInfo.cs` files. This puts GitVersion.MsBuild in charge 
 versioning your assemblies.
 
 For SDK-style projects, add the following properties set to `false`:
-```
+
+```xml
     <!-- GitVersion DotNet SDK Compatibility -->
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By default, DotNet SDK-style projects will generate all assembly info with or without assemblyinfo.cs.
The only 

## Related Issue
Closes #2840 

## Motivation and Context
After upgrading a .NET Framework project to build with the DotNet SDK whilst still targetting net4.6.2, I had run into a build error which was easily traced to a conflict with GitVersion's assembly info.

## How Has This Been Tested?
Trial and error and hours of scouring MS Docs until I narrowed down the minimal changes needed to resolve the build error.
https://github.com/HaloSPV3/HXE/commit/c3267e06e7d85c2e1a1517755ea51072ab932034
https://gist.github.com/BinToss/334f5bd8677a7e27fa2e1848d5eb7c53#file-output-log-L2575-L2579

## Screenshots (if appropriate):
If NOT `<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>`
![image](https://user-images.githubusercontent.com/7243190/132003479-737db36e-fd2b-46a3-b252-8117b5eaaa19.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@asbjornu 