### PR TITLE
Revert "Use GITHUB_REF only for CI builds on branches"

### DIFF
--- a/src/GitVersion.Core.Tests/BuildAgents/AzurePipelinesTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/AzurePipelinesTests.cs
@@ -80,43 +80,4 @@ public class AzurePipelinesTests : TestBase
         var logMessage = this.buildServer.GenerateSetVersionMessage(vars);
         logMessage.ShouldBe(logPrefix + expectedBuildNumber);
     }
-
-    [Test]
-    public void GetCurrentBranchShouldHandleBranches()
-    {
-        // Arrange
-        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", $"refs/heads/{MainBranch}");
-
-        // Act
-        var result = this.buildServer.GetCurrentBranch(false);
-
-        // Assert
-        result.ShouldBe($"refs/heads/{MainBranch}");
-    }
-
-    [Test]
-    public void GetCurrentBranchShouldHandleTags()
-    {
-        // Arrange
-        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/tags/1.0.0");
-
-        // Act
-        var result = this.buildServer.GetCurrentBranch(false);
-
-        // Assert
-        result.ShouldBeNull();
-    }
-
-    [Test]
-    public void GetCurrentBranchShouldHandlePullRequests()
-    {
-        // Arrange
-        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/pull/1/merge");
-
-        // Act
-        var result = this.buildServer.GetCurrentBranch(false);
-
-        // Assert
-        result.ShouldBeNull();
-    }
 }

--- a/src/GitVersion.Core.Tests/BuildAgents/BuildKiteTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/BuildKiteTests.cs
@@ -72,7 +72,7 @@ public class BuildKiteTests : TestBase
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBeNull();
+        result.ShouldBe("refs/pull/55/head");
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/BuildAgents/CodeBuildTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/CodeBuildTests.cs
@@ -102,30 +102,4 @@ public sealed class CodeBuildTests : TestBase
         props.ShouldContain("GitVersion_Major=1");
         props.ShouldContain("GitVersion_Minor=2");
     }
-
-    [Test]
-    public void GetCurrentBranchShouldHandleTags()
-    {
-        // Arrange
-        this.environment.SetEnvironmentVariable("CODEBUILD_WEBHOOK_HEAD_REF", "refs/tags/1.0.0");
-
-        // Act
-        var result = this.buildServer.GetCurrentBranch(false);
-
-        // Assert
-        result.ShouldBeNull();
-    }
-
-    [Test]
-    public void GetCurrentBranchShouldHandlePullRequests()
-    {
-        // Arrange
-        this.environment.SetEnvironmentVariable("CODEBUILD_SOURCE_VERSION", "refs/pull/1/merge");
-
-        // Act
-        var result = this.buildServer.GetCurrentBranch(false);
-
-        // Assert
-        result.ShouldBeNull();
-    }
 }

--- a/src/GitVersion.Core.Tests/BuildAgents/GitHubActionsTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/GitHubActionsTests.cs
@@ -83,7 +83,7 @@ public class GitHubActionsTests : TestBase
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBeNull();
+        result.ShouldBe("refs/tags/1.0.0");
     }
 
     [Test]
@@ -96,7 +96,7 @@ public class GitHubActionsTests : TestBase
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBeNull();
+        result.ShouldBe("refs/pull/1/merge");
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/BuildAgents/SpaceAutomationTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/SpaceAutomationTests.cs
@@ -1,10 +1,11 @@
+using GitVersion;
 using GitVersion.BuildAgents;
 using GitVersion.Core.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
 
-namespace GitVersion.Core.Tests.BuildAgents;
+namespace GitVersionCore.Tests.BuildAgents;
 
 [TestFixture]
 public class SpaceAutomationTests : TestBase
@@ -70,7 +71,7 @@ public class SpaceAutomationTests : TestBase
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBeNull();
+        result.ShouldBe("refs/tags/1.0.0");
     }
 
     [Test]
@@ -83,7 +84,7 @@ public class SpaceAutomationTests : TestBase
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBeNull();
+        result.ShouldBe("refs/pull/1/merge");
     }
 
     [Test]

