### PR TITLE
Sped up the Normalization by removing an unnecessary O(n^2) loop

### DIFF
--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -314,15 +314,14 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
         {
             var remoteTrackingReferenceName = remoteTrackingReference.Name.Canonical;
             var branchName = remoteTrackingReferenceName.Substring(prefix.Length);
-            var localCanonicalName = "refs/heads/" + branchName;
+            var localReferenceName = ReferenceName.FromBranchName(branchName);
 
-            var referenceName = ReferenceName.Parse(localCanonicalName);
             // We do not want to touch our current branch
             if (this.repository.Head.Name.EquivalentTo(branchName)) continue;
 
-            if (this.repository.Refs.Any(x => x.Name.Equals(referenceName)))
+            if (this.repository.Refs[localReferenceName] is not null)
             {
-                var localRef = this.repository.Refs[localCanonicalName]!;
+                var localRef = this.repository.Refs[localReferenceName]!;
                 if (localRef.TargetIdentifier == remoteTrackingReference.TargetIdentifier)
                 {
                     this.log.Info($"Skipping update of '{remoteTrackingReference.Name.Canonical}' as it already matches the remote ref.");
@@ -335,7 +334,7 @@ Please run `git {GitExtensions.CreateGitLogArgs(100)}` and submit it along with 
             }
 
             this.log.Info($"Creating local branch from remote tracking '{remoteTrackingReference.Name.Canonical}'.");
-            this.repository.Refs.Add(localCanonicalName, remoteTrackingReference.TargetIdentifier, true);
+            this.repository.Refs.Add(localReferenceName.Canonical, remoteTrackingReference.TargetIdentifier, true);
 
             var branch = this.repository.Branches[branchName]!;
             this.repository.Branches.UpdateTrackedBranch(branch, remoteTrackingReferenceName);

--- a/src/GitVersion.Core/Git/IReferenceCollection.cs
+++ b/src/GitVersion.Core/Git/IReferenceCollection.cs
@@ -4,6 +4,7 @@ public interface IReferenceCollection : IEnumerable<IReference>
 {
     IReference? Head { get; }
     IReference? this[string name] { get; }
+    IReference? this[ReferenceName referenceName] { get; }
     void Add(string name, string canonicalRefNameOrObjectish, bool allowOverwrite = false);
     void UpdateTarget(IReference directRef, IObjectId targetId);
     IEnumerable<IReference> FromGlob(string prefix);

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -38,6 +38,9 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
         }
         throw new ArgumentException($"The {nameof(canonicalName)} is not a Canonical name");
     }
+
+    public static ReferenceName FromBranchName(string branchName) => Parse(LocalBranchPrefix + branchName);
+
     public string Canonical { get; }
     public string Friendly { get; }
     public string WithoutRemote { get; }

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -22,6 +22,8 @@ internal sealed class ReferenceCollection : IReferenceCollection
         }
     }
 
+    public IReference? this[ReferenceName referenceName] => this[referenceName.Canonical];
+
     public IReference? Head => this["HEAD"];
 
     public IEnumerable<IReference> FromGlob(string prefix) => this.innerCollection.FromGlob(prefix).Select(reference => new Reference(reference));


### PR DESCRIPTION
This should speedup the normalization when there are a lot of branches.
The `.Any(x => x.Name.Equals(referenceName)` was causing an unnecessary O(n^2) loop, as `Refs` is already an indexed structure (Dict).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
