### PR TITLE
Various fixes for GH-2967

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -517,6 +517,26 @@ public class MainlineDevelopmentMode : TestBase
         fixture.AssertFullSemver("3.1.3", minorIncrementConfig);
         Console.WriteLine(fixture.SequenceDiagram.GetDiagram());
     }
+
+    [Test]
+    public void BranchWithoutMergeBaseMainlineBranchIsFound()
+    {
+        var currentConfig = new Config
+        {
+            VersioningMode = VersioningMode.Mainline,
+            AssemblyFileVersioningScheme = AssemblyFileVersioningScheme.MajorMinorPatchTag
+        };
+
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("master"));
+        fixture.Repository.Branches.Remove(fixture.Repository.Branches["main"]);
+        fixture.Repository.MakeCommits(2);
+        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("issue-branch"));
+        fixture.Repository.MakeACommit();
+        fixture.AssertFullSemver("0.1.3-issue-branch.1", currentConfig);
+    }
+
 }
 
 internal static class CommitExtensions

--- a/src/GitVersion.Core/Configuration/ConfigExtensions.cs
+++ b/src/GitVersion.Core/Configuration/ConfigExtensions.cs
@@ -9,7 +9,16 @@ public static class ConfigExtensions
 {
     public static BranchConfig? GetConfigForBranch(this Config config, string? branchName)
     {
-        if (branchName == null) throw new ArgumentNullException(nameof(branchName));
+        if (branchName == null)
+        {
+            throw new ArgumentNullException(nameof(branchName));
+        }
+
+        if (config?.Branches is null)
+        {
+            return null;
+        }
+
         var matches = config.Branches
             .Where(b => Regex.IsMatch(branchName, b.Value?.Regex, RegexOptions.IgnoreCase))
             .ToArray();

--- a/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
@@ -126,13 +126,28 @@ internal class MainlineVersionCalculator : IMainlineVersionCalculator
         var mainlineBranchConfigs = context.FullConfiguration?.Branches.Where(b => b.Value?.IsMainline == true).ToList();
         var mainlineBranches = this.repositoryStore.GetMainlineBranches(context.CurrentCommit!, mainlineBranchConfigs);
 
-        var allMainlines = mainlineBranches.Values.SelectMany(branches => branches.Select(b => b.Name.Friendly));
-        this.log.Info("Found possible mainline branches: " + string.Join(", ", allMainlines));
+        if (!mainlineBranches.Any())
+        {
+            throw new WarningException("No mainline branches found!");
+        }
+
+        var mainlineBranchNames = mainlineBranches.Values.SelectMany(branches => branches.Select(b => b.Name.Friendly));
+        this.log.Info("Found possible mainline branches: " + string.Join(", ", mainlineBranchNames));
 
         // Find closest mainline branch
-        var firstMatchingCommit = context.CurrentBranch?.Commits.First(c => mainlineBranches.ContainsKey(c.Sha));
-        var possibleMainlineBranches = mainlineBranches[firstMatchingCommit!.Sha];
+        var firstMatchingCommit = context.CurrentBranch?.Commits.FirstOrDefault(c => mainlineBranches.ContainsKey(c.Sha));
+        if (firstMatchingCommit is null)
+        {
+            var mainlineBranchList = mainlineBranches.Values.SelectMany(x => x).ToList();
+            return FindMainlineBranch(mainlineBranchList, baseVersionSource, context.CurrentCommit);
+        }
 
+        var possibleMainlineBranches = mainlineBranches[firstMatchingCommit!.Sha];
+        return FindMainlineBranch(possibleMainlineBranches, baseVersionSource, firstMatchingCommit);
+    }
+
+    private IBranch FindMainlineBranch(List<IBranch> possibleMainlineBranches, ICommit? baseVersionSource, ICommit? firstMatchingCommit)
+    {
         if (possibleMainlineBranches.Count == 1)
         {
             var mainlineBranch = possibleMainlineBranches[0];
@@ -144,11 +159,14 @@ internal class MainlineVersionCalculator : IMainlineVersionCalculator
         if (possibleMainlineBranches.Any(context.CurrentBranch!.Equals))
         {
             this.log.Info($"Choosing {context.CurrentBranch} as mainline because it is the current branch");
-            return context.CurrentBranch;
+            return context.CurrentBranch!;
         }
 
         // prefer a branch on which the merge base was a direct commit, if there is such a branch
-        var firstMatchingCommitBranch = possibleMainlineBranches.FirstOrDefault(b => this.repositoryStore.IsCommitOnBranch(baseVersionSource, b, firstMatchingCommit));
+        var firstMatchingCommitBranch = firstMatchingCommit != null
+            ? possibleMainlineBranches.FirstOrDefault(b => this.repositoryStore.IsCommitOnBranch(baseVersionSource, b, firstMatchingCommit))
+            : null;
+
         if (firstMatchingCommitBranch != null)
         {
             var message = string.Format(


### PR DESCRIPTION
This PR should fix #2967. 

## Description
There are quite a bit of assumptions in the Mainline codepath that doesn't seem to hold true, such as all branches having a merge base. I believe it should be a viable fallback to look for the current branch's origin commit when a merge base cannot be found. That and a few other fixes (mostly `null` protection) is added to fix #2967.

## Related Issue
Fixes #2967.

## Motivation and Context
We don't want GitVersion to throw `NullReferenceException`. Ever.

## How Has This Been Tested?
I have not been able to conjure a test that provokes this problem yet, but I'll try once I find time. I'm keeping this in draft until such a test is implemented.


## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
