### PR TITLE
Fix issue 3074 by ignoring commits in several places

### DIFF
--- a/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
@@ -25,6 +25,7 @@ public static class GitToolsTestingExtensions
         objectId.Sha.Returns(Guid.NewGuid().ToString("n") + "00000000");
 
         var commit = Substitute.For<ICommit>();
+        commit.IgnoredState.Returns(IgnoredState.Included);
         commit.Id.Returns(objectId);
         commit.Sha.Returns(objectId.Sha);
         commit.Message.Returns("Commit " + commitCount++);
@@ -32,6 +33,7 @@ public static class GitToolsTestingExtensions
         commit.When.Returns(when.AddSeconds(1));
         return commit;
     }
+
     public static IBranch CreateMockBranch(string name, params ICommit[] commits)
     {
         var branch = Substitute.For<IBranch>();

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreBeforeScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreBeforeScenarios.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace GitVersion.Core.Tests.IntegrationTests;
 
+// TODO 3074: add test cases for ignored commits
 [TestFixture]
 public class IgnoreBeforeScenarios : TestBase
 {
@@ -55,6 +56,6 @@ public class IgnoreBeforeScenarios : TestBase
                 }
             }).Build();
 
-        fixture.AssertFullSemver("1.1.0-alpha.2", config);
+        fixture.AssertFullSemver("1.1.0-alpha.3", config);
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreBeforeScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreBeforeScenarios.cs
@@ -2,6 +2,7 @@ using GitTools.Testing;
 using GitVersion.Configuration;
 using GitVersion.Core.Tests.Helpers;
 using GitVersion.Model.Configuration;
+using LibGit2Sharp;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -29,5 +30,31 @@ public class IgnoreBeforeScenarios : TestBase
             }).Build();
 
         fixture.AssertFullSemver("0.1.0+0", config);
