### PR TITLE
Refactor next version calculator (get rid of `taggedSemanticVersion`)

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -88,10 +88,10 @@ public class ReleaseBranchScenarios : TestBase
         fixture.Repository.MakeCommits(5);
         fixture.Repository.CreateBranch("releases/2.0.0");
         fixture.Checkout("releases/2.0.0");
-        fixture.Repository.ApplyTag("v2.0.0-1");
+        fixture.Repository.ApplyTag("v2.0.0-beta.1");
 
         var variables = fixture.GetVersion();
-        Assert.AreEqual("2.0.0-1", variables.FullSemVer);
+        Assert.AreEqual("2.0.0-beta.1", variables.FullSemVer);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -309,7 +309,9 @@ public class NextVersionCalculatorTests : TestBase
         repositoryStoreMock.GetSourceBranches(branchMock, configuration, Arg.Any<HashSet<IBranch>>()).Returns(Enumerable.Empty<IBranch>());
         var dateTimeOffset = DateTimeOffset.Now;
         var versionStrategies = new IVersionStrategy[] { new V1Strategy(DateTimeOffset.Now), new V2Strategy(dateTimeOffset) };
-        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), Substitute.For<IMainlineVersionCalculator>(),
+        var mainlineVersionCalculatorMock = Substitute.For<IMainlineVersionCalculator>();
+        mainlineVersionCalculatorMock.CreateVersionBuildMetaData(Arg.Any<ICommit?>()).Returns(new SemanticVersionBuildMetaData());
+        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), mainlineVersionCalculatorMock,
             repositoryStoreMock, new(context), versionStrategies, effectiveBranchConfigurationFinderMock, incrementStrategyFinderMock);
 
         // Act
@@ -338,7 +340,9 @@ public class NextVersionCalculatorTests : TestBase
         repositoryStoreMock.GetSourceBranches(branchMock, configuration, Arg.Any<HashSet<IBranch>>()).Returns(Enumerable.Empty<IBranch>());
         var when = DateTimeOffset.Now;
         var versionStrategies = new IVersionStrategy[] { new V1Strategy(when), new V2Strategy(null) };
-        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), Substitute.For<IMainlineVersionCalculator>(),
+        var mainlineVersionCalculatorMock = Substitute.For<IMainlineVersionCalculator>();
+        mainlineVersionCalculatorMock.CreateVersionBuildMetaData(Arg.Any<ICommit?>()).Returns(new SemanticVersionBuildMetaData());
+        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), mainlineVersionCalculatorMock,
             repositoryStoreMock, new(context), versionStrategies, effectiveBranchConfigurationFinderMock, incrementStrategyFinderMock);
 
         // Act
@@ -367,7 +371,9 @@ public class NextVersionCalculatorTests : TestBase
         repositoryStoreMock.GetSourceBranches(branchMock, configuration, Arg.Any<HashSet<IBranch>>()).Returns(Enumerable.Empty<IBranch>());
         var when = DateTimeOffset.Now;
         var versionStrategies = new IVersionStrategy[] { new V2Strategy(null), new V1Strategy(when) };
-        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), Substitute.For<IMainlineVersionCalculator>(),
+        var mainlineVersionCalculatorMock = Substitute.For<IMainlineVersionCalculator>();
+        mainlineVersionCalculatorMock.CreateVersionBuildMetaData(Arg.Any<ICommit?>()).Returns(new SemanticVersionBuildMetaData());
+        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), mainlineVersionCalculatorMock,
             repositoryStoreMock, new(context), versionStrategies, effectiveBranchConfigurationFinderMock, incrementStrategyFinderMock);
 
         // Act
@@ -397,7 +403,9 @@ public class NextVersionCalculatorTests : TestBase
         repositoryStoreMock.GetSourceBranches(branchMock, configuration, Arg.Any<HashSet<IBranch>>()).Returns(Enumerable.Empty<IBranch>());
         var version = new BaseVersion("dummy", false, new SemanticVersion(2), GitToolsTestingExtensions.CreateMockCommit(), null);
         var versionStrategies = new IVersionStrategy[] { new TestVersionStrategy(version) };
-        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), Substitute.For<IMainlineVersionCalculator>(),
+        var mainlineVersionCalculatorMock = Substitute.For<IMainlineVersionCalculator>();
+        mainlineVersionCalculatorMock.CreateVersionBuildMetaData(Arg.Any<ICommit?>()).Returns(new SemanticVersionBuildMetaData());
+        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), mainlineVersionCalculatorMock,
             repositoryStoreMock, new(context), versionStrategies, effectiveBranchConfigurationFinderMock, incrementStrategyFinderMock);
 
         // Act
@@ -427,7 +435,9 @@ public class NextVersionCalculatorTests : TestBase
         var higherVersion = new BaseVersion("exclude", false, new SemanticVersion(2), GitToolsTestingExtensions.CreateMockCommit(), null);
         var lowerVersion = new BaseVersion("dummy", false, new SemanticVersion(1), GitToolsTestingExtensions.CreateMockCommit(), null);
         var versionStrategies = new IVersionStrategy[] { new TestVersionStrategy(higherVersion, lowerVersion) };
-        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), Substitute.For<IMainlineVersionCalculator>(),
+        var mainlineVersionCalculatorMock = Substitute.For<IMainlineVersionCalculator>();
+        mainlineVersionCalculatorMock.CreateVersionBuildMetaData(Arg.Any<ICommit?>()).Returns(new SemanticVersionBuildMetaData());
+        var unitUnderTest = new NextVersionCalculator(Substitute.For<ILog>(), mainlineVersionCalculatorMock,
             repositoryStoreMock, new(context), versionStrategies, effectiveBranchConfigurationFinderMock, incrementStrategyFinderMock);
 
         // Act

--- a/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
@@ -49,11 +49,9 @@ public class SemanticVersionTests : TestBase
         Assert.AreEqual(major, version.Major);
         Assert.AreEqual(minor, version.Minor);
         Assert.AreEqual(patch, version.Patch);
-        version.PreReleaseTag.ShouldNotBeNull();
         Assert.AreEqual(tag, version.PreReleaseTag.Name);
         Assert.AreEqual(tagNumber, version.PreReleaseTag.Number);
 
-        version.BuildMetaData.ShouldNotBeNull();
         Assert.AreEqual(numberOfBuilds, version.BuildMetaData.CommitsSinceTag);
         Assert.AreEqual(branchName, version.BuildMetaData.Branch);
         Assert.AreEqual(sha, version.BuildMetaData.Sha);

--- a/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
@@ -23,7 +23,6 @@ public class VersionSourceTests : TestBase
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
-        nextVersion.IncrementedVersion.BuildMetaData.ShouldNotBeNull();
         nextVersion.IncrementedVersion.BuildMetaData.VersionSourceSha.ShouldBeNull();
         nextVersion.IncrementedVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(3);
     }
@@ -38,7 +37,6 @@ public class VersionSourceTests : TestBase
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
-        nextVersion.IncrementedVersion.BuildMetaData.ShouldNotBeNull();
         nextVersion.IncrementedVersion.BuildMetaData.VersionSourceSha.ShouldBeNull();
         nextVersion.IncrementedVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(1);
     }
@@ -59,7 +57,6 @@ public class VersionSourceTests : TestBase
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
-        nextVersion.IncrementedVersion.BuildMetaData.ShouldNotBeNull();
         nextVersion.IncrementedVersion.BuildMetaData.VersionSourceSha.ShouldBe(secondCommit.Sha);
         nextVersion.IncrementedVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(1);
     }

--- a/src/GitVersion.Core/Extensions/AssemblyVersionsGeneratorExtensions.cs
+++ b/src/GitVersion.Core/Extensions/AssemblyVersionsGeneratorExtensions.cs
@@ -8,7 +8,7 @@ public static class AssemblyVersionsGeneratorExtensions
             AssemblyVersioningScheme.Major => $"{sv.Major}.0.0.0",
             AssemblyVersioningScheme.MajorMinor => $"{sv.Major}.{sv.Minor}.0.0",
             AssemblyVersioningScheme.MajorMinorPatch => $"{sv.Major}.{sv.Minor}.{sv.Patch}.0",
-            AssemblyVersioningScheme.MajorMinorPatchTag => $"{sv.Major}.{sv.Minor}.{sv.Patch}.{sv.PreReleaseTag?.Number ?? 0}",
+            AssemblyVersioningScheme.MajorMinorPatchTag => $"{sv.Major}.{sv.Minor}.{sv.Patch}.{sv.PreReleaseTag.Number ?? 0}",
             AssemblyVersioningScheme.None => null,
             _ => throw new ArgumentException($"Unexpected value ({scheme}).", nameof(scheme))
         };
@@ -19,7 +19,7 @@ public static class AssemblyVersionsGeneratorExtensions
             AssemblyFileVersioningScheme.Major => $"{sv.Major}.0.0.0",
             AssemblyFileVersioningScheme.MajorMinor => $"{sv.Major}.{sv.Minor}.0.0",
             AssemblyFileVersioningScheme.MajorMinorPatch => $"{sv.Major}.{sv.Minor}.{sv.Patch}.0",
-            AssemblyFileVersioningScheme.MajorMinorPatchTag => $"{sv.Major}.{sv.Minor}.{sv.Patch}.{sv.PreReleaseTag?.Number ?? 0}",
+            AssemblyFileVersioningScheme.MajorMinorPatchTag => $"{sv.Major}.{sv.Minor}.{sv.Patch}.{sv.PreReleaseTag.Number ?? 0}",
             AssemblyFileVersioningScheme.None => null,
             _ => throw new ArgumentException($"Unexpected value ({scheme}).", nameof(scheme))
         };

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -1,55 +1,4 @@
 #nullable enable
