### PR TITLE
Ensuring intermediate output path exists

### DIFF
--- a/src/GitVersion.MsBuild.Tests/Tasks/GenerateGitVersionInformationTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/GenerateGitVersionInformationTest.cs
@@ -104,7 +104,101 @@ public class GenerateGitVersionInformationTest : TestTaskBase
         fileContent.ShouldContain($@"{nameof(VersionVariables.FullSemVer)} = ""1.0.1+1""");
     }
 
-    private static void AddGenerateGitVersionInformationTask(ProjectCreator project, string targetToRun, string taskName, string outputProperty)
+    [Test]
+    public void GenerateGitVersionInformationTaskShouldCreateFileWhenIntermediateOutputPathDoesNotExist()
+    {
+        var task = new GenerateGitVersionInformation { IntermediateOutputPath = Guid.NewGuid().ToString("N") };
+
+        using var result = ExecuteMsBuildTask(task);
+
+        result.Success.ShouldBe(true);
+        result.Errors.ShouldBe(0);
+        result.Task.GitVersionInformationFilePath.ShouldNotBeNull();
+
+        var fileContent = File.ReadAllText(result.Task.GitVersionInformationFilePath);
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Major)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Minor)} = ""2""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Patch)} = ""4""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.MajorMinorPatch)} = ""1.2.4""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.FullSemVer)} = ""1.2.4+1""");
+    }
+
+    [Test]
+    public void GenerateGitVersionInformationTaskShouldCreateFileInBuildServerWhenIntermediateOutputPathDoesNotExist()
+    {
+        var task = new GenerateGitVersionInformation { IntermediateOutputPath = Guid.NewGuid().ToString("N") };
+
+        using var result = ExecuteMsBuildTaskInAzurePipeline(task);
+
+        result.Success.ShouldBe(true);
+        result.Errors.ShouldBe(0);
+        result.Task.GitVersionInformationFilePath.ShouldNotBeNull();
+
+        var fileContent = File.ReadAllText(result.Task.GitVersionInformationFilePath);
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Major)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Minor)} = ""0""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Patch)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.MajorMinorPatch)} = ""1.0.1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.FullSemVer)} = ""1.0.1+1""");
+    }
+
+    [Test]
+    [Category(NoNet48)]
+    [Category(NoMono)]
+    public void GenerateGitVersionInformationTaskShouldCreateFileWhenRunWithMsBuildAndIntermediateOutputPathDoesNotExist()
+    {
+        const string taskName = nameof(GenerateGitVersionInformation);
+        const string outputProperty = nameof(GenerateGitVersionInformation.GitVersionInformationFilePath);
+        var randDir = Guid.NewGuid().ToString("N");
+
+        using var result = ExecuteMsBuildExe(project => AddGenerateGitVersionInformationTask(project, taskName, taskName, outputProperty, Path.Combine("$(MSBuildProjectDirectory)", randDir)));
+
+        result.ProjectPath.ShouldNotBeNullOrWhiteSpace();
+        result.MsBuild.Count.ShouldBeGreaterThan(0);
+        result.MsBuild.OverallSuccess.ShouldBe(true);
+        result.MsBuild.ShouldAllBe(x => x.Succeeded);
+        result.Output.ShouldNotBeNullOrWhiteSpace();
+
+        var generatedFilePath = PathHelper.Combine(Path.GetDirectoryName(result.ProjectPath), randDir, "GitVersionInformation.g.cs");
+        result.Output.ShouldContain($"{outputProperty}: {generatedFilePath}");
+
+        var fileContent = File.ReadAllText(generatedFilePath);
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Major)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Minor)} = ""2""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Patch)} = ""4""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.MajorMinorPatch)} = ""1.2.4""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.FullSemVer)} = ""1.2.4+1""");
+    }
+
+    [Test]
+    [Category(NoNet48)]
+    [Category(NoMono)]
+    public void GenerateGitVersionInformationTaskShouldCreateFileWhenRunWithMsBuildAndIntermediateOutputPathDoesNotExistInBuildServer()
+    {
+        const string taskName = nameof(GenerateGitVersionInformation);
+        const string outputProperty = nameof(GenerateGitVersionInformation.GitVersionInformationFilePath);
+        var randDir = Guid.NewGuid().ToString("N");
+
+        using var result = ExecuteMsBuildExeInAzurePipeline(project => AddGenerateGitVersionInformationTask(project, taskName, taskName, outputProperty, Path.Combine("$(MSBuildProjectDirectory)", randDir)));
+
+        result.ProjectPath.ShouldNotBeNullOrWhiteSpace();
+        result.MsBuild.Count.ShouldBeGreaterThan(0);
+        result.MsBuild.OverallSuccess.ShouldBe(true);
+        result.MsBuild.ShouldAllBe(x => x.Succeeded);
+        result.Output.ShouldNotBeNullOrWhiteSpace();
+
+        var generatedFilePath = PathHelper.Combine(Path.GetDirectoryName(result.ProjectPath), randDir, "GitVersionInformation.g.cs");
+        result.Output.ShouldContain($"{outputProperty}: {generatedFilePath}");
+
+        var fileContent = File.ReadAllText(generatedFilePath);
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Major)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Minor)} = ""0""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.Patch)} = ""1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.MajorMinorPatch)} = ""1.0.1""");
+        fileContent.ShouldContain($@"{nameof(VersionVariables.FullSemVer)} = ""1.0.1+1""");
+    }
+
+    private static void AddGenerateGitVersionInformationTask(ProjectCreator project, string targetToRun, string taskName, string outputProperty, string intermediateOutputPath = "$(MSBuildProjectDirectory)")
     {
         var assemblyFileLocation = typeof(GitVersionTaskBase).Assembly.Location;
         project.UsingTaskAssemblyFile(taskName, assemblyFileLocation)
@@ -115,7 +209,7 @@ public class GenerateGitVersionInformationTest : TestTaskBase
                 { "SolutionDirectory", "$(MSBuildProjectDirectory)" },
                 { "VersionFile", "$(MSBuildProjectDirectory)/gitversion.json" },
                 { "ProjectFile", "$(MSBuildProjectFullPath)" },
-                { "IntermediateOutputPath", "$(MSBuildProjectDirectory)" },
+                { "IntermediateOutputPath", intermediateOutputPath },
                 { "Language", "$(Language)" }
             })
             .TaskOutputProperty(outputProperty, outputProperty)

