### PR TITLE
Ensure track-merge-target: Strategy which will look for tagged merge commits directly off the current branch

### DIFF
--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -18,6 +18,7 @@ public interface IRepositoryStore
     IBranch GetTargetBranch(string? targetBranchName);
     IBranch? FindBranch(string? branchName);
     IBranch? FindMainBranch(GitVersionConfiguration configuration);
+    IEnumerable<IBranch> FindMainlineBranches(GitVersionConfiguration configuration);
     IEnumerable<IBranch> GetReleaseBranches(IEnumerable<KeyValuePair<string, BranchConfiguration>> releaseBranchConfig);
     IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude);
     IEnumerable<IBranch> GetBranchesContainingCommit(ICommit? commit, IEnumerable<IBranch>? branches = null, bool onlyTrackedBranches = false);
@@ -41,8 +42,7 @@ public interface IRepositoryStore
     SemanticVersion? GetCurrentCommitTaggedVersion(ICommit? commit, string? tagPrefix, SemanticVersionFormat versionFormat, bool handleDetachedBranch);
 
     IEnumerable<SemanticVersion> GetVersionTagsOnBranch(IBranch branch, string? tagPrefixRegex, SemanticVersionFormat versionFormat);
-    IEnumerable<(ITag Tag, SemanticVersion Semver, ICommit Commit)> GetValidVersionTags(string? tagPrefixRegex, SemanticVersionFormat versionFormat, DateTimeOffset? olderThan = null);
-
+    IEnumerable<SemanticVersionWithTag> GetSemanticVersionFromTags(string? tagPrefixRegex, SemanticVersionFormat semanticVersionFormat);
     bool IsCommitOnBranch(ICommit? baseVersionSource, IBranch branch, ICommit firstMatchingCommit);
 
     int GetNumberOfUncommittedChanges();

