### PR TITLE
tracks-release-branches won't track remote release branches without regex mod

### DIFF
--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -163,7 +163,7 @@ public class PullRequestInBuildAgentTest
             remoteRepository.Refs.Add(pullRequestRef, new ObjectId(mergeCommitSha));
 
             // Checkout PR commit
-            Commands.Fetch((Repository)fixture.Repository, "origin", Array.Empty<string>(), new FetchOptions(), null);
+            Commands.Fetch(fixture.Repository, "origin", Array.Empty<string>(), new FetchOptions(), null);
             Commands.Checkout(fixture.Repository, mergeCommitSha);
         }
 
@@ -199,7 +199,7 @@ public class PullRequestInBuildAgentTest
         var refName = new ReferenceName(pullRequestRef);
 
         Assert.AreEqual(friendly, refName.Friendly);
-        Assert.AreEqual(isBranch, refName.IsBranch);
+        Assert.AreEqual(isBranch, refName.IsLocalBranch);
         Assert.AreEqual(isPullRequest, refName.IsPullRequest);
         Assert.AreEqual(isRemote, refName.IsRemoteBranch);
     }

--- a/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
+++ b/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
@@ -51,7 +51,7 @@ public class TagCheckoutInBuildAgentTests
             remoteRepository.MergeNoFF("release/0.2.0", Generate.SignatureNow());
             remoteRepository.MakeATaggedCommit("0.2.0");
 
-            Commands.Fetch((Repository)fixture.Repository, "origin", Array.Empty<string>(), new FetchOptions(), null);
+            Commands.Fetch(fixture.Repository, "origin", Array.Empty<string>(), new FetchOptions(), null);
             Commands.Checkout(fixture.Repository, "0.2.0");
         }
 

--- a/src/GitVersion.Core.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Core.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -24,4 +24,37 @@ public class ConfigurationExtensionsTests : TestBase
         result.Count.ShouldBe(2);
         result.ShouldNotContain(b => b.Key == "foo");
     }
+
+    [TestCase("release/2.0.0",
+        "refs/heads/release/2.0.0", "release/2.0.0", "release/2.0.0",
+        true, false, false, false, true)]
+    [TestCase("upstream/release/2.0.0",
+        "refs/heads/upstream/release/2.0.0", "upstream/release/2.0.0", "upstream/release/2.0.0",
+        true, false, false, false, false)]
+    [TestCase("origin/release/2.0.0",
+        "refs/heads/origin/release/2.0.0", "origin/release/2.0.0", "origin/release/2.0.0",
+        true, false, false, false, false)]
+    [TestCase("refs/remotes/upstream/release/2.0.0",
+        "refs/remotes/upstream/release/2.0.0", "upstream/release/2.0.0", "upstream/release/2.0.0",
+        false, false, true, false, false)]
+    [TestCase("refs/remotes/origin/release/2.0.0",
+        "refs/remotes/origin/release/2.0.0", "origin/release/2.0.0", "release/2.0.0",
+        false, false, true, false, true)]
+    public void EnsureIsReleaseBranchWithReferenceNameWorksAsExpected(string branchName, string expectedCanonical, string expectedFriendly, string expectedWithoutRemote,
+        bool expectedIsLocalBranch, bool expectedIsPullRequest, bool expectedIsRemoteBranch, bool expectedIsTag, bool expectedIsReleaseBranch)
+    {
+        var configuration = GitFlowConfigurationBuilder.New.Build();
+
+        var actual = ReferenceName.FromBranchName(branchName);
+        var isReleaseBranch = configuration.IsReleaseBranch(actual);
+
+        actual.Canonical.ShouldBe(expectedCanonical);
+        actual.Friendly.ShouldBe(expectedFriendly);
+        actual.WithoutRemote.ShouldBe(expectedWithoutRemote);
+        actual.IsLocalBranch.ShouldBe(expectedIsLocalBranch);
+        actual.IsPullRequest.ShouldBe(expectedIsPullRequest);
+        actual.IsRemoteBranch.ShouldBe(expectedIsRemoteBranch);
+        actual.IsTag.ShouldBe(expectedIsTag);
+        isReleaseBranch.ShouldBe(expectedIsReleaseBranch);
+    }
 }