--- a/src/GitVersion.MsBuild.Tests/Tasks/UpdateAssemblyInfoTaskTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/UpdateAssemblyInfoTaskTest.cs
@@ -87,7 +87,85 @@ public class UpdateAssemblyInfoTaskTest : TestTaskBase
         fileContent.ShouldContain(@"[assembly: AssemblyVersion(""1.0.1.0"")]");
     }
 
-    private static void AddUpdateAssemblyInfoTask(ProjectCreator project, string targetToRun, string taskName, string outputProperty)
+    [Test]
+    public void UpdateAssemblyInfoTaskShouldCreateFileWhenIntermediateOutputPathDoesNotExist()
+    {
+        var task = new UpdateAssemblyInfo { IntermediateOutputPath = Guid.NewGuid().ToString("N") };
+
+        using var result = ExecuteMsBuildTask(task);
+
+        result.Success.ShouldBe(true);
+        result.Errors.ShouldBe(0);
+        result.Task.AssemblyInfoTempFilePath.ShouldNotBeNull();
+
+        var fileContent = File.ReadAllText(result.Task.AssemblyInfoTempFilePath);
+        fileContent.ShouldContain(@"[assembly: AssemblyVersion(""1.2.4.0"")]");
+    }
+
+    [Test]
+    public void UpdateAssemblyInfoTaskShouldCreateFileWhenIntermediateOutputPathDoesNotExistInBuildServer()
+    {
+        var task = new UpdateAssemblyInfo { IntermediateOutputPath = Guid.NewGuid().ToString("N") };
+
+        using var result = ExecuteMsBuildTaskInAzurePipeline(task);
+
+        result.Success.ShouldBe(true);
+        result.Errors.ShouldBe(0);
+        result.Task.AssemblyInfoTempFilePath.ShouldNotBeNull();
+
+        var fileContent = File.ReadAllText(result.Task.AssemblyInfoTempFilePath);
+        fileContent.ShouldContain(@"[assembly: AssemblyVersion(""1.0.1.0"")]");
+    }
+
+    [Test]
+    [Category(NoNet48)]
+    [Category(NoMono)]
+    public void UpdateAssemblyInfoTaskShouldCreateFileWhenRunWithMsBuildAndIntermediateOutputPathDoesNotExist()
+    {
+        const string taskName = nameof(UpdateAssemblyInfo);
+        const string outputProperty = nameof(UpdateAssemblyInfo.AssemblyInfoTempFilePath);
+        var randDir = Guid.NewGuid().ToString("N");
+
+        using var result = ExecuteMsBuildExe(project => AddUpdateAssemblyInfoTask(project, taskName, taskName, outputProperty, Path.Combine("$(MSBuildProjectDirectory)", randDir)));
+
+        result.ProjectPath.ShouldNotBeNullOrWhiteSpace();
+        result.MsBuild.Count.ShouldBeGreaterThan(0);
+        result.MsBuild.OverallSuccess.ShouldBe(true);
+        result.MsBuild.ShouldAllBe(x => x.Succeeded);
+        result.Output.ShouldNotBeNullOrWhiteSpace();
+
+        var generatedFilePath = PathHelper.Combine(Path.GetDirectoryName(result.ProjectPath), randDir, "AssemblyInfo.g.cs");
+        result.Output.ShouldContain($"{outputProperty}: {generatedFilePath}");
+
+        var fileContent = File.ReadAllText(generatedFilePath);
+        fileContent.ShouldContain(@"[assembly: AssemblyVersion(""1.2.4.0"")]");
+    }
+
+    [Test]
+    [Category(NoNet48)]
+    [Category(NoMono)]
+    public void UpdateAssemblyInfoTaskShouldCreateFileWhenRunWithMsBuildAndIntermediateOutputPathDoesNotExistInBuildServer()
+    {
+        const string taskName = nameof(UpdateAssemblyInfo);
+        const string outputProperty = nameof(UpdateAssemblyInfo.AssemblyInfoTempFilePath);
+        var randDir = Guid.NewGuid().ToString("N");
+
+        using var result = ExecuteMsBuildExeInAzurePipeline(project => AddUpdateAssemblyInfoTask(project, taskName, taskName, outputProperty, Path.Combine("$(MSBuildProjectDirectory)", randDir)));
+
+        result.ProjectPath.ShouldNotBeNullOrWhiteSpace();
+        result.MsBuild.Count.ShouldBeGreaterThan(0);
+        result.MsBuild.OverallSuccess.ShouldBe(true);
+        result.MsBuild.ShouldAllBe(x => x.Succeeded);
+        result.Output.ShouldNotBeNullOrWhiteSpace();
+
+        var generatedFilePath = PathHelper.Combine(Path.GetDirectoryName(result.ProjectPath), randDir, "AssemblyInfo.g.cs");
+        result.Output.ShouldContain($"{outputProperty}: {generatedFilePath}");
+
+        var fileContent = File.ReadAllText(generatedFilePath);
+        fileContent.ShouldContain(@"[assembly: AssemblyVersion(""1.0.1.0"")]");
+    }
+
+    private static void AddUpdateAssemblyInfoTask(ProjectCreator project, string targetToRun, string taskName, string outputProperty, string intermediateOutputPath = "$(MSBuildProjectDirectory)")
     {
         var assemblyFileLocation = typeof(GitVersionTaskBase).Assembly.Location;
         project.UsingTaskAssemblyFile(taskName, assemblyFileLocation)
@@ -98,7 +176,7 @@ public class UpdateAssemblyInfoTaskTest : TestTaskBase
                 { "SolutionDirectory", "$(MSBuildProjectDirectory)" },
                 { "VersionFile", "$(MSBuildProjectDirectory)/gitversion.json" },
                 { "ProjectFile", "$(MSBuildProjectFullPath)" },
-                { "IntermediateOutputPath", "$(MSBuildProjectDirectory)" },
+                { "IntermediateOutputPath", intermediateOutputPath },
                 { "Language", "$(Language)" },
                 { "CompileFiles", "@(Compile)" }
             })

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -34,6 +34,12 @@ public class GitVersionTaskExecutor : IGitVersionTaskExecutor
         var versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
         FileHelper.DeleteTempFiles();
         FileHelper.CheckForInvalidFiles(task.CompileFiles, task.ProjectFile);
