### PR TITLE
Add `null` protection

### DIFF
--- a/src/GitVersion.LibGit2Sharp/Git/Branch.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Branch.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -11,7 +12,7 @@ internal sealed class Branch : IBranch
 
     internal Branch(LibGit2Sharp.Branch branch)
     {
-        this.innerBranch = branch;
+        this.innerBranch = branch.NotNull();
         Name = new ReferenceName(branch.CanonicalName);
 
         var commit = this.innerBranch.Tip;
@@ -20,19 +21,17 @@ internal sealed class Branch : IBranch
         var commits = this.innerBranch.Commits;
         Commits = commits is null ? null : new CommitCollection(commits);
     }
+
     public ReferenceName Name { get; }
     public ICommit? Tip { get; }
     public ICommitCollection? Commits { get; }
-
     public int CompareTo(IBranch other) => comparerHelper.Compare(this, other);
     public bool Equals(IBranch? other) => equalityHelper.Equals(this, other);
+    public bool IsDetachedHead => Name.Canonical.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
+    public bool IsRemote => this.innerBranch.IsRemote;
+    public bool IsTracking => this.innerBranch.IsTracking;
     public override bool Equals(object obj) => Equals((obj as IBranch));
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => Name.ToString();
     public static implicit operator LibGit2Sharp.Branch(Branch d) => d.innerBranch;
-
-    public bool IsDetachedHead => Name.Canonical.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
-
-    public bool IsRemote => this.innerBranch.IsRemote;
-    public bool IsTracking => this.innerBranch.IsTracking;
 }

--- a/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
@@ -1,23 +1,47 @@
+using GitVersion.Extensions;
+using LibGit2Sharp;
+
 namespace GitVersion;
 
 internal sealed class BranchCollection : IBranchCollection
 {
     private readonly LibGit2Sharp.BranchCollection innerCollection;
-    internal BranchCollection(LibGit2Sharp.BranchCollection collection) => this.innerCollection = collection;
 
-    public IEnumerator<IBranch> GetEnumerator() => this.innerCollection.Select(branch => new Branch(branch)).GetEnumerator();
+    internal BranchCollection(LibGit2Sharp.BranchCollection collection)
+        => this.innerCollection = collection.NotNull();
+
+    public IEnumerator<IBranch> GetEnumerator()
+        => this.innerCollection.Select(branch => new Branch(branch)).GetEnumerator();
+
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
     public IBranch? this[string name]
     {
         get
         {
+            name = name.NotNull();
             var branch = this.innerCollection[name];
             return branch is null ? null : new Branch(branch);
         }
     }
 
-    public IEnumerable<IBranch> ExcludeBranches(IEnumerable<IBranch> branchesToExclude) =>
-        this.Where(b => branchesToExclude.All(bte => !b.Equals(bte)));
-    public void UpdateTrackedBranch(IBranch branch, string remoteTrackingReferenceName) =>
-        this.innerCollection.Update((Branch)branch, b => b.TrackedBranch = remoteTrackingReferenceName);
+    public IEnumerable<IBranch> ExcludeBranches(IEnumerable<IBranch> branchesToExclude)
+    {
+        branchesToExclude = branchesToExclude.NotNull();
+
+        bool BranchIsNotExcluded(IBranch branch)
+            => branchesToExclude.All(branchToExclude => !branch.Equals(branchToExclude));
+
+        return this.Where(BranchIsNotExcluded);
+    }
+
+    public void UpdateTrackedBranch(IBranch branch, string remoteTrackingReferenceName)
+    {
+        var branchToUpdate = (Branch)branch.NotNull();
+
+        void Updater(BranchUpdater branchUpdater) =>
+            branchUpdater.TrackedBranch = remoteTrackingReferenceName;
+
+        this.innerCollection.Update(branchToUpdate, Updater);
+    }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -11,20 +12,18 @@ internal sealed class Commit : GitObject, ICommit
 
     internal Commit(LibGit2Sharp.Commit innerCommit) : base(innerCommit)
     {
-        this.innerCommit = innerCommit;
+        this.innerCommit = innerCommit.NotNull();
         Parents = innerCommit.Parents.Select(parent => new Commit(parent));
         When = innerCommit.Committer.When;
     }
 
     public int CompareTo(ICommit other) => comparerHelper.Compare(this, other);
     public bool Equals(ICommit? other) => equalityHelper.Equals(this, other);
+    public IEnumerable<ICommit> Parents { get; }
+    public DateTimeOffset When { get; }
+    public string Message => this.innerCommit.Message;
     public override bool Equals(object obj) => Equals((obj as ICommit));
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => $"{Id.ToString(7)} {this.innerCommit.MessageShort}";
     public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
-
-    public IEnumerable<ICommit> Parents { get; }
-    public DateTimeOffset When { get; }
-
-    public string Message => this.innerCommit.Message;
 }

