### PR TITLE
fix!: no-bump-message now takes precedence over *-version-bump-message.

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+*   When using a commit message that matches **both** `*-version-bump-message` and `no-bump-message`, there is no increment for that commit. In other words, `no-bump-message` now takes precedence over `*-version-bump-message`.
+
 ## v5.0.0
 
 *   Version numbers in branches other than `release` branches are no longer

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -191,6 +191,9 @@ Used to tell GitVersion not to increment when in Mainline development mode.
 Default `\+semver:\s?(none|skip)`, which will match occurrences of `+semver:
 none` and `+semver: skip`
 
+When a commit matches **both** the `no-bump-message` **and** any combination of
+the `version-bump-message`, `no-bump-message` takes precedence and no increment is applied.
+
 ### tag-pre-release-weight
 
 The pre-release weight in case of tagged commits. If the value is not set in the

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentMode.cs
@@ -523,6 +523,28 @@ public class MainlineDevelopmentMode : TestBase
         exception.ShouldNotBeNull();
         exception.Message.ShouldMatch("No branches can be found matching the commit .* in the configured Mainline branches: main, support");
     }
+
+    [TestCase("feat!: Break stuff +semver: none")]
+    [TestCase("feat: Add stuff +semver: none")]
+    [TestCase("fix: Fix stuff +semver: none")]
+    public void NoBumpMessageTakesPrecedenceOverBumpMessage(string commitMessage)
+    {
+        // Same configuration as found here: https://gitversion.net/docs/reference/version-increments#conventional-commit-messages
+        var conventionalCommitsConfig = new Config
+        {
+            VersioningMode = VersioningMode.Mainline,
+            MajorVersionBumpMessage = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)",
+            MinorVersionBumpMessage = "^(feat)(\\([\\w\\s-]*\\))?:",
+            PatchVersionBumpMessage = "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:",
+        };
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.0.0");
+
+        fixture.MakeACommit(commitMessage);
+
+        fixture.AssertFullSemver("1.0.0", conventionalCommitsConfig);
+    }
+
 }
 
 internal static class CommitExtensions

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -134,10 +134,10 @@ public class IncrementStrategyFinder : IIncrementStrategyFinder
 
     private static VersionField? GetIncrementFromMessage(string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex none)
     {
+        if (none.IsMatch(message)) return VersionField.None;
         if (majorRegex.IsMatch(message)) return VersionField.Major;
         if (minorRegex.IsMatch(message)) return VersionField.Minor;
         if (patchRegex.IsMatch(message)) return VersionField.Patch;
-        if (none.IsMatch(message)) return VersionField.None;
         return null;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the behavior of `commit-message-incrementing` when using commits that matches both `*-version-bump-message` and `no-bump-message`. `no-bump-message` now takes precedence over `*-version-bump-message`.

### Previous Behavior
Commits that match both `*-version-bump-message` and `no-bump-message` use the highest increment associated with `*-version-bump-message`.
### New Behavior
Commits that match both `*-version-bump-message` and `no-bump-message` don't have an increment.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #3172.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Repositories that enforce conventional commits along with `commit-message-incrementing` (with a config [like this](https://gitversion.net/docs/reference/version-increments#conventional-commit-messages)) can now have commits that don't have version bumps.

Example:
```
chore: Adjust .editorconfig for coding convention.
+semver: skip
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
An integration test was added to ensure the new behavior is covered by tests.
The newly added test fails when reverting the changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
