### PR TITLE
Removed setting Language=C# from GitVersion.MsBuild.props

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -4,7 +4,6 @@
     <PropertyGroup>
         <GitVersionOutputFile Condition="'$(GitVersionOutputFile)' == ''">$([MSBuild]::EnsureTrailingSlash($(BaseIntermediateOutputPath)))gitversion.json</GitVersionOutputFile>
 
-        <Language Condition=" '$(Language)' == '' Or '$(DefaultLanguageSourceExtension)' == ''">C#</Language>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)/../</SolutionDir>
         <GitVersionPath Condition="'$(GitVersionPath)' == '' And '$(GitVersionUseSolutionDir)' == 'true'">$(SolutionDir)</GitVersionPath>
         <GitVersionPath Condition="'$(GitVersionPath)' == ''">$(MSBuildProjectDirectory)</GitVersionPath>


### PR DESCRIPTION
## Description

Removed this line:

https://github.com/GitTools/GitVersion/blob/1db2828d799db4352b0d81948ca5267d9dcf48ce/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props#L7

## Related Issue

Resolves #3654.

## Motivation and Context

GitVersion should not force C# language for projects that aren't C#, such as F# or generic *.msbuildproject.

## How Has This Been Tested?

See #3654 and a detailed investigation in [dotnet/project-system#9012](https://github.com/dotnet/project-system/issues/9012)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