--- a/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using LibGit2Sharp;
 
 namespace GitVersion;
@@ -5,13 +6,17 @@ namespace GitVersion;
 internal sealed class CommitCollection : ICommitCollection
 {
     private readonly ICommitLog innerCollection;
-    internal CommitCollection(ICommitLog collection) => this.innerCollection = collection;
 
-    public IEnumerator<ICommit> GetEnumerator() => this.innerCollection.Select(commit => new Commit(commit)).GetEnumerator();
+    internal CommitCollection(ICommitLog collection) => this.innerCollection = collection.NotNull();
+
+    public IEnumerator<ICommit> GetEnumerator()
+        => this.innerCollection.Select(commit => new Commit(commit)).GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public IEnumerable<ICommit> GetCommitsPriorTo(DateTimeOffset olderThan) => this.SkipWhile(c => c.When > olderThan);
+    public IEnumerable<ICommit> GetCommitsPriorTo(DateTimeOffset olderThan)
+        => this.SkipWhile(c => c.When > olderThan);
+
     public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter)
     {
         static object? GetReacheableFrom(object? item) =>
@@ -24,13 +29,7 @@ internal sealed class CommitCollection : ICommitCollection
 
         var includeReachableFrom = GetReacheableFrom(commitFilter.IncludeReachableFrom);
         var excludeReachableFrom = GetReacheableFrom(commitFilter.ExcludeReachableFrom);
-        var filter = new LibGit2Sharp.CommitFilter
-        {
-            IncludeReachableFrom = includeReachableFrom,
-            ExcludeReachableFrom = excludeReachableFrom,
-            FirstParentOnly = commitFilter.FirstParentOnly,
-            SortBy = (LibGit2Sharp.CommitSortStrategies)commitFilter.SortBy
-        };
+        var filter = new LibGit2Sharp.CommitFilter { IncludeReachableFrom = includeReachableFrom, ExcludeReachableFrom = excludeReachableFrom, FirstParentOnly = commitFilter.FirstParentOnly, SortBy = (LibGit2Sharp.CommitSortStrategies)commitFilter.SortBy };
         var commitLog = ((IQueryableCommitLog)this.innerCollection).QueryBy(filter);
         return new CommitCollection(commitLog);
     }

--- a/src/GitVersion.LibGit2Sharp/Git/GitObject.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitObject.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -9,6 +10,7 @@ internal class GitObject : IGitObject
 
     internal GitObject(LibGit2Sharp.GitObject innerGitObject)
     {
+        innerGitObject = innerGitObject.NotNull();
         Id = new ObjectId(innerGitObject.Id);
         Sha = innerGitObject.Sha;
     }

--- a/src/GitVersion.LibGit2Sharp/Git/ObjectId.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ObjectId.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -8,7 +9,9 @@ internal sealed class ObjectId : IObjectId
     private static readonly LambdaKeyComparer<IObjectId, string> comparerHelper = new(x => x.Sha);
 
     private readonly LibGit2Sharp.ObjectId innerObjectId;
