### PR TITLE
Add .net 8.0 support

### DIFF
--- a/.github/actions/docker-test/action.yml
+++ b/.github/actions/docker-test/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'debian.11'
   targetFramework:
     description: '.net version'
-    default: '7.0'
+    default: '8.0'
 
 runs:
   using: 'composite'

--- a/.github/workflows/_artifacts_linux.yml
+++ b/.github/workflows/_artifacts_linux.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ alpine.3.16, alpine.3.17, centos.7, centos.stream.8, fedora.36, debian.11, ubuntu.20.04, ubuntu.22.04 ]
-        targetFramework: [ '7.0', '6.0' ]
+        distro: [ alpine.3.17, alpine.3.18, centos.stream.8, debian.11, fedora.37, ubuntu.20.04, ubuntu.22.04 ]
+        targetFramework: [ '6.0', '7.0', '8.0' ]
 
     steps:
     -

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ alpine.3.16, alpine.3.17, centos.7, centos.stream.8, fedora.36, debian.11, ubuntu.20.04, ubuntu.22.04 ]
-        targetFramework: [ '7.0', '6.0' ]
+        distro: [ alpine.3.17, alpine.3.18, centos.stream.8, debian.11, fedora.37, ubuntu.20.04, ubuntu.22.04 ]
+        targetFramework: [ '6.0', '7.0', '8.0' ]
 
     steps:
     -