--- a/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
@@ -225,9 +225,12 @@ public class RepositoryStoreTests : TestBase
 
         var branch = localRepository.FindBranch("main");
         branch.ShouldNotBeNull();
-        var branchedCommit = gitRepoMetadataProvider.FindCommitBranchWasBranchedFrom(branch, new GitVersionConfiguration(), Array.Empty<IBranch>());
 
-        Assert.IsNull(branchedCommit.Branch);
-        Assert.IsNull(branchedCommit.Commit);
+        var configuration = GitFlowConfigurationBuilder.New.Build();
+        var branchedCommit = gitRepoMetadataProvider.FindCommitBranchWasBranchedFrom(branch, configuration, Array.Empty<IBranch>());
+        branchedCommit.ShouldBe(BranchCommit.Empty);
+
+        var branchedCommits = gitRepoMetadataProvider.FindCommitBranchesWasBranchedFrom(branch, configuration).ToArray();
+        branchedCommits.ShouldBeEmpty();
     }
 }

--- a/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
@@ -45,7 +45,9 @@ public static class GitToolsTestingExtensions
         return branch;
     }
 
-    public static IBranch FindBranch(this IGitRepository repository, string branchName) => repository.Branches.First(x => x.Name.WithoutRemote == branchName) ?? throw new GitVersionException($"Branch {branchName} not found");
+    public static IBranch FindBranch(this IGitRepository repository, string branchName)
+        => repository.Branches.FirstOrDefault(branch => branch.Name.WithoutRemote == branchName)
+            ?? throw new GitVersionException($"Branch {branchName} not found");
 
     public static void DumpGraph(this IGitRepository repository, Action<string>? writer = null, int? maxCommits = null) => GitExtensions.DumpGraph(repository.Path, writer, maxCommits);
 

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -18,13 +18,14 @@ public class TestBase
         return services.BuildServiceProvider();
     }
 
-    protected static IServiceProvider BuildServiceProvider(string workingDirectory, IGitRepository repository, string branch, IReadOnlyDictionary<object, object?>? configuration = null)
+    protected static IServiceProvider BuildServiceProvider(IGitRepository repository,
+        string? targetBranch = null, IReadOnlyDictionary<object, object?>? configuration = null)
     {
         var options = Options.Create(new GitVersionOptions
         {
-            WorkingDirectory = workingDirectory,
+            WorkingDirectory = repository.Path,
             ConfigurationInfo = { OverrideConfiguration = configuration },
-            RepositoryInfo = { TargetBranch = branch }
+            RepositoryInfo = { TargetBranch = targetBranch }
         });
 
         var sp = ConfigureServices(services =>

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
@@ -21,7 +21,7 @@ public class OtherScenarios : TestBase
         fixture.MakeACommit();
         fixture.Repository.CreateBranch("develop");
 
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
         Commands.Checkout(fixture.LocalRepositoryFixture.Repository, fixture.Repository.Head.Tip);
         fixture.LocalRepositoryFixture.Repository.Branches.Remove(MainBranch);
         fixture.InitializeRepo();
@@ -87,7 +87,7 @@ public class OtherScenarios : TestBase
         fixture.MakeACommit();
         fixture.Repository.CreateBranch("feature/someFeature");
 
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
         Commands.Checkout(fixture.LocalRepositoryFixture.Repository, fixture.Repository.Head.Tip);
         fixture.LocalRepositoryFixture.Repository.Branches.Remove(MainBranch);
         fixture.InitializeRepo();

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -79,7 +79,7 @@ public class RemoteRepositoryScenarios : TestBase
         fixture.AssertFullSemver("0.0.1+6");
         fixture.AssertFullSemver("0.0.1+5", repository: fixture.LocalRepositoryFixture.Repository);
         var buildSignature = fixture.LocalRepositoryFixture.Repository.Config.BuildSignature(new DateTimeOffset(DateTime.Now));
-        Commands.Pull((Repository)fixture.LocalRepositoryFixture.Repository, buildSignature, new PullOptions());
+        Commands.Pull(fixture.LocalRepositoryFixture.Repository, buildSignature, new PullOptions());
         fixture.AssertFullSemver("0.0.1+6", repository: fixture.LocalRepositoryFixture.Repository);
     }
 
@@ -134,5 +134,23 @@ public class RemoteRepositoryScenarios : TestBase
                 }
             }
         }