+    }
+
+    [Test]
+    public void ShouldFallbackToBaseVersionWhenAllMergeCommitsAreIgnored()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.3");
+        fixture.Repository.CreateBranch("develop");
+        fixture.Repository.MakeCommits(1);
+
+        fixture.Repository.CreateBranch("feature/feature1");
+        fixture.Checkout("feature/feature1");
+        var commit = fixture.Repository.MakeACommit("+semver:major");
+        fixture.Checkout("develop");
+        fixture.Repository.MergeNoFF("feature/feature1", Generate.SignatureNow());
+
+        var config = new ConfigurationBuilder()
+            .Add(new Config
+            {
+                Ignore = new IgnoreConfig
+                {
+                    ShAs = new[] { commit.Sha }
+                }
+            }).Build();
+
+        fixture.AssertFullSemver("1.1.0-alpha.2", config);
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -180,11 +180,11 @@ public class BaseVersionCalculatorTests : TestBase
 
     private class ExcludeSourcesContainingExclude : IVersionFilter
     {
-        public bool Exclude(BaseVersion version, out string? reason)
+        public bool Exclude(ICommit commit, out string? reason)
         {
             reason = null;
 
-            if (!version.Source.Contains("exclude"))
+            if (!commit.Message.Contains("exclude"))
                 return false;
 
             reason = "was excluded";

--- a/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -35,6 +35,7 @@ public class BaseVersionCalculatorTests : TestBase
     [Test]
     public void UsesWhenFromNextBestMatchIfHighestDoesntHaveWhen()
     {
+        // TODO 3074: re-work: this test tested that the filter had been called inside of the calculator. this is not the case any more. rewrite or drop this test
         var when = DateTimeOffset.Now;
 
         var versionCalculator = GetBaseVersionCalculator(contextBuilder =>

--- a/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -96,29 +96,6 @@ public class BaseVersionCalculatorTests : TestBase
     }
 
     [Test]
-    public void ShouldFilterVersion()
-    {
-        var fakeIgnoreConfig = new TestIgnoreConfig(new ExcludeSourcesContainingExclude());
-
-        var higherVersion = new BaseVersion("exclude", false, new SemanticVersion(2), GitToolsTestingExtensions.CreateMockCommit(), null);
-        var lowerVersion = new BaseVersion("dummy", false, new SemanticVersion(1), GitToolsTestingExtensions.CreateMockCommit(), null);
-
-        var versionCalculator = GetBaseVersionCalculator(contextBuilder => contextBuilder
-            .WithConfig(new Config { Ignore = fakeIgnoreConfig })
-            .OverrideServices(services =>
-            {
-                services.RemoveAll<IVersionStrategy>();
-                services.AddSingleton<IVersionStrategy>(new TestVersionStrategy(higherVersion, lowerVersion));
-            }));
-        var baseVersion = versionCalculator.GetBaseVersion();
-
-        baseVersion.Source.ShouldNotBe(higherVersion.Source);
-        baseVersion.SemanticVersion.ShouldNotBe(higherVersion.SemanticVersion);
-        baseVersion.Source.ShouldBe(lowerVersion.Source);
-        baseVersion.SemanticVersion.ShouldBe(lowerVersion.SemanticVersion);
-    }
-
-    [Test]
     public void ShouldIgnorePreReleaseVersionInMainlineMode()
     {
         var fakeIgnoreConfig = new TestIgnoreConfig(new ExcludeSourcesContainingExclude());

--- a/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -35,7 +35,6 @@ public class BaseVersionCalculatorTests : TestBase
     [Test]
     public void UsesWhenFromNextBestMatchIfHighestDoesntHaveWhen()
     {
-        // TODO 3074: re-work: this test tested that the filter had been called inside of the calculator. this is not the case any more. rewrite or drop this test
         var when = DateTimeOffset.Now;
 
         var versionCalculator = GetBaseVersionCalculator(contextBuilder =>

--- a/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
@@ -9,6 +9,15 @@ namespace GitVersion.Core.Tests;
 public class MinDateVersionFilterTests : TestBase
 {
     [Test]
+    public void VerifyNullGuard()
+    {
+        var dummy = DateTimeOffset.UtcNow.AddSeconds(1.0);
+        var sut = new MinDateVersionFilter(dummy);
+
+        Should.Throw<ArgumentNullException>(() => sut.Exclude(null, out _));
+    }
+
+    [Test]
     public void WhenCommitShouldExcludeWithReason()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();

--- a/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
@@ -9,23 +9,13 @@ namespace GitVersion.Core.Tests;
 public class MinDateVersionFilterTests : TestBase
 {
     [Test]
-    public void VerifyNullGuard()
-    {
-        var dummy = DateTimeOffset.UtcNow.AddSeconds(1.0);
-        var sut = new MinDateVersionFilter(dummy);
-
-        Should.Throw<ArgumentNullException>(() => sut.Exclude(null, out _));
-    }
-
-    [Test]
     public void WhenCommitShouldExcludeWithReason()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
         var futureDate = DateTimeOffset.UtcNow.AddYears(1);
         var sut = new MinDateVersionFilter(futureDate);
 
-        sut.Exclude(version, out var reason).ShouldBeTrue();
+        sut.Exclude(commit, out var reason).ShouldBeTrue();
         reason.ShouldNotBeNullOrWhiteSpace();
     }
 
@@ -33,22 +23,10 @@ public class MinDateVersionFilterTests : TestBase
     public void WhenShaMismatchShouldNotExclude()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
         var pastDate = DateTimeOffset.UtcNow.AddYears(-1);
         var sut = new MinDateVersionFilter(pastDate);
 
-        sut.Exclude(version, out var reason).ShouldBeFalse();
-        reason.ShouldBeNull();
-    }
-
-    [Test]
-    public void ExcludeShouldAcceptVersionWithNullCommit()
-    {
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), null, string.Empty);
-        var futureDate = DateTimeOffset.UtcNow.AddYears(1);
-        var sut = new MinDateVersionFilter(futureDate);
-
-        sut.Exclude(version, out var reason).ShouldBeFalse();
+        sut.Exclude(commit, out var reason).ShouldBeFalse();
         reason.ShouldBeNull();
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
@@ -9,15 +9,6 @@ namespace GitVersion.Core.Tests;
 public class MinDateVersionFilterTests : TestBase
 {
     [Test]
-    public void VerifyNullGuard()
-    {
-        var dummy = DateTimeOffset.UtcNow.AddSeconds(1.0);
-        var sut = new MinDateVersionFilter(dummy);
-
-        Should.Throw<ArgumentNullException>(() => sut.Exclude(null, out _));
-    }
-
-    [Test]
     public void WhenCommitShouldExcludeWithReason()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();

--- a/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
@@ -9,15 +9,6 @@ namespace GitVersion.Core.Tests;
 public class ShaVersionFilterTests : TestBase
 {
     [Test]
-    public void VerifyNullGuard2()
-    {
-        var commit = GitToolsTestingExtensions.CreateMockCommit();
-        var sut = new ShaVersionFilter(new[] { commit.Sha });
-
-        Should.Throw<ArgumentNullException>(() => sut.Exclude(null, out _));
-    }
-
-    [Test]
     public void WhenShaMatchShouldExcludeWithReason()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();

--- a/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
@@ -21,10 +21,9 @@ public class ShaVersionFilterTests : TestBase
     public void WhenShaMatchShouldExcludeWithReason()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
         var sut = new ShaVersionFilter(new[] { commit.Sha });
 
-        sut.Exclude(version, out var reason).ShouldBeTrue();
+        sut.Exclude(commit, out var reason).ShouldBeTrue();
         reason.ShouldNotBeNullOrWhiteSpace();
     }
 
@@ -32,20 +31,9 @@ public class ShaVersionFilterTests : TestBase
     public void WhenShaMismatchShouldNotExclude()
     {
         var commit = GitToolsTestingExtensions.CreateMockCommit();
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), commit, string.Empty);
         var sut = new ShaVersionFilter(new[] { "mismatched" });
 
-        sut.Exclude(version, out var reason).ShouldBeFalse();
-        reason.ShouldBeNull();
-    }
-
-    [Test]
-    public void ExcludeShouldAcceptVersionWithNullCommit()
-    {
-        var version = new BaseVersion("dummy", false, new SemanticVersion(1), null, string.Empty);
-        var sut = new ShaVersionFilter(new[] { "mismatched" });
-
-        sut.Exclude(version, out var reason).ShouldBeFalse();
+        sut.Exclude(commit, out var reason).ShouldBeFalse();
         reason.ShouldBeNull();
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -192,13 +192,17 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     private class MockCommit : ICommit
     {
         public bool Equals(ICommit? other) => throw new NotImplementedException();
+
         public int CompareTo(ICommit? other) => throw new NotImplementedException();
+
         public bool Equals(IGitObject? other) => throw new NotImplementedException();
+
         public int CompareTo(IGitObject? other) => throw new NotImplementedException();
         public IObjectId Id => throw new NotImplementedException();
         public string Sha => throw new NotImplementedException();
         public IEnumerable<ICommit> Parents => throw new NotImplementedException();
         public DateTimeOffset When => throw new NotImplementedException();
         public string Message => throw new NotImplementedException();
+        public IgnoredState IgnoredState => throw new NotImplementedException();
     }
 }

--- a/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
+++ b/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
@@ -67,7 +67,7 @@ internal class BranchesContainingCommitFinder
     private IEnumerable<ICommit> GetCommitsReacheableFrom(IGitObject commit, IBranch branch)
     {
         var filter = new CommitFilter { IncludeReachableFrom = branch };
-        var commitCollection = this.repository.Commits.QueryBy(filter);
+        var commitCollection = this.repository.QueryBy(filter);
 
         return commitCollection.Where(c => c.Sha == commit.Sha);
     }

--- a/src/GitVersion.Core/Core/MergeBaseFinder.cs
+++ b/src/GitVersion.Core/Core/MergeBaseFinder.cs
@@ -116,7 +116,7 @@ internal class MergeBaseFinder
             IncludeReachableFrom = commitToFindCommonBase,
             ExcludeReachableFrom = findMergeBase
         };
-        var commitCollection = this.repository.Commits.QueryBy(filter);
+        var commitCollection = this.repository.QueryBy(filter);
 
         return commitCollection.FirstOrDefault(c => c.Parents.Contains(findMergeBase));
     }

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -62,7 +62,7 @@ public class RepositoryStore : IRepositoryStore
         try
         {
             var filter = new CommitFilter { IncludeReachableFrom = currentBranchTip };
-            var commitCollection = this.repository.Commits.QueryBy(filter);
+            var commitCollection = this.repository.QueryBy(filter);
 
             return commitCollection.First(c => !c.Parents.Any());
         }
@@ -81,13 +81,13 @@ public class RepositoryStore : IRepositoryStore
 
         var filter = new CommitFilter { IncludeReachableFrom = mainlineTip, ExcludeReachableFrom = baseVersionSource, SortBy = CommitSortStrategies.Reverse, FirstParentOnly = true };
 
-        return this.repository.Commits.QueryBy(filter);
+        return this.repository.QueryBy(filter);
     }
 
     public IEnumerable<ICommit> GetMergeBaseCommits(ICommit? mergeCommit, ICommit? mergedHead, ICommit? findMergeBase)
     {
         var filter = new CommitFilter { IncludeReachableFrom = mergedHead, ExcludeReachableFrom = findMergeBase };
-        var commitCollection = this.repository.Commits.QueryBy(filter);
+        var commitCollection = this.repository.QueryBy(filter);
 
         var commits = mergeCommit != null
             ? new[] { mergeCommit }.Union(commitCollection)
@@ -179,7 +179,6 @@ public class RepositoryStore : IRepositoryStore
         var mainlineBranchFinder = new MainlineBranchFinder(this, this.repository, configuration, mainlineBranchConfigs, this.log);
         return mainlineBranchFinder.FindMainlineBranches(commit);
     }
-
 
     /// <summary>
     ///     Find the commit where the given branch was branched from another branch.
@@ -273,7 +272,7 @@ public class RepositoryStore : IRepositoryStore
     {
         var filter = new CommitFilter { IncludeReachableFrom = currentCommit, ExcludeReachableFrom = baseVersionSource, SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time };
 
-        return this.repository.Commits.QueryBy(filter);
+        return this.repository.QueryBy(filter);
     }
 
     public VersionField? DetermineIncrementedField(BaseVersion baseVersion, GitVersionContext context) =>
@@ -282,7 +281,7 @@ public class RepositoryStore : IRepositoryStore
     public bool IsCommitOnBranch(ICommit? baseVersionSource, IBranch branch, ICommit firstMatchingCommit)
     {
         var filter = new CommitFilter { IncludeReachableFrom = branch, ExcludeReachableFrom = baseVersionSource, FirstParentOnly = true };
-        var commitCollection = this.repository.Commits.QueryBy(filter);
+        var commitCollection = this.repository.QueryBy(filter);
         return commitCollection.Contains(firstMatchingCommit);
     }
 

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -5,4 +5,5 @@ public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, IGitObjec
     IEnumerable<ICommit> Parents { get; }
     DateTimeOffset When { get; }
     string Message { get; }
+    IgnoredState IgnoredState { get; }
 }

