### PR TITLE
Use the environment variable `GIT_BRANCH` as the current branch everywhere

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -99,6 +99,23 @@ public class RemoteRepositoryScenarios : TestBase
     }
 
     [Test]
+    public void GivenARemoteGitRepositoryWhenCheckingOutDetachedHeadWithEnvironmentVariableSucceeds()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        var local = fixture.LocalRepositoryFixture;
+        Commands.Checkout(local.Repository, local.Repository.Head.Tip);
+
+        fixture.AssertFullSemver("0.1.0+4",
+            repository: local.Repository,
+            configureServices: sp =>
+            {
+                sp.GetRequiredService<IEnvironment>().SetEnvironmentVariable("GIT_BRANCH", "main");
+                sp.GetRequiredService<IGitPreparer>().Prepare();
+            });
+    }
+
+
+    [Test]
     [Ignore("Needs more investigations.")]
     public void GivenARemoteGitRepositoryWhenCheckingOutDetachedHeadUsingTrackingBranchOnlyBehaviourShouldReturnVersion014Plus5()
     {

--- a/src/GitVersion.Core/BuildAgents/LocalBuild.cs
+++ b/src/GitVersion.Core/BuildAgents/LocalBuild.cs
@@ -5,10 +5,13 @@ namespace GitVersion.BuildAgents;
 
 public class LocalBuild : BuildAgentBase
 {
-    public LocalBuild(IEnvironment environment, ILog log) : base(environment, log)
+    public LocalBuild(IEnvironment environment, ILog log)
+        : base(environment, log)
     {
     }
+
     protected override string EnvironmentVariable => string.Empty;
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("GIT_BRANCH");
     public override bool CanApplyToCurrentContext() => true;
     public override string? GenerateSetVersionMessage(VersionVariables variables) => null;
     public override string[] GenerateSetParameterMessage(string name, string value) => Array.Empty<string>();

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -44,8 +44,7 @@ public class GitPreparer : IGitPreparer
         // Normalize if we are running on build server
         var normalizeGitDirectory = !gitVersionOptions.Settings.NoNormalize && this.buildAgent is not LocalBuild;
         var shouldCleanUpRemotes = this.buildAgent.ShouldCleanUpRemotes();
-        var currentBranch = ResolveCurrentBranch();
-
+        var currentBranch = this.context.CurrentBranch?.Name.WithoutRemote;
         var dotGitDirectory = this.repositoryInfo.DotGitDirectory;
         var projectRoot = this.repositoryInfo.ProjectRootDirectory;
 
@@ -77,18 +76,6 @@ public class GitPreparer : IGitPreparer
 
             NormalizeGitDirectory(currentBranch, false);
         }
-    }
-
-    private string? ResolveCurrentBranch()
-    {
-        var gitVersionOptions = this.options.Value;
-        var targetBranch = gitVersionOptions.RepositoryInfo.TargetBranch;
-
-        var isDynamicRepository = !gitVersionOptions.RepositoryInfo.DynamicRepositoryClonePath.IsNullOrWhiteSpace();
-        var currentBranch = this.buildAgent.GetCurrentBranch(isDynamicRepository) ?? targetBranch;
-        this.log.Info("Branch from build environment: " + currentBranch);
-
-        return currentBranch;
     }
 
     private void CleanupDuplicateOrigin()

--- a/src/GitVersion.Core/Core/GitVersionContextFactory.cs
+++ b/src/GitVersion.Core/Core/GitVersionContextFactory.cs
@@ -1,6 +1,8 @@
+using GitVersion.BuildAgents;
 using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
+using GitVersion.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GitVersion;
@@ -10,36 +12,81 @@ public class GitVersionContextFactory : IGitVersionContextFactory
     private readonly IConfigProvider configProvider;
     private readonly IRepositoryStore repositoryStore;
     private readonly IBranchConfigurationCalculator branchConfigurationCalculator;
+    private readonly IBuildAgent buildAgent;
+    private readonly ILog log;
     private readonly IOptions<GitVersionOptions> options;
 
