### PR TITLE
Update conventional commits regex to allow "-" in the scope

### DIFF
--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -95,9 +95,9 @@ you can leverage this feature as follows:
 
 ```yaml
 mode: MainLine # Only add this if you want every version to be created automatically on your main branch.
-major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
-minor-version-bump-message: "^(feat)(\\([\\w\\s]*\\))?:"
-patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
+patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
 ```
 
 This will ensure that your version gets bumped according to the commits you've

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -75,14 +75,14 @@ public class VersionBumpingScenarios : TestBase
         {
             VersioningMode = GitVersion.VersionCalculation.VersioningMode.Mainline,
 
-            // For future debugging of this regex: https://regex101.com/r/CRoBol/1
-            MajorVersionBumpMessage = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)",
+            // For future debugging of this regex: https://regex101.com/r/CRoBol/2
+            MajorVersionBumpMessage = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)",
 
-            // For future debugging of this regex: https://regex101.com/r/9ccNam/1
-            MinorVersionBumpMessage = "^(feat)(\\([\\w\\s]*\\))?:",
+            // For future debugging of this regex: https://regex101.com/r/9ccNam/3
+            MinorVersionBumpMessage = "^(feat)(\\([\\w\\s-]*\\))?:",
 
-            // For future debugging of this regex: https://regex101.com/r/oFpqxA/1
-            PatchVersionBumpMessage = "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"
+            // For future debugging of this regex: https://regex101.com/r/oFpqxA/2
+            PatchVersionBumpMessage = "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
         };
         using var fixture = new EmptyRepositoryFixture();
         fixture.Repository.MakeACommit();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update conventional commits regex to allow "-" in the scope. It is common to use Jira tickets as scope and they usually have a dash in them.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