-    internal ObjectId(LibGit2Sharp.ObjectId objectId) => this.innerObjectId = objectId;
+
+    internal ObjectId(LibGit2Sharp.ObjectId objectId) =>
+        this.innerObjectId = objectId.NotNull();
 
     public ObjectId(string sha) : this(new LibGit2Sharp.ObjectId(sha))
     {

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -6,17 +7,16 @@ public class RefSpec : IRefSpec
 {
     private static readonly LambdaEqualityHelper<IRefSpec> equalityHelper = new(x => x.Specification);
     private static readonly LambdaKeyComparer<IRefSpec, string> comparerHelper = new(x => x.Specification);
-
     private readonly LibGit2Sharp.RefSpec innerRefSpec;
 
-    internal RefSpec(LibGit2Sharp.RefSpec refSpec) => this.innerRefSpec = refSpec;
+    internal RefSpec(LibGit2Sharp.RefSpec refSpec) => this.innerRefSpec = refSpec.NotNull();
     public int CompareTo(IRefSpec other) => comparerHelper.Compare(this, other);
     public bool Equals(IRefSpec? other) => equalityHelper.Equals(this, other);
-    public override bool Equals(object obj) => Equals((obj as IRefSpec));
-    public override int GetHashCode() => equalityHelper.GetHashCode(this);
-    public override string ToString() => Specification;
     public string Specification => this.innerRefSpec.Specification;
     public RefSpecDirection Direction => (RefSpecDirection)this.innerRefSpec.Direction;
     public string Source => this.innerRefSpec.Source;
     public string Destination => this.innerRefSpec.Destination;
+    public override bool Equals(object obj) => Equals((obj as IRefSpec));
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Specification;
 }

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
@@ -1,9 +1,14 @@
+using GitVersion.Extensions;
+
 namespace GitVersion;
 
 internal sealed class RefSpecCollection : IRefSpecCollection
 {
     private readonly LibGit2Sharp.RefSpecCollection innerCollection;
-    internal RefSpecCollection(LibGit2Sharp.RefSpecCollection collection) => this.innerCollection = collection;
+
+    internal RefSpecCollection(LibGit2Sharp.RefSpecCollection collection)
+        => this.innerCollection = collection.NotNull();
+
     public IEnumerator<IRefSpec> GetEnumerator() => this.innerCollection.Select(tag => new RefSpec(tag)).GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Reference.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Reference.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 using LibGit2Sharp;
 
@@ -7,25 +8,26 @@ namespace GitVersion
     {
         private static readonly LambdaEqualityHelper<IReference> equalityHelper = new(x => x.Name.Canonical);
         private static readonly LambdaKeyComparer<IReference, string> comparerHelper = new(x => x.Name.Canonical);
-
         internal readonly LibGit2Sharp.Reference innerReference;
 
         internal Reference(LibGit2Sharp.Reference reference)
         {
-            this.innerReference = reference;
+            this.innerReference = reference.NotNull();
             Name = new ReferenceName(reference.CanonicalName);
 
             if (reference is DirectReference)
                 ReferenceTargetId = new ObjectId(reference.TargetIdentifier);
         }
+
         public ReferenceName Name { get; }
         public IObjectId? ReferenceTargetId { get; }
         public int CompareTo(IReference other) => comparerHelper.Compare(this, other);
-        public override bool Equals(object obj) => Equals((obj as IReference));
+        public override bool Equals(object obj) => Equals(obj as IReference);
         public bool Equals(IReference? other) => equalityHelper.Equals(this, other);
         public override int GetHashCode() => equalityHelper.GetHashCode(this);
         public override string ToString() => Name.ToString();
         public string TargetIdentifier => this.innerReference.TargetIdentifier;
-        public static implicit operator LibGit2Sharp.Reference(Reference d) => d.innerReference;
+        public static implicit operator LibGit2Sharp.Reference(Reference d)
+            => d.NotNull().innerReference;
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -1,9 +1,13 @@
+using GitVersion.Extensions;
+
 namespace GitVersion;
 
 internal sealed class ReferenceCollection : IReferenceCollection
 {
     private readonly LibGit2Sharp.ReferenceCollection innerCollection;
-    internal ReferenceCollection(LibGit2Sharp.ReferenceCollection collection) => this.innerCollection = collection;
+
+    internal ReferenceCollection(LibGit2Sharp.ReferenceCollection collection)
+        => this.innerCollection = collection.NotNull();
 
     public IEnumerator<IReference> GetEnumerator() => this.innerCollection.Select(reference => new Reference(reference)).GetEnumerator();
 

--- a/src/GitVersion.LibGit2Sharp/Git/Remote.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Remote.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -9,13 +10,10 @@ internal sealed class Remote : IRemote
 
     private readonly LibGit2Sharp.Remote innerRemote;
 
-    internal Remote(LibGit2Sharp.Remote remote) => this.innerRemote = remote;
+    internal Remote(LibGit2Sharp.Remote remote) => this.innerRemote = remote.NotNull();
 
     public int CompareTo(IRemote other) => comparerHelper.Compare(this, other);
     public bool Equals(IRemote? other) => equalityHelper.Equals(this, other);
-    public override bool Equals(object obj) => Equals((obj as IRemote));
-    public override int GetHashCode() => equalityHelper.GetHashCode(this);
-    public override string ToString() => Name;
     public string Name => this.innerRemote.Name;
     public string Url => this.innerRemote.Url;
 
@@ -29,7 +27,10 @@ internal sealed class Remote : IRemote
                 : new RefSpecCollection((LibGit2Sharp.RefSpecCollection)refSpecs);
         }
     }
-    public IEnumerable<IRefSpec> FetchRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Fetch);
 
+    public IEnumerable<IRefSpec> FetchRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Fetch);
     public IEnumerable<IRefSpec> PushRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Push);
+    public override bool Equals(object obj) => Equals((obj as IRemote));
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name;
 }

