### PR TITLE
Add local project file location to exception when parsing fails

### DIFF
--- a/src/GitVersion.Core/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersion.Core/VersionConverters/AssemblyInfo/ProjectFileUpdater.cs
@@ -47,7 +47,15 @@ public sealed class ProjectFileUpdater : IProjectFileUpdater
             var localProjectFile = projectFile.FullName;
 
             var originalFileContents = this.fileSystem.ReadAllText(localProjectFile);
-            var fileXml = XElement.Parse(originalFileContents);
+            XElement fileXml;
+            try
+            {
+                fileXml = XElement.Parse(originalFileContents);
+            }
+            catch (XmlException e)
+            {
+                throw new XmlException($"Unable to parse file as xml: {localProjectFile}", e);
+            }
 
             if (!CanUpdateProjectFile(fileXml))
             {


### PR DESCRIPTION
## Description
Just wrap xml parsing call in try/catch.
Helps in solutions with multiple projects, when one of csproj files becomes corrupt. User knows where to apply fixes.

## Related Issue
Fixes #3178.

## Motivation and Context
Updating csproj files in a large solution with multiple projects.

## How Has This Been Tested?
- Ran it in a well-formed solutio with well formed projects - ran fine as usual.
- Corrupted one of `csproj` files by inserting a few random characters before the starting `<Project` element. This causes `System.Xml.Linq.XElement.Parse()` method call to fail parsing. The printed error log after applying the change contained the location of the file and all the same information as before as well (location within the file where the parsing error occured) as well as git log lines.

## Screenshots (if appropriate):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
