### PR TITLE
[Feature] Do not fail AppVeyor builds on force-push

### DIFF
--- a/src/GitVersion.Core/BuildAgents/AppVeyor.cs
+++ b/src/GitVersion.Core/BuildAgents/AppVeyor.cs
@@ -33,7 +33,7 @@ public class AppVeyor : BuildAgentBase
             var response = httpClient.PutAsync("api/build", stringContent).GetAwaiter().GetResult();
             response.EnsureSuccessStatusCode();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return $"Failed to set AppVeyor build number to '{variables.FullSemVer}'. The error was: {ex.Message}";
         }


### PR DESCRIPTION
## Description
I've added a `try-catch` around the api access in AppVeyor.
This way the build will not fail if it is somehow not possible to rename the build in AppVeyor.

## Related Issue
fixes #2876 

## Motivation and Context
#2876 

## How Has This Been Tested?
Sadly, this has not been tested at all. I'm unsure how to create a unit test for that.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. --> No, there were 10 failed and 20 skipped tests on a clean checkout
