### PR TITLE
Enable correct PR versioning for Buildkite

### DIFF
--- a/src/GitVersion.Core.Tests/BuildAgents/BuildKiteTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/BuildKiteTests.cs
@@ -52,12 +52,27 @@ public class BuildKiteTests : TestBase
     {
         // Arrange
         this.environment.SetEnvironmentVariable("BUILDKITE_BRANCH", MainBranch);
+        this.environment.SetEnvironmentVariable("BUILDKITE_PULL_REQUEST", "false");
 
         // Act
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
         result.ShouldBe(MainBranch);
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldHandlePullRequests()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILDKITE_BRANCH", "feature/new");
+        this.environment.SetEnvironmentVariable("BUILDKITE_PULL_REQUEST", "55");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBe("refs/pull/55/head");
     }
 
     [Test]

--- a/src/GitVersion.Core/BuildAgents/BuildKite.cs
+++ b/src/GitVersion.Core/BuildAgents/BuildKite.cs
@@ -22,7 +22,7 @@ public class BuildKite : BuildAgentBase
         Array.Empty<string>(); // There is no equivalent function in BuildKite.
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
-    {        
+    {
         var pullRequest = Environment.GetEnvironmentVariable("BUILDKITE_PULL_REQUEST");
         if (string.IsNullOrEmpty(pullRequest) || pullRequest == "false")
         {
@@ -30,7 +30,7 @@ public class BuildKite : BuildAgentBase
         }
         else
         {
-            // for pull requests BUILDKITE_BRANCH refers to the head, so adjust the 
+            // For pull requests BUILDKITE_BRANCH refers to the head, so adjust the
             // branch name for pull request versioning to function as expected
             return string.Format("refs/pull/{0}/head", pullRequest);
         }

--- a/src/GitVersion.Core/BuildAgents/BuildKite.cs
+++ b/src/GitVersion.Core/BuildAgents/BuildKite.cs
@@ -21,7 +21,20 @@ public class BuildKite : BuildAgentBase
     public override string[] GenerateSetParameterMessage(string name, string value) =>
         Array.Empty<string>(); // There is no equivalent function in BuildKite.
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("BUILDKITE_BRANCH");
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {        
+        var pullRequest = Environment.GetEnvironmentVariable("BUILDKITE_PULL_REQUEST");
+        if (string.IsNullOrEmpty(pullRequest) || pullRequest == "false")
+        {
+            return Environment.GetEnvironmentVariable("BUILDKITE_BRANCH");
+        }
+        else
+        {
+            // for pull requests BUILDKITE_BRANCH refers to the head, so adjust the 
+            // branch name for pull request versioning to function as expected
+            return string.Format("refs/pull/{0}/head", pullRequest);
+        }
+    }
 
     public override bool PreventFetch() => true;
 }


### PR DESCRIPTION
Enable correct PR versioning for Buildkite

## Description
Pull requests were not being detected for Buildkite environments even though support was added in 5.8.2. It is necessary to also check the `BUILDKITE_PULL_REQUEST` env var, which as per the [documentation](https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-pull-request), will indicate whether the current branch is a pull request, or be "false" if it is not.

## Related Issue
Fixes https://github.com/GitTools/GitVersion/issues/3012

## Motivation and Context
Delivers a consistent experience across CI environments.

## How Has This Been Tested?
Unit tests have been added/modified.
Manual testing has confirmed correct functionality on local repo in mocked Buildkite environment.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