--- a/src/GitVersion.Core/Git/IGitRepository.cs
+++ b/src/GitVersion.Core/Git/IGitRepository.cs
@@ -9,9 +9,12 @@ public interface IGitRepository
     ITagCollection Tags { get; }
     IReferenceCollection Refs { get; }
     IBranchCollection Branches { get; }
-    ICommitCollection Commits { get; }
+    IEnumerable<ICommit> Commits { get; }
+
+    IEnumerable<ICommit> QueryBy(CommitFilter commitFilter);
     IRemoteCollection Remotes { get; }
 
     ICommit? FindMergeBase(ICommit commit, ICommit otherCommit);
+
     int GetNumberOfUncommittedChanges();
 }

--- a/src/GitVersion.Core/Git/IgnoredState.cs
+++ b/src/GitVersion.Core/Git/IgnoredState.cs
@@ -1,0 +1,15 @@
+﻿namespace GitVersion;
+
+public class IgnoredState
+{
+    public static IgnoredState Ignored = new IgnoredState(true);
+    public static IgnoredState Included = new IgnoredState(false);
+
+    private IgnoredState(bool isIgnored)
+    {
+        IsIgnored = isIgnored;
+    }
+
+    public bool IsIgnored { get; }
+    public bool IsIncluded => !IsIgnored;
+}