+    }
+
+    [TestCase("origin", "release-2.0.0", "2.1.0-alpha.0")]
+    [TestCase("custom", "release-2.0.0", "0.1.0-alpha.5")]
+    [TestCase("origin", "release/3.0.0", "3.1.0-alpha.0")]
+    [TestCase("custom", "release/3.0.0", "0.1.0-alpha.5")]
+    public void EnsureRemoteReleaseBranchesAreTracked(string origin, string branchName, string expectedVersion)
+    {
+        using var fixture = new RemoteRepositoryFixture("develop");
+
+        fixture.CreateBranch(branchName);
+        fixture.MakeACommit();
+
+        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", origin);
+        fixture.LocalRepositoryFixture.Fetch(origin);
+        fixture.LocalRepositoryFixture.Checkout("develop");
+
+        fixture.LocalRepositoryFixture.AssertFullSemver(expectedVersion);
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
@@ -44,7 +44,7 @@ public class VersionInCurrentBranchNameScenarios : TestBase
         using var fixture = new RemoteRepositoryFixture();
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
 
         fixture.LocalRepositoryFixture.Checkout("origin/release/2.0.0");
 
@@ -52,16 +52,16 @@ public class VersionInCurrentBranchNameScenarios : TestBase
     }
 
     [Test]
