### PR TITLE
Fix: Process all release branch configs

### DIFF
--- a/src/GitVersion.Core.Tests/Configuration/ConfigExtensionsTests.cs
+++ b/src/GitVersion.Core.Tests/Configuration/ConfigExtensionsTests.cs
@@ -1,0 +1,30 @@
+using GitVersion.Configuration;
+using GitVersion.Core.Tests.Helpers;
+using GitVersion.Model.Configuration;
+using NUnit.Framework;
+using Shouldly;
+
+namespace GitVersion.Core.Tests.Configuration;
+
+[TestFixture]
+public class ConfigExtensionsTests : TestBase
+{
+    [Test]
+    public void GetReleaseBranchConfigReturnsAllReleaseBranches()
+    {
+        var config = new Config()
+        {
+            Branches = new Dictionary<string, BranchConfig>
+            {
+                { "foo", new BranchConfig { Name = "foo" } },
+                { "bar", new BranchConfig { Name = "bar", IsReleaseBranch = true } },
+                { "baz", new BranchConfig { Name = "baz", IsReleaseBranch = true } }
+            }
+        };
+
+        var result = config.GetReleaseBranchConfig();
+
+        result.Count.ShouldBe(2);
+        result.ShouldNotContain(b => b.Key == "foo");
+    }
+}

--- a/src/GitVersion.Core/Configuration/ConfigExtensions.cs
+++ b/src/GitVersion.Core/Configuration/ConfigExtensions.cs
@@ -142,15 +142,8 @@ public static class ConfigExtensions
         return tagToUse;
     }
 
-    public static List<KeyValuePair<string, BranchConfig>> GetReleaseBranchConfig(this Config configuration)
-    {
-        foreach (var (key, value) in configuration.Branches)
-        {
-            if (value?.IsReleaseBranch != null && value.IsReleaseBranch.Value)
-            {
-                return new List<KeyValuePair<string, BranchConfig>> { new(key, value) };
-            }
-        }
-        return new List<KeyValuePair<string, BranchConfig>>();
-    }
+    public static List<KeyValuePair<string, BranchConfig>> GetReleaseBranchConfig(this Config configuration) =>
+        configuration.Branches
+            .Where(b => b.Value.IsReleaseBranch == true)
+            .ToList();
 }


### PR DESCRIPTION
Addresses behaviour change introduced in https://github.com/GitTools/GitVersion/commit/666bd37b59ae731b1d2bd40b20364b692b21796e#diff-ed7cd46ab7275f1c6426494ffd4b47c5a493ffc28232439fe6abe78eee2ee9e2L150-R155

Prior to that commit, it would process all release branch configs. With the commit, it would exit out on the first release branch.

## Description
<!--- Describe your changes in detail -->

## Related Issue
Fixes #3050

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See #3050

## How Has This Been Tested?

There is a new test added to confirm the existing behaviour that it returns multiple release branches.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
