### PR TITLE
Fix issue with pullrequests in Azure DevOps

### DIFF
--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -15,7 +15,9 @@ public class PullRequestInBuildAgentTest
     {
         "refs/pull-requests/5/merge",
         "refs/pull/5/merge",
-        "refs/heads/pull/5/head"
+        "refs/heads/pull/5/head",
+        "refs/remotes/pull/5/merge",
+        "refs/remotes/pull-requests/5/merge"
     };
 
     [TestCaseSource(nameof(PrMergeRefs))]
@@ -48,7 +50,6 @@ public class PullRequestInBuildAgentTest
         };
         await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
     }
-
 
     [TestCaseSource(nameof(PrMergeRefs))]
     public async Task VerifyDronePullRequest(string pullRequestRef)
@@ -128,7 +129,6 @@ public class PullRequestInBuildAgentTest
         await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
     }
 
-
     [TestCaseSource(nameof(PrMergeRefs))]
     public async Task VerifyBitBucketPipelinesPullRequest(string pullRequestRef)
     {
@@ -179,5 +179,24 @@ public class PullRequestInBuildAgentTest
 
         // Cleanup repository files
         DirectoryHelper.DeleteDirectory(remoteRepositoryPath);
+    }
+
+    private static readonly object[] PrMergeRefInputs =
+    {
+        new object[] { "refs/pull-requests/5/merge", "refs/pull-requests/5/merge", false, true, false },
+        new object[] { "refs/pull/5/merge", "refs/pull/5/merge", false, true, false},
+        new object[] { "refs/heads/pull/5/head", "pull/5/head", true, false, false },
+        new object[] { "refs/remotes/pull/5/merge", "pull/5/merge", false, true, true },
+    };
+
+    [TestCaseSource(nameof(PrMergeRefInputs))]
+    public void VerifyPullRequestInput(string pullRequestRef, string friendly, bool isBranch, bool isPullRequest, bool isRemote)
+    {
+        var refName = new ReferenceName(pullRequestRef);
+
+        Assert.AreEqual(friendly, refName.Friendly);
+        Assert.AreEqual(isBranch, refName.IsBranch);
+        Assert.AreEqual(isPullRequest, refName.IsPullRequest);
+        Assert.AreEqual(isRemote, refName.IsRemoteBranch);
     }
 }

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -13,6 +13,8 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     private const string TagPrefix = "refs/tags/";
     private const string PullRequestPrefix1 = "refs/pull/";
     private const string PullRequestPrefix2 = "refs/pull-requests/";
+    private const string RemotePullRequestPrefix1 = "refs/remotes/pull/";
+    private const string RemotePullRequestPrefix2 = "refs/remotes/pull-requests/";
 
     public ReferenceName(string canonical)
     {
@@ -23,7 +25,10 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
         IsBranch = IsPrefixedBy(Canonical, LocalBranchPrefix);
         IsRemoteBranch = IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix);
         IsTag = IsPrefixedBy(Canonical, TagPrefix);
-        IsPullRequest = IsPrefixedBy(Canonical, PullRequestPrefix1) || IsPrefixedBy(Canonical, PullRequestPrefix2);
+        IsPullRequest = IsPrefixedBy(Canonical, PullRequestPrefix1)
+            || IsPrefixedBy(Canonical, PullRequestPrefix2)
+            || IsPrefixedBy(Canonical, RemotePullRequestPrefix1)
+            || IsPrefixedBy(Canonical, RemotePullRequestPrefix2);
     }
 
     public static ReferenceName Parse(string canonicalName)
@@ -75,9 +80,17 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     {
         var isRemote = IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix);
 
-        return isRemote
-            ? Friendly.Substring(Friendly.IndexOf("/", StringComparison.Ordinal) + 1)
-            : Friendly;
+        if (isRemote)
+        {
+            var isPullRequest = IsPrefixedBy(Canonical, RemotePullRequestPrefix1)
+                || IsPrefixedBy(Canonical, RemotePullRequestPrefix2);
+
+            if (!isPullRequest)
+                return Friendly.Substring(Friendly.IndexOf("/", StringComparison.Ordinal) + 1);
+        }
+
+        return Friendly;
     }
+
     private static bool IsPrefixedBy(string input, string prefix) => input.StartsWith(prefix, StringComparison.Ordinal);
 }

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -11,24 +11,25 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     private const string LocalBranchPrefix = "refs/heads/";
     private const string RemoteTrackingBranchPrefix = "refs/remotes/";
     private const string TagPrefix = "refs/tags/";