-abstract GitVersion.BuildAgents.BuildAgentBase.EnvironmentVariable.get -> string!
-abstract GitVersion.BuildAgents.BuildAgentBase.GenerateSetParameterMessage(string! name, string! value) -> string![]!
-abstract GitVersion.BuildAgents.BuildAgentBase.GenerateSetVersionMessage(GitVersion.OutputVariables.VersionVariables! variables) -> string?
-abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.DefaultResult.get -> string?
-abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.GetPrompt(GitVersion.Configuration.GitVersionConfiguration! configuration, string! workingDirectory) -> string!
-abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.HandleResult(string? result, System.Collections.Generic.Queue<GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep!>! steps, GitVersion.Configuration.GitVersionConfiguration! configuration, string! workingDirectory) -> GitVersion.Configuration.Init.StepResult!
-abstract GitVersion.GitVersionModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
-abstract GitVersion.VersionCalculation.VersionStrategyBase.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
-const GitVersion.BuildAgents.AppVeyor.EnvironmentVariableName = "APPVEYOR" -> string!
-const GitVersion.BuildAgents.AzurePipelines.EnvironmentVariableName = "TF_BUILD" -> string!
-const GitVersion.BuildAgents.BitBucketPipelines.BranchEnvironmentVariableName = "BITBUCKET_BRANCH" -> string!
-const GitVersion.BuildAgents.BitBucketPipelines.EnvironmentVariableName = "BITBUCKET_WORKSPACE" -> string!
-const GitVersion.BuildAgents.BitBucketPipelines.PullRequestEnvironmentVariableName = "BITBUCKET_PR_ID" -> string!
-const GitVersion.BuildAgents.BitBucketPipelines.TagEnvironmentVariableName = "BITBUCKET_TAG" -> string!
-const GitVersion.BuildAgents.BuildKite.EnvironmentVariableName = "BUILDKITE" -> string!
-const GitVersion.BuildAgents.CodeBuild.SourceVersionEnvironmentVariableName = "CODEBUILD_SOURCE_VERSION" -> string!
-const GitVersion.BuildAgents.CodeBuild.WebHookEnvironmentVariableName = "CODEBUILD_WEBHOOK_HEAD_REF" -> string!
-const GitVersion.BuildAgents.ContinuaCi.EnvironmentVariableName = "ContinuaCI.Version" -> string!
-const GitVersion.BuildAgents.Drone.EnvironmentVariableName = "DRONE" -> string!
-const GitVersion.BuildAgents.EnvRun.EnvironmentVariableName = "ENVRUN_DATABASE" -> string!
-const GitVersion.BuildAgents.GitHubActions.EnvironmentVariableName = "GITHUB_ACTIONS" -> string!
-const GitVersion.BuildAgents.GitHubActions.GitHubSetEnvTempFileEnvironmentVariableName = "GITHUB_ENV" -> string!
-const GitVersion.BuildAgents.GitLabCi.EnvironmentVariableName = "GITLAB_CI" -> string!
-const GitVersion.BuildAgents.Jenkins.EnvironmentVariableName = "JENKINS_URL" -> string!
-const GitVersion.BuildAgents.MyGet.EnvironmentVariableName = "BuildRunner" -> string!
-const GitVersion.BuildAgents.SpaceAutomation.EnvironmentVariableName = "JB_SPACE_PROJECT_KEY" -> string!
-const GitVersion.BuildAgents.TeamCity.EnvironmentVariableName = "TEAMCITY_VERSION" -> string!
-const GitVersion.BuildAgents.TravisCi.EnvironmentVariableName = "TRAVIS" -> string!
-const GitVersion.Configuration.ConfigurationFileLocator.DefaultFileName = "GitVersion.yml" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.DefaultLabelPrefix = "[vV]?" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.DevelopBranchKey = "develop" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.DevelopBranchRegex = "^dev(elop)?(ment)?$" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.FeatureBranchKey = "feature" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.FeatureBranchRegex = "^features?[/-]" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.HotfixBranchKey = "hotfix" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.HotfixBranchRegex = "^hotfix(es)?[/-]" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.MainBranchKey = "main" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.MainBranchRegex = "^master$|^main$" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.MasterBranchKey = "master" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.PullRequestBranchKey = "pull-request" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.PullRequestRegex = "^(pull|pull\\-requests|pr)[/-]" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.ReleaseBranchKey = "release" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.ReleaseBranchRegex = "^releases?[/-]" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.SupportBranchKey = "support" -> string!
-const GitVersion.Configuration.GitVersionConfiguration.SupportBranchRegex = "^support[/-]" -> string!
-const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMajorPattern = "\\+semver:\\s?(breaking|major)" -> string!
-const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMinorPattern = "\\+semver:\\s?(feature|minor)" -> string!
-const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultNoBumpPattern = "\\+semver:\\s?(none|skip)" -> string!
-const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultPatchPattern = "\\+semver:\\s?(fix|patch)" -> string!
-const GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageStrategyPrefix = "Merge message" -> string!
-const GitVersion.VersionConverters.WixUpdater.WixVersionFileUpdater.WixVersionFileName = "GitVersion_WixVersion.wxi" -> string!
 GitVersion.AssemblyInfoData
 GitVersion.AssemblyInfoData.AssemblyInfoData() -> void
 GitVersion.AssemblyInfoData.EnsureAssemblyInfo -> bool
@@ -144,9 +93,9 @@ GitVersion.CommitSortStrategies.Topological = 1 -> GitVersion.CommitSortStrategi
 GitVersion.Common.IRepositoryStore
 GitVersion.Common.IRepositoryStore.ExcludingBranches(System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! branchesToExclude) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.FindBranch(string? branchName) -> GitVersion.IBranch?
-GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
-GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.Common.IRepositoryStore.FindCommitBranchWasBranchedFrom(GitVersion.IBranch? branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> GitVersion.BranchCommit
+GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
+GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.Common.IRepositoryStore.FindMainBranch(GitVersion.Configuration.GitVersionConfiguration! configuration) -> GitVersion.IBranch?
 GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.IBranch? branch, GitVersion.IBranch? otherBranch) -> GitVersion.ICommit?
 GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! mainlineTip) -> GitVersion.ICommit?
@@ -159,8 +108,8 @@ GitVersion.Common.IRepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? base
 GitVersion.Common.IRepositoryStore.GetMergeBaseCommits(GitVersion.ICommit? mergeCommit, GitVersion.ICommit? mergedHead, GitVersion.ICommit? findMergeBase) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.Common.IRepositoryStore.GetNumberOfUncommittedChanges() -> int
 GitVersion.Common.IRepositoryStore.GetReleaseBranches(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Configuration.BranchConfiguration!>>! releaseBranchConfig) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
-GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
+GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.IBranch!
 GitVersion.Common.IRepositoryStore.GetValidVersionTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat, System.DateTimeOffset? olderThan = null) -> System.Collections.Generic.IEnumerable<(GitVersion.ITag! Tag, GitVersion.SemanticVersion! Semver, GitVersion.ICommit! Commit)>!
 GitVersion.Common.IRepositoryStore.GetVersionTagsOnBranch(GitVersion.IBranch! branch, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersion!>!
@@ -185,6 +134,10 @@ GitVersion.Configuration.BranchConfiguration.IsReleaseBranch.get -> bool?
 GitVersion.Configuration.BranchConfiguration.IsReleaseBranch.set -> void
 GitVersion.Configuration.BranchConfiguration.IsSourceBranchFor.get -> System.Collections.Generic.HashSet<string!>?
 GitVersion.Configuration.BranchConfiguration.IsSourceBranchFor.set -> void
+GitVersion.Configuration.BranchConfiguration.Label.get -> string?
+GitVersion.Configuration.BranchConfiguration.Label.set -> void
+GitVersion.Configuration.BranchConfiguration.LabelNumberPattern.get -> string?
+GitVersion.Configuration.BranchConfiguration.LabelNumberPattern.set -> void
 GitVersion.Configuration.BranchConfiguration.MergeTo(GitVersion.Configuration.BranchConfiguration! targetConfig) -> void
 GitVersion.Configuration.BranchConfiguration.Name.get -> string!
 GitVersion.Configuration.BranchConfiguration.Name.set -> void
@@ -196,10 +149,6 @@ GitVersion.Configuration.BranchConfiguration.Regex.get -> string?
 GitVersion.Configuration.BranchConfiguration.Regex.set -> void
 GitVersion.Configuration.BranchConfiguration.SourceBranches.get -> System.Collections.Generic.HashSet<string!>?
 GitVersion.Configuration.BranchConfiguration.SourceBranches.set -> void
-GitVersion.Configuration.BranchConfiguration.Label.get -> string?
-GitVersion.Configuration.BranchConfiguration.Label.set -> void
-GitVersion.Configuration.BranchConfiguration.LabelNumberPattern.get -> string?
-GitVersion.Configuration.BranchConfiguration.LabelNumberPattern.set -> void
 GitVersion.Configuration.BranchConfiguration.TrackMergeTarget.get -> bool?
 GitVersion.Configuration.BranchConfiguration.TrackMergeTarget.set -> void
 GitVersion.Configuration.BranchConfiguration.TracksReleaseBranches.get -> bool?
@@ -252,6 +201,10 @@ GitVersion.Configuration.EffectiveConfiguration.EffectiveConfiguration(GitVersio
 GitVersion.Configuration.EffectiveConfiguration.Increment.get -> GitVersion.IncrementStrategy
 GitVersion.Configuration.EffectiveConfiguration.IsMainline.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.IsReleaseBranch.get -> bool
+GitVersion.Configuration.EffectiveConfiguration.Label.get -> string!
+GitVersion.Configuration.EffectiveConfiguration.LabelNumberPattern.get -> string?
+GitVersion.Configuration.EffectiveConfiguration.LabelPreReleaseWeight.get -> int
+GitVersion.Configuration.EffectiveConfiguration.LabelPrefix.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.MajorVersionBumpMessage.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.MinorVersionBumpMessage.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.NextVersion.get -> string?
@@ -261,10 +214,6 @@ GitVersion.Configuration.EffectiveConfiguration.PreReleaseWeight.get -> int
 GitVersion.Configuration.EffectiveConfiguration.PreventIncrementOfMergedBranchVersion.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.SemanticVersionFormat.get -> GitVersion.SemanticVersionFormat
 GitVersion.Configuration.EffectiveConfiguration.SemanticVersionFormat.set -> void
-GitVersion.Configuration.EffectiveConfiguration.Label.get -> string!
-GitVersion.Configuration.EffectiveConfiguration.LabelNumberPattern.get -> string?
-GitVersion.Configuration.EffectiveConfiguration.LabelPrefix.get -> string?
-GitVersion.Configuration.EffectiveConfiguration.LabelPreReleaseWeight.get -> int
 GitVersion.Configuration.EffectiveConfiguration.TrackMergeTarget.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.TracksReleaseBranches.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.UpdateBuildNumber.get -> bool
@@ -294,6 +243,10 @@ GitVersion.Configuration.GitVersionConfiguration.Ignore.get -> GitVersion.Config
 GitVersion.Configuration.GitVersionConfiguration.Ignore.set -> void
 GitVersion.Configuration.GitVersionConfiguration.Increment.get -> GitVersion.IncrementStrategy?
 GitVersion.Configuration.GitVersionConfiguration.Increment.set -> void
+GitVersion.Configuration.GitVersionConfiguration.LabelPreReleaseWeight.get -> int?
+GitVersion.Configuration.GitVersionConfiguration.LabelPreReleaseWeight.set -> void
+GitVersion.Configuration.GitVersionConfiguration.LabelPrefix.get -> string?
+GitVersion.Configuration.GitVersionConfiguration.LabelPrefix.set -> void
 GitVersion.Configuration.GitVersionConfiguration.MajorVersionBumpMessage.get -> string?
 GitVersion.Configuration.GitVersionConfiguration.MajorVersionBumpMessage.set -> void
 GitVersion.Configuration.GitVersionConfiguration.MergeMessageFormats.get -> System.Collections.Generic.Dictionary<string!, string!>!
@@ -308,10 +261,6 @@ GitVersion.Configuration.GitVersionConfiguration.PatchVersionBumpMessage.get -> 
 GitVersion.Configuration.GitVersionConfiguration.PatchVersionBumpMessage.set -> void
 GitVersion.Configuration.GitVersionConfiguration.SemanticVersionFormat.get -> GitVersion.SemanticVersionFormat
 GitVersion.Configuration.GitVersionConfiguration.SemanticVersionFormat.set -> void
-GitVersion.Configuration.GitVersionConfiguration.LabelPrefix.get -> string?
-GitVersion.Configuration.GitVersionConfiguration.LabelPrefix.set -> void
-GitVersion.Configuration.GitVersionConfiguration.LabelPreReleaseWeight.get -> int?
-GitVersion.Configuration.GitVersionConfiguration.LabelPreReleaseWeight.set -> void
 GitVersion.Configuration.GitVersionConfiguration.UpdateBuildNumber.get -> bool?
 GitVersion.Configuration.GitVersionConfiguration.UpdateBuildNumber.set -> void
 GitVersion.Configuration.GitVersionConfiguration.VersioningMode.get -> GitVersion.VersionCalculation.VersioningMode?
@@ -515,8 +464,8 @@ GitVersion.IBranch.IsTracking.get -> bool
 GitVersion.IBranch.Tip.get -> GitVersion.ICommit?
 GitVersion.IBranchCollection
 GitVersion.IBranchCollection.ExcludeBranches(System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! branchesToExclude) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
-GitVersion.IBranchCollection.this[string! name].get -> GitVersion.IBranch?
 GitVersion.IBranchCollection.UpdateTrackedBranch(GitVersion.IBranch! branch, string! remoteTrackingReferenceName) -> void
+GitVersion.IBranchCollection.this[string! name].get -> GitVersion.IBranch?
 GitVersion.ICommit
 GitVersion.ICommit.Message.get -> string!
 GitVersion.ICommit.Parents.get -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
@@ -583,16 +532,15 @@ GitVersion.IMutatingGitRepository.CreateBranchForPullRequestBranch(GitVersion.Au
 GitVersion.IMutatingGitRepository.Fetch(string! remote, System.Collections.Generic.IEnumerable<string!>! refSpecs, GitVersion.AuthenticationInfo! auth, string? logMessage) -> void
 GitVersion.INamedReference
 GitVersion.INamedReference.Name.get -> GitVersion.ReferenceName!
-GitVersion.IncrementStrategy
-GitVersion.IncrementStrategy.Inherit = 4 -> GitVersion.IncrementStrategy
-GitVersion.IncrementStrategy.Major = 1 -> GitVersion.IncrementStrategy
-GitVersion.IncrementStrategy.Minor = 2 -> GitVersion.IncrementStrategy
-GitVersion.IncrementStrategy.None = 0 -> GitVersion.IncrementStrategy
-GitVersion.IncrementStrategy.Patch = 3 -> GitVersion.IncrementStrategy
-GitVersion.IncrementStrategyExtensions
 GitVersion.IObjectId
 GitVersion.IObjectId.Sha.get -> string!
 GitVersion.IObjectId.ToString(int prefixLength) -> string!
+GitVersion.IRefSpec
+GitVersion.IRefSpec.Destination.get -> string!
+GitVersion.IRefSpec.Direction.get -> GitVersion.RefSpecDirection
+GitVersion.IRefSpec.Source.get -> string!
+GitVersion.IRefSpec.Specification.get -> string!
+GitVersion.IRefSpecCollection
 GitVersion.IReference
 GitVersion.IReference.ReferenceTargetId.get -> GitVersion.IObjectId?
 GitVersion.IReference.TargetIdentifier.get -> string!
@@ -600,15 +548,9 @@ GitVersion.IReferenceCollection
 GitVersion.IReferenceCollection.Add(string! name, string! canonicalRefNameOrObject, bool allowOverwrite = false) -> void
 GitVersion.IReferenceCollection.FromGlob(string! prefix) -> System.Collections.Generic.IEnumerable<GitVersion.IReference!>!
 GitVersion.IReferenceCollection.Head.get -> GitVersion.IReference?
+GitVersion.IReferenceCollection.UpdateTarget(GitVersion.IReference! directRef, GitVersion.IObjectId! targetId) -> void
 GitVersion.IReferenceCollection.this[GitVersion.ReferenceName! referenceName].get -> GitVersion.IReference?
 GitVersion.IReferenceCollection.this[string! name].get -> GitVersion.IReference?
-GitVersion.IReferenceCollection.UpdateTarget(GitVersion.IReference! directRef, GitVersion.IObjectId! targetId) -> void
-GitVersion.IRefSpec
-GitVersion.IRefSpec.Destination.get -> string!
-GitVersion.IRefSpec.Direction.get -> GitVersion.RefSpecDirection
-GitVersion.IRefSpec.Source.get -> string!
-GitVersion.IRefSpec.Specification.get -> string!
-GitVersion.IRefSpecCollection
 GitVersion.IRemote
 GitVersion.IRemote.FetchRefSpecs.get -> System.Collections.Generic.IEnumerable<GitVersion.IRefSpec!>!
 GitVersion.IRemote.Name.get -> string!
@@ -617,12 +559,19 @@ GitVersion.IRemote.RefSpecs.get -> System.Collections.Generic.IEnumerable<GitVer
 GitVersion.IRemote.Url.get -> string!
 GitVersion.IRemoteCollection
 GitVersion.IRemoteCollection.Remove(string! remoteName) -> void
-GitVersion.IRemoteCollection.this[string! name].get -> GitVersion.IRemote?
 GitVersion.IRemoteCollection.Update(string! remoteName, string! refSpec) -> void
+GitVersion.IRemoteCollection.this[string! name].get -> GitVersion.IRemote?
 GitVersion.ITag
 GitVersion.ITag.PeeledTargetCommit() -> GitVersion.ICommit?
 GitVersion.ITag.TargetSha.get -> string?
 GitVersion.ITagCollection
+GitVersion.IncrementStrategy
+GitVersion.IncrementStrategy.Inherit = 4 -> GitVersion.IncrementStrategy
+GitVersion.IncrementStrategy.Major = 1 -> GitVersion.IncrementStrategy
+GitVersion.IncrementStrategy.Minor = 2 -> GitVersion.IncrementStrategy
+GitVersion.IncrementStrategy.None = 0 -> GitVersion.IncrementStrategy
+GitVersion.IncrementStrategy.Patch = 3 -> GitVersion.IncrementStrategy
+GitVersion.IncrementStrategyExtensions
 GitVersion.LockedFileException
 GitVersion.LockedFileException.LockedFileException(System.Exception! inner) -> void
 GitVersion.Logging.ConsoleAdapter
@@ -689,8 +638,8 @@ GitVersion.Logging.Verbosity.Verbose = 3 -> GitVersion.Logging.Verbosity
 GitVersion.MergeMessage
 GitVersion.MergeMessage.FormatName.get -> string?
 GitVersion.MergeMessage.IsMergedPullRequest.get -> bool
-GitVersion.MergeMessage.MergedBranch.get -> string!
 GitVersion.MergeMessage.MergeMessage(string? mergeMessage, GitVersion.Configuration.GitVersionConfiguration! configuration) -> void
+GitVersion.MergeMessage.MergedBranch.get -> string!
 GitVersion.MergeMessage.PullRequestNumber.get -> int?
 GitVersion.MergeMessage.TargetBranch.get -> string?
 GitVersion.MergeMessage.Version.get -> GitVersion.SemanticVersion?
@@ -725,12 +674,12 @@ GitVersion.OutputVariables.VersionVariables.PreReleaseTagWithDash.get -> string?
 GitVersion.OutputVariables.VersionVariables.SemVer.get -> string!
 GitVersion.OutputVariables.VersionVariables.Sha.get -> string?
 GitVersion.OutputVariables.VersionVariables.ShortSha.get -> string?
-GitVersion.OutputVariables.VersionVariables.this[string! variable].get -> string?
 GitVersion.OutputVariables.VersionVariables.TryGetValue(string! variable, out string? variableValue) -> bool
 GitVersion.OutputVariables.VersionVariables.UncommittedChanges.get -> string?
 GitVersion.OutputVariables.VersionVariables.VersionSourceSha.get -> string?
 GitVersion.OutputVariables.VersionVariables.VersionVariables(string! major, string! minor, string! patch, string? buildMetaData, string? fullBuildMetaData, string? branchName, string? escapedBranchName, string? sha, string? shortSha, string! majorMinorPatch, string! semVer, string! fullSemVer, string? assemblySemVer, string? assemblySemFileVer, string? preReleaseTag, string? preReleaseTagWithDash, string? preReleaseLabel, string? preReleaseLabelWithDash, string? preReleaseNumber, string! weightedPreReleaseNumber, string? informationalVersion, string? commitDate, string? versionSourceSha, string? commitsSinceVersionSource, string? uncommittedChanges) -> void
 GitVersion.OutputVariables.VersionVariables.WeightedPreReleaseNumber.get -> string!
+GitVersion.OutputVariables.VersionVariables.this[string! variable].get -> string?
 GitVersion.OutputVariables.VersionVariablesJsonModel
 GitVersion.OutputVariables.VersionVariablesJsonModel.AssemblySemFileVer.get -> string?
 GitVersion.OutputVariables.VersionVariablesJsonModel.AssemblySemFileVer.set -> void
@@ -787,6 +736,9 @@ GitVersion.OutputVariables.VersionVariablesJsonNumberConverter
 GitVersion.OutputVariables.VersionVariablesJsonNumberConverter.VersionVariablesJsonNumberConverter() -> void
 GitVersion.OutputVariables.VersionVariablesJsonStringConverter
 GitVersion.OutputVariables.VersionVariablesJsonStringConverter.VersionVariablesJsonStringConverter() -> void
+GitVersion.RefSpecDirection
+GitVersion.RefSpecDirection.Fetch = 0 -> GitVersion.RefSpecDirection
+GitVersion.RefSpecDirection.Push = 1 -> GitVersion.RefSpecDirection
 GitVersion.ReferenceName
 GitVersion.ReferenceName.Canonical.get -> string!
 GitVersion.ReferenceName.CompareTo(GitVersion.ReferenceName? other) -> int
@@ -799,9 +751,6 @@ GitVersion.ReferenceName.IsRemoteBranch.get -> bool
 GitVersion.ReferenceName.IsTag.get -> bool
 GitVersion.ReferenceName.ReferenceName(string! canonical) -> void
 GitVersion.ReferenceName.WithoutRemote.get -> string!
-GitVersion.RefSpecDirection
-GitVersion.RefSpecDirection.Fetch = 0 -> GitVersion.RefSpecDirection
-GitVersion.RefSpecDirection.Push = 1 -> GitVersion.RefSpecDirection
 GitVersion.RepositoryInfo
 GitVersion.RepositoryInfo.ClonePath -> string?
 GitVersion.RepositoryInfo.CommitId -> string?
@@ -811,9 +760,9 @@ GitVersion.RepositoryInfo.TargetUrl -> string?
 GitVersion.RepositoryStore
 GitVersion.RepositoryStore.ExcludingBranches(System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! branchesToExclude) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.FindBranch(string? branchName) -> GitVersion.IBranch?
-GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
-GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.RepositoryStore.FindCommitBranchWasBranchedFrom(GitVersion.IBranch? branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> GitVersion.BranchCommit
+GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
+GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.RepositoryStore.FindMainBranch(GitVersion.Configuration.GitVersionConfiguration! configuration) -> GitVersion.IBranch?
 GitVersion.RepositoryStore.FindMergeBase(GitVersion.IBranch? branch, GitVersion.IBranch? otherBranch) -> GitVersion.ICommit?
 GitVersion.RepositoryStore.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! mainlineTip) -> GitVersion.ICommit?
@@ -826,15 +775,15 @@ GitVersion.RepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? baseVersionS
 GitVersion.RepositoryStore.GetMergeBaseCommits(GitVersion.ICommit? mergeCommit, GitVersion.ICommit? mergedHead, GitVersion.ICommit? findMergeBase) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.RepositoryStore.GetNumberOfUncommittedChanges() -> int
 GitVersion.RepositoryStore.GetReleaseBranches(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Configuration.BranchConfiguration!>>! releaseBranchConfig) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
-GitVersion.RepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
+GitVersion.RepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.IBranch!
 GitVersion.RepositoryStore.GetValidVersionTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat, System.DateTimeOffset? olderThan = null) -> System.Collections.Generic.IEnumerable<(GitVersion.ITag! Tag, GitVersion.SemanticVersion! Semver, GitVersion.ICommit! Commit)>!
 GitVersion.RepositoryStore.GetVersionTagsOnBranch(GitVersion.IBranch! branch, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersion!>!
 GitVersion.RepositoryStore.IsCommitOnBranch(GitVersion.ICommit? baseVersionSource, GitVersion.IBranch! branch, GitVersion.ICommit! firstMatchingCommit) -> bool
 GitVersion.RepositoryStore.RepositoryStore(GitVersion.Logging.ILog! log, GitVersion.IGitRepository! repository) -> void
 GitVersion.SemanticVersion
-GitVersion.SemanticVersion.BuildMetaData -> GitVersion.SemanticVersionBuildMetaData?
+GitVersion.SemanticVersion.BuildMetaData -> GitVersion.SemanticVersionBuildMetaData!
 GitVersion.SemanticVersion.CompareTo(GitVersion.SemanticVersion? value) -> int
 GitVersion.SemanticVersion.CompareTo(GitVersion.SemanticVersion? value, bool includePrerelease) -> int
 GitVersion.SemanticVersion.Equals(GitVersion.SemanticVersion? obj) -> bool
@@ -844,7 +793,7 @@ GitVersion.SemanticVersion.IsEmpty() -> bool
 GitVersion.SemanticVersion.Major -> long
 GitVersion.SemanticVersion.Minor -> long
 GitVersion.SemanticVersion.Patch -> long
-GitVersion.SemanticVersion.PreReleaseTag -> GitVersion.SemanticVersionPreReleaseTag?
+GitVersion.SemanticVersion.PreReleaseTag -> GitVersion.SemanticVersionPreReleaseTag!
 GitVersion.SemanticVersion.SemanticVersion(GitVersion.SemanticVersion? semanticVersion) -> void
 GitVersion.SemanticVersion.SemanticVersion(long major = 0, long minor = 0, long patch = 0) -> void
 GitVersion.SemanticVersion.ToString(string! format) -> string!
@@ -888,8 +837,8 @@ GitVersion.SemanticVersionFormatValues.PreReleaseLabelWithDash.get -> string?
 GitVersion.SemanticVersionFormatValues.PreReleaseNumber.get -> string?
 GitVersion.SemanticVersionFormatValues.PreReleaseTag.get -> string?
 GitVersion.SemanticVersionFormatValues.PreReleaseTagWithDash.get -> string?
-GitVersion.SemanticVersionFormatValues.SemanticVersionFormatValues(GitVersion.SemanticVersion! semver, GitVersion.Configuration.EffectiveConfiguration! configuration) -> void
 GitVersion.SemanticVersionFormatValues.SemVer.get -> string!
+GitVersion.SemanticVersionFormatValues.SemanticVersionFormatValues(GitVersion.SemanticVersion! semver, GitVersion.Configuration.EffectiveConfiguration! configuration) -> void
 GitVersion.SemanticVersionFormatValues.Sha.get -> string?
 GitVersion.SemanticVersionFormatValues.ShortSha.get -> string?
 GitVersion.SemanticVersionFormatValues.UncommittedChanges.get -> string?
@@ -958,10 +907,6 @@ GitVersion.VersionCalculation.IIncrementStrategyFinder.GetIncrementForCommits(Gi
 GitVersion.VersionCalculation.IMainlineVersionCalculator
 GitVersion.VersionCalculation.IMainlineVersionCalculator.CreateVersionBuildMetaData(GitVersion.ICommit? baseVersionSource) -> GitVersion.SemanticVersionBuildMetaData!
 GitVersion.VersionCalculation.IMainlineVersionCalculator.FindMainlineModeVersion(GitVersion.VersionCalculation.BaseVersion! baseVersion) -> GitVersion.SemanticVersion!
-GitVersion.VersionCalculation.IncrementStrategyFinder
-GitVersion.VersionCalculation.IncrementStrategyFinder.DetermineIncrementedField(GitVersion.GitVersionContext! context, GitVersion.VersionCalculation.BaseVersion! baseVersion, GitVersion.Configuration.EffectiveConfiguration! configuration) -> GitVersion.VersionField
-GitVersion.VersionCalculation.IncrementStrategyFinder.GetIncrementForCommits(GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.ICommit!>! commits) -> GitVersion.VersionField?
-GitVersion.VersionCalculation.IncrementStrategyFinder.IncrementStrategyFinder(GitVersion.IGitRepository! repository) -> void
 GitVersion.VersionCalculation.INextVersionCalculator
 GitVersion.VersionCalculation.INextVersionCalculator.FindVersion() -> GitVersion.VersionCalculation.NextVersion!
 GitVersion.VersionCalculation.IVariableProvider
@@ -970,6 +915,10 @@ GitVersion.VersionCalculation.IVersionFilter
 GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.VersionCalculation.BaseVersion! version, out string? reason) -> bool
 GitVersion.VersionCalculation.IVersionStrategy
 GitVersion.VersionCalculation.IVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
+GitVersion.VersionCalculation.IncrementStrategyFinder
+GitVersion.VersionCalculation.IncrementStrategyFinder.DetermineIncrementedField(GitVersion.GitVersionContext! context, GitVersion.VersionCalculation.BaseVersion! baseVersion, GitVersion.Configuration.EffectiveConfiguration! configuration) -> GitVersion.VersionField
+GitVersion.VersionCalculation.IncrementStrategyFinder.GetIncrementForCommits(GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.ICommit!>! commits) -> GitVersion.VersionField?
+GitVersion.VersionCalculation.IncrementStrategyFinder.IncrementStrategyFinder(GitVersion.IGitRepository! repository) -> void
 GitVersion.VersionCalculation.MergeMessageVersionStrategy
 GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageVersionStrategy(GitVersion.Logging.ILog! log, System.Lazy<GitVersion.GitVersionContext!>! versionContext, GitVersion.Common.IRepositoryStore! repositoryStore) -> void
 GitVersion.VersionCalculation.MinDateVersionFilter
@@ -1006,15 +955,15 @@ GitVersion.VersionCalculation.VersionCalculationModule.RegisterTypes(Microsoft.E
 GitVersion.VersionCalculation.VersionCalculationModule.VersionCalculationModule() -> void
 GitVersion.VersionCalculation.VersionInBranchNameVersionStrategy
 GitVersion.VersionCalculation.VersionInBranchNameVersionStrategy.VersionInBranchNameVersionStrategy(GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
-GitVersion.VersionCalculation.VersioningMode
-GitVersion.VersionCalculation.VersioningMode.ContinuousDelivery = 0 -> GitVersion.VersionCalculation.VersioningMode
-GitVersion.VersionCalculation.VersioningMode.ContinuousDeployment = 1 -> GitVersion.VersionCalculation.VersioningMode
-GitVersion.VersionCalculation.VersioningMode.Mainline = 2 -> GitVersion.VersionCalculation.VersioningMode
 GitVersion.VersionCalculation.VersionStrategyBase
 GitVersion.VersionCalculation.VersionStrategyBase.Context.get -> GitVersion.GitVersionContext!
 GitVersion.VersionCalculation.VersionStrategyBase.VersionStrategyBase(System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.VersionStrategyModule
 GitVersion.VersionCalculation.VersionStrategyModule.VersionStrategyModule() -> void
+GitVersion.VersionCalculation.VersioningMode
+GitVersion.VersionCalculation.VersioningMode.ContinuousDelivery = 0 -> GitVersion.VersionCalculation.VersioningMode
+GitVersion.VersionCalculation.VersioningMode.ContinuousDeployment = 1 -> GitVersion.VersionCalculation.VersioningMode
+GitVersion.VersionCalculation.VersioningMode.Mainline = 2 -> GitVersion.VersionCalculation.VersioningMode
 GitVersion.VersionConverters.AssemblyInfo.AssemblyInfoContext
 GitVersion.VersionConverters.AssemblyInfo.AssemblyInfoContext.AssemblyInfoContext() -> void
 GitVersion.VersionConverters.AssemblyInfo.AssemblyInfoContext.AssemblyInfoContext(string! workingDirectory, bool ensureAssemblyInfo, params string![]! assemblyInfoFiles) -> void
@@ -1081,6 +1030,57 @@ GitVersion.WarningException.WarningException(string! message) -> void
 GitVersion.WixInfo
 GitVersion.WixInfo.ShouldUpdate -> bool
 GitVersion.WixInfo.WixInfo() -> void
+abstract GitVersion.BuildAgents.BuildAgentBase.EnvironmentVariable.get -> string!
+abstract GitVersion.BuildAgents.BuildAgentBase.GenerateSetParameterMessage(string! name, string! value) -> string![]!
+abstract GitVersion.BuildAgents.BuildAgentBase.GenerateSetVersionMessage(GitVersion.OutputVariables.VersionVariables! variables) -> string?
+abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.DefaultResult.get -> string?
+abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.GetPrompt(GitVersion.Configuration.GitVersionConfiguration! configuration, string! workingDirectory) -> string!
+abstract GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep.HandleResult(string? result, System.Collections.Generic.Queue<GitVersion.Configuration.Init.Wizard.ConfigInitWizardStep!>! steps, GitVersion.Configuration.GitVersionConfiguration! configuration, string! workingDirectory) -> GitVersion.Configuration.Init.StepResult!
+abstract GitVersion.GitVersionModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
+abstract GitVersion.VersionCalculation.VersionStrategyBase.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
+const GitVersion.BuildAgents.AppVeyor.EnvironmentVariableName = "APPVEYOR" -> string!
+const GitVersion.BuildAgents.AzurePipelines.EnvironmentVariableName = "TF_BUILD" -> string!
+const GitVersion.BuildAgents.BitBucketPipelines.BranchEnvironmentVariableName = "BITBUCKET_BRANCH" -> string!
+const GitVersion.BuildAgents.BitBucketPipelines.EnvironmentVariableName = "BITBUCKET_WORKSPACE" -> string!
+const GitVersion.BuildAgents.BitBucketPipelines.PullRequestEnvironmentVariableName = "BITBUCKET_PR_ID" -> string!
+const GitVersion.BuildAgents.BitBucketPipelines.TagEnvironmentVariableName = "BITBUCKET_TAG" -> string!
+const GitVersion.BuildAgents.BuildKite.EnvironmentVariableName = "BUILDKITE" -> string!
+const GitVersion.BuildAgents.CodeBuild.SourceVersionEnvironmentVariableName = "CODEBUILD_SOURCE_VERSION" -> string!
+const GitVersion.BuildAgents.CodeBuild.WebHookEnvironmentVariableName = "CODEBUILD_WEBHOOK_HEAD_REF" -> string!
+const GitVersion.BuildAgents.ContinuaCi.EnvironmentVariableName = "ContinuaCI.Version" -> string!
+const GitVersion.BuildAgents.Drone.EnvironmentVariableName = "DRONE" -> string!
+const GitVersion.BuildAgents.EnvRun.EnvironmentVariableName = "ENVRUN_DATABASE" -> string!
+const GitVersion.BuildAgents.GitHubActions.EnvironmentVariableName = "GITHUB_ACTIONS" -> string!
+const GitVersion.BuildAgents.GitHubActions.GitHubSetEnvTempFileEnvironmentVariableName = "GITHUB_ENV" -> string!
+const GitVersion.BuildAgents.GitLabCi.EnvironmentVariableName = "GITLAB_CI" -> string!
+const GitVersion.BuildAgents.Jenkins.EnvironmentVariableName = "JENKINS_URL" -> string!
+const GitVersion.BuildAgents.MyGet.EnvironmentVariableName = "BuildRunner" -> string!
+const GitVersion.BuildAgents.SpaceAutomation.EnvironmentVariableName = "JB_SPACE_PROJECT_KEY" -> string!
+const GitVersion.BuildAgents.TeamCity.EnvironmentVariableName = "TEAMCITY_VERSION" -> string!
+const GitVersion.BuildAgents.TravisCi.EnvironmentVariableName = "TRAVIS" -> string!
+const GitVersion.Configuration.ConfigurationFileLocator.DefaultFileName = "GitVersion.yml" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.DefaultLabelPrefix = "[vV]?" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.DevelopBranchKey = "develop" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.DevelopBranchRegex = "^dev(elop)?(ment)?$" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.FeatureBranchKey = "feature" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.FeatureBranchRegex = "^features?[/-]" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.HotfixBranchKey = "hotfix" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.HotfixBranchRegex = "^hotfix(es)?[/-]" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.MainBranchKey = "main" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.MainBranchRegex = "^master$|^main$" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.MasterBranchKey = "master" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.PullRequestBranchKey = "pull-request" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.PullRequestRegex = "^(pull|pull\\-requests|pr)[/-]" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.ReleaseBranchKey = "release" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.ReleaseBranchRegex = "^releases?[/-]" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.SupportBranchKey = "support" -> string!
+const GitVersion.Configuration.GitVersionConfiguration.SupportBranchRegex = "^support[/-]" -> string!
+const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMajorPattern = "\\+semver:\\s?(breaking|major)" -> string!
+const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMinorPattern = "\\+semver:\\s?(feature|minor)" -> string!
+const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultNoBumpPattern = "\\+semver:\\s?(none|skip)" -> string!
+const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultPatchPattern = "\\+semver:\\s?(fix|patch)" -> string!
+const GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageStrategyPrefix = "Merge message" -> string!
+const GitVersion.VersionConverters.WixUpdater.WixVersionFileUpdater.WixVersionFileName = "GitVersion_WixVersion.wxi" -> string!
 override GitVersion.BranchCommit.Equals(object? obj) -> bool
 override GitVersion.BranchCommit.GetHashCode() -> int
 override GitVersion.BuildAgents.AppVeyor.EnvironmentVariable.get -> string!
@@ -1279,21 +1279,21 @@ static GitVersion.Extensions.ServiceCollectionExtensions.AddModule(this Microsof
 static GitVersion.Extensions.ServiceCollectionExtensions.GetServiceForType<TService, TType>(this System.IServiceProvider! serviceProvider) -> TService
 static GitVersion.Extensions.StringExtensions.AppendLineFormat(this System.Text.StringBuilder! stringBuilder, string! format, params object![]! args) -> void
 static GitVersion.Extensions.StringExtensions.ArgumentRequiresValue(this string! argument, int argumentIndex) -> bool
+static GitVersion.Extensions.StringExtensions.IsEmpty(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsEquivalentTo(this string! self, string? other) -> bool
 static GitVersion.Extensions.StringExtensions.IsFalse(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsHelp(this string! singleArgument) -> bool
 static GitVersion.Extensions.StringExtensions.IsInit(this string! singleArgument) -> bool
 static GitVersion.Extensions.StringExtensions.IsNullOrEmpty(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsNullOrWhiteSpace(this string? value) -> bool
-static GitVersion.Extensions.StringExtensions.IsEmpty(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsSwitch(this string? value, string! switchName) -> bool
 static GitVersion.Extensions.StringExtensions.IsSwitchArgument(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsTrue(this string? value) -> bool
 static GitVersion.Extensions.StringExtensions.IsValidPath(this string? path) -> bool
 static GitVersion.Extensions.StringExtensions.RegexReplace(this string! input, string! pattern, string! replace, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None) -> string!
 static GitVersion.GitVersionModule.FindAllDerivedTypes<T>(System.Reflection.Assembly? assembly) -> System.Collections.Generic.IEnumerable<System.Type!>!
-static GitVersion.Helpers.EncodingHelper.DetectEncoding(string? filename) -> System.Text.Encoding?
 static GitVersion.Helpers.EncodingHelper.DetectEncoding(System.Collections.Generic.IList<byte>! bytes) -> System.Text.Encoding?
+static GitVersion.Helpers.EncodingHelper.DetectEncoding(string? filename) -> System.Text.Encoding?
 static GitVersion.Helpers.PathHelper.Combine(string? path1) -> string!
 static GitVersion.Helpers.PathHelper.Combine(string? path1, string? path2) -> string!
 static GitVersion.Helpers.PathHelper.Combine(string? path1, string? path2, string? path3) -> string!
@@ -1335,19 +1335,20 @@ static GitVersion.OutputVariables.VersionVariables.FromFile(string! filePath, Gi
 static GitVersion.OutputVariables.VersionVariables.FromJson(string! json) -> GitVersion.OutputVariables.VersionVariables!
 static GitVersion.ReferenceName.FromBranchName(string! branchName) -> GitVersion.ReferenceName!
 static GitVersion.ReferenceName.Parse(string! canonicalName) -> GitVersion.ReferenceName!
+static GitVersion.SemanticVersion.Parse(string! version, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat = GitVersion.SemanticVersionFormat.Strict) -> GitVersion.SemanticVersion!
+static GitVersion.SemanticVersion.TryParse(string! version, string? tagPrefixRegex, out GitVersion.SemanticVersion? semanticVersion, GitVersion.SemanticVersionFormat format = GitVersion.SemanticVersionFormat.Strict) -> bool
 static GitVersion.SemanticVersion.operator !=(GitVersion.SemanticVersion? v1, GitVersion.SemanticVersion? v2) -> bool
 static GitVersion.SemanticVersion.operator <(GitVersion.SemanticVersion! v1, GitVersion.SemanticVersion! v2) -> bool
 static GitVersion.SemanticVersion.operator <=(GitVersion.SemanticVersion! v1, GitVersion.SemanticVersion! v2) -> bool
 static GitVersion.SemanticVersion.operator ==(GitVersion.SemanticVersion? v1, GitVersion.SemanticVersion? v2) -> bool
 static GitVersion.SemanticVersion.operator >(GitVersion.SemanticVersion! v1, GitVersion.SemanticVersion! v2) -> bool
 static GitVersion.SemanticVersion.operator >=(GitVersion.SemanticVersion! v1, GitVersion.SemanticVersion! v2) -> bool
-static GitVersion.SemanticVersion.Parse(string! version, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat = GitVersion.SemanticVersionFormat.Strict) -> GitVersion.SemanticVersion!
-static GitVersion.SemanticVersion.TryParse(string! version, string? tagPrefixRegex, out GitVersion.SemanticVersion? semanticVersion, GitVersion.SemanticVersionFormat format = GitVersion.SemanticVersionFormat.Strict) -> bool
+static GitVersion.SemanticVersionBuildMetaData.Parse(string? buildMetaData) -> GitVersion.SemanticVersionBuildMetaData!
 static GitVersion.SemanticVersionBuildMetaData.implicit operator GitVersion.SemanticVersionBuildMetaData!(string! preReleaseTag) -> GitVersion.SemanticVersionBuildMetaData!
 static GitVersion.SemanticVersionBuildMetaData.implicit operator string?(GitVersion.SemanticVersionBuildMetaData? preReleaseTag) -> string?
 static GitVersion.SemanticVersionBuildMetaData.operator !=(GitVersion.SemanticVersionBuildMetaData? left, GitVersion.SemanticVersionBuildMetaData? right) -> bool
 static GitVersion.SemanticVersionBuildMetaData.operator ==(GitVersion.SemanticVersionBuildMetaData? left, GitVersion.SemanticVersionBuildMetaData? right) -> bool
-static GitVersion.SemanticVersionBuildMetaData.Parse(string? buildMetaData) -> GitVersion.SemanticVersionBuildMetaData!
+static GitVersion.SemanticVersionPreReleaseTag.Parse(string? preReleaseTag) -> GitVersion.SemanticVersionPreReleaseTag!
 static GitVersion.SemanticVersionPreReleaseTag.implicit operator GitVersion.SemanticVersionPreReleaseTag!(string? preReleaseTag) -> GitVersion.SemanticVersionPreReleaseTag!
 static GitVersion.SemanticVersionPreReleaseTag.implicit operator string?(GitVersion.SemanticVersionPreReleaseTag? preReleaseTag) -> string?
 static GitVersion.SemanticVersionPreReleaseTag.operator !=(GitVersion.SemanticVersionPreReleaseTag? left, GitVersion.SemanticVersionPreReleaseTag? right) -> bool
@@ -1356,7 +1357,6 @@ static GitVersion.SemanticVersionPreReleaseTag.operator <=(GitVersion.SemanticVe
 static GitVersion.SemanticVersionPreReleaseTag.operator ==(GitVersion.SemanticVersionPreReleaseTag? left, GitVersion.SemanticVersionPreReleaseTag? right) -> bool
 static GitVersion.SemanticVersionPreReleaseTag.operator >(GitVersion.SemanticVersionPreReleaseTag? left, GitVersion.SemanticVersionPreReleaseTag? right) -> bool
 static GitVersion.SemanticVersionPreReleaseTag.operator >=(GitVersion.SemanticVersionPreReleaseTag? left, GitVersion.SemanticVersionPreReleaseTag? right) -> bool
-static GitVersion.SemanticVersionPreReleaseTag.Parse(string? preReleaseTag) -> GitVersion.SemanticVersionPreReleaseTag!
 static GitVersion.VersionCalculation.NextVersion.operator !=(GitVersion.VersionCalculation.NextVersion! left, GitVersion.VersionCalculation.NextVersion! right) -> bool
 static GitVersion.VersionCalculation.NextVersion.operator <(GitVersion.VersionCalculation.NextVersion! left, GitVersion.VersionCalculation.NextVersion! right) -> bool
 static GitVersion.VersionCalculation.NextVersion.operator <=(GitVersion.VersionCalculation.NextVersion! left, GitVersion.VersionCalculation.NextVersion! right) -> bool

--- a/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
@@ -23,7 +23,7 @@ internal class MainlineVersionCalculator : IMainlineVersionCalculator
 
     public SemanticVersion FindMainlineModeVersion(BaseVersion baseVersion)
     {
-        if (baseVersion.SemanticVersion.PreReleaseTag?.HasTag() == true)
+        if (baseVersion.SemanticVersion.PreReleaseTag.HasTag() == true)
         {
             throw new NotSupportedException("Mainline development mode doesn't yet support pre-release tags on main");
         }

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -145,8 +145,7 @@ public class NextVersionCalculator : INextVersionCalculator
         semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(preReleaseTagName, number);
     }
 
-    private static bool MajorMinorPatchEqual(SemanticVersion lastTag, SemanticVersion baseVersion) =>
-        lastTag.Major == baseVersion.Major && lastTag.Minor == baseVersion.Minor && lastTag.Patch == baseVersion.Patch;
+    private static bool MajorMinorPatchEqual(SemanticVersion version, SemanticVersion other) => version.CompareTo(other, false) == 0;
 
     private NextVersion Calculate(IBranch branch, GitVersionConfiguration configuration)
     {

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -44,16 +44,17 @@ public class NextVersionCalculator : INextVersionCalculator
         }
 
         var nextVersion = Calculate(Context.CurrentBranch, Context.Configuration);
-        var preReleaseTagName = nextVersion.Configuration.GetBranchSpecificTag(this.log, Context.CurrentBranch.Name.Friendly, nextVersion.BaseVersion.BranchNameOverride);
+        var baseVersion = nextVersion.BaseVersion;
+        var preReleaseTagName = nextVersion.Configuration.GetBranchSpecificTag(this.log, Context.CurrentBranch.Name.Friendly, baseVersion.BranchNameOverride);
 
         SemanticVersion semver;
         if (Context.Configuration.VersioningMode == VersioningMode.Mainline)
         {
-            semver = this.mainlineVersionCalculator.FindMainlineModeVersion(nextVersion.BaseVersion);
+            semver = this.mainlineVersionCalculator.FindMainlineModeVersion(baseVersion);
         }
         else
         {
-            var baseVersionBuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
+            var baseVersionBuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
 
             if (baseVersionBuildMetaData == null || baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData?.Sha)
             {
@@ -61,7 +62,7 @@ public class NextVersionCalculator : INextVersionCalculator
             }
             else
             {
-                semver = nextVersion.BaseVersion.SemanticVersion;
+                semver = baseVersion.SemanticVersion;
             }
 
             semver.BuildMetaData = baseVersionBuildMetaData;
@@ -103,7 +104,7 @@ public class NextVersionCalculator : INextVersionCalculator
             semver.PreReleaseTag = new SemanticVersionPreReleaseTag();
         }
 
-        return new(semver, nextVersion.BaseVersion, new(nextVersion.Branch, nextVersion.Configuration));
+        return new(semver, baseVersion, new(nextVersion.Branch, nextVersion.Configuration));
     }
 
     private static bool MajorMinorPatchEqual(SemanticVersion version, SemanticVersion other) => version.CompareTo(other, false) == 0;

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -56,7 +56,7 @@ public class NextVersionCalculator : INextVersionCalculator
         {
             var baseVersionBuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
 
-            if (baseVersionBuildMetaData == null || baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData?.Sha)
+            if (baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData?.Sha)
             {
                 semver = nextVersion.IncrementedVersion;
             }

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -69,17 +69,18 @@ public class NextVersionCalculator : INextVersionCalculator
         }
         else
         {
-            nextVersion.BaseVersion.SemanticVersion.BuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
+            var baseVersionBuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
 
-            if (taggedSemanticVersion?.BuildMetaData == null || (taggedSemanticVersion.BuildMetaData?.Sha != nextVersion.BaseVersion.SemanticVersion.BuildMetaData.Sha))
+            if (baseVersionBuildMetaData == null || baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData?.Sha)
             {
                 semver = nextVersion.IncrementedVersion;
-                semver.BuildMetaData = nextVersion.BaseVersion.SemanticVersion.BuildMetaData;
             }
             else
             {
                 semver = nextVersion.BaseVersion.SemanticVersion;
             }
+
+            semver.BuildMetaData = baseVersionBuildMetaData;
         }
 
         var hasPreReleaseTag = semver.HasPreReleaseTagWithLabel;

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -61,7 +61,7 @@ public class NextVersionCalculator : INextVersionCalculator
         //
 
         var nextVersion = Calculate(Context.CurrentBranch, Context.Configuration);
-        nextVersion.BaseVersion.SemanticVersion.BuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
+
         SemanticVersion semver;
         if (Context.Configuration.VersioningMode == VersioningMode.Mainline)
         {
@@ -69,10 +69,12 @@ public class NextVersionCalculator : INextVersionCalculator
         }
         else
         {
+            nextVersion.BaseVersion.SemanticVersion.BuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
+
             if (taggedSemanticVersion?.BuildMetaData == null || (taggedSemanticVersion.BuildMetaData?.Sha != nextVersion.BaseVersion.SemanticVersion.BuildMetaData.Sha))
             {
                 semver = nextVersion.IncrementedVersion;
-                semver.BuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(nextVersion.BaseVersion.BaseVersionSource);
+                semver.BuildMetaData = nextVersion.BaseVersion.SemanticVersion.BuildMetaData;
             }
             else
             {

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -126,19 +126,21 @@ public class NextVersionCalculator : INextVersionCalculator
             return;
         }
 
-        long? number = null;
-
         // TODO: Please update the pre release-tag in the IVersionStrategy implementation.
         var lastTag = this.repositoryStore
             .GetVersionTagsOnBranch(Context.CurrentBranch, Context.Configuration.LabelPrefix, Context.Configuration.SemanticVersionFormat)
             .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(tagToUse) == true);
 
+        long? number = null;
+
         if (lastTag != null && MajorMinorPatchEqual(lastTag, semanticVersion) && lastTag.HasPreReleaseTagWithLabel)
         {
             number = lastTag.PreReleaseTag?.Number + 1;
         }
-
-        number ??= 1;
+        else
+        {
+            number = 1;
+        }
 
         semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(tagToUse, number);
     }

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -118,31 +118,31 @@ public class NextVersionCalculator : INextVersionCalculator
 
     private void UpdatePreReleaseTag(EffectiveBranchConfiguration configuration, SemanticVersion semanticVersion, string? branchNameOverride)
     {
-        var tagToUse = configuration.Value.GetBranchSpecificTag(this.log, Context.CurrentBranch.Name.Friendly, branchNameOverride);
+        var preReleaseTagName = configuration.Value.GetBranchSpecificTag(this.log, Context.CurrentBranch.Name.Friendly, branchNameOverride);
 
-        if (configuration.Value.IsMainline && tagToUse.IsEmpty())
+        if (configuration.Value.IsMainline && preReleaseTagName.IsEmpty())
         {
-            semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(tagToUse, null);
+            semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(preReleaseTagName, null);
             return;
         }
 
         // TODO: Please update the pre release-tag in the IVersionStrategy implementation.
-        var lastTag = this.repositoryStore
-            .GetVersionTagsOnBranch(Context.CurrentBranch, Context.Configuration.LabelPrefix, Context.Configuration.SemanticVersionFormat)
-            .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(tagToUse) == true);
+        var lastPrefixedSemver = this.repositoryStore
+            .GetVersionTagsOnBranch(Context.CurrentBranch, Context.Configuration.LabelPrefix)
+            .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(preReleaseTagName) == true);
 
         long? number = null;
 
-        if (lastTag != null && MajorMinorPatchEqual(lastTag, semanticVersion) && lastTag.HasPreReleaseTagWithLabel)
+        if (lastPrefixedSemver != null && MajorMinorPatchEqual(lastPrefixedSemver, semanticVersion) && lastPrefixedSemver.HasPreReleaseTagWithLabel)
         {
-            number = lastTag.PreReleaseTag?.Number + 1;
+            number = lastPrefixedSemver.PreReleaseTag!.Number + 1;
         }
         else
         {
             number = 1;
         }
 
-        semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(tagToUse, number);
+        semanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(preReleaseTagName, number);
     }
 
     private static bool MajorMinorPatchEqual(SemanticVersion lastTag, SemanticVersion baseVersion) =>

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -56,7 +56,7 @@ public class NextVersionCalculator : INextVersionCalculator
         {
             var baseVersionBuildMetaData = this.mainlineVersionCalculator.CreateVersionBuildMetaData(baseVersion.BaseVersionSource);
 
-            if (baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData?.Sha)
+            if (baseVersionBuildMetaData.Sha != nextVersion.IncrementedVersion.BuildMetaData.Sha)
             {
                 semver = nextVersion.IncrementedVersion;
             }
@@ -69,8 +69,8 @@ public class NextVersionCalculator : INextVersionCalculator
 
             var lastPrefixedSemver = this.repositoryStore
                 .GetVersionTagsOnBranch(Context.CurrentBranch, Context.Configuration.LabelPrefix, Context.Configuration.SemanticVersionFormat)
-                .Where(v => MajorMinorPatchEqual(v, semver) && v.PreReleaseTag?.HasTag() == true)
-                .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(preReleaseTagName) == true);
+                .Where(v => MajorMinorPatchEqual(v, semver) && v.PreReleaseTag.HasTag() == true)
+                .FirstOrDefault(v => v.PreReleaseTag.Name?.IsEquivalentTo(preReleaseTagName) == true);
 
             if (lastPrefixedSemver != null)
             {
@@ -87,7 +87,7 @@ public class NextVersionCalculator : INextVersionCalculator
         {
             long? number;
 
-            if (semver.PreReleaseTag?.Name == preReleaseTagName)
+            if (semver.PreReleaseTag.Name == preReleaseTagName)
             {
                 number = semver.PreReleaseTag.Number + 1;
             }
@@ -214,7 +214,7 @@ public class NextVersionCalculator : INextVersionCalculator
 
                         if (configuration.VersioningMode == VersioningMode.Mainline)
                         {
-                            if (incrementedVersion.PreReleaseTag?.HasTag() == true)
+                            if (!(incrementedVersion.PreReleaseTag.HasTag() != true))
                             {
                                 continue;
                             }

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -129,11 +129,12 @@ public class NextVersionCalculator : INextVersionCalculator
         // TODO: Please update the pre release-tag in the IVersionStrategy implementation.
         var lastPrefixedSemver = this.repositoryStore
             .GetVersionTagsOnBranch(Context.CurrentBranch, Context.Configuration.LabelPrefix)
+            .Where(v => MajorMinorPatchEqual(v, semanticVersion) && v.HasPreReleaseTagWithLabel)
             .FirstOrDefault(v => v.PreReleaseTag?.Name?.IsEquivalentTo(preReleaseTagName) == true);
 
         long? number = null;
 
-        if (lastPrefixedSemver != null && MajorMinorPatchEqual(lastPrefixedSemver, semanticVersion) && lastPrefixedSemver.HasPreReleaseTagWithLabel)
+        if (lastPrefixedSemver != null)
         {
             number = lastPrefixedSemver.PreReleaseTag!.Number + 1;
         }

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersion.cs
@@ -21,10 +21,10 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
     public long Major;
     public long Minor;
     public long Patch;
-    public SemanticVersionPreReleaseTag? PreReleaseTag;
-    public SemanticVersionBuildMetaData? BuildMetaData;
+    public SemanticVersionPreReleaseTag PreReleaseTag;
+    public SemanticVersionBuildMetaData BuildMetaData;
 
-    public bool HasPreReleaseTagWithLabel => PreReleaseTag?.HasTag() == true;
+    public bool HasPreReleaseTagWithLabel => PreReleaseTag.HasTag() == true;
 
     public SemanticVersion(long major = 0, long minor = 0, long patch = 0)
     {
@@ -76,8 +76,8 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
             var hashCode = this.Major.GetHashCode();
             hashCode = (hashCode * 397) ^ this.Minor.GetHashCode();
             hashCode = (hashCode * 397) ^ this.Patch.GetHashCode();
-            hashCode = (hashCode * 397) ^ (this.PreReleaseTag != null ? this.PreReleaseTag.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (this.BuildMetaData != null ? this.BuildMetaData.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^ this.PreReleaseTag.GetHashCode();
+            hashCode = (hashCode * 397) ^ this.BuildMetaData.GetHashCode();
             return hashCode;
         }
     }
@@ -278,18 +278,18 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
             case "j":
                 return $"{this.Major}.{this.Minor}.{this.Patch}";
             case "s":
-                return this.PreReleaseTag?.HasTag() == true ? $"{ToString("j")}-{this.PreReleaseTag}" : ToString("j");
+                return this.PreReleaseTag.HasTag() == true ? $"{ToString("j")}-{this.PreReleaseTag}" : ToString("j");
             case "t":
-                return this.PreReleaseTag?.HasTag() == true ? $"{ToString("j")}-{this.PreReleaseTag.ToString("t")}" : ToString("j");
+                return this.PreReleaseTag.HasTag() == true ? $"{ToString("j")}-{this.PreReleaseTag.ToString("t")}" : ToString("j");
             case "f":
                 {
-                    var buildMetadata = this.BuildMetaData?.ToString();
+                    var buildMetadata = this.BuildMetaData.ToString();
 
                     return !buildMetadata.IsNullOrEmpty() ? $"{ToString("s")}+{buildMetadata}" : ToString("s");
                 }
             case "i":
                 {
-                    var buildMetadata = this.BuildMetaData?.ToString("f");
+                    var buildMetadata = this.BuildMetaData.ToString("f");
 
                     return !buildMetadata.IsNullOrEmpty() ? $"{ToString("s")}+{buildMetadata}" : ToString("s");
                 }
@@ -301,7 +301,7 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
     public SemanticVersion IncrementVersion(VersionField incrementStrategy)
     {
         var incremented = new SemanticVersion(this);
-        if (incremented.PreReleaseTag?.HasTag() != true)
+        if (incremented.PreReleaseTag.HasTag() != true)
         {
             switch (incrementStrategy)
             {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -23,19 +23,19 @@ public class SemanticVersionFormatValues
 
     public string? PreReleaseTag => this.semver.PreReleaseTag;
 
-    public string? PreReleaseTagWithDash => this.semver.PreReleaseTag?.HasTag() == true ? "-" + this.semver.PreReleaseTag : null;
+    public string? PreReleaseTagWithDash => this.semver.PreReleaseTag.HasTag() == true ? "-" + this.semver.PreReleaseTag : null;
 
-    public string? PreReleaseLabel => this.semver.PreReleaseTag?.HasTag() == true ? this.semver.PreReleaseTag.Name : null;
+    public string? PreReleaseLabel => this.semver.PreReleaseTag.HasTag() == true ? this.semver.PreReleaseTag.Name : null;
 
-    public string? PreReleaseLabelWithDash => this.semver.PreReleaseTag?.HasTag() == true ? "-" + this.semver.PreReleaseTag.Name : null;
+    public string? PreReleaseLabelWithDash => this.semver.PreReleaseTag.HasTag() == true ? "-" + this.semver.PreReleaseTag.Name : null;
 
-    public string? PreReleaseNumber => this.semver.PreReleaseTag?.HasTag() == true ? this.semver.PreReleaseTag.Number.ToString() : null;
+    public string? PreReleaseNumber => this.semver.PreReleaseTag.HasTag() == true ? this.semver.PreReleaseTag.Number.ToString() : null;
 
     public string WeightedPreReleaseNumber => GetWeightedPreReleaseNumber();
 
     public string? BuildMetaData => this.semver.BuildMetaData;
 
-    public string? FullBuildMetaData => this.semver.BuildMetaData?.ToString("f");
+    public string? FullBuildMetaData => this.semver.BuildMetaData.ToString("f");
 
     public string MajorMinorPatch => $"{this.semver.Major}.{this.semver.Minor}.{this.semver.Patch}";
 
@@ -47,28 +47,28 @@ public class SemanticVersionFormatValues
 
     public string FullSemVer => this.semver.ToString("f");
 
-    public string? BranchName => this.semver.BuildMetaData?.Branch;
+    public string? BranchName => this.semver.BuildMetaData.Branch;
 
-    public string? EscapedBranchName => this.semver.BuildMetaData?.Branch?.RegexReplace("[^a-zA-Z0-9-]", "-");
+    public string? EscapedBranchName => this.semver.BuildMetaData.Branch?.RegexReplace("[^a-zA-Z0-9-]", "-");
 
-    public string? Sha => this.semver.BuildMetaData?.Sha;
+    public string? Sha => this.semver.BuildMetaData.Sha;
 
-    public string? ShortSha => this.semver.BuildMetaData?.ShortSha;
+    public string? ShortSha => this.semver.BuildMetaData.ShortSha;
 
-    public string? CommitDate => this.semver.BuildMetaData?.CommitDate?.UtcDateTime.ToString(this.configuration.CommitDateFormat, CultureInfo.InvariantCulture);
+    public string? CommitDate => this.semver.BuildMetaData.CommitDate?.UtcDateTime.ToString(this.configuration.CommitDateFormat, CultureInfo.InvariantCulture);
 
     public string InformationalVersion => this.semver.ToString("i");
 
-    public string? VersionSourceSha => this.semver.BuildMetaData?.VersionSourceSha;
+    public string? VersionSourceSha => this.semver.BuildMetaData.VersionSourceSha;
 
-    public string? CommitsSinceVersionSource => this.semver.BuildMetaData?.CommitsSinceVersionSource?.ToString(CultureInfo.InvariantCulture);
+    public string? CommitsSinceVersionSource => this.semver.BuildMetaData.CommitsSinceVersionSource?.ToString(CultureInfo.InvariantCulture);
 
-    public string? UncommittedChanges => this.semver.BuildMetaData?.UncommittedChanges.ToString(CultureInfo.InvariantCulture);
+    public string? UncommittedChanges => this.semver.BuildMetaData.UncommittedChanges.ToString(CultureInfo.InvariantCulture);
 
     private string GetWeightedPreReleaseNumber()
     {
         var weightedPreReleaseNumber =
-            this.semver.PreReleaseTag?.HasTag() == true ? (this.semver.PreReleaseTag.Number + this.configuration.PreReleaseWeight).ToString() : null;
+            this.semver.PreReleaseTag.HasTag() == true ? (this.semver.PreReleaseTag.Number + this.configuration.PreReleaseWeight).ToString() : null;
 
         return weightedPreReleaseNumber.IsNullOrEmpty()
             ? $"{this.configuration.LabelPreReleaseWeight}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Suggest to review by commits :) I tried to make them as atomic as possible.

## Description
<!--- Describe your changes in detail -->
Minor changes:
- Rearranging code 
- Renaming variables
- Reusing existing functionality

Change next version calculator to act according to the next algorithm:
1. Calculate next version candidate based on the base one
2. Look for the latest `PreReleaseTag` matching Major, Minor and Patch of the next version candidate.
3. Append the `PreReleaseTag`, if found, to the next version candidate.
4. Compare the next version candidate with `Context.CurrentCommitTaggedVersion` including the `PreReleaseTag` comparison.
5. Increment the `PreReleaseTag` of the next version candidate if versions mismatch.
6. Return the next version candidate.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I found `NextVersionCalculator` logic complicated and decided to simplify it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running all existing tests.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