--- a/src/GitVersion.Core/Git/IgnoredState.cs
+++ b/src/GitVersion.Core/Git/IgnoredState.cs
@@ -1,14 +1,11 @@
-﻿namespace GitVersion;
+namespace GitVersion;
 
 public class IgnoredState
 {
-    public static IgnoredState Ignored = new IgnoredState(true);
-    public static IgnoredState Included = new IgnoredState(false);
+    public static IgnoredState Ignored = new(true);
+    public static IgnoredState Included = new(false);
 
-    private IgnoredState(bool isIgnored)
-    {
-        IsIgnored = isIgnored;
-    }
+    private IgnoredState(bool isIgnored) => IsIgnored = isIgnored;
 
     public bool IsIgnored { get; }
     public bool IsIncluded => !IsIgnored;

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -433,7 +433,6 @@ GitVersion.IGitPreparer.EnsureLocalBranchExistsForCurrentBranch(GitVersion.IRemo
 GitVersion.IGitPreparer.Prepare() -> void
 GitVersion.IGitRepository
 GitVersion.IGitRepository.Branches.get -> GitVersion.IBranchCollection!
-GitVersion.IGitRepository.Commits.get -> GitVersion.ICommitCollection!
 GitVersion.IGitRepository.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! otherCommit) -> GitVersion.ICommit?
 GitVersion.IGitRepository.GetNumberOfUncommittedChanges() -> int
 GitVersion.IGitRepository.Head.get -> GitVersion.IBranch!
@@ -971,19 +970,16 @@ GitVersion.VersionCalculation.INextVersionCalculator.FindVersion() -> GitVersion
 GitVersion.VersionCalculation.IVariableProvider
 GitVersion.VersionCalculation.IVariableProvider.GetVariablesFor(GitVersion.SemanticVersion! semanticVersion, GitVersion.Model.Configuration.EffectiveConfiguration! config, bool isCurrentCommitTagged) -> GitVersion.OutputVariables.VersionVariables!
 GitVersion.VersionCalculation.IVersionFilter
-GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.VersionCalculation.BaseVersion! version, out string? reason) -> bool
 GitVersion.VersionCalculation.IVersionStrategy
 GitVersion.VersionCalculation.IVersionStrategy.GetVersions() -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
 GitVersion.VersionCalculation.MergeMessageVersionStrategy
 GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageVersionStrategy(GitVersion.Logging.ILog! log, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.MinDateVersionFilter
-GitVersion.VersionCalculation.MinDateVersionFilter.Exclude(GitVersion.VersionCalculation.BaseVersion? version, out string? reason) -> bool
 GitVersion.VersionCalculation.MinDateVersionFilter.MinDateVersionFilter(System.DateTimeOffset minimum) -> void
 GitVersion.VersionCalculation.NextVersionCalculator
 GitVersion.VersionCalculation.NextVersionCalculator.FindVersion() -> GitVersion.SemanticVersion!
 GitVersion.VersionCalculation.NextVersionCalculator.NextVersionCalculator(GitVersion.Logging.ILog! log, GitVersion.VersionCalculation.IBaseVersionCalculator! baseVersionCalculator, GitVersion.VersionCalculation.IMainlineVersionCalculator! mainlineVersionCalculator, GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.ShaVersionFilter
-GitVersion.VersionCalculation.ShaVersionFilter.Exclude(GitVersion.VersionCalculation.BaseVersion? version, out string? reason) -> bool
 GitVersion.VersionCalculation.ShaVersionFilter.ShaVersionFilter(System.Collections.Generic.IEnumerable<string!>! shas) -> void
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy.TaggedCommitVersionStrategy(GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -1364,3 +1364,10 @@ virtual GitVersion.Model.Configuration.IgnoreConfig.IsEmpty.get -> bool
 virtual GitVersion.Model.Configuration.IgnoreConfig.ToFilters() -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.IVersionFilter!>!
 virtual GitVersion.VersionCalculation.TaggedCommitVersionStrategy.FormatSource(GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit! version) -> string!
 virtual GitVersion.VersionCalculation.VersionStrategyBase.GetVersions() -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
+
+GitVersion.ICommit.IgnoredState.get -> GitVersion.IgnoredState!
+GitVersion.IgnoredState
+GitVersion.IgnoredState.IsIgnored.get -> bool
+GitVersion.IgnoredState.IsIncluded.get -> bool
+static GitVersion.IgnoredState.Ignored -> GitVersion.IgnoredState!
+static GitVersion.IgnoredState.Included -> GitVersion.IgnoredState!

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -433,6 +433,8 @@ GitVersion.IGitPreparer.EnsureLocalBranchExistsForCurrentBranch(GitVersion.IRemo
 GitVersion.IGitPreparer.Prepare() -> void
 GitVersion.IGitRepository
 GitVersion.IGitRepository.Branches.get -> GitVersion.IBranchCollection!
+GitVersion.IGitRepository.Commits.get -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
+GitVersion.IGitRepository.QueryBy(GitVersion.CommitFilter! commitFilter) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.IGitRepository.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! otherCommit) -> GitVersion.ICommit?
 GitVersion.IGitRepository.GetNumberOfUncommittedChanges() -> int
 GitVersion.IGitRepository.Head.get -> GitVersion.IBranch!
@@ -964,6 +966,7 @@ GitVersion.VersionCalculation.IMainlineVersionCalculator.FindMainlineModeVersion
 GitVersion.VersionCalculation.IncrementStrategyFinder
 GitVersion.VersionCalculation.IncrementStrategyFinder.DetermineIncrementedField(GitVersion.IGitRepository! repository, GitVersion.GitVersionContext! context, GitVersion.VersionCalculation.BaseVersion! baseVersion) -> GitVersion.VersionField?
 GitVersion.VersionCalculation.IncrementStrategyFinder.GetIncrementForCommits(GitVersion.GitVersionContext! context, System.Collections.Generic.IEnumerable<GitVersion.ICommit!>! commits) -> GitVersion.VersionField?
+GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
 GitVersion.VersionCalculation.IncrementStrategyFinder.IncrementStrategyFinder() -> void
 GitVersion.VersionCalculation.INextVersionCalculator
 GitVersion.VersionCalculation.INextVersionCalculator.FindVersion() -> GitVersion.SemanticVersion!
@@ -975,12 +978,14 @@ GitVersion.VersionCalculation.IVersionStrategy.GetVersions() -> System.Collectio
 GitVersion.VersionCalculation.MergeMessageVersionStrategy
 GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageVersionStrategy(GitVersion.Logging.ILog! log, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.MinDateVersionFilter
+GitVersion.VersionCalculation.MinDateVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
 GitVersion.VersionCalculation.MinDateVersionFilter.MinDateVersionFilter(System.DateTimeOffset minimum) -> void
 GitVersion.VersionCalculation.NextVersionCalculator
 GitVersion.VersionCalculation.NextVersionCalculator.FindVersion() -> GitVersion.SemanticVersion!
 GitVersion.VersionCalculation.NextVersionCalculator.NextVersionCalculator(GitVersion.Logging.ILog! log, GitVersion.VersionCalculation.IBaseVersionCalculator! baseVersionCalculator, GitVersion.VersionCalculation.IMainlineVersionCalculator! mainlineVersionCalculator, GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.ShaVersionFilter
 GitVersion.VersionCalculation.ShaVersionFilter.ShaVersionFilter(System.Collections.Generic.IEnumerable<string!>! shas) -> void
+GitVersion.VersionCalculation.ShaVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy.TaggedCommitVersionStrategy(GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+GitVersion.IGitRepository.Commits.get -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
+GitVersion.IGitRepository.QueryBy(GitVersion.CommitFilter! commitFilter) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
+GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
+GitVersion.VersionCalculation.MinDateVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
+GitVersion.VersionCalculation.ShaVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-GitVersion.IGitRepository.Commits.get -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
-GitVersion.IGitRepository.QueryBy(GitVersion.CommitFilter! commitFilter) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
-GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
-GitVersion.VersionCalculation.MinDateVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool
-GitVersion.VersionCalculation.ShaVersionFilter.Exclude(GitVersion.ICommit! commit, out string? reason) -> bool

--- a/src/GitVersion.Core/VersionCalculation/Abstractions/IVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/Abstractions/IVersionFilter.cs
@@ -2,5 +2,5 @@ namespace GitVersion.VersionCalculation;
 
 public interface IVersionFilter
 {
-    bool Exclude(BaseVersion version, out string? reason);
+    bool Exclude(ICommit commit, out string? reason);
 }

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -106,7 +106,6 @@ public class BaseVersionCalculator : IBaseVersionCalculator
 
             this.log.Info(version.ToString());
 
-            // TODO 3074: test
             if (strategy is FallbackVersionStrategy || version.BaseVersionSource == null || version.BaseVersionSource.IgnoredState.IsIncluded)
                 yield return version;
         }

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -105,10 +105,8 @@ public class BaseVersionCalculator : IBaseVersionCalculator
             if (version == null) continue;
 
             this.log.Info(version.ToString());
-            if (strategy is FallbackVersionStrategy)
-            {
-                yield return version;
-            }
+
+            yield return version;
         }
     }
 

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -97,6 +97,7 @@ public class BaseVersionCalculator : IBaseVersionCalculator
             return calculatedBase;
         }
     }
+
     private IEnumerable<BaseVersion> GetBaseVersions(IVersionStrategy strategy)
     {
         foreach (var version in strategy.GetVersions())
@@ -104,26 +105,11 @@ public class BaseVersionCalculator : IBaseVersionCalculator
             if (version == null) continue;
 
             this.log.Info(version.ToString());
-            if (strategy is FallbackVersionStrategy || IncludeVersion(version))
+            if (strategy is FallbackVersionStrategy)
             {
                 yield return version;
             }
         }
-    }
-    private bool IncludeVersion(BaseVersion version)
-    {
-        foreach (var filter in context.Configuration.VersionFilters)
-        {
-            if (filter.Exclude(version, out var reason))
-            {
-                if (reason != null)
-                {
-                    this.log.Info(reason);
-                }
-                return false;
-            }
-        }
-        return true;
     }
 
     private void FixTheBaseVersionSourceOfMergeMessageStrategyIfReleaseBranchWasMergedAndDeleted(IEnumerable<Versions> baseVersions)

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculator.cs
@@ -106,7 +106,9 @@ public class BaseVersionCalculator : IBaseVersionCalculator
 
             this.log.Info(version.ToString());
 