+        
+        if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
+        {
+            // Ensure provided output path exists first. Fixes issue #2815.
+            fileSystem.CreateDirectory(task.IntermediateOutputPath);
+        }
 
         var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "AssemblyInfo");
         task.AssemblyInfoTempFilePath = PathHelper.Combine(fileWriteInfo.WorkingDirectory, fileWriteInfo.FileName);
@@ -54,7 +60,7 @@ public class GitVersionTaskExecutor : IGitVersionTaskExecutor
         if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
         {
             // Ensure provided output path exists first. Fixes issue #2815.
-            this.fileSystem.CreateDirectory(task.IntermediateOutputPath);
+            fileSystem.CreateDirectory(task.IntermediateOutputPath);
         }
 
         var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "GitVersionInformation");

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -50,6 +50,13 @@ public class GitVersionTaskExecutor : IGitVersionTaskExecutor
     public void GenerateGitVersionInformation(GenerateGitVersionInformation task)
     {
         var versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
+
+        if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
+        {
+            // Ensure provided output path exists first. Fixes issue #2815.
+            this.fileSystem.CreateDirectory(task.IntermediateOutputPath);
+        }
+
         var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "GitVersionInformation");
         task.GitVersionInformationFilePath = PathHelper.Combine(fileWriteInfo.WorkingDirectory, fileWriteInfo.FileName);
 

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -34,7 +34,7 @@ public class GitVersionTaskExecutor : IGitVersionTaskExecutor
         var versionVariables = VersionVariables.FromFile(task.VersionFile, fileSystem);
         FileHelper.DeleteTempFiles();
         FileHelper.CheckForInvalidFiles(task.CompileFiles, task.ProjectFile);
-        
+
         if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
         {
             // Ensure provided output path exists first. Fixes issue #2815.


### PR DESCRIPTION
Fixes #2815

When generating the GitVersionInformation.g.cs file, checks that the `IntermediateOutputPath` exists before attempting to write the file.

## Description
Added `CreateDirectory()` when calling `GenerateGitVersionInformation` task.

## Related Issue
#2815 

## Motivation and Context
Fixes above issue, which I'm able to reproduce in my own project.

## How Has This Been Tested?
- [x] Unit tests
- [x] Run against sample project from issue

## Checklist:
- [x] My code follows the code style of this project.
- [X] My change requires a change to the documentation. --> no
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
