### PR TITLE
Improve performance on repositories with a lot of tags

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/PerformanceScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PerformanceScenarios.cs
@@ -1,0 +1,29 @@
+using GitVersion.Configuration;
+using GitVersion.Core.Tests.Helpers;
+
+namespace GitVersion.Core.Tests.IntegrationTests;
+
+public class PerformanceScenarios : TestBase
+{
+    [Test]
+    public void RepositoryWithALotOfTags()
+    {
+        var configuration = GitFlowConfigurationBuilder.New.Build();
+
+        using var fixture = new EmptyRepositoryFixture();
+
+        const int maxCommits = 500;
+        for (int i = 0; i < maxCommits; i++)
+        {
+            fixture.MakeATaggedCommit($"1.0.{i}");
+        }
+
+        fixture.BranchTo("feature");
+        fixture.MakeACommit();
+
+        var sw = Stopwatch.StartNew();
+
+        fixture.AssertFullSemver($"1.0.{maxCommits}-feature.1+1", configuration);
+        sw.ElapsedMilliseconds.ShouldBeLessThan(5000);
+    }
+}


### PR DESCRIPTION
## Description
Added a tag SHA cache into IncrementStrategyFinder to prevent read of all tags from repository each time when FindCommitMessageIncrement is called.

## Related Issue
Fixes #3212 Fixes #2881 Fixes #2885

## Motivation and Context
GitVersion runs slowly on repositories with a lot of tags when there is no gitversion_cache available.
Each tag produces a base version which goes through IncrementStrategyFinder, which in turn reads all tags from repository. This causes N^2 tags to be read from repository in total.

## How Has This Been Tested?
Manually checked performance improvement via profiler on a repository with 200 commits & tags. See screenshot attached below.
A test that recreates a repository with a similar structure is provided in pull request.

## Screenshots (if appropriate):
![image](https://github.com/GitTools/GitVersion/assets/135106921/3145d20d-3d08-4203-bfb9-89ae3ee7a94d)
Performance before (right) and after (left).

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
