### PR TITLE
don't call gitPreparer when checkout a tagged version. Avoid throwing WarningException.  #2927

### DIFF
--- a/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
+++ b/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
@@ -40,7 +40,10 @@ public class GitVersionCalculateTool : IGitVersionCalculateTool
 
     public VersionVariables CalculateVersionVariables()
     {
-        this.gitPreparer.Prepare(); //we need to prepare the repository before using it for version calculation
+        if (!this.context.IsCurrentCommitTagged)
+        {
+            this.gitPreparer.Prepare(); //we need to prepare the repository before using it for version calculation
+        }
 
         var gitVersionOptions = this.options.Value;
 


### PR DESCRIPTION
#2927

## Description
if IsCurrentCommitTagged of GitVersionContext is true, don't call IGitPreparer's Prepare method. 

## Related Issue
#2927

## Motivation and Context
This causes build failed on a CI agent (JENKINS), while it success on a workstation.  

## How Has This Been Tested?
test the Reproduce case in #2927 

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
