### PR TITLE
Check that repository isn't a shallow clone and show an error if it is

### DIFF
--- a/docs/input/docs/reference/build-servers/azure-devops.md
+++ b/docs/input/docs/reference/build-servers/azure-devops.md
@@ -14,6 +14,14 @@ either using the Command Line build step or install an extension / custom build
 step. The custom build step requires a one-time setup to import the GitVersion
 task into your TFS or Azure DevOps Pipeline instance.
 
+:::{.alert .alert-danger}
+**Important**
+
+You must disable shallow fetch, either in the pipeline settings UI or by setting `fetchDepth: 0` in your `checkout` step;
+without it, Azure DevOps Pipelines will perform a shallow clone, which will cause GitVersion will display an error message.
+See [the Azure DevOps documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines#shallow-fetch) for more information.
+:::
+
 ## Executing GitVersion
 
 ### Using GitVersion with the MSBuild Task NuGet Package

--- a/docs/input/docs/reference/build-servers/azure-devops.md
+++ b/docs/input/docs/reference/build-servers/azure-devops.md
@@ -18,7 +18,7 @@ task into your TFS or Azure DevOps Pipeline instance.
 **Important**
 
 You must disable shallow fetch, either in the pipeline settings UI or by setting `fetchDepth: 0` in your `checkout` step;
-without it, Azure DevOps Pipelines will perform a shallow clone, which will cause GitVersion will display an error message.
+without it, Azure DevOps Pipelines will perform a shallow clone, which will cause GitVersion to display an error message.
 See [the Azure DevOps documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines#shallow-fetch) for more information.
 :::
 

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -183,6 +183,11 @@ internal class GitPreparer : IGitPreparer
 
         EnsureHeadIsAttachedToBranch(currentBranchName, authentication);
         EnsureRepositoryHeadDuringNormalisation(nameof(EnsureHeadIsAttachedToBranch), expectedSha);
+
+        if (this.repository.IsShallow)
+        {
+            throw new WarningException("Repository is a shallow clone. Git repositories must be contain the full history.");
+        }
     }
 
     private void EnsureRepositoryHeadDuringNormalisation(string occasion, string? expectedSha)

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -186,7 +186,7 @@ internal class GitPreparer : IGitPreparer
 
         if (this.repository.IsShallow)
         {
-            throw new WarningException("Repository is a shallow clone. Git repositories must be contain the full history.");
+            throw new WarningException("Repository is a shallow clone. Git repositories must contain the full history. See https://gitversion.net/docs/reference/requirements#unshallow for more info.");
         }
     }
 

--- a/src/GitVersion.Core/Git/IGitRepository.cs
+++ b/src/GitVersion.Core/Git/IGitRepository.cs
@@ -5,6 +5,7 @@ public interface IGitRepository : IDisposable
     string Path { get; }
     string WorkingDirectory { get; }
     bool IsHeadDetached { get; }
+    bool IsShallow { get; }
     IBranch Head { get; }
     ITagCollection Tags { get; }
     IReferenceCollection Refs { get; }

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -335,6 +335,7 @@ GitVersion.IGitRepository.FindMergeBase(GitVersion.ICommit! commit, GitVersion.I
 GitVersion.IGitRepository.GetNumberOfUncommittedChanges() -> int
 GitVersion.IGitRepository.Head.get -> GitVersion.IBranch!
 GitVersion.IGitRepository.IsHeadDetached.get -> bool
+GitVersion.IGitRepository.IsShallow.get -> bool
 GitVersion.IGitRepository.Path.get -> string!
 GitVersion.IGitRepository.Refs.get -> GitVersion.IReferenceCollection!
 GitVersion.IGitRepository.Remotes.get -> GitVersion.IRemoteCollection!

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -20,6 +20,7 @@ internal sealed partial class GitRepository
     public string Path => RepositoryInstance.Info.Path;
     public string WorkingDirectory => RepositoryInstance.Info.WorkingDirectory;
     public bool IsHeadDetached => RepositoryInstance.Info.IsHeadDetached;
+    public bool IsShallow => RepositoryInstance.Info.IsShallow;
     public IBranch Head => new Branch(RepositoryInstance.Head);
     public ITagCollection Tags => new TagCollection(RepositoryInstance.Tags);
     public IReferenceCollection Refs => new ReferenceCollection(RepositoryInstance.Refs);

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -127,6 +127,15 @@ public abstract class RepositoryFixtureBase : IDisposable
         return new LocalRepositoryFixture(new Repository(localPath));
     }
 
+    /// <summary>
+    ///     Pulls with a depth of 1 and prunes all older commits, making the repository shallow.
+    /// </summary>
+    public void MakeShallow()
+    {
+        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} pull --depth 1");
+        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} gc --prune=all");
+    }
+
     public void Fetch(string remote, FetchOptions? options = null)
         => Commands.Fetch(Repository, remote, Array.Empty<string>(), options, null);
 }


### PR DESCRIPTION
## Description
This change detects shallow repositories and exits early with a proper error message.

## Related Issue
Fixes #3188.

## Motivation and Context
Since September 2022, Azure DevOps has shallow fetch enabled by default in new pipelines. GitVersion doesn't work with shallowly cloned repositories and currently shows a hard-to-debug error message about a `NullReferenceException` in `LibGit2Sharp` when encountering such a repository. A better error message will make it easier for users to find and disable shallow fetching.

## How Has This Been Tested?
This has an automated test that creates a shallow copy and asserts that the correct error message is shown.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
