### PR TITLE
Add HEAD support for 5.x version, without introduction of new configuration properties.

### DIFF
--- a/docs/input/docs/reference/requirements.md
+++ b/docs/input/docs/reference/requirements.md
@@ -28,11 +28,6 @@ The repository needs to have an existing local `master` or `main` branch.
 For some branch strategies (such as [Git Flow][gitflow]), a local `develop`
 branch needs to exist.
 
-### Switched branch
-
-The repository should be [switched][git-switch] to a named, existing branch
-pointing to the commit being built (i.e. no detached `HEAD`).
-
 ### Configuration
 
 If using a `GitVersion.yml` [configuration][configuration] file, that file

--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -115,6 +115,11 @@ If you create a branch with the version number in the branch name, such as
 from the branch name as a source. However, GitVersion can't use the [branch
 name as a version source for _other branches_][faq-branch-name-source].
 
+### Detached HEAD
+If HEAD is in detached state tag will be `-no-branch-`. 
+
+Example: `0.1.0--no-branch-.1+4`
+
 ### Tagging commit
 
 By tagging a commit, GitVersion will use that tag for the version of that

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -5,7 +5,6 @@ using LibGit2Sharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
-using Shouldly;
 
 namespace GitVersion.Core.Tests.IntegrationTests;
 
@@ -94,8 +93,7 @@ public class RemoteRepositoryScenarios : TestBase
             fixture.LocalRepositoryFixture.Repository,
             fixture.LocalRepositoryFixture.Repository.Head.Tip);
 
-        Should.Throw<WarningException>(() => fixture.AssertFullSemver("0.1.0+4", repository: fixture.LocalRepositoryFixture.Repository, onlyTrackedBranches: false),
-            $"It looks like the branch being examined is a detached Head pointing to commit '{fixture.LocalRepositoryFixture.Repository.Head.Tip.Id.ToString(7)}'. Without a proper branch name GitVersion cannot determine the build version.");
+        fixture.AssertFullSemver("0.1.0--no-branch-.1+4", repository: fixture.LocalRepositoryFixture.Repository, onlyTrackedBranches: false);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -86,7 +86,7 @@ public class RemoteRepositoryScenarios : TestBase
     }
 
     [Test]
