### PR TITLE
Modify access modifier in GlobalModeSetting class.

### DIFF
--- a/src/GitVersion.Core/Configuration/Init/SetConfig/GlobalModeSetting.cs
+++ b/src/GitVersion.Core/Configuration/Init/SetConfig/GlobalModeSetting.cs
@@ -9,7 +9,7 @@ internal class GlobalModeSetting : ConfigInitWizardStep
     private ConfigInitWizardStep returnToStep;
     private bool isPartOfWizard;
 
-    protected GlobalModeSetting(IConsole console, IFileSystem fileSystem, ILog log, IConfigInitStepFactory stepFactory) : base(console, fileSystem, log, stepFactory)
+    public GlobalModeSetting(IConsole console, IFileSystem fileSystem, ILog log, IConfigInitStepFactory stepFactory) : base(console, fileSystem, log, stepFactory)
     {
     }
 


### PR DESCRIPTION
I modified the access modifier of the GlobalModeSetting class constructor

## Description
The server changes the Service Provider to create an instance of the class when requested

## Related Issue
Issue #3716 

## Motivation and Context
Without this change, when a user tried to set the global strategy for the branches, from the init menu, if option 5 was chosen, the software went into error and crashed.