--- a/src/GitVersion.Core/BuildAgents/AzurePipelines.cs
+++ b/src/GitVersion.Core/BuildAgents/AzurePipelines.cs
@@ -21,17 +21,7 @@ public class AzurePipelines : BuildAgentBase
         $"##vso[task.setvariable variable=GitVersion.{name};isOutput=true]{value}"
     };
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos)
-    {
-        // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
-        // BUILD_SOURCEBRANCH does not contain the branch name if the build was triggered by a tag or pull request.
-        string? branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
-        if (branchName != null && branchName.StartsWith("refs/heads/"))
-        {
-            return branchName;
-        }
-        return null;
-    }
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
     public override bool PreventFetch() => true;
 

--- a/src/GitVersion.Core/BuildAgents/BuildKite.cs
+++ b/src/GitVersion.Core/BuildAgents/BuildKite.cs
@@ -30,9 +30,9 @@ public class BuildKite : BuildAgentBase
         }
         else
         {
-            // To align the behavior with the other BuildAgent implementations
-            // we return here also null.
-            return null;
+            // For pull requests BUILDKITE_BRANCH refers to the head, so adjust the
+            // branch name for pull request versioning to function as expected
+            return string.Format("refs/pull/{0}/head", pullRequest);
         }
     }
 

--- a/src/GitVersion.Core/BuildAgents/CodeBuild.cs
+++ b/src/GitVersion.Core/BuildAgents/CodeBuild.cs
@@ -25,17 +25,9 @@ public sealed class CodeBuild : BuildAgentBase
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        string? branchName = Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName);
-        if (string.IsNullOrEmpty(branchName))
-        {
-            branchName = Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName);
-        }
+        var currentBranch = Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName);
 
-        if (branchName != null && branchName.StartsWith("refs/heads/"))
-        {
-            return branchName;
-        }
-        return null;
+        return currentBranch.IsNullOrEmpty() ? Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName) : currentBranch;
     }
 
     public override void WriteIntegration(Action<string?> writer, VersionVariables variables, bool updateBuildNumber = true)

--- a/src/GitVersion.Core/BuildAgents/GitHubActions.cs
+++ b/src/GitVersion.Core/BuildAgents/GitHubActions.cs
@@ -50,18 +50,7 @@ public class GitHubActions : BuildAgentBase
         }
     }
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos)
-    {
-        // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-        // GITHUB_REF must be used only for "real" branches, not for tags and pull requests.
-        // Bug fix for https://github.com/GitTools/GitVersion/issues/2838
-        string? githubRef = Environment.GetEnvironmentVariable("GITHUB_REF");
-        if (githubRef != null && githubRef.StartsWith("refs/heads/"))
-        {
-            return githubRef;
-        }
-        return null;
-    }
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("GITHUB_REF");
 
     public override bool PreventFetch() => true;
 }

--- a/src/GitVersion.Core/BuildAgents/GitLabCi.cs
+++ b/src/GitVersion.Core/BuildAgents/GitLabCi.cs
@@ -22,9 +22,7 @@ public class GitLabCi : BuildAgentBase
         $"GitVersion_{name}={value}"
     };
 
-    // According to https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-    // the CI_COMMIT_BRANCH environment variable must be used.
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("CI_COMMIT_BRANCH");
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
 
     public override bool PreventFetch() => true;
 

--- a/src/GitVersion.Core/BuildAgents/SpaceAutomation.cs
+++ b/src/GitVersion.Core/BuildAgents/SpaceAutomation.cs
@@ -13,15 +13,7 @@ public class SpaceAutomation : BuildAgentBase
 
     protected override string EnvironmentVariable => EnvironmentVariableName;
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos)
-    {
-        string? branchName = Environment.GetEnvironmentVariable("JB_SPACE_GIT_BRANCH");
-        if (branchName != null && branchName.StartsWith("refs/heads/"))
-        {
-            return branchName;
-        }
-        return null;
-    }
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("JB_SPACE_GIT_BRANCH");
 
     public override string[] GenerateSetParameterMessage(string name, string value) => Array.Empty<string>();
 


### PR DESCRIPTION
Reverts GitTools/GitVersion#3033

This one could fix #3081, #3082, #3083