-    public void TakesVersionFromNameOfRemoteReleaseBranchInCustom()
+    public void DoesNotTakeVersionFromNameOfRemoteReleaseBranchInCustomRemote()
     {
         using var fixture = new RemoteRepositoryFixture();
         fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", "upstream");
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
 
         fixture.LocalRepositoryFixture.Checkout("upstream/release/2.0.0");
 
-        fixture.LocalRepositoryFixture.AssertFullSemver("2.0.0-beta.1+1");
+        fixture.LocalRepositoryFixture.AssertFullSemver("0.0.1-upstream-release-2-0-0.1+6");
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
@@ -45,7 +45,7 @@ public class VersionInMergedBranchNameScenarios : TestBase
         using var fixture = new RemoteRepositoryFixture();
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
 
         fixture.LocalRepositoryFixture.MergeNoFF("origin/release/2.0.0");
 
@@ -59,7 +59,7 @@ public class VersionInMergedBranchNameScenarios : TestBase
         fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", "upstream");
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        fixture.LocalRepositoryFixture.Fetch("upstream");
 
         fixture.LocalRepositoryFixture.MergeNoFF("upstream/release/2.0.0");
 

--- a/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
@@ -1,6 +1,5 @@
 using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GitVersion.Core.Tests;
@@ -12,14 +11,14 @@ public class VersionSourceTests : TestBase
     public void VersionSourceSha()
     {
         using var fixture = new EmptyRepositoryFixture();
-        _ = fixture.Repository.MakeACommit();
-        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
-        _ = fixture.Repository.MakeACommit();
-        var featureBranch = fixture.Repository.CreateBranch("feature/foo");
-        Commands.Checkout(fixture.Repository, featureBranch);
-        _ = fixture.Repository.MakeACommit();
 
-        var nextVersionCalculator = GetNextVersionCalculator(fixture);
+        fixture.MakeACommit();
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+
+        var nextVersionCalculator = GetNextVersionCalculator(fixture.Repository.ToGitRepository());
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
@@ -31,9 +30,10 @@ public class VersionSourceTests : TestBase
     public void VersionSourceShaOneCommit()
     {
         using var fixture = new EmptyRepositoryFixture();
-        _ = fixture.Repository.MakeACommit();
 
-        var nextVersionCalculator = GetNextVersionCalculator(fixture);
+        fixture.MakeACommit();
+
+        var nextVersionCalculator = GetNextVersionCalculator(fixture.Repository.ToGitRepository());
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
@@ -45,25 +45,24 @@ public class VersionSourceTests : TestBase
     public void VersionSourceShaUsingTag()
     {
         using var fixture = new EmptyRepositoryFixture();
-        _ = fixture.Repository.MakeACommit();
-        Commands.Checkout(fixture.Repository, fixture.Repository.CreateBranch("develop"));
-        var secondCommit = fixture.Repository.MakeACommit();
-        _ = fixture.Repository.Tags.Add("1.0.0", secondCommit);
-        var featureBranch = fixture.Repository.CreateBranch("feature/foo");
-        Commands.Checkout(fixture.Repository, featureBranch);
-        _ = fixture.Repository.MakeACommit();
 
-        var nextVersionCalculator = GetNextVersionCalculator(fixture);
+        fixture.MakeACommit();
+        fixture.BranchTo("develop");
+        var secondCommitSha = fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+
+        var nextVersionCalculator = GetNextVersionCalculator(fixture.Repository.ToGitRepository());
 
         var nextVersion = nextVersionCalculator.FindVersion();
 
-        nextVersion.IncrementedVersion.BuildMetaData.VersionSourceSha.ShouldBe(secondCommit.Sha);
+        nextVersion.IncrementedVersion.BuildMetaData.VersionSourceSha.ShouldBe(secondCommitSha);
         nextVersion.IncrementedVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(1);
     }
 
-    private static INextVersionCalculator GetNextVersionCalculator(RepositoryFixtureBase fixture)
+    private static INextVersionCalculator GetNextVersionCalculator(IGitRepository repository)
     {
-        var sp = BuildServiceProvider(fixture.RepositoryPath, fixture.Repository.ToGitRepository(), fixture.Repository.Head.CanonicalName);
-        return sp.GetRequiredService<INextVersionCalculator>();
+        var serviceProvider = BuildServiceProvider(repository);
+        return serviceProvider.GetRequiredService<INextVersionCalculator>();
     }
 }

--- a/src/GitVersion.Core/BranchCommit.cs
+++ b/src/GitVersion.Core/BranchCommit.cs
@@ -5,6 +5,7 @@ namespace GitVersion;
 /// <summary>
 /// A commit, together with the branch to which the commit belongs.
 /// </summary>
+[DebuggerDisplay("{Branch} {Commit}")]
 public readonly struct BranchCommit : IEquatable<BranchCommit?>
 {
     public static readonly BranchCommit Empty = new();

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -115,7 +115,7 @@ public class RepositoryStore : IRepositoryStore
         }
 
         return this.repository.Branches.FirstOrDefault(b =>
-            Regex.IsMatch(b.Name.Friendly, mainBranchRegex, RegexOptions.IgnoreCase));
+            Regex.IsMatch(b.Name.WithoutRemote, mainBranchRegex, RegexOptions.IgnoreCase));
     }
 
     public IEnumerable<IBranch> FindMainlineBranches(GitVersionConfiguration configuration)
@@ -134,6 +134,9 @@ public class RepositoryStore : IRepositoryStore
 
     public IEnumerable<IBranch> GetReleaseBranches(IEnumerable<KeyValuePair<string, BranchConfiguration>> releaseBranchConfig)
         => this.repository.Branches.Where(b => IsReleaseBranch(b, releaseBranchConfig));