--- a/src/GitVersion.Core/Core/MergeCommitFinder.cs
+++ b/src/GitVersion.Core/Core/MergeCommitFinder.cs
@@ -6,7 +6,7 @@ namespace GitVersion;
 
 internal class MergeCommitFinder
 {
-    private readonly IEnumerable<IBranch> excludedBranches;
+    private readonly IEnumerable<IBranch> branches;
     private readonly ILog log;
     private readonly Dictionary<IBranch, List<BranchCommit>> mergeBaseCommitsCache = new();
     private readonly RepositoryStore repositoryStore;
@@ -16,7 +16,7 @@ internal class MergeCommitFinder
     {
         this.repositoryStore = repositoryStore.NotNull();
         this.configuration = configuration.NotNull();
-        this.excludedBranches = repositoryStore.ExcludingBranches(excludedBranches.NotNull());
+        this.branches = repositoryStore.ExcludingBranches(excludedBranches.NotNull());
         this.log = log.NotNull();
     }
 
@@ -41,7 +41,7 @@ internal class MergeCommitFinder
 
     private IEnumerable<BranchCommit> FindMergeBases(IBranch branch)
     {
-        var sourceBranches = new SourceBranchFinder(this.excludedBranches, this.configuration)
+        var sourceBranches = new SourceBranchFinder(this.branches, this.configuration)
             .FindSourceBranchesOf(branch);
 
         foreach (var sourceBranch in sourceBranches)

--- a/src/GitVersion.Core/Git/ITag.cs
+++ b/src/GitVersion.Core/Git/ITag.cs
@@ -3,5 +3,6 @@ namespace GitVersion;
 public interface ITag : IEquatable<ITag?>, IComparable<ITag>, INamedReference
 {
     string? TargetSha { get; }
-    ICommit? PeeledTargetCommit();
+
+    ICommit Commit { get; }
 }

--- a/src/GitVersion.Core/GitVersionContext.cs
+++ b/src/GitVersion.Core/GitVersionContext.cs
@@ -1,4 +1,5 @@
 using GitVersion.Configuration;
+using GitVersion.Extensions;
 
 namespace GitVersion;
 
@@ -25,9 +26,9 @@ public class GitVersionContext
     public GitVersionContext(IBranch currentBranch, ICommit? currentCommit,
         GitVersionConfiguration configuration, SemanticVersion? currentCommitTaggedVersion, int numberOfUncommittedChanges)
     {
-        CurrentBranch = currentBranch;
+        CurrentBranch = currentBranch.NotNull();
         CurrentCommit = currentCommit;
-        Configuration = configuration;
+        Configuration = configuration.NotNull();
         CurrentCommitTaggedVersion = currentCommitTaggedVersion;
         NumberOfUncommittedChanges = numberOfUncommittedChanges;
     }

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -72,6 +72,7 @@ GitVersion.Common.IRepositoryStore.FindCommitBranchWasBranchedFrom(GitVersion.IB
 GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.Common.IRepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.Common.IRepositoryStore.FindMainBranch(GitVersion.Configuration.GitVersionConfiguration! configuration) -> GitVersion.IBranch?
+GitVersion.Common.IRepositoryStore.FindMainlineBranches(GitVersion.Configuration.GitVersionConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.IBranch? branch, GitVersion.IBranch? otherBranch) -> GitVersion.ICommit?
 GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! mainlineTip) -> GitVersion.ICommit?
 GitVersion.Common.IRepositoryStore.GetBranchesContainingCommit(GitVersion.ICommit? commit, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>? branches = null, bool onlyTrackedBranches = false) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
@@ -83,10 +84,10 @@ GitVersion.Common.IRepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? base
 GitVersion.Common.IRepositoryStore.GetMergeBaseCommits(GitVersion.ICommit? mergeCommit, GitVersion.ICommit? mergedHead, GitVersion.ICommit? findMergeBase) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.Common.IRepositoryStore.GetNumberOfUncommittedChanges() -> int
 GitVersion.Common.IRepositoryStore.GetReleaseBranches(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Configuration.BranchConfiguration!>>! releaseBranchConfig) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
+GitVersion.Common.IRepositoryStore.GetSemanticVersionFromTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat semanticVersionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersionWithTag!>!
 GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.Common.IRepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.IBranch!
-GitVersion.Common.IRepositoryStore.GetValidVersionTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat, System.DateTimeOffset? olderThan = null) -> System.Collections.Generic.IEnumerable<(GitVersion.ITag! Tag, GitVersion.SemanticVersion! Semver, GitVersion.ICommit! Commit)>!
 GitVersion.Common.IRepositoryStore.GetVersionTagsOnBranch(GitVersion.IBranch! branch, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersion!>!
 GitVersion.Common.IRepositoryStore.IsCommitOnBranch(GitVersion.ICommit? baseVersionSource, GitVersion.IBranch! branch, GitVersion.ICommit! firstMatchingCommit) -> bool
 GitVersion.Configuration.BranchConfiguration
@@ -528,7 +529,7 @@ GitVersion.IRemoteCollection.Remove(string! remoteName) -> void
 GitVersion.IRemoteCollection.Update(string! remoteName, string! refSpec) -> void
 GitVersion.IRemoteCollection.this[string! name].get -> GitVersion.IRemote?
 GitVersion.ITag
-GitVersion.ITag.PeeledTargetCommit() -> GitVersion.ICommit?
+GitVersion.ITag.Commit.get -> GitVersion.ICommit!
 GitVersion.ITag.TargetSha.get -> string?
 GitVersion.ITagCollection
 GitVersion.IVersionConverter<T>
@@ -730,6 +731,7 @@ GitVersion.RepositoryStore.FindCommitBranchWasBranchedFrom(GitVersion.IBranch? b
 GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.RepositoryStore.FindCommitBranchesWasBranchedFrom(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.BranchCommit>!
 GitVersion.RepositoryStore.FindMainBranch(GitVersion.Configuration.GitVersionConfiguration! configuration) -> GitVersion.IBranch?
+GitVersion.RepositoryStore.FindMainlineBranches(GitVersion.Configuration.GitVersionConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.FindMergeBase(GitVersion.IBranch? branch, GitVersion.IBranch? otherBranch) -> GitVersion.ICommit?
 GitVersion.RepositoryStore.FindMergeBase(GitVersion.ICommit! commit, GitVersion.ICommit! mainlineTip) -> GitVersion.ICommit?
 GitVersion.RepositoryStore.GetBranchesContainingCommit(GitVersion.ICommit? commit, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>? branches = null, bool onlyTrackedBranches = false) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
@@ -741,10 +743,10 @@ GitVersion.RepositoryStore.GetMainlineCommitLog(GitVersion.ICommit? baseVersionS
 GitVersion.RepositoryStore.GetMergeBaseCommits(GitVersion.ICommit? mergeCommit, GitVersion.ICommit? mergedHead, GitVersion.ICommit? findMergeBase) -> System.Collections.Generic.IEnumerable<GitVersion.ICommit!>!
 GitVersion.RepositoryStore.GetNumberOfUncommittedChanges() -> int
 GitVersion.RepositoryStore.GetReleaseBranches(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, GitVersion.Configuration.BranchConfiguration!>>! releaseBranchConfig) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
+GitVersion.RepositoryStore.GetSemanticVersionFromTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat semanticVersionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersionWithTag!>!
 GitVersion.RepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.GetSourceBranches(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration, params GitVersion.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.IBranch!>!
 GitVersion.RepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.IBranch!
-GitVersion.RepositoryStore.GetValidVersionTags(string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat, System.DateTimeOffset? olderThan = null) -> System.Collections.Generic.IEnumerable<(GitVersion.ITag! Tag, GitVersion.SemanticVersion! Semver, GitVersion.ICommit! Commit)>!
 GitVersion.RepositoryStore.GetVersionTagsOnBranch(GitVersion.IBranch! branch, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat) -> System.Collections.Generic.IEnumerable<GitVersion.SemanticVersion!>!
 GitVersion.RepositoryStore.IsCommitOnBranch(GitVersion.ICommit? baseVersionSource, GitVersion.IBranch! branch, GitVersion.ICommit! firstMatchingCommit) -> bool
 GitVersion.RepositoryStore.RepositoryStore(GitVersion.Logging.ILog! log, GitVersion.IGitRepository! repository) -> void
@@ -825,6 +827,12 @@ GitVersion.SemanticVersionPreReleaseTag.SemanticVersionPreReleaseTag(GitVersion.
 GitVersion.SemanticVersionPreReleaseTag.SemanticVersionPreReleaseTag(string? name, long? number) -> void
 GitVersion.SemanticVersionPreReleaseTag.ToString(string! format) -> string!
 GitVersion.SemanticVersionPreReleaseTag.ToString(string? format, System.IFormatProvider? formatProvider) -> string!
+GitVersion.SemanticVersionWithTag
+GitVersion.SemanticVersionWithTag.SemanticVersionWithTag(GitVersion.SemanticVersion! Value, GitVersion.ITag! Tag) -> void
+GitVersion.SemanticVersionWithTag.Tag.get -> GitVersion.ITag!
+GitVersion.SemanticVersionWithTag.Tag.init -> void
+GitVersion.SemanticVersionWithTag.Value.get -> GitVersion.SemanticVersion!
+GitVersion.SemanticVersionWithTag.Value.init -> void
 GitVersion.Settings
 GitVersion.Settings.NoCache -> bool
 GitVersion.Settings.NoFetch -> bool
@@ -906,11 +914,6 @@ GitVersion.VersionCalculation.ShaVersionFilter.Exclude(GitVersion.VersionCalcula
 GitVersion.VersionCalculation.ShaVersionFilter.ShaVersionFilter(System.Collections.Generic.IEnumerable<string!>! shas) -> void
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy
 GitVersion.VersionCalculation.TaggedCommitVersionStrategy.TaggedCommitVersionStrategy(GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
-GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit
-GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit.Commit -> GitVersion.ICommit!
-GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit.SemVer -> GitVersion.SemanticVersion!
-GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit.Tag -> string!
-GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit.VersionTaggedCommit(GitVersion.ICommit! commit, GitVersion.SemanticVersion! semVer, string! tag) -> void
 GitVersion.VersionCalculation.TrackReleaseBranchesVersionStrategy
 GitVersion.VersionCalculation.TrackReleaseBranchesVersionStrategy.TrackReleaseBranchesVersionStrategy(GitVersion.Common.IRepositoryStore! repositoryStore, System.Lazy<GitVersion.GitVersionContext!>! versionContext) -> void
 GitVersion.VersionCalculation.VariableProvider
@@ -1040,6 +1043,7 @@ override GitVersion.SemanticVersionBuildMetaData.ToString() -> string!
 override GitVersion.SemanticVersionPreReleaseTag.Equals(object? obj) -> bool
 override GitVersion.SemanticVersionPreReleaseTag.GetHashCode() -> int
 override GitVersion.SemanticVersionPreReleaseTag.ToString() -> string!
+override GitVersion.SemanticVersionWithTag.ToString() -> string!
 override GitVersion.VersionCalculation.BaseVersion.ToString() -> string!
 override GitVersion.VersionCalculation.ConfigNextVersionVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
 override GitVersion.VersionCalculation.MergeMessageVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
@@ -1047,7 +1051,6 @@ override GitVersion.VersionCalculation.NextVersion.Equals(object? other) -> bool
 override GitVersion.VersionCalculation.NextVersion.GetHashCode() -> int
 override GitVersion.VersionCalculation.NextVersion.ToString() -> string!
 override GitVersion.VersionCalculation.TaggedCommitVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
-override GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit.ToString() -> string!
 override GitVersion.VersionCalculation.TrackReleaseBranchesVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
 override GitVersion.VersionCalculation.VersionInBranchNameVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
 override GitVersion.VersionCalculation.VersionStrategyModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
@@ -1210,4 +1213,4 @@ virtual GitVersion.Configuration.IgnoreConfiguration.ToFilters() -> System.Colle
 virtual GitVersion.VersionCalculation.EffectiveBranchConfigurationFinder.GetConfigurations(GitVersion.IBranch! branch, GitVersion.Configuration.GitVersionConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.Configuration.EffectiveBranchConfiguration!>!
 virtual GitVersion.VersionCalculation.FallbackVersionStrategy.GetBaseVersions(GitVersion.Configuration.EffectiveBranchConfiguration! configuration) -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.BaseVersion!>!
 virtual GitVersion.VersionCalculation.NextVersionCalculator.FindVersion() -> GitVersion.VersionCalculation.NextVersion!
-virtual GitVersion.VersionCalculation.TaggedCommitVersionStrategy.FormatSource(GitVersion.VersionCalculation.TaggedCommitVersionStrategy.VersionTaggedCommit! version) -> string!
+virtual GitVersion.VersionCalculation.TaggedCommitVersionStrategy.FormatSource(GitVersion.SemanticVersionWithTag! semanticVersion) -> string!

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/TrackReleaseBranchesVersionStrategy.cs
@@ -36,17 +36,7 @@ public class TrackReleaseBranchesVersionStrategy : VersionStrategyBase
     }
 
     public override IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration) =>
-        configuration.Value.TracksReleaseBranches ? ReleaseBranchBaseVersions().Union(MainTagsVersions()) : Array.Empty<BaseVersion>();
-
-    private IEnumerable<BaseVersion> MainTagsVersions()
-    {
-        var configuration = Context.Configuration;
-        var mainBranch = this.repositoryStore.FindMainBranch(configuration);
-
-        return mainBranch != null
-            ? this.taggedCommitVersionStrategy.GetTaggedVersions(mainBranch, null)
-            : Array.Empty<BaseVersion>();
-    }
+        configuration.Value.TracksReleaseBranches ? ReleaseBranchBaseVersions() : Array.Empty<BaseVersion>();
 
     private IEnumerable<BaseVersion> ReleaseBranchBaseVersions()
     {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion;
+namespace GitVersion;
 
 public sealed record SemanticVersionWithTag(SemanticVersion Value, ITag Tag)
 {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
@@ -1,0 +1,6 @@
+﻿namespace GitVersion;
+
+public sealed record SemanticVersionWithTag(SemanticVersion Value, ITag Tag)
+{
+    public override string ToString() => $"{Tag} | {Tag.Commit} | {Value}";
+}

--- a/src/GitVersion.LibGit2Sharp/Git/Tag.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Tag.cs
@@ -9,19 +9,22 @@ internal sealed class Tag : ITag
     private static readonly LambdaEqualityHelper<ITag> equalityHelper = new(x => x.Name.Canonical);
     private static readonly LambdaKeyComparer<ITag, string> comparerHelper = new(x => x.Name.Canonical);
     private readonly LibGit2Sharp.Tag innerTag;
+    private readonly Lazy<ICommit?> _commitLazy;
 
     internal Tag(LibGit2Sharp.Tag tag)
     {
         this.innerTag = tag.NotNull();
         Name = new ReferenceName(this.innerTag.CanonicalName);
+        _commitLazy = new Lazy<ICommit?>(PeeledTargetCommit);
     }
 
     public ReferenceName Name { get; }
     public int CompareTo(ITag? other) => comparerHelper.Compare(this, other);
     public bool Equals(ITag? other) => equalityHelper.Equals(this, other);
     public string? TargetSha => this.innerTag.Target.Sha;
+    public ICommit Commit => _commitLazy.Value.NotNull();
 
-    public ICommit? PeeledTargetCommit()
+    private ICommit? PeeledTargetCommit()
     {
         var target = this.innerTag.Target;
 


### PR DESCRIPTION
Closes https://github.com/GitTools/GitVersion/issues/1789 and https://github.com/GitTools/GitVersion/issues/3052

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

> track-merge-target
> 
> Strategy which will look for tagged merge commits directly off the current branch. For example develop → release/1.0.0 → merge into master and tag 1.0.0. The tag is not on develop, but develop should be version 1.0.0 now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