-            yield return version;
+            // TODO 3074: test
+            if (strategy is FallbackVersionStrategy || version.BaseVersionSource == null || version.BaseVersionSource.IgnoredState.IsIncluded)
+                yield return version;
         }
     }
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -134,7 +134,6 @@ public class IncrementStrategyFinder : IIncrementStrategyFinder
 
     private static VersionField? GetIncrementFromMessage(IgnoredState ignoredState, string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex none)
     {
-        // TODO 3074: test
         if (ignoredState.IsIgnored) return null;
 
         if (majorRegex.IsMatch(message)) return VersionField.Major;

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -153,6 +153,6 @@ public class IncrementStrategyFinder : IIncrementStrategyFinder
             SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse
         };
 
-        return repo.Commits.QueryBy(filter);
+        return repo.QueryBy(filter);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -130,14 +130,18 @@ public class IncrementStrategyFinder : IIncrementStrategyFinder
 
     private VersionField? GetIncrementFromCommit(ICommit commit, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex none) =>
         this.commitIncrementCache.GetOrAdd(commit.Sha, () =>
-            GetIncrementFromMessage(commit.Message, majorRegex, minorRegex, patchRegex, none));
+            GetIncrementFromMessage(commit.IgnoredState, commit.Message, majorRegex, minorRegex, patchRegex, none));
 
-    private static VersionField? GetIncrementFromMessage(string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex none)
+    private static VersionField? GetIncrementFromMessage(IgnoredState ignoredState, string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex none)
     {
+        // TODO 3074: test
+        if (ignoredState.IsIgnored) return null;
+
         if (majorRegex.IsMatch(message)) return VersionField.Major;
         if (minorRegex.IsMatch(message)) return VersionField.Minor;
         if (patchRegex.IsMatch(message)) return VersionField.Patch;
         if (none.IsMatch(message)) return VersionField.None;
+
         return null;
     }
 

--- a/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace GitVersion.VersionCalculation;
 
 public class MinDateVersionFilter : IVersionFilter
@@ -8,16 +6,14 @@ public class MinDateVersionFilter : IVersionFilter
 
     public MinDateVersionFilter(DateTimeOffset minimum) => this.minimum = minimum;
 
-    public bool Exclude(BaseVersion? version, [NotNullWhen(true)] out string? reason)
+    public bool Exclude(ICommit commit, out string? reason)
     {
-        if (version == null) throw new ArgumentNullException(nameof(version));
-
         reason = null;
 
-        if (version.BaseVersionSource == null || version.BaseVersionSource.When >= this.minimum)
+        if (commit.When >= this.minimum)
             return false;
 
-        reason = "Source was ignored due to commit date being outside of configured range";
+        reason = $"Source {commit} was ignored due to commit date being outside of configured range";
         return true;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
@@ -1,3 +1,5 @@
+using GitVersion.Extensions;
+
 namespace GitVersion.VersionCalculation;
 
 public class MinDateVersionFilter : IVersionFilter
@@ -8,6 +10,8 @@ public class MinDateVersionFilter : IVersionFilter
 
     public bool Exclude(ICommit commit, out string? reason)
     {
+        commit.NotNull();
+
         reason = null;
 
         if (commit.When >= this.minimum)

--- a/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using GitVersion.Extensions;
 
 namespace GitVersion.VersionCalculation;
@@ -9,17 +8,14 @@ public class ShaVersionFilter : IVersionFilter
 
     public ShaVersionFilter(IEnumerable<string> shas) => this.shas = shas.NotNull();
 
-    public bool Exclude(BaseVersion? version, [NotNullWhen(true)] out string? reason)
+    public bool Exclude(ICommit commit, out string? reason)
     {
-        if (version == null) throw new ArgumentNullException(nameof(version));
-
         reason = null;
 
-        if (version.BaseVersionSource == null || !this.shas.Any(sha => version.BaseVersionSource.Sha.StartsWith(sha, StringComparison.OrdinalIgnoreCase)))
+        if (!this.shas.Any(sha => commit.Sha.StartsWith(sha, StringComparison.OrdinalIgnoreCase)))
             return false;
 
-        reason = $"Sha {version.BaseVersionSource} was ignored due to commit having been excluded by configuration";
+        reason = $"Sha {commit} was ignored due to commit having been excluded by configuration";
         return true;
-
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
@@ -10,6 +10,8 @@ public class ShaVersionFilter : IVersionFilter
 
     public bool Exclude(ICommit commit, out string? reason)
     {
+        commit.NotNull();
+
         reason = null;
 
         if (!this.shas.Any(sha => commit.Sha.StartsWith(sha, StringComparison.OrdinalIgnoreCase)))

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -18,12 +18,18 @@ internal sealed class Commit : GitObject, ICommit
     }
 
     public int CompareTo(ICommit other) => comparerHelper.Compare(this, other);
+
     public bool Equals(ICommit? other) => equalityHelper.Equals(this, other);
     public IEnumerable<ICommit> Parents { get; }
     public DateTimeOffset When { get; }
     public string Message => this.innerCommit.Message;
+    public IgnoredState IgnoredState => IgnoredState.Included;
+
     public override bool Equals(object obj) => Equals((obj as ICommit));
+
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
+
     public override string ToString() => $"{Id.ToString(7)} {this.innerCommit.MessageShort}";
+
     public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
 }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -42,7 +42,11 @@ internal sealed class GitRepository : IMutatingGitRepository
     public ITagCollection Tags => new TagCollection(RepositoryInstance.Tags);
     public IReferenceCollection Refs => new ReferenceCollection(RepositoryInstance.Refs);
     public IBranchCollection Branches => new BranchCollection(RepositoryInstance.Branches);
-    public ICommitCollection Commits => new CommitCollection(RepositoryInstance.Commits);
+    public IEnumerable<ICommit> Commits => new CommitCollection(RepositoryInstance.Commits);
+
+    public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter) =>
+        new CommitCollection(RepositoryInstance.Commits).QueryBy(commitFilter);
+
     public IRemoteCollection Remotes => new RemoteCollection(RepositoryInstance.Network.Remotes);
 
     public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -90,7 +90,6 @@ internal class GitRepositoryInfo : IGitRepositoryInfo
         if (gitDirectory.IsNullOrEmpty())
             throw new DirectoryNotFoundException("Cannot find the .git directory");
 
-        // TODO: should possibly be a separate class
         return new GitRepository(gitDirectory).WorkingDirectory;
     }
 
