### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ env:
 
   ENABLED_DIAGNOSTICS: ${{ secrets.ENABLED_DIAGNOSTICS }}
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,15 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,6 +19,9 @@ on:
     - '**'
     - '!docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [release]
+permissions:
+  contents: read
+
 jobs:
   homebrew:
+    permissions:
+      contents: none
     name: Bump Homebrew formula
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
