### PR TITLE
#2986 Quote `merge-message-formats` example in doc

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -258,7 +258,7 @@ e.g.
 
 ```yaml
 merge-message-formats:
-    tfs: ^Merged (?:PR (?<PullRequestNumber>\d+)): Merge (?<SourceBranch>.+) to (?<TargetBranch>.+)
+    tfs: '^Merged (?:PR (?<PullRequestNumber>\d+)): Merge (?<SourceBranch>.+) to (?<TargetBranch>.+)'
 ```
 
 The regular expression should contain the following capture groups:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Quote `merge-message-formats` example in doc.

## Related Issue
Fixes #2986

## Motivation and Context
This avoids throwing the following error when using the documentation example: `YamlDotNet.Core.SemanticErrorException: While scanning a plain scalar value, found invalid mapping.`

## How Has This Been Tested?
I have tried the quoted value in my own GitVersion file and there was no error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