--- a/.github/workflows/_docker_manifests.yml
+++ b/.github/workflows/_docker_manifests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ alpine.3.16, alpine.3.17, centos.7, centos.stream.8, fedora.36, debian.11, ubuntu.20.04, ubuntu.22.04 ]
-        targetFramework: [ '7.0', '6.0' ]
+        distro: [ alpine.3.17, alpine.3.18, centos.stream.8, debian.11, fedora.37, ubuntu.20.04, ubuntu.22.04 ]
+        targetFramework: [ '6.0', '7.0', '8.0' ]
 
     steps:
     -

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        targetFramework: [net7.0, net6.0]
+        targetFramework: [ 'net8.0', 'net7.0', 'net6.0' ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,6 +34,6 @@ jobs:
     -
       name: Test Summary
       uses: test-summary/action@v2
-      if: matrix.targetFramework == 'net7.0'
+      if: matrix.targetFramework == 'net8.0'
       with:
         paths: artifacts/test-results/*.results.xml

--- a/build/.run/Artifacts DotnetTool Test.run.xml
+++ b/build/.run/Artifacts DotnetTool Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts Executable Test.run.xml
+++ b/build/.run/Artifacts Executable Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts MsBuildCore Test.run.xml
+++ b/build/.run/Artifacts MsBuildCore Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts MsBuildFull Test.run.xml
+++ b/build/.run/Artifacts MsBuildFull Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts Native Test.run.xml
+++ b/build/.run/Artifacts Native Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts Prepare.run.xml
+++ b/build/.run/Artifacts Prepare.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Artifacts Test.run.xml
+++ b/build/.run/Artifacts Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Build Docs.run.xml
+++ b/build/.run/Build Docs.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Build Prepare.run.xml
+++ b/build/.run/Build Prepare.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Build.run.xml
+++ b/build/.run/Build.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Clean.run.xml
+++ b/build/.run/Clean.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Code Format.run.xml
+++ b/build/.run/Code Format.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Artifacts.run.xml
+++ b/build/.run/Default Artifacts.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Build.run.xml
+++ b/build/.run/Default Build.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Chores.run.xml
+++ b/build/.run/Default Chores.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Docker.run.xml
+++ b/build/.run/Default Docker.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Docs.run.xml
+++ b/build/.run/Default Docs.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Default Publish.run.xml
+++ b/build/.run/Default Publish.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Docker Build.run.xml
+++ b/build/.run/Docker Build.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Docker Manifest.run.xml
+++ b/build/.run/Docker Manifest.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Docker Publish.run.xml
+++ b/build/.run/Docker Publish.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Docker Test.run.xml
+++ b/build/.run/Docker Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/DockerHub Readme Publish.run.xml
+++ b/build/.run/DockerHub Readme Publish.run.xml
@@ -17,7 +17,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Generate Schemas.run.xml
+++ b/build/.run/Generate Schemas.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Package Archive.run.xml
+++ b/build/.run/Package Archive.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Package Chocolatey.run.xml
+++ b/build/.run/Package Chocolatey.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Package Nuget.run.xml
+++ b/build/.run/Package Nuget.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Package Prepare.run.xml
+++ b/build/.run/Package Prepare.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Package.run.xml
+++ b/build/.run/Package.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Preview Docs.run.xml
+++ b/build/.run/Preview Docs.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Publish Chocolatey.run.xml
+++ b/build/.run/Publish Chocolatey.run.xml
@@ -16,7 +16,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Publish Docs.run.xml
+++ b/build/.run/Publish Docs.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Publish Nuget.run.xml
+++ b/build/.run/Publish Nuget.run.xml
@@ -16,7 +16,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Publish Release.run.xml
+++ b/build/.run/Publish Release.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/PublishCoverage.run.xml
+++ b/build/.run/PublishCoverage.run.xml
@@ -16,7 +16,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Test.run.xml
+++ b/build/.run/Test.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/Tools Install.run.xml
+++ b/build/.run/Tools Install.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/UnitTest (6.0).run.xml
+++ b/build/.run/UnitTest (6.0).run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/UnitTest (7.0).run.xml
+++ b/build/.run/UnitTest (7.0).run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/.run/UnitTest (8.0).run.xml
+++ b/build/.run/UnitTest (8.0).run.xml
@@ -1,16 +1,13 @@
 ﻿<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Tools Update" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/../run/chores.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ToolsUpdate" />
+  <configuration default="false" name="UnitTest (8.0)" type="DotNetProject" factoryName=".NET Project" folderName="Unit Test">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/../run/build.exe" />
+    <option name="PROGRAM_PARAMETERS" value="--target=UnitTest --dotnet_target=net8.0" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
-    <envs>
-      <env name="DOTNET_ROLL_FORWARD" value="Major" />
-    </envs>
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
-    <option name="PROJECT_PATH" value="$PROJECT_DIR$/chores/chores.csproj" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/build/build.csproj" />
     <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />

--- a/build/.run/Validate Version.run.xml
+++ b/build/.run/Validate Version.run.xml
@@ -15,7 +15,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
         <OutputPath>..\..\run\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
+++ b/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
@@ -5,7 +5,7 @@ namespace Artifacts.Tasks;
 [TaskName(nameof(ArtifactsDotnetToolTest))]
 [TaskDescription("Tests the dotnet global tool in docker container")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [IsDependentOn(typeof(ArtifactsPrepare))]
 public class ArtifactsDotnetToolTest : FrostingTask<BuildContext>

--- a/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
@@ -5,7 +5,7 @@ namespace Artifacts.Tasks;
 [TaskName(nameof(ArtifactsMsBuildCoreTest))]
 [TaskDescription("Tests the msbuild package in docker container")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [IsDependentOn(typeof(ArtifactsPrepare))]
 public class ArtifactsMsBuildCoreTest : FrostingTask<BuildContext>
@@ -38,7 +38,7 @@ public class ArtifactsMsBuildCoreTest : FrostingTask<BuildContext>
 
             var targetFramework = framework switch
             {
-                Constants.Version60 or Constants.Version70 => $"net{framework}",
+                Constants.Version60 or Constants.Version70 or Constants.Version80 => $"net{framework}",
                 _ => framework
             };
 

--- a/build/artifacts/Tasks/ArtifactsMsBuildFullTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildFullTest.cs
@@ -23,8 +23,7 @@ public class ArtifactsMsBuildFullTest : FrostingTask<BuildContext>
         var nugetSource = context.MakeAbsolute(Paths.Nuget).FullPath;
 
         context.Information("\nTesting msbuild task with dotnet build\n");
-        var frameworks = new[] { Constants.NetVersion60, Constants.NetVersion70 };
-        foreach (var framework in frameworks)
+        foreach (var framework in Constants.Frameworks)
         {
             var dotnetMsBuildSettings = new DotNetMSBuildSettings();
             dotnetMsBuildSettings.SetTargetFramework(framework);

--- a/build/artifacts/Tasks/ArtifactsNativeTest.cs
+++ b/build/artifacts/Tasks/ArtifactsNativeTest.cs
@@ -5,7 +5,7 @@ namespace Artifacts.Tasks;
 [TaskName(nameof(ArtifactsNativeTest))]
 [TaskDescription("Tests the native executables in docker container")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [IsDependentOn(typeof(ArtifactsPrepare))]
 public class ArtifactsNativeTest : FrostingTask<BuildContext>

--- a/build/artifacts/Tasks/ArtifactsPrepare.cs
+++ b/build/artifacts/Tasks/ArtifactsPrepare.cs
@@ -5,7 +5,7 @@ namespace Artifacts.Tasks;
 [TaskName(nameof(ArtifactsPrepare))]
 [TaskDescription("Pulls the docker images needed for testing the artifacts")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 public class ArtifactsPrepare : FrostingTask<BuildContext>
 {

--- a/build/artifacts/Tasks/ArtifactsTest.cs
+++ b/build/artifacts/Tasks/ArtifactsTest.cs
@@ -5,7 +5,7 @@ namespace Artifacts.Tasks;
 [TaskName(nameof(ArtifactsTest))]
 [TaskDescription("Tests packages in docker container")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [IsDependentOn(typeof(ArtifactsNativeTest))]
 [IsDependentOn(typeof(ArtifactsDotnetToolTest))]

--- a/build/build/BuildLifetime.cs
+++ b/build/build/BuildLifetime.cs
@@ -41,5 +41,8 @@ public class BuildLifetime : BuildLifetimeBase<BuildContext>
         msBuildSettings.WithProperty("RepositoryCommit", version.GitVersion.Sha);
         msBuildSettings.WithProperty("NoPackageAnalysis", "true");
         msBuildSettings.WithProperty("UseSharedCompilation", "false");
+
+        // https://github.com/dotnet/docs/issues/37674
+        msBuildSettings.WithProperty("IncludeSourceRevisionInInformationalVersion", "false");
     }
 }

--- a/build/build/Tasks/Test/UnitTest.cs
+++ b/build/build/Tasks/Test/UnitTest.cs
@@ -8,7 +8,7 @@ namespace Build.Tasks;
 
 [TaskName(nameof(UnitTest))]
 [TaskDescription("Run the unit tests")]
-[TaskArgument(Arguments.DotnetTarget, Constants.NetVersion60, Constants.NetVersion70)]
+[TaskArgument(Arguments.DotnetTarget, Constants.NetVersion60, Constants.NetVersion70, Constants.NetVersion80)]
 [IsDependentOn(typeof(Build))]
 public class UnitTest : FrostingTask<BuildContext>
 {
@@ -17,7 +17,7 @@ public class UnitTest : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         var dotnetTarget = context.Argument(Arguments.DotnetTarget, string.Empty);
-        var frameworks = new[] { Constants.NetVersion60, Constants.NetVersion70 };
+        var frameworks = Constants.Frameworks;
         if (!string.IsNullOrWhiteSpace(dotnetTarget))
         {
             if (!frameworks.Contains(dotnetTarget, StringComparer.OrdinalIgnoreCase))

--- a/build/common/Lifetime/BuildLifetimeBase.cs
+++ b/build/common/Lifetime/BuildLifetimeBase.cs
@@ -30,12 +30,12 @@ public class BuildLifetimeBase<T> : FrostingLifetime<T> where T : BuildContextBa
             context.Information("Running BuildPrepare...");
             return;
         }
-        var gitversionTool = context.GetGitVersionDotnetToolLocation();
+        var gitVersionTool = context.GetGitVersionDotnetToolLocation();
         var gitVersionSettings = new GitVersionSettings
         {
-            OutputTypes = new HashSet<GitVersionOutput> { GitVersionOutput.Json, GitVersionOutput.BuildServer },
+            OutputTypes = new() { GitVersionOutput.Json, GitVersionOutput.BuildServer },
             ToolPath = context.Tools.Resolve(new[] { "dotnet.exe", "dotnet" }),
-            ArgumentCustomization = args => args.Prepend(gitversionTool!.FullPath)
+            ArgumentCustomization = args => args.Prepend(gitVersionTool!.FullPath)
         };
 
         var gitVersion = context.GitVersion(gitVersionSettings);

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -7,19 +7,23 @@ public class Constants
 
     public const string Version60 = "6.0";
     public const string Version70 = "7.0";
-    public const string VersionLatest = Version70;
+    public const string Version80 = "8.0";
+    public const string VersionLatest = Version80;
 
     public const string NetVersion60 = $"net{Version60}";
     public const string NetVersion70 = $"net{Version70}";
+    public const string NetVersion80 = $"net{Version80}";
     public const string NetVersionLatest = $"net{VersionLatest}";
 
     public const string DefaultBranch = "main";
     public const string DefaultConfiguration = "Release";
 
     public static readonly Architecture[] ArchToBuild = { Architecture.Amd64, Architecture.Arm64 };
-    public static readonly string[] VersionsToBuild = { Version60, Version70 };
-    public static readonly string[] DistrosToSkipForArtifacts = { Centos7 };
-    public static readonly string[] DistrosToSkipForDocker = { Centos7 };
+    public static readonly string[] VersionsToBuild = { Version60, Version70, Version80 };
+    public static readonly string[] Frameworks = { NetVersion60, NetVersion70, NetVersion80 };
+
+    public static readonly string[] DistrosToSkipForArtifacts = Array.Empty<string>();
+    public static readonly string[] DistrosToSkipForDocker = Array.Empty<string>();
 
     public const string DockerBaseImageName = "gittools/build-images";
     public const string DockerImageName = "gittools/gitversion";
@@ -32,27 +36,25 @@ public class Constants
     public const string Arm64 = "arm64";
     public const string Amd64 = "amd64";
 
-    public const string Alpine316 = "alpine.3.16";
     public const string Alpine317 = "alpine.3.17";
-    public const string Centos7 = "centos.7";
+    public const string Alpine318 = "alpine.3.18";
     public const string CentosStream8 = "centos.stream.8";
-    public const string Fedora36 = "fedora.36";
     public const string Debian11 = "debian.11";
+    public const string Fedora37 = "fedora.37";
     public const string Ubuntu2004 = "ubuntu.20.04";
     public const string Ubuntu2204 = "ubuntu.22.04";
     public const string DockerDistroLatest = Debian11;
     public const string DebianLatest = Debian11;
     public const string UbuntuLatest = Ubuntu2204;
-    public const string AlpineLatest = Alpine317;
+    public const string AlpineLatest = Alpine318;
 
     public static readonly string[] DockerDistrosToBuild =
     {
-        Alpine316,
         Alpine317,
-        Centos7,
+        Alpine318,
         CentosStream8,
-        Fedora36,
         Debian11,
+        Fedora37,
         Ubuntu2004,
         Ubuntu2204
     };

--- a/build/docker/Tasks/DockerBuild.cs
+++ b/build/docker/Tasks/DockerBuild.cs
@@ -5,7 +5,7 @@ namespace Docker.Tasks;
 [TaskName(nameof(DockerBuild))]
 [TaskDescription("Build the docker images containing the GitVersion Tool")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [TaskArgument(Arguments.Architecture, Constants.Amd64, Constants.Arm64)]
 public class DockerBuild : FrostingTask<BuildContext>

--- a/build/docker/Tasks/DockerManifest.cs
+++ b/build/docker/Tasks/DockerManifest.cs
@@ -5,7 +5,7 @@ namespace Docker.Tasks;
 [TaskName(nameof(DockerManifest))]
 [TaskDescription("Publish the docker manifest containing the images for amd64 and arm64")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [IsDependentOn(typeof(DockerManifestInternal))]
 public class DockerManifest : FrostingTask<BuildContext>

--- a/build/docker/Tasks/DockerPublish.cs
+++ b/build/docker/Tasks/DockerPublish.cs
@@ -5,7 +5,7 @@ namespace Docker.Tasks;
 [TaskName(nameof(DockerPublish))]
 [TaskDescription("Publish the docker images containing the GitVersion Tool")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [TaskArgument(Arguments.Architecture, Constants.Amd64, Constants.Arm64)]
 [IsDependentOn(typeof(DockerPublishInternal))]

--- a/build/docker/Tasks/DockerTest.cs
+++ b/build/docker/Tasks/DockerTest.cs
@@ -5,7 +5,7 @@ namespace Docker.Tasks;
 [TaskName(nameof(DockerTest))]
 [TaskDescription("Test the docker images containing the GitVersion Tool")]
 [TaskArgument(Arguments.DockerRegistry, Constants.DockerHub, Constants.GitHub)]
-[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70)]
+[TaskArgument(Arguments.DockerDotnetVersion, Constants.Version60, Constants.Version70, Constants.Version80)]
 [TaskArgument(Arguments.DockerDistro, Constants.AlpineLatest, Constants.DebianLatest, Constants.UbuntuLatest)]
 [TaskArgument(Arguments.Architecture, Constants.Amd64, Constants.Arm64)]
 [IsDependentOn(typeof(DockerBuild))]

--- a/global.json
+++ b/global.json
@@ -1,5 +1,11 @@
 {
+  "projects": [
+    "build",
+    "src"
+  ],
   "sdk": {
-    "version": "7.0.400"
+    "version": "8.0.100-rc.2.23502.2",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
   }
 }

--- a/new-cli/.run/Calculate.run.xml
+++ b/new-cli/.run/Calculate.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Calculate" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/calculate.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Config Help.run.xml
+++ b/new-cli/.run/Config Help.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Config Help" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/config-help.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Config Init.run.xml
+++ b/new-cli/.run/Config Init.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Config Init" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/config-init.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Config Show.run.xml
+++ b/new-cli/.run/Config Show.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Config Show" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/config-show.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Help.run.xml
+++ b/new-cli/.run/Help.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Help" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/help.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Normalize.run.xml
+++ b/new-cli/.run/Normalize.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Normalize" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/normalize.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Output AssemblyInfo.run.xml
+++ b/new-cli/.run/Output AssemblyInfo.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Output AssemblyInfo" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/output-assemblyinfo.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Output Help.run.xml
+++ b/new-cli/.run/Output Help.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Output Help" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/output-help.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Output Project.run.xml
+++ b/new-cli/.run/Output Project.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Output Project" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/output-project.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Output Wix.run.xml
+++ b/new-cli/.run/Output Wix.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Output Wix" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/output-wix.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Tester.run.xml
+++ b/new-cli/.run/Tester.run.xml
@@ -1,8 +1,8 @@
 ﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Tester" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Core.Tester/bin/Debug/net7.0/gv.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Core.Tester/bin/Debug/net8.0/gv.exe" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GitVersion.Core.Tester/bin/Debug/net7.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GitVersion.Core.Tester/bin/Debug/net8.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/.run/Version.run.xml
+++ b/new-cli/.run/Version.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Version" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net7.0/gitversion.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.Cli/bin/Debug/net8.0/gitversion.exe" />
     <option name="PROGRAM_PARAMETERS" value="@docs/version.rsp" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="0" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net7.0" />
+    <option name="PROJECT_TFM" value="net8.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/new-cli/Directory.Build.props
+++ b/new-cli/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>GitVersion</RootNamespace>
 
         <LangVersion>latest</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
         <EndYear>$([System.DateTime]::Today.Year)</EndYear>
         <Authors>GitTools and Contributors</Authors>

--- a/src/GitVersion.App/GitVersion.App.csproj
+++ b/src/GitVersion.App/GitVersion.App.csproj
@@ -10,7 +10,7 @@
 
     <!-- workaround for https://github.com/dotnet/runtime/issues/49508 -->
     <PropertyGroup Condition=" '$(OsxArm64)' == 'true'">
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">

--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -36,6 +36,7 @@
 
         <None Include="$(ExePublishPath)/net6.0/publish/**/*;$(BinPath)/net6.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net6.0" />
         <None Include="$(ExePublishPath)/net7.0/publish/**/*;$(BinPath)/net7.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net7.0" />
+        <None Include="$(ExePublishPath)/net8.0/publish/**/*;$(BinPath)/net8.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net8.0" />
         
     </ItemGroup>
 

--- a/tests/scripts/test-msbuild-task.sh
+++ b/tests/scripts/test-msbuild-task.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
-# sh /scripts/test-msbuild-task.sh --version 5.7.1-beta1.56 --nugetPath /nuget --repoPath /repo/tests/integration --targetframework net7.0
+# sh /scripts/test-msbuild-task.sh --version 6.0.0 --nugetPath /nuget --repoPath /repo/tests/integration --targetframework net8.0
 while test "$#" -gt 0
 do
     case $1 in


### PR DESCRIPTION
Upgraded the Target Framework Moniker (TFM) from net7.0 to net8.0 in multiple configurations, project files, and script files. This includes modifying the task arguments, project configurations, constants, and GitHub workflows to reflect the changes made to accommodate the new net8.0 framework.

The SDK version has been updated in the global.json file to "8.0.100-rc.2.23502.2", and additional properties such as "allowPrerelease" and "rollForward" have been set. In the BuildLifetime.cs file, a new property "IncludeSourceRevisionInInformationalVersion" has also been added to address a specific issue namely, 'dotnet/docs#37674'.