### PR TITLE
Fix closing pull request from hotfix to support failed to inherit Increment branch configuration

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/Issue3020FailedToInherit.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/Issue3020FailedToInherit.cs
@@ -1,11 +1,9 @@
 using GitTools.Testing;
 using GitVersion.Core.Tests.Helpers;
-using GitVersion.Extensions;
 using GitVersion.Model.Configuration;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 using NUnit.Framework;
-using Shouldly;
 
 namespace GitVersion.Core.Tests.IntegrationTests;
 
@@ -17,15 +15,15 @@ public class Issue3020FailedToInherit : TestBase
         Branches = new Dictionary<string, BranchConfig>
         {
             { MainBranch, new BranchConfig { Tag = "beta", Increment = IncrementStrategy.Minor } },
-            { "pull-request", new BranchConfig { Tag = "alpha-pr" } },
+            { "pull-request", new BranchConfig { Tag = "alpha-pr", Increment = IncrementStrategy.Inherit } }, // Inherit is indeed the default
             { "support", new BranchConfig { Tag = "beta" } }
         }
     };
 
     [Test]
-    public void LocalOnly()
+    public void MergingHotFixIntoSupportLocalOnly()
     {
-        var fixture = PrepareLocalRepo();
+        using var fixture = PrepareLocalRepoForHotFix();
 
         fixture.AssertFullSemver("1.0.2-alpha-pr0002.2", config);
 
@@ -33,25 +31,25 @@ public class Issue3020FailedToInherit : TestBase
     }
 
     [Test]
-    public void WithRemote()
+    public void MergingHotFixIntoSupportWithRemote()
     {
-        var fixture = PrepareLocalRepo();
+        using var fixture = PrepareLocalRepoForHotFix();
 
-        var local = fixture.CloneRepository();
+        using var local = fixture.CloneRepository();
         local.Checkout("origin/hotfix/v1.0.2");
         local.BranchTo("hotfix/v1.0.2", "hotfix");
         local.Checkout("origin/support/v1.0.x");
         local.BranchTo("support/v1.0.x", "support");
-        local.Checkout("origin/main");
-        local.BranchTo("main", "main");
+        local.Checkout($"origin/{MainBranch}");
+        local.BranchTo(MainBranch, MainBranch);
         local.Checkout("pull/2/merge");
-
+        
         local.AssertFullSemver("1.0.2-alpha-pr0002.2", config);
 
         local.Repository.DumpGraph();
     }
 
-    private static RepositoryFixtureBase PrepareLocalRepo()
+    private static RepositoryFixtureBase PrepareLocalRepoForHotFix()
     {
         var fixture = new EmptyRepositoryFixture();
 
@@ -71,6 +69,52 @@ public class Issue3020FailedToInherit : TestBase
         fixture.Checkout("support/v1.0.x");
         fixture.BranchTo("pull/2/merge", "pr-merge");
         fixture.MergeNoFF("hotfix/v1.0.2");
+
+        return fixture;
+    }
+
+    [Test]
+    public void MergingFeatureIntoMainLocalOnly()
+    {
+        using var fixture = PrepareLocalRepoForFeature();
+
+        fixture.AssertFullSemver("1.1.0-alpha-pr0002.3", config);
+
+        fixture.Repository.DumpGraph();
+    }
+
+    [Test]
+    public void MergingFeatureIntoMainWithRemote()
+    {
+        using var fixture = PrepareLocalRepoForFeature();
+
+        using var local = fixture.CloneRepository();
+        local.Checkout("origin/feature/my-incredible-feature");
+        local.BranchTo("feature/my-incredible-feature", "feature");
+        local.Checkout($"origin/{MainBranch}");
+        local.BranchTo(MainBranch, MainBranch);
+        local.Checkout("pull/2/merge");
+
+        local.AssertFullSemver("1.1.0-alpha-pr0002.3", config);
+
+        local.Repository.DumpGraph();
+    }
+
+    private static RepositoryFixtureBase PrepareLocalRepoForFeature()
+    {
+        var fixture = new EmptyRepositoryFixture();
+
+        fixture.Repository.MakeACommit("First commit");
+        fixture.Repository.ApplyTag("v1.0.0", new Signature("Michael Denny", "micdenny@gmail.com", DateTimeOffset.Now), "Release v1.0.0");
+
+        fixture.Repository.MakeACommit("Merged PR 1: new feature");
+        
+        fixture.BranchTo("feature/my-incredible-feature", "feature");
+        fixture.Repository.MakeACommit("incredible feature");
+
+        fixture.Checkout(MainBranch);
+        fixture.BranchTo("pull/2/merge", "pr-merge");
+        fixture.MergeNoFF("feature/my-incredible-feature");
 
         return fixture;
     }

