### PR TITLE
Handle int64 numbers when writing version variables

### DIFF
--- a/src/GitVersion.Core/Model/VersionVariablesJsonNumberConverter.cs
+++ b/src/GitVersion.Core/Model/VersionVariablesJsonNumberConverter.cs
@@ -34,7 +34,7 @@ public class VersionVariablesJsonNumberConverter : JsonConverter<string>
         {
             writer.WriteNullValue();
         }
-        else if (int.TryParse(value, out var number))
+        else if (long.TryParse(value, out var number))
         {
             writer.WriteNumberValue(number);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Long numeric values for certain version variable fields (e.g. PreReleaseNumber) cause the number parsing to fail and throw the InvalidOperationException.
[WriteNumberValue](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.utf8jsonwriter.writenumbervalue?view=net-6.0#system-text-json-utf8jsonwriter-writenumbervalue(system-int64)) supports int64 so this should be a pretty safe update.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
