### PR TITLE
Change `Int32` to `Int64`

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
@@ -35,8 +35,10 @@ public class SemanticVersionTests : TestBase
     [TestCase("version-1.2.3", 1, 2, 3, null, null, null, null, null, null, "1.2.3", "version-")]
     [TestCase("1", 1, 0, 0, null, null, null, null, null, null, "1.0.0", null)]
     [TestCase("1.1", 1, 1, 0, null, null, null, null, null, null, "1.1.0", null)]
+    [TestCase("1.0.0-develop-20201007113711", 1, 0, 0, "develop-20201007113711", null, null, null, null, null, "1.0.0-develop-20201007113711", null)]
+    [TestCase("20201007113711.658165168461351.64136516984163213-develop-20201007113711.98848747823+65416321321", 20201007113711, 658165168461351, 64136516984163213, "develop-20201007113711", 98848747823, 65416321321, null, null, null, "20201007113711.658165168461351.64136516984163213-develop-20201007113711.98848747823+65416321321", null)]
     public void ValidateVersionParsing(
-        string versionString, int major, int minor, int patch, string tag, int? tagNumber, int? numberOfBuilds,
+        string versionString, long major, long minor, long patch, string tag, long? tagNumber, long? numberOfBuilds,
         string branchName, string sha, string otherMetaData, string fullFormattedVersionString, string tagPrefixRegex)
     {
         fullFormattedVersionString ??= versionString;

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -117,7 +117,7 @@ public class NextVersionCalculator : INextVersionCalculator
     {
         var tagToUse = context.Configuration?.GetBranchSpecificTag(this.log, context.CurrentBranch?.Name.Friendly, branchNameOverride);
 
-        int? number = null;
+        long? number = null;
 
         var lastTag = this.repositoryStore
             .GetVersionTagsOnBranch(context.CurrentBranch!, context.Configuration?.GitTagPrefix)

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -13,13 +13,13 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
         @"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
         RegexOptions.Compiled);
 
-    public int Major;
-    public int Minor;
-    public int Patch;
+    public long Major;
+    public long Minor;
+    public long Patch;
     public SemanticVersionPreReleaseTag? PreReleaseTag;
     public SemanticVersionBuildMetaData? BuildMetaData;
 
-    public SemanticVersion(int major = 0, int minor = 0, int patch = 0)
+    public SemanticVersion(long major = 0, long minor = 0, long patch = 0)
     {
         this.Major = major;
         this.Minor = minor;
@@ -74,9 +74,9 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
     {
         unchecked
         {
-            var hashCode = this.Major;
-            hashCode = (hashCode * 397) ^ this.Minor;
-            hashCode = (hashCode * 397) ^ this.Patch;
+            var hashCode = this.Major.GetHashCode();
+            hashCode = (hashCode * 397) ^ this.Minor.GetHashCode();
+            hashCode = (hashCode * 397) ^ this.Patch.GetHashCode();
             hashCode = (hashCode * 397) ^ (this.PreReleaseTag != null ? this.PreReleaseTag.GetHashCode() : 0);
             hashCode = (hashCode * 397) ^ (this.BuildMetaData != null ? this.BuildMetaData.GetHashCode() : 0);
             return hashCode;
@@ -168,9 +168,9 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
 
         semanticVersion = new SemanticVersion
         {
-            Major = int.Parse(parsed.Groups["Major"].Value),
-            Minor = parsed.Groups["Minor"].Success ? int.Parse(parsed.Groups["Minor"].Value) : 0,
-            Patch = parsed.Groups["Patch"].Success ? int.Parse(parsed.Groups["Patch"].Value) : 0,
+            Major = long.Parse(parsed.Groups["Major"].Value),
+            Minor = parsed.Groups["Minor"].Success ? long.Parse(parsed.Groups["Minor"].Value) : 0,
+            Patch = parsed.Groups["Patch"].Success ? long.Parse(parsed.Groups["Patch"].Value) : 0,
             PreReleaseTag = SemanticVersionPreReleaseTag.Parse(parsed.Groups["Tag"].Value),
             BuildMetaData = semanticVersionBuildMetaData
         };

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs
@@ -14,15 +14,15 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
     private static readonly LambdaEqualityHelper<SemanticVersionBuildMetaData> EqualityHelper =
         new(x => x.CommitsSinceTag, x => x.Branch, x => x.Sha);
 
-    public int? CommitsSinceTag;
+    public long? CommitsSinceTag;
     public string? Branch;
     public string? Sha;
     public string? ShortSha;
     public string? OtherMetaData;
     public DateTimeOffset? CommitDate;
     public string? VersionSourceSha;
-    public int? CommitsSinceVersionSource;
-    public int UncommittedChanges;
+    public long? CommitsSinceVersionSource;
+    public long UncommittedChanges;
 
     public SemanticVersionBuildMetaData()
     {
@@ -124,7 +124,7 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
 
         if (parsed.Groups["BuildNumber"].Success)
         {
-            semanticVersionBuildMetaData.CommitsSinceTag = int.Parse(parsed.Groups["BuildNumber"].Value);
+            semanticVersionBuildMetaData.CommitsSinceTag = long.Parse(parsed.Groups["BuildNumber"].Value);
             semanticVersionBuildMetaData.CommitsSinceVersionSource = semanticVersionBuildMetaData.CommitsSinceTag ?? 0;
         }
 

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs
@@ -15,7 +15,7 @@ public class SemanticVersionPreReleaseTag :
     {
     }
 
-    public SemanticVersionPreReleaseTag(string? name, int? number)
+    public SemanticVersionPreReleaseTag(string? name, long? number)
     {
         Name = name;
         Number = number;
@@ -29,7 +29,7 @@ public class SemanticVersionPreReleaseTag :
     }
 
     public string? Name { get; set; }
-    public int? Number { get; set; }
+    public long? Number { get; set; }
     public bool? PromotedFromCommits { get; set; }
 
     public override bool Equals(object? obj) => Equals(obj as SemanticVersionPreReleaseTag);
@@ -76,7 +76,7 @@ public class SemanticVersionPreReleaseTag :
         }
 
         var value = match.Groups["name"].Value;
-        var number = match.Groups["number"].Success ? int.Parse(match.Groups["number"].Value) : (int?)null;
+        var number = match.Groups["number"].Success ? long.Parse(match.Groups["number"].Value) : (long?)null;
         if (value.EndsWith("-"))
             return new SemanticVersionPreReleaseTag(preReleaseTag, null);
 


### PR DESCRIPTION
Change the following properties from `Int32` to to `Int64` to avoid `System.OverflowException` on `int.Parse()` of very large numbers:

- `SemanticVersion.Major`
- `SemanticVersion.Minor`
- `SemanticVersion.Patch`
- `SemanticVersionBuildMetaData.CommitsSinceTag`
- `SemanticVersionBuildMetaData.CommitsSinceVersionSource`
- `SemanticVersionBuildMetaData.UncommittedChanges`
- `SemanticVersionPreReleaseTag.Number`

## Related Issue
Fixes #2715.
Fixes #2915.
Fixes #2390.

## Motivation and Context
Large numbers in a version number may cause the following lines to throw a `System.OverflowException`:

https://github.com/GitTools/GitVersion/blob/32977368a9f29bb215273ca7e205fc7a96b42270/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs#L171-L173

https://github.com/GitTools/GitVersion/blob/32977368a9f29bb215273ca7e205fc7a96b42270/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionBuildMetaData.cs#L127

https://github.com/GitTools/GitVersion/blob/32977368a9f29bb215273ca7e205fc7a96b42270/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionPreReleaseTag.cs#L79

## How Has This Been Tested?
I've added test cases that failed before the code changes were implemented.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
