### PR TITLE
Fix issue with empty prerelease tags.

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
@@ -71,4 +71,31 @@ public class SupportBranchScenarios : TestBase
 
         fixture.AssertFullSemver("1.3.1+2");
     }
+
+    [Test]
+    public void WhenSupportIsBranchedFromMainWithSpecificTag()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.AssertFullSemver("0.1.0+0");
+
+        fixture.Repository.ApplyTag("1.4.0-rc");
+        fixture.Repository.MakeACommit();
+        fixture.Repository.CreateBranch("support/1");
+        Commands.Checkout(fixture.Repository, "support/1");
+        fixture.AssertFullSemver("1.4.0+1");
+    }
+
+    [Test]
+    public void WhenSupportIsBranchedFromMainWithSpecificTagOnCommit()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.AssertFullSemver("0.1.0+0");
+
+        fixture.Repository.ApplyTag("1.4.0-rc");
+        fixture.Repository.CreateBranch("support/1");
+        Commands.Checkout(fixture.Repository, "support/1");
+        fixture.AssertFullSemver("1.4.0");
+    }
 }

--- a/src/GitVersion.Core/Extensions/StringExtensions.cs
+++ b/src/GitVersion.Core/Extensions/StringExtensions.cs
@@ -102,4 +102,6 @@ public static class StringExtensions
 
     /// <inheritdoc cref="string.IsNullOrWhiteSpace"/>
     public static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? value) => string.IsNullOrWhiteSpace(value);
+
+    public static bool IsEmpty([NotNullWhen(false)] this string? value) => string.Empty.Equals(value);
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -1325,6 +1325,7 @@ static GitVersion.Extensions.StringExtensions.IsHelp(this string! singleArgument
 static GitVersion.Extensions.StringExtensions.IsInit(this string! singleArgument) -> bool
 static GitVersion.Extensions.StringExtensions.IsNullOrEmpty(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsNullOrWhiteSpace(this string? value) -> bool
+static GitVersion.Extensions.StringExtensions.IsEmpty(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsSwitch(this string? value, string! switchName) -> bool
 static GitVersion.Extensions.StringExtensions.IsSwitchArgument(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsTrue(this string? value) -> bool

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -97,6 +97,12 @@ public class NextVersionCalculator : INextVersionCalculator
             {
                 // set the commit count on the tagged ver
                 taggedSemanticVersion.BuildMetaData.CommitsSinceVersionSource = semver.BuildMetaData?.CommitsSinceVersionSource;
+
+                // set the updated prerelease tag when it doesn't match with prerelease tag defined in branch configuration
+                if (preReleaseTagDoesNotMatchConfiguration)
+                {
+                    taggedSemanticVersion.PreReleaseTag = semver.PreReleaseTag;
+                }
             }
         }
 


### PR DESCRIPTION
Fix issue when you have an empty tag configured in your branch defined as mainline.

## Description
Basically, the changes are related to detect if branchConfig is Mainline and has empty prerelease tag configured on it, then it will update prerelease tag in semver.

I created the branch from support/5.x

## Related Issue
Fix https://github.com/GitTools/GitVersion/issues/3218

## Motivation and Context
I want to use GitVersion in Azure DevOps with the gitversion.yml described in the bug.

Also, gitversion.yml of the [documentation](https://gitversion.net/docs/reference/configuration) has configured empty prerelease tag and mainline for main and support/* branches.

## How Has This Been Tested?
I tested locally and from the Azure DevOps.

![image](https://user-images.githubusercontent.com/16336745/194249850-3137c9e9-7924-407d-90ef-581d787a888e.png)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
