### PR TITLE
Htmlproofer fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
       uses: chabad360/htmlproofer@master
       with:
         directory: ./artifacts/docs/preview
-        arguments: --ignore-urls "/api/,/docs/" --allow-hash-href --assume-extension --disable-external --check_external_hash false
+        arguments: --ignore-urls "/api/,/docs/" --allow-hash-href --assume-extension --disable-external
     -
       name: '[Reviewdog Reporter]'
       id: reporter

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
       uses: chabad360/htmlproofer@master
       with:
         directory: ./artifacts/docs/preview
-        arguments: --ignore-urls /api/,/docs/ --allow-hash-href --assume-extension --disable-external --check_external_hash false
+        arguments: --ignore-urls "/api/,/docs/" --allow-hash-href --assume-extension --disable-external --check_external_hash false
     -
       name: '[Reviewdog Reporter]'
       id: reporter

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
       uses: chabad360/htmlproofer@master
       with:
         directory: ./artifacts/docs/preview
-        arguments: --ignore-urls /api/,/docs/ --allow-hash-href --assume-extension --disable-external
+        arguments: --ignore-urls /api/,/docs/ --allow-hash-href --assume-extension --disable-external --check_external_hash false
     -
       name: '[Reviewdog Reporter]'
       id: reporter


### PR DESCRIPTION
htmlproofer seems to be ignoring the --disable-external option seems to be ignored during the CI run of htmlProofer

## Description
updated the --ignore-urls to have " around them as documented to see if that fixes the issue, perhaps it is not parsing the rest of the arguments properly due to that?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
