### PR TITLE
Elaborate on `next-version`

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -68,8 +68,18 @@ The details of the available options are as follows:
 
 ### next-version
 
-Allows you to bump the next version explicitly, useful for bumping `main` or a
-feature with breaking changes (i.e., a major increment).
+Allows you to bump the next version explicitly. Useful for bumping `main` or a
+feature branch with breaking changes (i.e., a major increment), indicating what
+the next `git tag` is going to be.
+
+`next-version` is not a permanent replacement for `git tag` and should only be
+used intermittently. Since version 5.5 GitVersion supports `next-version` with
+`mode: Mainline` and should not be treated as a "base version".
+
+If you are using `next-version` and are experiencing weird versioning behaviour,
+please remove it, create a `git tag` with an appropriate version number on an
+appropriate historical commit and see if that resolves any versioning issues
+you may have.
 
 ### assembly-versioning-scheme
 


### PR DESCRIPTION
## Description

Elaborate on `next-version` and explain how it's not a replacement for `git tag`.

## Related Issue

#2441, #2454, #2461, #2467, #2610, #2661, #2670, #2694 and #2940.

## Motivation and Context

In #2441 and many duplicate and related issues, there has been uncovered confusion about what `next-version` actually means and how it's supposed to be used. This PR adds more information about how `next-version` is supposed to be used and that removing it entirely from the configuration may resolve versioning problems people experience.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
