### PR TITLE
Add link to conventional commits

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -286,6 +286,8 @@ The regular expression should contain the following capture groups:
 * `PullRequestNumber` - Captures the pull-request number
 
 Custom merge message formats are evaluated _before_ any built in formats.
+Support for [Conventional Commits][conventional-commits] can be
+[configured][conventional-commits-config].
 
 ### update-build-number
 
@@ -573,6 +575,8 @@ and [1366].
 [1145]: https://github.com/GitTools/GitVersion/issues/1145
 [1366]: https://github.com/GitTools/GitVersion/issues/1366
 [2506]: https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037
+[conventional-commits-config]: /docs/reference/version-increments#conventional-commit-messages
+[conventional-commits]: https://www.conventionalcommits.org/
 [installing]: /docs/usage/cli/installation
 [modes]: /docs/reference/modes
 [variables]: /docs/reference/variables


### PR DESCRIPTION
Add a link in the documentation to conventional commits so it's easier to find.

## Related Issue
Resolves #2691.

## Motivation and Context
It should be easy to find documentation for how to configure conventional commit support in GitVersion.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