-    private const string PullRequestPrefix1 = "refs/pull/";
-    private const string PullRequestPrefix2 = "refs/pull-requests/";
-    private const string RemotePullRequestPrefix1 = "refs/remotes/pull/";
-    private const string RemotePullRequestPrefix2 = "refs/remotes/pull-requests/";
+    private static readonly string[] PullRequestPrefixes =
+    {
+        "refs/pull/",
+        "refs/pull-requests/",
+        "refs/remotes/pull/",
+        "refs/remotes/pull-requests/"
+    };
 
     public ReferenceName(string canonical)
     {
         Canonical = canonical.NotNull();
-        Friendly = Shorten();
-        WithoutRemote = RemoveRemote();
 
         IsBranch = IsPrefixedBy(Canonical, LocalBranchPrefix);
         IsRemoteBranch = IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix);
         IsTag = IsPrefixedBy(Canonical, TagPrefix);
-        IsPullRequest = IsPrefixedBy(Canonical, PullRequestPrefix1)
-            || IsPrefixedBy(Canonical, PullRequestPrefix2)
-            || IsPrefixedBy(Canonical, RemotePullRequestPrefix1)
-            || IsPrefixedBy(Canonical, RemotePullRequestPrefix2);
+        IsPullRequest = IsPrefixedBy(Canonical, PullRequestPrefixes);
+
+        Friendly = Shorten();
+        WithoutRemote = RemoveRemote();
     }
 
     public static ReferenceName Parse(string canonicalName)
@@ -36,11 +37,11 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
         if (IsPrefixedBy(canonicalName, LocalBranchPrefix)
             || IsPrefixedBy(canonicalName, RemoteTrackingBranchPrefix)
             || IsPrefixedBy(canonicalName, TagPrefix)
-            || IsPrefixedBy(canonicalName, PullRequestPrefix1)
-            || IsPrefixedBy(canonicalName, PullRequestPrefix2))
+            || IsPrefixedBy(canonicalName, PullRequestPrefixes))
         {
             return new ReferenceName(canonicalName);
         }
+
         throw new ArgumentException($"The {nameof(canonicalName)} is not a Canonical name");
     }
 
@@ -67,25 +68,23 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
 
     private string Shorten()
     {
-        if (IsPrefixedBy(Canonical, LocalBranchPrefix))
+        if (IsBranch)
             return Canonical.Substring(LocalBranchPrefix.Length);
-        if (IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix))
+
+        if (IsRemoteBranch)
             return Canonical.Substring(RemoteTrackingBranchPrefix.Length);
-        if (IsPrefixedBy(Canonical, TagPrefix))
+
+        if (IsTag)
             return Canonical.Substring(TagPrefix.Length);
+
         return Canonical;
     }
 
     private string RemoveRemote()
     {
-        var isRemote = IsPrefixedBy(Canonical, RemoteTrackingBranchPrefix);
-
-        if (isRemote)
+        if (IsRemoteBranch)
         {
-            var isPullRequest = IsPrefixedBy(Canonical, RemotePullRequestPrefix1)
-                || IsPrefixedBy(Canonical, RemotePullRequestPrefix2);
-
-            if (!isPullRequest)
+            if (!IsPullRequest)
                 return Friendly.Substring(Friendly.IndexOf("/", StringComparison.Ordinal) + 1);
         }
 
@@ -93,4 +92,6 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     }
 
     private static bool IsPrefixedBy(string input, string prefix) => input.StartsWith(prefix, StringComparison.Ordinal);
+
+    private static bool IsPrefixedBy(string input, string[] prefixes) => prefixes.Any(prefix => IsPrefixedBy(input, prefix));
 }


### PR DESCRIPTION
Fix issue with PullRequests in Azure DevOps. PullRequest not well detected and Remotes not well replaced.

## Description
It detects correctly when a reference name is a PullRequest and also remove Remotes properly on a PullRequest.
Helps on Azure DevOps PullRequest completion. Otherwise it doesn't inherit semver calculated on source branch.

## Related Issue
Fix #3180

## Motivation and Context
I want to use GitVersion in Azure DevOps with the gitversion,xml described in the bug.

## How Has This Been Tested?
I tested it on Azure DevOps adding binaries to the repo and change yml file.

## Screenshots:

![image](https://user-images.githubusercontent.com/16336745/187140409-772a109c-b889-4f57-9606-e4ccc2b7ebaa.png)

![image](https://user-images.githubusercontent.com/16336745/187140511-fc615f19-b64f-4a7c-b73c-f0281936d6a5.png)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
