### PR TITLE
invalid  use of Lazy<GitVersionContext>, #2933 fix doesn't work actualy

### DIFF
--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -562,9 +562,6 @@ public class GitVersionExecutorTests : TestBase
         environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
-
-        var _ = this.sp.GetService<Lazy<GitVersionContext>>()?.Value;
-
         var sut = sp.GetService<IGitVersionCalculateTool>();
 
         // Execute & Verify
@@ -594,9 +591,6 @@ public class GitVersionExecutorTests : TestBase
         environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
-
-        var _ = this.sp.GetService<Lazy<GitVersionContext>>()?.Value;
-
         var sut = sp.GetService<IGitVersionCalculateTool>();
 
         // Execute

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -254,18 +254,15 @@ public class GitPreparer : IGitPreparer
                     }
                 }
             }
-            else if (!this.context.IsCurrentCommitTagged)
+            else if (localBranchesWhereCommitShaIsHead.Count == 0)
             {
-                if (localBranchesWhereCommitShaIsHead.Count == 0)
-                {
-                    this.log.Info($"No local branch pointing at the commit '{headSha}'. Fake branch needs to be created.");
-                    this.retryAction.Execute(() => this.repository.CreateBranchForPullRequestBranch(authentication));
-                }
-                else
-                {
-                    this.log.Info($"Checking out local branch 'refs/heads/{localBranchesWhereCommitShaIsHead[0]}'.");
-                    Checkout(localBranchesWhereCommitShaIsHead[0].Name.Friendly);
-                }
+                this.log.Info($"No local branch pointing at the commit '{headSha}'. Fake branch needs to be created.");
+                this.retryAction.Execute(() => this.repository.CreateBranchForPullRequestBranch(authentication));
+            }
+            else
+            {
+                this.log.Info($"Checking out local branch 'refs/heads/{localBranchesWhereCommitShaIsHead[0]}'.");
+                Checkout(localBranchesWhereCommitShaIsHead[0].Name.Friendly);
             }
         }
         finally

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -18,11 +18,13 @@ public class GitPreparer : IGitPreparer
     private readonly IRepositoryStore repositoryStore;
     private readonly ICurrentBuildAgent? buildAgent;
     private readonly RetryAction<LockedFileException> retryAction;
+    private readonly Lazy<GitVersionContext> versionContext;
+    private GitVersionContext context => this.versionContext.Value;
 
     private const string DefaultRemoteName = "origin";
 
     public GitPreparer(ILog log, IEnvironment environment, ICurrentBuildAgent? buildAgent, IOptions<GitVersionOptions> options,
-        IMutatingGitRepository repository, IGitRepositoryInfo repositoryInfo, IRepositoryStore repositoryStore)
+        IMutatingGitRepository repository, IGitRepositoryInfo repositoryInfo, IRepositoryStore repositoryStore, Lazy<GitVersionContext> versionContext)
     {
         this.log = log.NotNull();
         this.environment = environment.NotNull();
@@ -32,6 +34,7 @@ public class GitPreparer : IGitPreparer
         this.repositoryStore = repositoryStore.NotNull();
         this.buildAgent = buildAgent;
         this.retryAction = new RetryAction<LockedFileException>();
+        this.versionContext = versionContext.NotNull();
     }
 
     public void Prepare()
@@ -245,21 +248,24 @@ public class GitPreparer : IGitPreparer
                         this.log.Warning($"Choosing {branchWithoutSeparator.Name.Canonical} as it is the only branch without / or - in it. " + moveBranchMsg);
                         Checkout(branchWithoutSeparator.Name.Canonical);
                     }
-                    else
+                    else if (!this.context.IsCurrentCommitTagged)
                     {
                         throw new WarningException("Failed to try and guess branch to use. " + moveBranchMsg);
                     }
                 }
             }
-            else if (localBranchesWhereCommitShaIsHead.Count == 0)
+            else if (!this.context.IsCurrentCommitTagged)
             {
-                this.log.Info($"No local branch pointing at the commit '{headSha}'. Fake branch needs to be created.");
-                this.retryAction.Execute(() => this.repository.CreateBranchForPullRequestBranch(authentication));
-            }
-            else
-            {
-                this.log.Info($"Checking out local branch 'refs/heads/{localBranchesWhereCommitShaIsHead[0]}'.");
-                Checkout(localBranchesWhereCommitShaIsHead[0].Name.Friendly);
+                if (localBranchesWhereCommitShaIsHead.Count == 0)
+                {
+                    this.log.Info($"No local branch pointing at the commit '{headSha}'. Fake branch needs to be created.");
+                    this.retryAction.Execute(() => this.repository.CreateBranchForPullRequestBranch(authentication));
+                }
+                else
+                {
+                    this.log.Info($"Checking out local branch 'refs/heads/{localBranchesWhereCommitShaIsHead[0]}'.");
+                    Checkout(localBranchesWhereCommitShaIsHead[0].Name.Friendly);
+                }
             }
         }
         finally

--- a/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
+++ b/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
@@ -40,10 +40,7 @@ public class GitVersionCalculateTool : IGitVersionCalculateTool
 
     public VersionVariables CalculateVersionVariables()
     {
-        if (!context.IsCurrentCommitTagged)
-        {
-            this.gitPreparer.Prepare(); //we need to prepare the repository before using it for version calculation
-        }
+        this.gitPreparer.Prepare(); //we need to prepare the repository before using it for version calculation
 
         var gitVersionOptions = this.options.Value;
 

--- a/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
+++ b/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
@@ -40,10 +40,7 @@ public class GitVersionCalculateTool : IGitVersionCalculateTool
 
     public VersionVariables CalculateVersionVariables()
     {
-        bool isCurrentCommitTagged = this.versionContext.IsValueCreated &&
-            this.versionContext.Value.IsCurrentCommitTagged;
-
-        if (!isCurrentCommitTagged)
+        if (!context.IsCurrentCommitTagged)
         {
             this.gitPreparer.Prepare(); //we need to prepare the repository before using it for version calculation
         }


### PR DESCRIPTION
## Description
Fixes #2927

## Related Issue
#2927

## Motivation and Context
Invalid use of Lazy<GitVersionContext> leads the fix of #2933 doesn't work properly. this.versionContext.Value will always be null. This problem was bypassed by way of early access in unit test. 
if replace 
```
        bool isCurrentCommitTagged = this.versionContext.IsValueCreated &&
            this.versionContext.Value.IsCurrentCommitTagged;
```

with 
`        bool isCurrentCommitTagged = context.IsCurrentCommitTagged;`, 
will cause many other unit tests failed. 
So I have to move the if statement into the NormalizeGitDirectory method. 


## How Has This Been Tested?
Tested the reproduce case in #2927. 
all unit tests passed

## Screenshots (if appropriate):

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