@@ -106,7 +105,6 @@ internal class GitRepositoryInfo : IGitRepositoryInfo
     {
         try
         {
-            // TODO: should possibly be a separate class
             var gitRepository = new GitRepository(possiblePath);
             return gitRepository.Remotes.Any(r => r.Url == targetUrl);
         }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -90,6 +90,7 @@ internal class GitRepositoryInfo : IGitRepositoryInfo
         if (gitDirectory.IsNullOrEmpty())
             throw new DirectoryNotFoundException("Cannot find the .git directory");
 
+        // TODO: should possibly be a separate class
         return new GitRepository(gitDirectory).WorkingDirectory;
     }
 
@@ -105,6 +106,7 @@ internal class GitRepositoryInfo : IGitRepositoryInfo
     {
         try
         {
+            // TODO: should possibly be a separate class
             var gitRepository = new GitRepository(possiblePath);
             return gitRepository.Remotes.Any(r => r.Url == targetUrl);
         }
@@ -113,5 +115,4 @@ internal class GitRepositoryInfo : IGitRepositoryInfo
             return false;
         }
     }
-
 }

--- a/src/GitVersion.LibGit2Sharp/Git/IIgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IIgnoredFilterProvider.cs
@@ -1,4 +1,4 @@
-﻿using GitVersion.VersionCalculation;
+using GitVersion.VersionCalculation;
 
 namespace GitVersion;
 

--- a/src/GitVersion.LibGit2Sharp/Git/IIgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IIgnoredFilterProvider.cs
@@ -1,0 +1,8 @@
+﻿using GitVersion.VersionCalculation;
+
+namespace GitVersion;
+
+public interface IIgnoredFilterProvider
+{
+    IVersionFilter[] Provide();
+}

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredCommit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredCommit.cs
@@ -1,4 +1,4 @@
-﻿using GitVersion.Extensions;
+using GitVersion.Extensions;
 
 namespace GitVersion;
 

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredCommit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredCommit.cs
@@ -1,0 +1,36 @@
+﻿using GitVersion.Extensions;
+
+namespace GitVersion;
+
+internal sealed class IgnoredCommit : ICommit
+{
+    private readonly IgnoredState ignoredState;
+
+    public IgnoredCommit(ICommit commit, IgnoredState ignoredState)
+    {
+        this.commit = commit.NotNull();
+        this.ignoredState = ignoredState.NotNull();
+    }
+
+    public IgnoredState IgnoredState => ignoredState;
+
+    public IEnumerable<ICommit> Parents => commit.Parents;
+
+    public DateTimeOffset When => commit.When;
+
+    public string Message => commit.Message;
+
+    public IObjectId Id => commit.Id;
+
+    public string Sha => commit.Sha;
+
+    private readonly ICommit commit;
+
+    public int CompareTo(ICommit other) => commit.CompareTo(other);
+
+    public int CompareTo(IGitObject other) => commit.CompareTo(other);
+
+    public bool Equals(ICommit? other) => commit.Equals(other);
+
+    public bool Equals(IGitObject? other) => commit.Equals(other);
+}

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
@@ -8,18 +8,16 @@ namespace GitVersion;
 // TODO 3074: test
 internal sealed class IgnoredFilterProvider : IIgnoredFilterProvider
 {
-    // TODO 3074: adjust naming, order, whitespaces etc.
-    public IConfigProvider ConfigProvider { get; }
-
-    public IOptions<GitVersionOptions> Options { get; }
+    private readonly IConfigProvider configProvider;
+    private readonly IOptions<GitVersionOptions> options;
 
     public IgnoredFilterProvider(IConfigProvider configProvider, IOptions<GitVersionOptions> options)
     {
-        ConfigProvider = configProvider.NotNull();
-        Options = options.NotNull();
+        this.configProvider = configProvider.NotNull();
+        this.options = options.NotNull();
     }
 
     public IVersionFilter[] Provide() =>
-        this.ConfigProvider.Provide(Options.Value.ConfigInfo.OverrideConfig)
+        this.configProvider.Provide(options.Value.ConfigInfo.OverrideConfig)
             .Ignore.ToFilters().ToArray();
 }

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
@@ -1,0 +1,26 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+using GitVersion.VersionCalculation;
+using Microsoft.Extensions.Options;
+
+namespace GitVersion;
+
+// TODO 3074: test
+internal sealed class IgnoredFilterProvider : IIgnoredFilterProvider
+{
+    // TODO 3074: adjust naming, order, whitespaces etc.
+    public IConfigProvider ConfigProvider { get; }
+
+    public IOptions<GitVersionOptions> Options { get; }
+
+    public IgnoredFilterProvider(IConfigProvider configProvider, IOptions<GitVersionOptions> options)
+    {
+        ConfigProvider = configProvider.NotNull();
+        Options = options.NotNull();
+    }
+
+    // TODO 3074: do in ctor?
+    public IVersionFilter[] Provide() =>
+        this.ConfigProvider.Provide(Options.Value.ConfigInfo.OverrideConfig)
+            .Ignore.ToFilters().ToArray();
+}

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Options;
 
 namespace GitVersion;
 