--- a/src/GitVersion.Core.Tests/IntegrationTests/Issue3020FailedToInherit.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/Issue3020FailedToInherit.cs
@@ -1,0 +1,77 @@
+using GitTools.Testing;
+using GitVersion.Core.Tests.Helpers;
+using GitVersion.Extensions;
+using GitVersion.Model.Configuration;
+using GitVersion.VersionCalculation;
+using LibGit2Sharp;
+using NUnit.Framework;
+using Shouldly;
+
+namespace GitVersion.Core.Tests.IntegrationTests;
+
+public class Issue3020FailedToInherit : TestBase
+{
+    private readonly Config config = new()
+    {
+        VersioningMode = VersioningMode.ContinuousDeployment,
+        Branches = new Dictionary<string, BranchConfig>
+        {
+            { MainBranch, new BranchConfig { Tag = "beta", Increment = IncrementStrategy.Minor } },
+            { "pull-request", new BranchConfig { Tag = "alpha-pr" } },
+            { "support", new BranchConfig { Tag = "beta" } }
+        }
+    };
+
+    [Test]
+    public void LocalOnly()
+    {
+        var fixture = PrepareLocalRepo();
+
+        fixture.AssertFullSemver("1.0.2-alpha-pr0002.2", config);
+
+        fixture.Repository.DumpGraph();
+    }
+
+    [Test]
+    public void WithRemote()
+    {
+        var fixture = PrepareLocalRepo();
+
+        var local = fixture.CloneRepository();
+        local.Checkout("origin/hotfix/v1.0.2");
+        local.BranchTo("hotfix/v1.0.2", "hotfix");
+        local.Checkout("origin/support/v1.0.x");
+        local.BranchTo("support/v1.0.x", "support");
+        local.Checkout("origin/main");
+        local.BranchTo("main", "main");
+        local.Checkout("pull/2/merge");
+
+        local.AssertFullSemver("1.0.2-alpha-pr0002.2", config);
+
+        local.Repository.DumpGraph();
+    }
+
+    private static RepositoryFixtureBase PrepareLocalRepo()
+    {
+        var fixture = new EmptyRepositoryFixture();
+
+        fixture.Repository.MakeACommit("First commit");
+        fixture.Repository.ApplyTag("v1.0.0", new Signature("Michael Denny", "micdenny@gmail.com", DateTimeOffset.Now), "Release v1.0.0");
+
+        fixture.Repository.MakeACommit("Merged PR 1: new feature");
+
+        fixture.Checkout("tags/v1.0.0");
+        fixture.BranchTo("support/v1.0.x", "support");
+        fixture.Repository.MakeACommit("hotfix 1");
+        fixture.Repository.ApplyTag("v1.0.1", new Signature("Michael Denny", "micdenny@gmail.com", DateTimeOffset.Now), "hotfix 1");
+
+        fixture.BranchTo("hotfix/v1.0.2", "hotfix");
+        fixture.Repository.MakeACommit("hotfix 2");
+
+        fixture.Checkout("support/v1.0.x");
+        fixture.BranchTo("pull/2/merge", "pr-merge");
+        fixture.MergeNoFF("hotfix/v1.0.2");
+
+        return fixture;
+    }
+}

--- a/src/GitVersion.Core/Configuration/BranchConfigurationCalculator.cs
+++ b/src/GitVersion.Core/Configuration/BranchConfigurationCalculator.cs
@@ -89,7 +89,7 @@ public class BranchConfigurationCalculator : IBranchConfigurationCalculator
             {
                 excludedInheritBranches.Add(excludedBranch);
             }
-            var branchesToEvaluate = this.repositoryStore.ExcludingBranches(excludedInheritBranches)
+            var branchesToEvaluate = this.repositoryStore.ExcludingBranches(excludedInheritBranches, excludeRemotes: true)
                 .Distinct(new LocalRemoteBranchEqualityComparer())
                 .ToList();
 

--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -23,7 +23,7 @@ public interface IRepositoryStore
     IEnumerable<IBranch> GetBranchesForCommit(ICommit commit);
     IEnumerable<IBranch> GetExcludedInheritBranches(Config configuration);
     IEnumerable<IBranch> GetReleaseBranches(IEnumerable<KeyValuePair<string, BranchConfig>> releaseBranchConfig);
-    IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude);
+    IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude, bool excludeRemotes = false);
     IEnumerable<IBranch> GetBranchesContainingCommit(ICommit? commit, IEnumerable<IBranch>? branches = null, bool onlyTrackedBranches = false);
     IDictionary<string, List<IBranch>> GetMainlineBranches(ICommit commit, Config configuration, IEnumerable<KeyValuePair<string, BranchConfig>>? mainlineBranchConfigs);
 

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -166,7 +166,15 @@ public class RepositoryStore : IRepositoryStore
     public IEnumerable<IBranch> GetReleaseBranches(IEnumerable<KeyValuePair<string, BranchConfig>> releaseBranchConfig)
         => this.repository.Branches.Where(b => IsReleaseBranch(b, releaseBranchConfig));
 
-    public IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude) => this.repository.Branches.ExcludeBranches(branchesToExclude);
+    public IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude, bool excludeRemotes = false)
+    {
+        var branches = this.repository.Branches.ExcludeBranches(branchesToExclude);
+        if (excludeRemotes)
+        {
+            branches = branches.Where(b => !b.IsRemote);
+        }
+        return branches;
+    }
 
     public IEnumerable<IBranch> GetBranchesContainingCommit(ICommit? commit, IEnumerable<IBranch>? branches = null, bool onlyTrackedBranches = false)
     {

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+GitVersion.RepositoryStore.ExcludingBranches(System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! branchesToExclude, bool excludeRemotes = false) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the public method `ExcludingBranches` of `IRepositoryStore` adding an optional parameter `bool excludeRemotes = false`, it this way it should be backward compatible, actual calls to it like in `MergeCommitFinder` remains with the same behaviour, instead the call we did on `BranchConfigurationCalculator` in the `InheritBranchConfiguration` method, can be called passing `excludeRemotes: true` and this fixes the bug well explained in the issue.

Unfortunately this is a breaking change because I've changed a public api, even if we add a separated method, would break who is inherits from `RepositoryStore` or implement `IRepositoryStore`.

If you have a better idea, or a better name for `excludeRemotes` you're welcome to suggest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3020

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves a problem with the calculation of the inherits gitversion increment strategy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can check the integration tests I've added in the solution called `Issue3020FailedToInherit`, and it is welcome suggestion on better names and position of the file.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
