### PR TITLE
feat: Build Ubuntu 22.04 Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     strategy:
       matrix:
         targetFramework: [ '3.1', '6.0' ]
-        distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04 ]
+        distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
       fail-fast: false
 
     steps:
@@ -289,7 +289,7 @@ jobs:
     strategy:
       matrix:
         targetFramework: [ '3.1', '6.0' ]
-        distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04 ]
+        distro: [ alpine.3.12, alpine.3.13, alpine.3.14, centos.7, centos.8, debian.9, debian.10, debian.11, fedora.33, ubuntu.18.04, ubuntu.20.04, ubuntu.22.04 ]
       fail-fast: false
 
     steps:

--- a/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
+++ b/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
@@ -27,7 +27,7 @@ public class ArtifactsDotnetToolTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
 
             var cmd = $"{rootPrefix}/scripts/test-global-tool.sh --version {version} --nugetPath {rootPrefix}/nuget --repoPath {rootPrefix}/repo";
 

--- a/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
@@ -27,7 +27,7 @@ public class ArtifactsMsBuildCoreTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
 
             string distro = dockerImage.Distro;
             string targetFramework = dockerImage.TargetFramework;

--- a/build/artifacts/Tasks/ArtifactsNativeTest.cs
+++ b/build/artifacts/Tasks/ArtifactsNativeTest.cs
@@ -27,7 +27,7 @@ public class ArtifactsNativeTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
 
             var runtime = dockerImage.Architecture == Architecture.Amd64 ? "linux-x64" : "linux-arm64";
             if (dockerImage.Distro.StartsWith("alpine"))

--- a/build/artifacts/Tasks/ArtifactsPrepare.cs
+++ b/build/artifacts/Tasks/ArtifactsPrepare.cs
@@ -21,7 +21,7 @@ public class ArtifactsPrepare : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
             context.DockerPullImage(dockerImage);
         }
     }

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -37,6 +37,7 @@ public class Constants
     public const string Fedora33 = "fedora.33";
     public const string Ubuntu1804 = "ubuntu.18.04";
     public const string Ubuntu2004 = "ubuntu.20.04";
+    public const string Ubuntu2204 = "ubuntu.22.04";
     public const string DockerDistroLatest = Debian10;
     public static readonly string[] DockerDistrosToBuild =
     {
@@ -50,7 +51,8 @@ public class Constants
         Debian11,
         Fedora33,
         Ubuntu1804,
-        Ubuntu2004
+        Ubuntu2004,
+        Ubuntu2204
     };
     public const string NugetOrgUrl = "https://api.nuget.org/v3/index.json";
     public const string GithubPackagesUrl = "https://nuget.pkg.github.com/gittools/index.json";

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -9,12 +9,17 @@ public enum Architecture
 }
 public static class DockerContextExtensions
 {
-    public static bool SkipArm64Image(this ICakeContext context, DockerImage dockerImage)
+    public static bool SkipImage(this ICakeContext context, DockerImage dockerImage)
     {
-        if (dockerImage.Architecture != Architecture.Arm64) return false;
-        if (!Constants.DistrosToSkip.Contains(dockerImage.Distro)) return false;
+        var (distro, targetFramework, architecture, _, _) = dockerImage;
 
-        context.Information($"Skipping Target: {dockerImage.TargetFramework}, Distro: {dockerImage.Distro}, Arch: {dockerImage.Architecture}");
+        // TODO skip this because of https://github.com/GitTools/GitVersion/pull/3148, remove after .net core 3.1 is removed
+        if (distro == Constants.Ubuntu2204 && targetFramework == Constants.Version31) return true;
+
+        if (architecture != Architecture.Arm64) return false;
+        if (!Constants.DistrosToSkip.Contains(distro)) return false;
+
+        context.Information($"Skipping Target: {targetFramework}, Distro: {distro}, Arch: {architecture}");
         return true;
     }
 

--- a/build/docker/Tasks/DockerBuild.cs
+++ b/build/docker/Tasks/DockerBuild.cs
@@ -27,7 +27,7 @@ public class DockerBuild : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
             context.DockerBuildImage(dockerImage);
         }
     }

--- a/build/docker/Tasks/DockerManifest.cs
+++ b/build/docker/Tasks/DockerManifest.cs
@@ -46,7 +46,7 @@ public class DockerManifestInternal : FrostingTask<BuildContext>
         {
             var amd64DockerImage = group.First(x => x.Architecture == Architecture.Amd64);
             var arm64DockerImage = group.First(x => x.Architecture == Architecture.Arm64);
-            context.DockerCreateManifest(amd64DockerImage, context.SkipArm64Image(arm64DockerImage));
+            context.DockerCreateManifest(amd64DockerImage, context.SkipImage(arm64DockerImage));
             context.DockerPushManifest(amd64DockerImage);
         }
     }

--- a/build/docker/Tasks/DockerPublish.cs
+++ b/build/docker/Tasks/DockerPublish.cs
@@ -45,7 +45,7 @@ public class DockerPublishInternal : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
             context.DockerPushImage(dockerImage);
         }
     }

--- a/build/docker/Tasks/DockerTest.cs
+++ b/build/docker/Tasks/DockerTest.cs
@@ -23,7 +23,7 @@ public class DockerTest : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipArm64Image(dockerImage)) continue;
+            if (context.SkipImage(dockerImage)) continue;
             context.DockerTestImage(dockerImage);
         }
     }


### PR DESCRIPTION
Build Ubuntu 22.04 Docker image

## Description
Related to https://github.com/GitTools/build-images/pull/4

## How Has This Been Tested?
All tests (except the one for dotnet 3.1) pass in the pipeline. As I understand it, dotnet 3.1 is not supported in Ubuntu 22.04, see for instance https://github.com/google/or-tools/issues/3276.

## Checklist:
- [x] My code follows the code style of this project.
- [x] ~~My change requires a change to the documentation.~~
- [x] ~~I have updated the documentation accordingly.~~
- [x] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed. (except for dotnet 3.1)
