### PR TITLE
docs: fix Conventional Commits PATCH rule

### DIFF
--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -95,9 +95,9 @@ you can leverage this feature as follows:
 
 ```yaml
 mode: MainLine # Only add this if you want every version to be created automatically on your main branch.
-major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
-minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
-patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-]*\\))?:"
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-,/\\\\]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-,/\\\\]*\\))?:"
+patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-,/\\\\]*\\))?:"
 ```
 
 This will ensure that your version gets bumped according to the commits you've

--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -103,6 +103,10 @@ patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-]*\\))?:"
 This will ensure that your version gets bumped according to the commits you've
 created.
 
+If your CI/CD workflow uses semantic-release's commit-analyzer, change `(fix|perf)` to `(fix|perf|revert)`. [Why?](https://github.com/semantic-release/commit-analyzer/blob/75c9c87c88772d7ded4ca9614852b42519e41931/lib/default-release-rules.js#L8C1-L8C38)
+
+Alternatively, you can override this rule in the [configuration](https://github.com/semantic-release/commit-analyzer/tree/master#usage) of \@semantic-release/commit-analyzer.
+
 ### GitVersion.yml
 
 The first is by setting the `next-version` property in the GitVersion.yml file.

--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -105,7 +105,7 @@ created.
 
 If your CI/CD workflow uses semantic-release's commit-analyzer, change `(fix|perf)` to `(fix|perf|revert)`. [Why?](https://github.com/semantic-release/commit-analyzer/blob/75c9c87c88772d7ded4ca9614852b42519e41931/lib/default-release-rules.js#L8C1-L8C38)
 
-Alternatively, you can override this rule in the [configuration](https://github.com/semantic-release/commit-analyzer/tree/master#usage) of \@semantic-release/commit-analyzer.
+Alternatively, you can override this rule in the [configuration](https://github.com/semantic-release/commit-analyzer/tree/master#usage) of \@semantic-release/commit-analyzer. If you intend to write rules with patterns, note that instead of using Regular Expression, \@semantic-release/commit-analyzer uses [micromatch's glob implementation](https://github.com/micromatch/micromatch#matching-features).
 
 ### GitVersion.yml
 

--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -120,7 +120,7 @@ from the branch name as a source. However, GitVersion can't use the [branch
 name as a version source for _other branches_][faq-branch-name-source].
 
 ### Detached HEAD
-If HEAD is in detached state tag will be `-no-branch-`. 
+If HEAD is in detached state tag will be `-no-branch-`.
 
 Example: `0.0.1--no-branch-.1+4`
 

--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -97,7 +97,7 @@ you can leverage this feature as follows:
 mode: MainLine # Only add this if you want every version to be created automatically on your main branch.
 major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
 minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
-patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
+patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-]*\\))?:"
 ```
 
 This will ensure that your version gets bumped according to the commits you've


### PR DESCRIPTION
This PR changes the "Conventional Commit" RegEx to be more in line with Convention Commits 1.0.0 and commitlint specifications.

This PR also adds notes for configuring GitVersion and semantic-release to generate the same version.

I'm considering adding a separate section for the `angular` commit format since that is what semantic-release defaults to. It's...nearly identical to Conventional Commits, but is more concrete in its specifications e.g. a reverted commit's header (`type(scope): header message`) is to be the revert commit's header message.

## Related Issue

resolves #3627

## Motivation and Context

I use GitVersion for stamping .NET assemblies and NuGet packages with version information, but I use semantic-release for git tags, release commits, change logs, release notes, GitHub releases, and more.

Because they both have commit analysis and version generation capabilities, I've found that ensuring both generate the same version can be quite finicky. 

## How Has This Been Tested?

https://regexr.com/7h6lv

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