-    public void GivenARemoteGitRepositoryWhenCheckingOutDetachedHeadUsingExistingImplementationThrowsException()
+    public void GivenARemoteGitRepositoryWhenCheckingOutDetachedHeadUsingExistingImplementationHandleDetachedBranch()
     {
         using var fixture = new RemoteRepositoryFixture();
         Commands.Checkout(

--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -33,7 +33,7 @@ public interface IRepositoryStore
     /// </summary>
     BranchCommit FindCommitBranchWasBranchedFrom(IBranch? branch, Config configuration, params IBranch[] excludedBranches);
 
-    SemanticVersion GetCurrentCommitTaggedVersion(ICommit? commit, string? tagPrefix);
+    SemanticVersion GetCurrentCommitTaggedVersion(ICommit? commit, string? tagPrefix, bool handleDetachedBranch);
     IEnumerable<SemanticVersion> GetVersionTagsOnBranch(IBranch branch, string? tagPrefixRegex);
     IEnumerable<(ITag Tag, SemanticVersion Semver, ICommit Commit)> GetValidVersionTags(string? tagPrefixRegex, DateTimeOffset? olderThan = null);
 

--- a/src/GitVersion.Core/Core/GitVersionContextFactory.cs
+++ b/src/GitVersion.Core/Core/GitVersionContextFactory.cs
@@ -33,7 +33,7 @@ public class GitVersionContextFactory : IGitVersionContextFactory
             currentBranch = branchForCommit ?? currentBranch;
         }
 
-        var currentCommitTaggedVersion = this.repositoryStore.GetCurrentCommitTaggedVersion(currentCommit, configuration.TagPrefix);
+        var currentCommitTaggedVersion = this.repositoryStore.GetCurrentCommitTaggedVersion(currentCommit, configuration.TagPrefix, handleDetachedBranch: currentBranch.IsDetachedHead);
         var numberOfUncommittedChanges = this.repositoryStore.GetNumberOfUncommittedChanges();
 
         return new GitVersionContext(currentBranch, currentCommit, configuration, currentCommitTaggedVersion, numberOfUncommittedChanges);

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -157,7 +157,7 @@ GitVersion.Common.IRepositoryStore.GetBranchesForCommit(GitVersion.ICommit! comm
 GitVersion.Common.IRepositoryStore.GetChosenBranch(GitVersion.Model.Configuration.Config! configuration) -> GitVersion.IBranch?
 GitVersion.Common.IRepositoryStore.GetCommitLog(GitVersion.ICommit? baseVersionSource, GitVersion.ICommit? currentCommit) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.Common.IRepositoryStore.GetCurrentCommit(GitVersion.IBranch! currentBranch, string? commitId) -> GitVersion.ICommit?
-GitVersion.Common.IRepositoryStore.GetCurrentCommitTaggedVersion(GitVersion.ICommit? commit, string? tagPrefix) -> GitVersion.SemanticVersion!
+GitVersion.Common.IRepositoryStore.GetCurrentCommitTaggedVersion(GitVersion.ICommit? commit, string? tagPrefix, bool handleDetachedBranch) -> GitVersion.SemanticVersion!
 GitVersion.Common.IRepositoryStore.GetExcludedInheritBranches(GitVersion.Model.Configuration.Config! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.GetMainlineBranches(GitVersion.ICommit! commit, GitVersion.Model.Configuration.Config! configuration, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Model.Configuration.BranchConfig!>>? mainlineBranchConfigs) -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.List<GitVersion.IBranch!>!>!
 GitVersion.Common.IRepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? baseVersionSource, GitVersion.ICommit? mainlineTip) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
@@ -859,7 +859,7 @@ GitVersion.RepositoryStore.GetBranchesForCommit(GitVersion.ICommit! commit) -> S
 GitVersion.RepositoryStore.GetChosenBranch(GitVersion.Model.Configuration.Config! configuration) -> GitVersion.IBranch?
 GitVersion.RepositoryStore.GetCommitLog(GitVersion.ICommit? baseVersionSource, GitVersion.ICommit? currentCommit) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.RepositoryStore.GetCurrentCommit(GitVersion.IBranch! currentBranch, string? commitId) -> GitVersion.ICommit?
-GitVersion.RepositoryStore.GetCurrentCommitTaggedVersion(GitVersion.ICommit? commit, string? tagPrefix) -> GitVersion.SemanticVersion!
+GitVersion.RepositoryStore.GetCurrentCommitTaggedVersion(GitVersion.ICommit? commit, string? tagPrefix, bool handleDetachedBranch) -> GitVersion.SemanticVersion!
 GitVersion.RepositoryStore.GetExcludedInheritBranches(GitVersion.Model.Configuration.Config! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.GetMainlineBranches(GitVersion.ICommit! commit, GitVersion.Model.Configuration.Config! configuration, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Model.Configuration.BranchConfig!>>? mainlineBranchConfigs) -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.List<GitVersion.IBranch!>!>!
 GitVersion.RepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? baseVersionSource, GitVersion.ICommit? mainlineTip) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -53,7 +53,7 @@ public class IncrementStrategyFinder : IIncrementStrategyFinder
             return defaultIncrement;
         }
 
-        return commitMessageIncrement ?? VersionField.None;
+        return commitMessageIncrement.Value;
     }
 
     public VersionField? GetIncrementForCommits(Config configuration, IEnumerable<ICommit> commits)

--- a/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersionCalculator.cs
@@ -40,10 +40,6 @@ public class NextVersionCalculator : INextVersionCalculator
         {
             this.log.Info($"Current commit is tagged with version {Context.CurrentCommitTaggedVersion}, " + "version calculation is for metadata only.");
         }
-        else
-        {
-            EnsureHeadIsNotDetached(Context);
-        }
 
         SemanticVersion? taggedSemanticVersion = null;
 


### PR DESCRIPTION
This is an adaptation of #3241 to 5.x version without introduction of new configuration properties.
I would really like to see this behavior in 5.x version.
In our company we have sub repository in every project, and we struggle every time with the error.

## Related Issue
https://github.com/GitTools/GitVersion/issues/3233

## How Has This Been Tested?
* Adapted and renamed existing test according to new behavior `GivenARemoteGitRepositoryWhenCheckingOutDetachedHeadUsingExistingImplementationHandleDetachedBranch`.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