+
+    private static bool IsReleaseBranch(INamedReference branch, IEnumerable<KeyValuePair<string, BranchConfiguration>> releaseBranchConfig)
+        => releaseBranchConfig.Any(c => c.Value.Regex != null && Regex.IsMatch(branch.Name.WithoutRemote, c.Value.Regex));
 
     public IEnumerable<IBranch> ExcludingBranches(IEnumerable<IBranch> branchesToExclude) => this.repository.Branches.ExcludeBranches(branchesToExclude);
 
@@ -295,9 +298,6 @@ public class RepositoryStore : IRepositoryStore
     public ICommit? FindMergeBase(ICommit commit, ICommit mainlineTip) => this.repository.FindMergeBase(commit, mainlineTip);
 
     public int GetNumberOfUncommittedChanges() => this.repository.GetNumberOfUncommittedChanges();
-
-    private static bool IsReleaseBranch(INamedReference branch, IEnumerable<KeyValuePair<string, BranchConfiguration>> releaseBranchConfig)
-        => releaseBranchConfig.Any(c => c.Value.Regex != null && Regex.IsMatch(branch.Name.Friendly, c.Value.Regex));
 
     private IEnumerable<SemanticVersion> GetCurrentCommitSemanticVersions(ICommit? commit, string? tagPrefix, ITag tag, SemanticVersionFormat versionFormat, bool handleDetachedBranch)
     {

--- a/src/GitVersion.Core/Core/SourceBranchFinder.cs
+++ b/src/GitVersion.Core/Core/SourceBranchFinder.cs
@@ -37,16 +37,14 @@ internal class SourceBranchFinder
             if (Equals(sourceBranchCandidate, this.branch))
                 return false;
 
-            var branchName = sourceBranchCandidate.Name.Friendly;
+            var branchName = sourceBranchCandidate.Name.WithoutRemote;
 
-            return this.sourceBranchRegexes
-                .Any(regex => Regex.IsMatch(branchName, regex));
+            return this.sourceBranchRegexes.Any(regex => Regex.IsMatch(branchName, regex));
         }
 
         private static IEnumerable<string> GetSourceBranchRegexes(INamedReference branch, GitVersionConfiguration configuration)
         {
-            var branchName = branch.Name.WithoutRemote;
-            var currentBranchConfig = configuration.GetBranchConfiguration(branchName);
+            var currentBranchConfig = configuration.GetBranchConfiguration(branch.Name);
             if (currentBranchConfig.SourceBranches == null)
             {
                 yield return ".*";

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -89,4 +89,14 @@ public class MergeMessage
 
         public Regex Pattern { get; }
     }
+
+    public ReferenceName GetMergedBranchName()
+    {
+        var mergedBranch = MergedBranch;
+        if (FormatName == "RemoteTracking" && !mergedBranch.StartsWith(ReferenceName.RemoteTrackingBranchPrefix))
+        {
+            mergedBranch = $"{ReferenceName.RemoteTrackingBranchPrefix}{mergedBranch}";
+        }
+        return ReferenceName.FromBranchName(mergedBranch);
+    }
 }

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+const GitVersion.ReferenceName.LocalBranchPrefix = "refs/heads/" -> string!
+const GitVersion.ReferenceName.RemotePrefix = "origin/" -> string!
+const GitVersion.ReferenceName.RemoteTrackingBranchPrefix = "refs/remotes/" -> string!
+const GitVersion.ReferenceName.TagPrefix = "refs/tags/" -> string!
 GitVersion.Agents.BuildAgentBase
 GitVersion.Agents.BuildAgentBase.BuildAgentBase(GitVersion.IEnvironment! environment, GitVersion.Logging.ILog! log) -> void
 GitVersion.Agents.BuildAgentBase.Environment.get -> GitVersion.IEnvironment!
@@ -608,6 +612,7 @@ GitVersion.Logging.Verbosity.Quiet = 0 -> GitVersion.Logging.Verbosity
 GitVersion.Logging.Verbosity.Verbose = 3 -> GitVersion.Logging.Verbosity
 GitVersion.MergeMessage
 GitVersion.MergeMessage.FormatName.get -> string?
