### PR TITLE
Remove NoMono

### DIFF
--- a/build/build/Tasks/Test/UnitTest.cs
+++ b/build/build/Tasks/Test/UnitTest.cs
@@ -89,7 +89,7 @@ public class UnitTest : FrostingTask<BuildContext>
 
         if (string.Equals(framework, Constants.FullFxVersion48))
         {
-            settings.Filter = context.IsRunningOnUnix() ? $"TestCategory!={Constants.NoMono}" : $"TestCategory!={Constants.NoNet48}";
+            settings.Filter = context.IsRunningOnUnix() ? string.Empty : $"TestCategory!={Constants.NoNet48}";
         }
 
         context.DotNetTest(project.FullPath, settings, coverletSettings);

--- a/src/GitVersion.Core.Tests/Configuration/ConfigProviderTests.cs
+++ b/src/GitVersion.Core.Tests/Configuration/ConfigProviderTests.cs
@@ -228,8 +228,6 @@ branches:
 
     [Test]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CanWriteOutEffectiveConfiguration()
     {
         var config = this.configProvider.Provide(this.repoPath);

--- a/src/GitVersion.Core.Tests/Configuration/Init/InitScenarios.cs
+++ b/src/GitVersion.Core.Tests/Configuration/Init/InitScenarios.cs
@@ -17,8 +17,6 @@ public class InitScenarios : TestBase
     public void Setup() => ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CanSetNextVersion()
     {
         var workingDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c:\\proj" : "/proj";

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -73,8 +73,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CacheKeyForWorktree()
     {
         using var fixture = new EmptyRepositoryFixture();
@@ -411,8 +409,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void GetProjectRootDirectoryWorkingDirectoryWithWorktree()
     {
         using var fixture = new EmptyRepositoryFixture();
@@ -480,8 +476,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void GetDotGitDirectoryWorktree()
     {
         using var fixture = new EmptyRepositoryFixture();
@@ -512,8 +506,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CalculateVersionFromWorktreeHead()
     {
         // Setup
@@ -543,8 +535,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CalculateVersionVariables_TwoBranchHasSameCommitHeadDetachedAndNotTagged_ThrowException()
     {
         // Setup
@@ -571,8 +561,6 @@ public class GitVersionExecutorTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CalculateVersionVariables_TwoBranchHasSameCommitHeadDetachedAndTagged_ReturnSemver()
     {
         // Setup

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -8,8 +8,6 @@ namespace GitVersion.Core.Tests.Helpers;
 
 public class TestBase
 {
-    protected const string NoMonoDescription = "Won't run on Mono due to source information not being available for ShouldMatchApproved.";
-    protected const string NoMono = "NoMono";
     protected const string NoNet48 = "NoNet48";
     public const string MainBranch = "main";
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
@@ -12,8 +12,6 @@ public class WorktreeScenarios : TestBase
 {
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UseWorktreeRepositoryForVersion()
     {
         using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
@@ -13,8 +13,6 @@ public class JsonVersionBuilderTests : TestBase
     public void Setup() => ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void Json()
     {
         var semanticVersion = new SemanticVersion

--- a/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
@@ -48,8 +48,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeliveryModeForPreRelease()
     {
         var semVer = new SemanticVersion
@@ -75,8 +73,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeliveryModeForPreReleaseWithPadding()
     {
         var semVer = new SemanticVersion
@@ -102,8 +98,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeploymentModeForPreRelease()
     {
         var semVer = new SemanticVersion
@@ -128,8 +122,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeliveryModeForStable()
     {
         var semVer = new SemanticVersion
@@ -153,8 +145,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeploymentModeForStable()
     {
         var semVer = new SemanticVersion
@@ -178,8 +168,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeploymentModeForStableWhenCurrentCommitIsTagged()
     {
         var semVer = new SemanticVersion
@@ -251,8 +239,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeliveryModeForFeatureBranch()
     {
         var semVer = new SemanticVersion
@@ -278,8 +264,6 @@ public class VariableProviderTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ProvidesVariablesInContinuousDeliveryModeForFeatureBranchWithCustomAssemblyInfoFormat()
     {
         var semVer = new SemanticVersion

--- a/src/GitVersion.Core.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionConverters/AssemblyInfoFileUpdaterTests.cs
@@ -35,8 +35,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs")]
     [TestCase("fs")]
     [TestCase("vb")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldCreateAssemblyInfoFileWhenNotExistsAndEnsureAssemblyInfo(string fileExtension)
     {
         var workingDir = Path.GetTempPath();
@@ -53,8 +51,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs")]
     [TestCase("fs")]
     [TestCase("vb")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldCreateAssemblyInfoFileAtPathWhenNotExistsAndEnsureAssemblyInfo(string fileExtension)
     {
         var workingDir = Path.GetTempPath();
@@ -71,8 +67,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs")]
     [TestCase("fs")]
     [TestCase("vb")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldCreateAssemblyInfoFilesAtPathWhenNotExistsAndEnsureAssemblyInfo(string fileExtension)
     {
         var workingDir = Path.GetTempPath();
@@ -162,8 +156,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs", "[assembly: AssemblyFileVersion(\"1.0.0.0\")]")]
     [TestCase("fs", "[<assembly: AssemblyFileVersion(\"1.0.0.0\")>]")]
     [TestCase("vb", "<Assembly: AssemblyFileVersion(\"1.0.0.0\")>")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldNotReplaceAssemblyVersionWhenVersionSchemeIsNone(string fileExtension, string assemblyFileContent)
     {
         var workingDir = Path.GetTempPath();
@@ -375,8 +367,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs", "[assembly: AssemblyVersion(\"1.0.0.0\")]\r\n[assembly: AssemblyFileVersion(\"1.0.0.0\")]")]
     [TestCase("fs", "[<assembly: AssemblyVersion(\"1.0.0.0\")>]\r\n[<assembly: AssemblyFileVersion(\"1.0.0.0\")>]")]
     [TestCase("vb", "<Assembly: AssemblyVersion(\"1.0.0.0\")>\r\n<Assembly: AssemblyFileVersion(\"1.0.0.0\")>")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldAddAssemblyInformationalVersionWhenUpdatingAssemblyVersionFile(string fileExtension, string assemblyFileContent)
     {
         var workingDir = Path.GetTempPath();
@@ -396,8 +386,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs", "[assembly: AssemblyVersion(\"1.0.0.0\")]\r\n[assembly: AssemblyFileVersion(\"1.0.0.0\")]\r\n// comment\r\n")]
     [TestCase("fs", "[<assembly: AssemblyVersion(\"1.0.0.0\")>]\r\n[<assembly: AssemblyFileVersion(\"1.0.0.0\")>]\r\ndo\r\n()\r\n")]
     [TestCase("vb", "<Assembly: AssemblyVersion(\"1.0.0.0\")>\r\n<Assembly: AssemblyFileVersion(\"1.0.0.0\")>\r\n' comment\r\n")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void Issue1183ShouldAddFSharpAssemblyInformationalVersionBesideOtherAttributes(string fileExtension, string assemblyFileContent)
     {
         var workingDir = Path.GetTempPath();
@@ -417,8 +405,6 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     [TestCase("cs", "[assembly: AssemblyFileVersion(\"1.0.0.0\")]")]
     [TestCase("fs", "[<assembly: AssemblyFileVersion(\"1.0.0.0\")>]")]
     [TestCase("vb", "<Assembly: AssemblyFileVersion(\"1.0.0.0\")>")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldNotAddAssemblyInformationalVersionWhenVersionSchemeIsNone(string fileExtension, string assemblyFileContent)
     {
         var workingDir = Path.GetTempPath();

--- a/src/GitVersion.Core.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionConverters/GitVersionInfoGeneratorTests.cs
@@ -18,8 +18,6 @@ public class GitVersionInfoGeneratorTests : TestBase
     [TestCase("cs")]
     [TestCase("fs")]
     [TestCase("vb")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void ShouldCreateFile(string fileExtension)
     {
         var directory = Path.GetTempPath();

--- a/src/GitVersion.Core.Tests/VersionConverters/ProjectFileUpdaterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionConverters/ProjectFileUpdaterTests.cs
@@ -37,8 +37,6 @@ public class ProjectFileUpdaterTests : TestBase
         this.projectFileUpdater = new ProjectFileUpdater(this.log, this.fileSystem);
     }
 
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     [TestCase("Microsoft.NET.Sdk")]
     [TestCase("Microsoft.NET.Sdk.Worker")]
     [TestCase("Microsoft.NET.Sdk.Web")]
@@ -69,8 +67,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>
 ")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CannotUpdateProjectFileWithIncorrectProjectSdk(string xml)
     {
         var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
@@ -90,8 +86,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>
 ")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CannotUpdateProjectFileWithMissingProjectSdk(string xml)
     {
         var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
@@ -112,8 +106,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>
 ")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CannotUpdateProjectFileWithoutAssemblyInfoGeneration(string xml)
     {
         var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
@@ -129,8 +121,6 @@ public class ProjectFileUpdaterTests : TestBase
 <Project Sdk=""Microsoft.NET.Sdk"">
 </Project>
 ")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void CannotUpdateProjectFileWithoutAPropertyGroup(string xml)
     {
         var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
@@ -150,8 +140,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>"
     )]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateProjectXmlVersionElementWithStandardXmlInsertsElement(string xml)
     {
         var variables = this.variableProvider.GetVariablesFor(SemanticVersion.Parse("2.0.0", "v"), new TestEffectiveConfiguration(), false);
@@ -179,8 +167,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>"
     )]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateProjectXmlVersionElementWithStandardXmlModifiesElement(string xml)
     {
         var variables = this.variableProvider.GetVariablesFor(SemanticVersion.Parse("2.0.0", "v"), new TestEffectiveConfiguration(), false);
@@ -211,8 +197,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>"
     )]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateProjectXmlVersionElementWithDuplicatePropertyGroupsModifiesLastElement(string xml)
     {
         var variables = this.variableProvider.GetVariablesFor(SemanticVersion.Parse("2.0.0", "v"), new TestEffectiveConfiguration(), false);
@@ -244,8 +228,6 @@ public class ProjectFileUpdaterTests : TestBase
   </PropertyGroup>
 </Project>"
     )]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateProjectXmlVersionElementWithMultipleVersionElementsLastOneIsModified(string xml)
     {
         var variables = this.variableProvider.GetVariablesFor(SemanticVersion.Parse("2.0.0", "v"), new TestEffectiveConfiguration(), false);
@@ -272,8 +254,6 @@ public class ProjectFileUpdaterTests : TestBase
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 </Project>")]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateProjectFileAddsVersionToFile(string xml)
     {
         var fileName = PathHelper.Combine(Path.GetTempPath(), "TestProject.csproj");

--- a/src/GitVersion.Core.Tests/VersionConverters/WixFileTests.cs
+++ b/src/GitVersion.Core.Tests/VersionConverters/WixFileTests.cs
@@ -17,8 +17,6 @@ internal class WixFileTests : TestBase
     public void Setup() => ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateWixVersionFile()
     {
         var workingDir = Path.GetTempPath();
@@ -60,8 +58,6 @@ internal class WixFileTests : TestBase
     }
 
     [Test]
-    [Category(NoMono)]
-    [Description(NoMonoDescription)]
     public void UpdateWixVersionFileWhenFileAlreadyExists()
     {
         var workingDir = Path.GetTempPath();

--- a/src/GitVersion.MsBuild.Tests/Tasks/GenerateGitVersionInformationTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/GenerateGitVersionInformationTest.cs
@@ -52,7 +52,6 @@ public class GenerateGitVersionInformationTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void GenerateGitVersionInformationTaskShouldCreateFileWhenRunWithMsBuild()
     {
         const string taskName = nameof(GenerateGitVersionInformation);
@@ -79,7 +78,6 @@ public class GenerateGitVersionInformationTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void GenerateGitVersionInformationTaskShouldCreateFileWhenRunWithMsBuildInBuildServer()
     {
         const string taskName = nameof(GenerateGitVersionInformation);

--- a/src/GitVersion.MsBuild.Tests/Tasks/GetVersionTaskTests.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/GetVersionTaskTests.cs
@@ -62,7 +62,6 @@ public class GetVersionTaskTests : TestTaskBase
     [TestCase(nameof(VersionVariables.MajorMinorPatch), "1.2.4")]
     [TestCase(nameof(VersionVariables.FullSemVer), "1.2.4+1")]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void GetVersionTaskShouldReturnVersionOutputVariablesWhenRunWithMsBuild(string outputProperty, string version)
     {
         const string taskName = nameof(GetVersion);
@@ -83,7 +82,6 @@ public class GetVersionTaskTests : TestTaskBase
     [TestCase(nameof(VersionVariables.MajorMinorPatch), "1.0.1")]
     [TestCase(nameof(VersionVariables.FullSemVer), "1.0.1+1")]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void GetVersionTaskShouldReturnVersionOutputVariablesWhenRunWithMsBuildInBuildServer(string outputProperty, string version)
     {
         const string taskName = nameof(GetVersion);

--- a/src/GitVersion.MsBuild.Tests/Tasks/UpdateAssemblyInfoTaskTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/UpdateAssemblyInfoTaskTest.cs
@@ -43,7 +43,6 @@ public class UpdateAssemblyInfoTaskTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void UpdateAssemblyInfoTaskShouldCreateFileWhenRunWithMsBuild()
     {
         const string taskName = nameof(UpdateAssemblyInfo);
@@ -66,7 +65,6 @@ public class UpdateAssemblyInfoTaskTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void UpdateAssemblyInfoTaskShouldCreateFileWhenRunWithMsBuildInBuildServer()
     {
         const string taskName = nameof(UpdateAssemblyInfo);

--- a/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
@@ -90,7 +90,6 @@ public class WriteVersionInfoTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void WriteVersionInfoTaskShouldNotLogOutputVariablesToBuildOutputWhenRunWithMsBuild()
     {
         const string taskName = nameof(WriteVersionInfoToBuildLog);
@@ -107,7 +106,6 @@ public class WriteVersionInfoTest : TestTaskBase
 
     [Test]
     [Category(NoNet48)]
-    [Category(NoMono)]
     public void WriteVersionInfoTaskShouldLogOutputVariablesToBuildOutputWhenRunWithMsBuildInAzurePipeline()
     {
         const string taskName = nameof(WriteVersionInfoToBuildLog);


### PR DESCRIPTION
Resolve #2316 by removing the `NoMono` test category.

## Description
It may be that we can do without the `NoMono` test category now. This PR tests that assumption.

## Related Issue
Resolves #2316.

## Motivation and Context
If we don't need to filter out tests to run, we shouldn't.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
