### PR TITLE
Disable auto-merge in forks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,7 @@ pull_request_rules:
       - check-success=Unit Test code (windows-latest, net5.0)
       - check-success=Unit Test code (windows-latest, net5.0)
       - check-success=Unit Test code (windows-latest, net5.0)
+      - repository-full-name=GitTools/GitVersion # Don't auto-merge PRs in forks
     actions:
       merge:
   - name: Thank contributor


### PR DESCRIPTION
This PR should disable Mergify's `merge` action in forks of GitVersion.

## Description
As it's impossible to disable Dependabot in a fork (see dependabot/dependabot-core#2804), this PR disables Mergify's `merge` action when `repository-full-name` is different from `GitTools/GitVersion`. Forks will still receive Dependabot pull requests, but at least they won't be automatically merged (see asbjornu/GitVersion#94 as an example), forcing the fork to reset and force-push:

```bash
git checkout main
git fetch upstream
git reset --hard upstream/main
git push --force
```

## How Has This Been Tested?
I haven't tested using `repository-full-name` anywhere before, so I'm just hoping this is going to work. I guess we'll have to wait and see until the next Dependabot PR is received.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
