### PR TITLE
[Bug] Wrong semver when making a PR from a hotfix branch to a main branch

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -98,4 +98,23 @@ public class PullRequestScenarios : TestBase
 
         fixture.AssertFullSemver("2.0.0-PullRequest2.0");
     }
+
+    [Test]
+    public void CalculatesCorrectVersionWhenPullRequestHotfixBranchToMain()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("0.1.0");
+        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
+        fixture.Repository.MakeACommit();
+
+        Commands.Checkout(fixture.Repository, "main");
+
+        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("hotfix/0.1.1"));
+        fixture.Repository.MakeACommit();
+        fixture.AssertFullSemver("0.1.1-beta.1+1");
+
+        fixture.Repository.CreatePullRequestRef("hotfix/0.1.1", MainBranch, normalise: true);
+
+        fixture.AssertFullSemver("0.1.1-PullRequest0002.2");
+    }
 }


### PR DESCRIPTION
**Describe the bug**
Running the gitversion calculation on a PR pull branch from Hotfix to Main result to a minor increment instead of a patch increment.
Here is some diagnostic logs :
```
 INFO [09/07/22 14:25:07:29] Found possible parent branches: master, origin/hotfix/0.4.1
    WARN [09/07/22 14:25:07:29] Failed to inherit Increment branch configuration, ended up with: master, origin/hotfix/0.4.1
Falling back to develop branch config
  INFO [09/07/22 14:25:07:29] End: Attempting to inherit branch configuration from parent branch (Took: 48.56ms)
```
I believe the fallback to develop causes the minor increment.

## Expected Behavior
A Patch increment

## Actual Behavior
A Minor increment

## Related issues

Resolves #3187.

## Possible Fix
<!-- Not obligatory, but suggest a fix or reason for the bug -->

## Steps to Reproduce
See the test in the PR


## Your Environment
- Version Used: 5.10.3
- Operating System and version (Windows 10, Ubuntu 22.04):
