### PR TITLE
Update arguments with correct usage of updateassemblyinfo filename

### DIFF
--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -56,14 +56,14 @@ GitVersion [path]
     /updateassemblyinfo
                     Will recursively search for all 'AssemblyInfo.cs' files in
                     the git repo and update them
+    /updateassemblyinfo filename
+                    Specify name of AssemblyInfo file to update. 
+                    e.g. /updateAssemblyInfo GlobalAssemblyInfo.cs
     /updateprojectfiles
                     Will recursively search for all project files
                     (.csproj/.vbproj/.fsproj) files in the git repo and update
                     them
                     Note: This is only compatible with the newer Sdk projects
-    /updateassemblyinfofilename
-                    Specify name of AssemblyInfo file. Can also
-                    /updateAssemblyInfo GlobalAssemblyInfo.cs as a shorthand
     /ensureassemblyinfo
                     If the assembly info file specified with
                     /updateassemblyinfo or /updateassemblyinfofilename is not


### PR DESCRIPTION
/updateassemblyinfofilename is not a valid argument but /updateassemblyinfo <filename> is. Updated usage and moved entry to follow /updateassemblyinfo for clarity.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
