### PR TITLE
Added support for Bitbucket Cloud merge messages

### DIFF
--- a/src/GitVersion.Core.Tests/MergeMessageTests.cs
+++ b/src/GitVersion.Core.Tests/MergeMessageTests.cs
@@ -174,6 +174,36 @@ Merge in aaa/777 from release/2.2.0 to {MainBranch}
         sut.Version.ShouldBe(expectedVersion);
     }
 
+    private static readonly object?[] BitBucketCloudPullMergeMessages =
+    {
+        new object?[] { $@"Merged in release/2.301.0 (pull request #1789)
+
+Release/2.301.0
+
+Approved-by: John Doe", "release/2.301.0", null, new SemanticVersion(2, 301), 1789  }
+    };
+
+    [TestCaseSource(nameof(BitBucketCloudPullMergeMessages))]
+    public void ParsesBitBucketCloudPullMergeMessage(
+        string message,
+        string expectedMergedBranch,
+        string expectedTargetBranch,
+        SemanticVersion expectedVersion,
+        int? expectedPullRequestNumber)
+    {
+        // Act
+        var sut = new MergeMessage(message, this.configurationBuilder.Build());
+
+        // Assert
+        sut.FormatName.ShouldBe("BitBucketCloudPull");
+        sut.TargetBranch.ShouldBe(expectedTargetBranch);
+        sut.MergedBranch.ShouldNotBeNull();
+        sut.MergedBranch.Friendly.ShouldBe(expectedMergedBranch);
+        sut.IsMergedPullRequest.ShouldBeTrue();
+        sut.PullRequestNumber.ShouldBe(expectedPullRequestNumber);
+        sut.Version.ShouldBe(expectedVersion);
+    }
+
     private static readonly object?[] SmartGitMergeMessages =
     {
         new object?[] { "Finish feature/one", "feature/one", null, null },

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -12,6 +12,7 @@ public class MergeMessage
         new("SmartGit",  @"^Finish (?<SourceBranch>[^\s]*)(?: into (?<TargetBranch>[^\s]*))*"),
         new("BitBucketPull", @"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)"),
         new("BitBucketPullv7", @"^Pull request #(?<PullRequestNumber>\d+).*\r?\n\r?\nMerge in (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)"),
+        new("BitBucketCloudPull", @"^Merged in (?<SourceBranch>[^\s]*) \(pull request #(?<PullRequestNumber>\d+)\)"),
         new("GitHubPull", @"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?:[^\s\/]+\/)?(?<SourceBranch>[^\s]*)(?: into (?<TargetBranch>[^\s]*))*"),
         new("RemoteTracking", @"^Merge remote-tracking branch '(?<SourceBranch>[^\s]*)'(?: into (?<TargetBranch>[^\s]*))*")
     };


### PR DESCRIPTION
## Description
We recently switched from Bitbucket Server to Bitbucket Cloud, and quickly discovered that our beloved GitVersion tool couldn't detect the new merge message format.

## Related Issue
#3506

## Motivation and Context
This change is required for GitVersion to get the right version following a merge from a release branch.

## How Has This Been Tested?
I added a test method in the MergeMessageTests class.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