-// TODO 3074: test
 internal sealed class IgnoredFilterProvider : IIgnoredFilterProvider
 {
     private readonly IConfigProvider configProvider;

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilterProvider.cs
@@ -19,7 +19,6 @@ internal sealed class IgnoredFilterProvider : IIgnoredFilterProvider
         Options = options.NotNull();
     }
 
-    // TODO 3074: do in ctor?
     public IVersionFilter[] Provide() =>
         this.ConfigProvider.Provide(Options.Value.ConfigInfo.OverrideConfig)
             .Ignore.ToFilters().ToArray();

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
@@ -1,0 +1,75 @@
+﻿using GitVersion.Extensions;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion;
+
+// TODO 3074: test
+internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepository
+{
+    public IVersionFilter[] VersionFilters { get; }
+    public IMutatingGitRepository Decoratee { get; }
+
+    // TODO 3074: better to use interface for GitRepository but must instantiate this class explicitly in module
+    public IgnoredFilteringGitRepositoryDecorator(IIgnoredFilterProvider ignoredFilterProvider, GitRepository decoratee)
+    {
+        Decoratee = decoratee.NotNull();
+        VersionFilters = ignoredFilterProvider.Provide();
+    }
+
+    public string Path => Decoratee.Path;
+
+    public string WorkingDirectory => Decoratee.WorkingDirectory;
+
+    public bool IsHeadDetached => Decoratee.IsHeadDetached;
+
+    public IBranch Head => Decoratee.Head;
+
+    public ITagCollection Tags => Decoratee.Tags;
+
+    public IReferenceCollection Refs => Decoratee.Refs;
+
+    public IBranchCollection Branches => Decoratee.Branches;
+
+    // TODO 3074: Need to be tested
+    public IEnumerable<ICommit> Commits =>
+        Decoratee.Commits
+            .Where(IncludeVersion)
+            .ToList();
+
+    public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter) =>
+        Decoratee.QueryBy(commitFilter)
+            .Where(IncludeVersion)
+            .ToList();
+
+    public IRemoteCollection Remotes => Decoratee.Remotes;
+
+    public void Checkout(string commitOrBranchSpec) => Decoratee.Checkout(commitOrBranchSpec);
+
+    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth) => Decoratee.Clone(sourceUrl, workdirPath, auth);
+
+    public void CreateBranchForPullRequestBranch(AuthenticationInfo auth) => Decoratee.CreateBranchForPullRequestBranch(auth);
+
+    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage) => Decoratee.Fetch(remote, refSpecs, auth, logMessage);
+
+    // TODO 3074: on ignored commits as output or input return null
+    public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit) => Decoratee.FindMergeBase(commit, otherCommit);
+
+    public int GetNumberOfUncommittedChanges() => Decoratee.GetNumberOfUncommittedChanges();
+
+    private bool IncludeVersion(ICommit commit)
+    {
+        foreach (var filter in VersionFilters)
+        {
+            if (filter.Exclude(commit, out var reason))
+            {
+                if (reason != null)
+                {
+                    // TODO 3074: add log to this class
+                    //this.log.Info(reason);
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
@@ -1,4 +1,5 @@
 using GitVersion.Extensions;
+using GitVersion.Logging;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion;
@@ -6,50 +7,52 @@ namespace GitVersion;
 // TODO 3074: test
 internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepository
 {
-    public IVersionFilter[] VersionFilters { get; }
-    public IMutatingGitRepository Decoratee { get; }
+    private readonly ILog log;
+    private readonly IVersionFilter[] versionFilters;
+    private readonly IMutatingGitRepository decoratee;
 
     // NOTE: it would be better to use the interface IMutatingGitRepository for gitRepository but this would be quite cumbersome to instantiate during startup: https://greatrexpectations.com/2018/10/25/decorators-in-net-core-with-dependency-injection
-    public IgnoredFilteringGitRepositoryDecorator(IIgnoredFilterProvider ignoredFilterProvider, GitRepository decoratee)
+    public IgnoredFilteringGitRepositoryDecorator(IIgnoredFilterProvider ignoredFilterProvider, ILog log, GitRepository decoratee)
     {
-        Decoratee = decoratee.NotNull();
-        VersionFilters = ignoredFilterProvider.Provide();
+        this.decoratee = decoratee.NotNull();
+        versionFilters = ignoredFilterProvider.Provide();
+        this.log = log;
     }
 
-    public string Path => Decoratee.Path;
+    public string Path => decoratee.Path;
 
-    public string WorkingDirectory => Decoratee.WorkingDirectory;
+    public string WorkingDirectory => decoratee.WorkingDirectory;
 
-    public bool IsHeadDetached => Decoratee.IsHeadDetached;
+    public bool IsHeadDetached => decoratee.IsHeadDetached;
 
-    public IBranch Head => Decoratee.Head;
+    public IBranch Head => decoratee.Head;
 
-    public ITagCollection Tags => Decoratee.Tags;
+    public ITagCollection Tags => decoratee.Tags;
 
-    public IReferenceCollection Refs => Decoratee.Refs;
+    public IReferenceCollection Refs => decoratee.Refs;
 
-    public IBranchCollection Branches => Decoratee.Branches;
+    public IBranchCollection Branches => decoratee.Branches;
 
     // TODO 3074: test
     public IEnumerable<ICommit> Commits =>
-        Decoratee.Commits
+        decoratee.Commits
             .Where(IncludeVersion)
             .ToList();
 
     public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter) =>
-        Decoratee.QueryBy(commitFilter)
+        decoratee.QueryBy(commitFilter)
             .Where(IncludeVersion)
             .ToList();
 
-    public IRemoteCollection Remotes => Decoratee.Remotes;
+    public IRemoteCollection Remotes => decoratee.Remotes;
 
-    public void Checkout(string commitOrBranchSpec) => Decoratee.Checkout(commitOrBranchSpec);
+    public void Checkout(string commitOrBranchSpec) => decoratee.Checkout(commitOrBranchSpec);
 
-    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth) => Decoratee.Clone(sourceUrl, workdirPath, auth);
+    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth) => decoratee.Clone(sourceUrl, workdirPath, auth);
 
-    public void CreateBranchForPullRequestBranch(AuthenticationInfo auth) => Decoratee.CreateBranchForPullRequestBranch(auth);
+    public void CreateBranchForPullRequestBranch(AuthenticationInfo auth) => decoratee.CreateBranchForPullRequestBranch(auth);
 
-    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage) => Decoratee.Fetch(remote, refSpecs, auth, logMessage);
+    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage) => decoratee.Fetch(remote, refSpecs, auth, logMessage);
 
     // TODO 3074: test
     public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)