--- a/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
@@ -1,11 +1,17 @@
+using GitVersion.Extensions;
+
 namespace GitVersion;
 
 internal sealed class RemoteCollection : IRemoteCollection
 {
     private readonly LibGit2Sharp.RemoteCollection innerCollection;
-    internal RemoteCollection(LibGit2Sharp.RemoteCollection collection) => this.innerCollection = collection;
 
-    public IEnumerator<IRemote> GetEnumerator() => this.innerCollection.Select(reference => new Remote(reference)).GetEnumerator();
+    internal RemoteCollection(LibGit2Sharp.RemoteCollection collection)
+        => this.innerCollection = collection.NotNull();
+
+    public IEnumerator<IRemote> GetEnumerator()
+        => this.innerCollection.Select(reference => new Remote(reference)).GetEnumerator();
+
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public IRemote? this[string name]
@@ -18,5 +24,7 @@ internal sealed class RemoteCollection : IRemoteCollection
     }
 
     public void Remove(string remoteName) => this.innerCollection.Remove(remoteName);
-    public void Update(string remoteName, string refSpec) => this.innerCollection.Update(remoteName, r => r.FetchRefSpecs.Add(refSpec));
+
+    public void Update(string remoteName, string refSpec)
+        => this.innerCollection.Update(remoteName, r => r.FetchRefSpecs.Add(refSpec));
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Tag.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Tag.cs
@@ -1,3 +1,4 @@
+using GitVersion.Extensions;
 using GitVersion.Helpers;
 using LibGit2Sharp;
 
@@ -7,20 +8,17 @@ internal sealed class Tag : ITag
 {
     private static readonly LambdaEqualityHelper<ITag> equalityHelper = new(x => x.Name.Canonical);
     private static readonly LambdaKeyComparer<ITag, string> comparerHelper = new(x => x.Name.Canonical);
-
     private readonly LibGit2Sharp.Tag innerTag;
+
     internal Tag(LibGit2Sharp.Tag tag)
     {
-        this.innerTag = tag;
+        this.innerTag = tag.NotNull();
         Name = new ReferenceName(this.innerTag.CanonicalName);
     }
-    public ReferenceName Name { get; }
 
+    public ReferenceName Name { get; }
     public int CompareTo(ITag other) => comparerHelper.Compare(this, other);
     public bool Equals(ITag? other) => equalityHelper.Equals(this, other);
-    public override bool Equals(object obj) => Equals((obj as ITag));
-    public override int GetHashCode() => equalityHelper.GetHashCode(this);
-    public override string ToString() => Name.ToString();
     public string? TargetSha => this.innerTag.Target.Sha;
 
     public ICommit? PeeledTargetCommit()
@@ -34,4 +32,8 @@ internal sealed class Tag : ITag
 
         return target is LibGit2Sharp.Commit commit ? new Commit(commit) : null;
     }
+
+    public override bool Equals(object obj) => Equals((obj as ITag));
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name.ToString();
 }

--- a/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
@@ -1,11 +1,16 @@
+using GitVersion.Extensions;
+
 namespace GitVersion;
 
 internal sealed class TagCollection : ITagCollection
 {
     private readonly LibGit2Sharp.TagCollection innerCollection;
-    internal TagCollection(LibGit2Sharp.TagCollection collection) => this.innerCollection = collection;
 
-    public IEnumerator<ITag> GetEnumerator() => this.innerCollection.Select(tag => new Tag(tag)).GetEnumerator();
+    internal TagCollection(LibGit2Sharp.TagCollection collection)
+        => this.innerCollection = collection.NotNull();
+
+    public IEnumerator<ITag> GetEnumerator()
+        => this.innerCollection.Select(tag => new Tag(tag)).GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GitVersion.sln.DotSettings
+++ b/src/GitVersion.sln.DotSettings
@@ -138,7 +138,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
 	
 	
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_MULTIPLE_TYPE_PARAMEER_CONSTRAINTS_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>


### PR DESCRIPTION
Add `null` guards to `GitObject` and `ObjectId` to avoid `NullReferenceException`.

## Description

This PR is an exploration of which `null` guards we can add to avoid `NullReferenceException` and possibly also avoiding `null` before they reach `GitVersion.Core`.

## Related Issue
Resolves #2775.

The following issues aren't fixed as this PR doesn't address the underlying issues, but this PR will provide a much more informative stack trace so if anyone encounters the underlying issues again, we'll have a better chance at figuring out what the issue is and actually fix it.

Closes #2605.
Closes #2631.
Closes #2695.
Closes #2734.
Closes #2825.

## Motivation and Context
See #2775 and all linked issues.

## How Has This Been Tested?
I'm counting on our existing test coverage to sufficiently exercise the code involved.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