-    public GitVersionContextFactory(IConfigProvider configProvider, IRepositoryStore repositoryStore, IBranchConfigurationCalculator branchConfigurationCalculator, IOptions<GitVersionOptions> options)
+    public GitVersionContextFactory(IConfigProvider configProvider, IRepositoryStore repositoryStore, IBranchConfigurationCalculator branchConfigurationCalculator, IBuildAgentResolver buildAgentResolver, ILog log, IOptions<GitVersionOptions> options)
     {
         this.configProvider = configProvider.NotNull();
         this.repositoryStore = repositoryStore.NotNull();
         this.branchConfigurationCalculator = branchConfigurationCalculator.NotNull();
+        this.buildAgent = buildAgentResolver.NotNull().Resolve();
+        this.log = log.NotNull();
         this.options = options.NotNull();
     }
 
     public GitVersionContext Create(GitVersionOptions gitVersionOptions)
     {
-        var currentBranch = this.repositoryStore.GetTargetBranch(gitVersionOptions.RepositoryInfo.TargetBranch);
-        if (currentBranch == null)
-            throw new InvalidOperationException("Need a branch to operate on");
-
-        var currentCommit = this.repositoryStore.GetCurrentCommit(currentBranch, gitVersionOptions.RepositoryInfo.CommitId);
-
+        var branchCommit = ResolveCurrentBranchCommit(gitVersionOptions);
+        var currentBranch = branchCommit.Branch;
+        var currentCommit = branchCommit.Commit;
         var configuration = this.configProvider.Provide(this.options.Value.ConfigInfo.OverrideConfig);
-        if (currentBranch.IsDetachedHead)
-        {
-            var branchForCommit = this.repositoryStore.GetBranchesContainingCommit(currentCommit, onlyTrackedBranches: gitVersionOptions.Settings.OnlyTrackedBranches).OnlyOrDefault();
-            currentBranch = branchForCommit ?? currentBranch;
-        }
-
         var currentBranchConfig = this.branchConfigurationCalculator.GetBranchConfiguration(currentBranch, currentCommit, configuration);
         var effectiveConfiguration = configuration.CalculateEffectiveConfiguration(currentBranchConfig);
         var currentCommitTaggedVersion = this.repositoryStore.GetCurrentCommitTaggedVersion(currentCommit, effectiveConfiguration);
         var numberOfUncommittedChanges = this.repositoryStore.GetNumberOfUncommittedChanges();
 
         return new GitVersionContext(currentBranch, currentCommit, configuration, effectiveConfiguration, currentCommitTaggedVersion, numberOfUncommittedChanges);
+    }
+
+    private BranchCommit ResolveCurrentBranchCommit(GitVersionOptions gitVersionOptions)
+    {
+        var currentBranch = ResolveCurrentBranch();
+        var currentCommit = this.repositoryStore.GetCurrentCommit(currentBranch, gitVersionOptions.RepositoryInfo.CommitId);
+
+        if (currentBranch.IsDetachedHead)
+        {
+            currentBranch = this.repositoryStore.GetBranchesContainingCommit(currentCommit,
+                onlyTrackedBranches: gitVersionOptions.Settings.OnlyTrackedBranches).OnlyOrDefault()
+                            ?? currentBranch;
+        }
+
+        return new BranchCommit(currentCommit, currentBranch);
+    }
+
+    private IBranch ResolveCurrentBranch()
+    {
+        var currentBranchName = ResolveCurrentBranchName();
+        var currentBranch = this.repositoryStore.GetTargetBranch(currentBranchName);
+
+        if (currentBranch == null)
+            throw new InvalidOperationException("Need a branch to operate on");
+
+        return currentBranch;
+    }
+
+    private string? ResolveCurrentBranchName()
+    {
+        var gitVersionOptions = this.options.Value;
+        var isDynamicRepository = !gitVersionOptions.RepositoryInfo.DynamicRepositoryClonePath.IsNullOrWhiteSpace();
+        var currentBranch = this.buildAgent.GetCurrentBranch(isDynamicRepository);
+
+        if (!currentBranch.IsNullOrWhiteSpace())
+        {
+            this.log.Info($"Branch from build environment: {currentBranch}");
+            return currentBranch;
+        }
+
+        var targetBranch = gitVersionOptions.RepositoryInfo.TargetBranch;
+
+        if (!targetBranch.IsNullOrWhiteSpace())
+        {
+            this.log.Info($"Branch from Git repository: {targetBranch}");
+            return targetBranch;
+        }
+
+        this.log.Info($"No branch found in environment or repository; this is probably a detached HEAD.");
+        return null;
     }
 }

--- a/src/GitVersion.Core/Model/GitVersionContext.cs
+++ b/src/GitVersion.Core/Model/GitVersionContext.cs
@@ -3,12 +3,28 @@ using GitVersion.Model.Configuration;
 namespace GitVersion;
 
 /// <summary>
-/// Contextual information about where GitVersion is being run
+///     Contextual information about where GitVersion is being run
 /// </summary>
 public class GitVersionContext
 {
+    public GitVersionContext(
+        IBranch currentBranch,
+        ICommit? currentCommit,
+        Config configuration,
+        EffectiveConfiguration effectiveConfiguration,
+        SemanticVersion currentCommitTaggedVersion,
+        int numberOfUncommittedChanges)
+    {
+        CurrentBranch = currentBranch;
+        CurrentCommit = currentCommit;
+        FullConfiguration = configuration;
+        Configuration = effectiveConfiguration;
+        CurrentCommitTaggedVersion = currentCommitTaggedVersion;
+        NumberOfUncommittedChanges = numberOfUncommittedChanges;
+    }
+
     /// <summary>
-    /// Contains the raw configuration, use Configuration for specific config based on the current GitVersion context.
+    ///     Contains the raw configuration, use Configuration for specific config based on the current GitVersion context.
     /// </summary>
     public Config FullConfiguration { get; }
 
@@ -17,20 +33,5 @@ public class GitVersionContext
     public IBranch CurrentBranch { get; }
     public ICommit? CurrentCommit { get; }
     public bool IsCurrentCommitTagged => CurrentCommitTaggedVersion != null;
-
     public int NumberOfUncommittedChanges { get; }
-
-    public GitVersionContext(IBranch currentBranch, ICommit? currentCommit,
-        Config configuration, EffectiveConfiguration effectiveConfiguration,
-        SemanticVersion currentCommitTaggedVersion, int numberOfUncommittedChanges)
-    {
-        CurrentBranch = currentBranch;
-        CurrentCommit = currentCommit;
-
-        FullConfiguration = configuration;
-        Configuration = effectiveConfiguration;
-
-        CurrentCommitTaggedVersion = currentCommitTaggedVersion;
-        NumberOfUncommittedChanges = numberOfUncommittedChanges;
-    }
 }


### PR DESCRIPTION
Currently, the environment variable `GIT_BRANCH` is used to override which branch the `GitPreparer` uses for its logic. This PR expands that usage to the entire codebase by moving the logic from `GitPreparer` to `GitVersionContextFactory`.

I will add documentation for this when time allows.

## Related Issue
Fixes #2900.

## Motivation and Context
It's unintuitive that `GIT_BRANCH` can be used to override the branch name only for normalization and not for version calculation.

## How Has This Been Tested?
I added a test and refactored the plumbing a bit so it's easier to set environment variables inside a test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
