### PR TITLE
fix version conflict of Microsoft.Build and Microsoft.Build.Framework…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,7 @@
         <PackageVersion_MicrosoftExtensions>6.0.0</PackageVersion_MicrosoftExtensions>
         <PackageVersion_MicrosoftJson>6.0.0</PackageVersion_MicrosoftJson>
         <PackageVersion_MicrosoftTextEncoding>6.0.0</PackageVersion_MicrosoftTextEncoding>
-        <PackageVersion_MsBuild>17.0.0</PackageVersion_MsBuild>
+        <PackageVersion_MsBuild>16.11.0</PackageVersion_MsBuild>
 
         <PackageVersion_MicrosoftTestSdk>17.0.0</PackageVersion_MicrosoftTestSdk>
         <PackageVersion_NSubstitute>4.2.2</PackageVersion_NSubstitute>

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
         <PackageReference Include="Buildalyzer" Version="3.2.6" />
         <PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3" />
-        <PackageReference Include="Microsoft.Build" Version="17.0.0" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" />
+        <PackageReference Include="Microsoft.Build" Version="16.11.0" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.11.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -6,22 +6,11 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-        <PackageReference Include="Buildalyzer" Version="3.2.2" />
-        <PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3" />
-        <PackageReference Include="Microsoft.Build" Version="16.9.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-        <PackageReference Include="Buildalyzer" Version="3.2.5" />
-        <PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3" />
-        <PackageReference Include="Microsoft.Build" Version="16.11.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' or '$(TargetFramework)' != 'net5.0' ">
-        <PackageReference Include="Buildalyzer" Version="3.2.5" />
+    <ItemGroup>
+        <PackageReference Include="Buildalyzer" Version="3.2.6" />
         <PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3" />
         <PackageReference Include="Microsoft.Build" Version="17.0.0" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
@arturcic 
fix version conflict of Microsoft.Build and Microsoft.Build.Framework.
And bump Buildalyzer version to 3.2.6


- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