+GitVersion.MergeMessage.GetMergedBranchName() -> GitVersion.ReferenceName!
 GitVersion.MergeMessage.IsMergedPullRequest.get -> bool
 GitVersion.MergeMessage.MergeMessage(string? mergeMessage, GitVersion.Configuration.GitVersionConfiguration! configuration) -> void
 GitVersion.MergeMessage.MergedBranch.get -> string!
@@ -705,6 +710,7 @@ GitVersion.OutputVariables.VersionVariablesJsonModel.WeightedPreReleaseNumber.ge
 GitVersion.OutputVariables.VersionVariablesJsonModel.WeightedPreReleaseNumber.set -> void
 GitVersion.OutputVariables.VersionVariablesJsonStringConverter
 GitVersion.OutputVariables.VersionVariablesJsonStringConverter.VersionVariablesJsonStringConverter() -> void
+GitVersion.ReferenceName.IsLocalBranch.get -> bool
 GitVersion.RefSpecDirection
 GitVersion.RefSpecDirection.Fetch = 0 -> GitVersion.RefSpecDirection
 GitVersion.RefSpecDirection.Push = 1 -> GitVersion.RefSpecDirection
@@ -714,7 +720,6 @@ GitVersion.ReferenceName.CompareTo(GitVersion.ReferenceName? other) -> int
 GitVersion.ReferenceName.Equals(GitVersion.ReferenceName? other) -> bool
 GitVersion.ReferenceName.EquivalentTo(string? name) -> bool
 GitVersion.ReferenceName.Friendly.get -> string!
-GitVersion.ReferenceName.IsBranch.get -> bool
 GitVersion.ReferenceName.IsPullRequest.get -> bool
 GitVersion.ReferenceName.IsRemoteBranch.get -> bool
 GitVersion.ReferenceName.IsTag.get -> bool
@@ -977,7 +982,6 @@ const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMajorPattern 
 const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultMinorPattern = "\\+semver:\\s?(feature|minor)" -> string!
 const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultNoBumpPattern = "\\+semver:\\s?(none|skip)" -> string!
 const GitVersion.VersionCalculation.IncrementStrategyFinder.DefaultPatchPattern = "\\+semver:\\s?(fix|patch)" -> string!
-const GitVersion.VersionCalculation.MergeMessageVersionStrategy.MergeMessageStrategyPrefix = "Merge message" -> string!
 override GitVersion.Agents.LocalBuild.CanApplyToCurrentContext() -> bool
 override GitVersion.Agents.LocalBuild.EnvironmentVariable.get -> string!
 override GitVersion.Agents.LocalBuild.GenerateSetParameterMessage(string! name, string! value) -> string![]!
@@ -1065,13 +1069,14 @@ static GitVersion.BranchCommit.operator !=(GitVersion.BranchCommit left, GitVers
 static GitVersion.BranchCommit.operator ==(GitVersion.BranchCommit left, GitVersion.BranchCommit right) -> bool
 static GitVersion.Configuration.BranchConfigurationBuilder.New.get -> GitVersion.Configuration.BranchConfigurationBuilder!
 static GitVersion.Configuration.ConfigurationExtensions.GetBranchConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.IBranch! branch) -> GitVersion.Configuration.BranchConfiguration!
-static GitVersion.Configuration.ConfigurationExtensions.GetBranchConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, string! branchName) -> GitVersion.Configuration.BranchConfiguration!
+static GitVersion.Configuration.ConfigurationExtensions.GetBranchConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.ReferenceName! branchName) -> GitVersion.Configuration.BranchConfiguration!
 static GitVersion.Configuration.ConfigurationExtensions.GetBranchSpecificTag(this GitVersion.Configuration.EffectiveConfiguration! configuration, GitVersion.Logging.ILog! log, string? branchFriendlyName, string? branchNameOverride) -> string!
 static GitVersion.Configuration.ConfigurationExtensions.GetEffectiveConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.IBranch! branch) -> GitVersion.Configuration.EffectiveConfiguration!
