### PR TITLE
Fixed typo in image reference commit id

### DIFF
--- a/docs/input/docs/learn/branching-strategies/index.cshtml
+++ b/docs/input/docs/learn/branching-strategies/index.cshtml
@@ -17,7 +17,7 @@ RedirectFrom:
 <pre><code class="language-shell">e137e9 -> 1.0.0+0
 a5f6c5 -> 1.0.1+1
 adb29a -> 1.0.1-feature-foo.1+1 (PR #5 Version: `1.0.1-PullRequest.5+2`)
-7c2438 -> 1.0.1-feature-foo.1+2 (PR #5 Version: `1.0.1-PullRequest.5+3`)
+7c2430 -> 1.0.1-feature-foo.1+2 (PR #5 Version: `1.0.1-PullRequest.5+3`)
 5f413b -> 1.0.1+4
 d6155b -> 2.0.0-rc.1+0 (Before and after tag)
 d53ab6 -> 2.0.0-rc.2+1 (Pre-release number was bumped because of the tag on previous commit)


### PR DESCRIPTION
## Description
There was a typo in commit id reference in document