@@ -60,7 +63,7 @@ internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepos
         if (IncludeVersion(otherCommit) == false)
             throw new ArgumentException($"Commit {otherCommit.Id.Sha} is ignored by date or SHA.", nameof(otherCommit));
 
-        var mergeBase = Decoratee.FindMergeBase(commit, otherCommit);
+        var mergeBase = decoratee.FindMergeBase(commit, otherCommit);
 
         if (mergeBase != null && IncludeVersion(mergeBase))
             return mergeBase;
@@ -68,19 +71,17 @@ internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepos
         return null;
     }
 
-    public int GetNumberOfUncommittedChanges() => Decoratee.GetNumberOfUncommittedChanges();
+    public int GetNumberOfUncommittedChanges() => decoratee.GetNumberOfUncommittedChanges();
 
     private bool IncludeVersion(ICommit commit)
     {
-        foreach (var filter in VersionFilters)
+        foreach (var filter in versionFilters)
         {
             if (filter.Exclude(commit, out var reason))
             {
                 if (reason != null)
-                {
-                    // TODO 3074: add log to this class
-                    //this.log.Info(reason);
-                }
+                    this.log.Info(reason);
+
                 return false;
             }
         }

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
@@ -4,6 +4,8 @@ using GitVersion.VersionCalculation;
 
 namespace GitVersion;
 
+// TODO 3074: re-work: IgnoredFilteringGitRepositoryDecorator must get the configuration and ICommit must get an Ignore Property with an enum: Included, Ignored. Or better a class with two properties for Ignored and Included with static fields for future extensions? Commit always returns "Included". This class adds a decorator to all ICommits that are ignored by SHA and filters those that are ignored by date also as a performance measure. BaseVersionCalculator has to filter for ignored commits again (possibly more than that too). IncrementStrategyFinder must not raise a version for ignored Commits.
+
 // TODO 3074: test
 internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepository
 {

--- a/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/IgnoredFilteringGitRepositoryDecorator.cs
@@ -4,7 +4,6 @@ using GitVersion.VersionCalculation;
 
 namespace GitVersion;
 
-// TODO 3074: test
 internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepository
 {
     private readonly ILog log;
@@ -33,11 +32,9 @@ internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepos
 
     public IBranchCollection Branches => decoratee.Branches;
 
-    // TODO 3074: test
     public IEnumerable<ICommit> Commits =>
         decoratee.Commits.Select(DecorateCommit);
 
-    // TODO 3074: test
     public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter) =>
         decoratee.QueryBy(commitFilter)
             .Select(DecorateCommit);
@@ -52,7 +49,6 @@ internal sealed class IgnoredFilteringGitRepositoryDecorator : IMutatingGitRepos
 
     public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage) => decoratee.Fetch(remote, refSpecs, auth, logMessage);
 
-    // TODO 3074: test
     public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)
     {
         var mergeBase = decoratee.FindMergeBase(commit, otherCommit);

--- a/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
+++ b/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
@@ -6,8 +6,11 @@ public class GitVersionLibGit2SharpModule : IGitVersionModule
 {
     public void RegisterTypes(IServiceCollection services)
     {
-        services.AddSingleton<IGitRepository, GitRepository>();
-        services.AddSingleton<IMutatingGitRepository, GitRepository>();
+        services.AddSingleton<GitRepository>();
+        services.AddSingleton<IIgnoredFilterProvider, IgnoredFilterProvider>();
+        services.AddSingleton<IGitRepository, IgnoredFilteringGitRepositoryDecorator>();
+        services.AddSingleton<IMutatingGitRepository, IgnoredFilteringGitRepositoryDecorator>();
+
         services.AddSingleton<IGitRepositoryInfo, GitRepositoryInfo>();
     }
 }

--- a/src/GitVersion.LibGit2Sharp/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.LibGit2Sharp/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+GitVersion.IIgnoredFilterProvider
+GitVersion.IIgnoredFilterProvider.Provide() -> GitVersion.VersionCalculation.IVersionFilter![]!


### PR DESCRIPTION
## Description
Previously commits where only ignored (by SHA or date) in one place when getting the base versions.
The info if a commit is ignored or not is now produced right when getting the commit log and can then be used where needed.
This info is now also evaluated when getting the increment of a single commit out of it's commit message. 

Up to now there could have been commits leading to a version raise (through their commit message) even though they were ignored by date or explicitly by SHA. This has been ammended.

## Related Issue
Fixes #3074.

## Motivation and Context
Bit-bucket in its default configuration adds the latest 20 commit message of a source branch to the commit of a PR merge. This multiplies the occurrences of "+semver:major" commit messages in the log which can't possibly be undone if you just see this some weeks later and there are several people on the project.
When doing PRs to merge from develop to a feature branch this can result in unwanted version raises.

## How Has This Been Tested?
I implemented/adapted some integration tests that were red to begin with and got green when I implemented my changes. When deactivating my changes several tests got red too.
Where I did refactorings I checked if their were tests for the previous code by uncommenting parts of it (See changes in BaseVersionCalculator).

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project. (I was using VS which should enforce .editorconfig)

... My change requires a change to the documentation. (The documentation already stated that you could ignore single commits by SHA which was not true for all cases. So the code now conforms better to the documented behavior)

... I have updated the documentation accordingly. (No.)

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (There were 10 red tests on main to begin with. See description in https://github.com/GitTools/GitVersion/issues/3074)