-static GitVersion.Configuration.ConfigurationExtensions.GetEffectiveConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, string! branchName) -> GitVersion.Configuration.EffectiveConfiguration!
+static GitVersion.Configuration.ConfigurationExtensions.GetEffectiveConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.ReferenceName! branchName) -> GitVersion.Configuration.EffectiveConfiguration!
 static GitVersion.Configuration.ConfigurationExtensions.GetFallbackBranchConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration) -> GitVersion.Configuration.BranchConfiguration!
 static GitVersion.Configuration.ConfigurationExtensions.GetReleaseBranchConfiguration(this GitVersion.Configuration.GitVersionConfiguration! configuration) -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string!, GitVersion.Configuration.BranchConfiguration!>>!
-static GitVersion.Configuration.ConfigurationExtensions.IsReleaseBranch(this GitVersion.Configuration.GitVersionConfiguration! configuration, string! branchName) -> bool
+static GitVersion.Configuration.ConfigurationExtensions.IsReleaseBranch(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.IBranch! branch) -> bool
+static GitVersion.Configuration.ConfigurationExtensions.IsReleaseBranch(this GitVersion.Configuration.GitVersionConfiguration! configuration, GitVersion.ReferenceName! branchName) -> bool
 static GitVersion.Configuration.ConfigurationSerializer.Deserialize<T>(string! input) -> T
 static GitVersion.Configuration.ConfigurationSerializer.Read(System.IO.TextReader! reader) -> GitVersion.Configuration.GitVersionConfiguration!
 static GitVersion.Configuration.ConfigurationSerializer.Serialize(object! graph) -> string!
@@ -1153,6 +1158,7 @@ static GitVersion.OutputVariables.VersionVariables.FromFile(string! filePath, Gi
 static GitVersion.OutputVariables.VersionVariables.FromJson(string! json) -> GitVersion.OutputVariables.VersionVariables!
 static GitVersion.ReferenceName.FromBranchName(string! branchName) -> GitVersion.ReferenceName!
 static GitVersion.ReferenceName.Parse(string! canonicalName) -> GitVersion.ReferenceName!
+static GitVersion.ReferenceName.TryParse(out GitVersion.ReferenceName? value, string! canonicalName) -> bool
 static GitVersion.SemanticVersion.Parse(string! version, string? tagPrefixRegex, GitVersion.SemanticVersionFormat versionFormat = GitVersion.SemanticVersionFormat.Strict) -> GitVersion.SemanticVersion!
 static GitVersion.SemanticVersion.TryParse(string! version, string? tagPrefixRegex, out GitVersion.SemanticVersion? semanticVersion, GitVersion.SemanticVersionFormat format = GitVersion.SemanticVersionFormat.Strict) -> bool
 static GitVersion.SemanticVersion.operator !=(GitVersion.SemanticVersion? v1, GitVersion.SemanticVersion? v2) -> bool

--- a/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/BaseVersionCalculators/VersionInBranchNameVersionStrategy.cs
@@ -21,7 +21,7 @@ public class VersionInBranchNameVersionStrategy : VersionStrategyBase
         if (!configuration.Value.IsReleaseBranch) yield break;
 
         var versionInBranch = GetVersionInBranch(
-            configuration.Branch.Name.Friendly, configuration.Value.LabelPrefix, configuration.Value.SemanticVersionFormat
+            configuration.Branch.Name, configuration.Value.LabelPrefix, configuration.Value.SemanticVersionFormat
         );
         if (versionInBranch != null)
         {
@@ -33,9 +33,10 @@ public class VersionInBranchNameVersionStrategy : VersionStrategyBase
         }
     }
 
-    private static Tuple<string, SemanticVersion>? GetVersionInBranch(string branchName, string? tagPrefixRegex, SemanticVersionFormat versionFormat)
+    private static Tuple<string, SemanticVersion>? GetVersionInBranch(
+        ReferenceName branchName, string? tagPrefixRegex, SemanticVersionFormat versionFormat)
     {
-        var branchParts = branchName.Split('/', '-');
+        var branchParts = branchName.WithoutRemote.Split('/', '-');
         foreach (var part in branchParts)
         {
             if (SemanticVersion.TryParse(part, tagPrefixRegex, out var semanticVersion, versionFormat))

--- a/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/MainlineVersionCalculator.cs
@@ -299,7 +299,8 @@ internal class MainlineVersionCalculator : IMainlineVersionCalculator
         if (mergeCommit != null)
         {
             var mergeMessage = new MergeMessage(mergeCommit.Message, context.Configuration);
-            var configuration = context.Configuration.GetBranchConfiguration(mergeMessage.MergedBranch);
+            var branchName = mergeMessage.GetMergedBranchName();
+            var configuration = context.Configuration.GetBranchConfiguration(branchName);
             if (configuration.Increment != IncrementStrategy.Inherit)
             {
                 return configuration.Increment.ToVersionField();

--- a/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
@@ -118,7 +118,7 @@ public class TestTaskBase : TestBase
         fixture.Repository.MakeACommit();
         fixture.Repository.CreateBranch("develop");
 
-        Commands.Fetch((Repository)fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
+        Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, Array.Empty<string>(), new FetchOptions(), null);
         Commands.Checkout(fixture.LocalRepositoryFixture.Repository, fixture.Repository.Head.Tip);
         fixture.LocalRepositoryFixture.Repository.Branches.Remove(MainBranch);
         fixture.InitializeRepo();

--- a/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
@@ -13,7 +13,7 @@ public class EmptyRepositoryFixture : RepositoryFixtureBase
     {
     }
 
-    private static IRepository CreateNewRepository(string path, string branchName)
+    private static Repository CreateNewRepository(string path, string branchName)
     {
         Init(path, branchName);
         Console.WriteLine("Created git repository at '{0}'", path);

--- a/src/GitVersion.Testing/Fixtures/LocalRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/LocalRepositoryFixture.cs
@@ -4,7 +4,7 @@ namespace GitVersion.Testing;
 
 public class LocalRepositoryFixture : RepositoryFixtureBase
 {
-    public LocalRepositoryFixture(IRepository repository) : base(repository)
+    public LocalRepositoryFixture(Repository repository) : base(repository)
     {
     }
 }

--- a/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
@@ -9,15 +9,15 @@ namespace GitVersion.Testing;
 /// </summary>
 public class RemoteRepositoryFixture : RepositoryFixtureBase
 {
-    public RemoteRepositoryFixture(Func<string, IRepository> builder)
+    public RemoteRepositoryFixture(Func<string, Repository> builder)
         : base(builder) => CreateLocalRepository();
 
     public RemoteRepositoryFixture() : this("main")
     {
     }
 
-    public RemoteRepositoryFixture(string branchName) :
-        this(path => CreateNewRepository(path, branchName))
+    public RemoteRepositoryFixture(string branchName)
+        : this(path => CreateNewRepository(path, branchName))
     {
     }
 
@@ -26,14 +26,14 @@ public class RemoteRepositoryFixture : RepositoryFixtureBase
     /// </summary>
     public LocalRepositoryFixture LocalRepositoryFixture { get; private set; }
 
-    private static IRepository CreateNewRepository(string path, string branchName)
+    private static Repository CreateNewRepository(string path, string branchName)
     {
         Init(path, branchName);
         Console.WriteLine("Created git repository at '{0}'", path);
 
-        var repo = new Repository(path);
-        repo.MakeCommits(5);
-        return repo;
+        var repository = new Repository(path);
+        repository.MakeCommits(5);
+        return repository;
     }
 
     private void CreateLocalRepository() => LocalRepositoryFixture = CloneRepository();


### PR DESCRIPTION
tracks-release-branches won't track remote release branches without regex mod 

Closes https://github.com/GitTools/GitVersion/issues/3337

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
