### PR TITLE
Re-fixed github actions tag handling

### DIFF
--- a/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
@@ -18,6 +18,7 @@ public class GitHubActionsTests : TestBase
         this.environment = sp.GetRequiredService<IEnvironment>();
         this.buildServer = sp.GetRequiredService<GitHubActions>();
         this.environment.SetEnvironmentVariable(GitHubActions.EnvironmentVariableName, "true");
+        this.environment.SetEnvironmentVariable("GITHUB_REF_TYPE", "branch");
 
         this.githubSetEnvironmentTempFilePath = Path.GetTempFileName();
         this.environment.SetEnvironmentVariable(GitHubActions.GitHubSetEnvTempFileEnvironmentVariableName, this.githubSetEnvironmentTempFilePath);
@@ -75,26 +76,30 @@ public class GitHubActionsTests : TestBase
     public void GetCurrentBranchShouldHandleTags()
     {
         // Arrange
+        this.environment.SetEnvironmentVariable("GITHUB_REF_TYPE", "tag");
         this.environment.SetEnvironmentVariable("GITHUB_REF", "refs/tags/1.0.0");
 
         // Act
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBe("refs/tags/1.0.0");
+        result.ShouldBeNull();
     }
 
     [Test]
     public void GetCurrentBranchShouldHandlePullRequests()
     {
         // Arrange
+        this.environment.SetEnvironmentVariable("GITHUB_EVENT_NAME", "pull_request");
+        this.environment.SetEnvironmentVariable("GITHUB_HEAD_REF", "some-branch");
+        this.environment.SetEnvironmentVariable("GITHUB_BASE_REF", MainBranch);
         this.environment.SetEnvironmentVariable("GITHUB_REF", "refs/pull/1/merge");
 
         // Act
         var result = this.buildServer.GetCurrentBranch(false);
 
         // Assert
-        result.ShouldBe("refs/pull/1/merge");
+        result.ShouldBe("some-branch");
     }
 
     [Test]

--- a/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
@@ -50,7 +50,28 @@ internal class GitHubActions : BuildAgentBase
         }
     }
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("GITHUB_REF");
+
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {
+        var refType = Environment.GetEnvironmentVariable("GITHUB_REF_TYPE") ?? "";
+        var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "";
+        // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+        // GITHUB_REF must be used only for "real" branches, not for tags.
+        // Bug fix for https://github.com/GitTools/GitVersion/issues/2838
+        
+        // pull_request or pull_request_target
+        if (eventName.StartsWith("pull_request", StringComparison.OrdinalIgnoreCase))
+        {
+            return Environment.GetEnvironmentVariable("GITHUB_HEAD_REF");
+        }
+
+        if (refType.Equals("tag", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+        
+        return Environment.GetEnvironmentVariable("GITHUB_REF");
+    }
 
     public override bool PreventFetch() => true;
 }


### PR DESCRIPTION
So similar changes to this were provided in PR #3033 (fix for #2838) however the changes Azure Pipelines caused it to quickly be reverted (#3081, #3082, #3083).  While I believe the Azure Pipelines issues were genuine, I don't believe the changes for Github Actions had any issues (that I'm aware of) however it currently causes mass headache when trying to push preview releases.

This change reintroduces only the github action changes.  I suspect the changes to Gitlab and others might still apply, however I would rather they get added as separate PRs in the event that one of them triggers another revert.

## Description
Updates the `GitHubActions` build agent to properly handle both tag builds and pull request builds based on the github actions docs. 

See: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables

## Related Issue
#2838, #3033, https://github.com/GitTools/GitVersion/discussions/3653

## Motivation and Context
Today github actions cannot properly create a tagged preview build because the version comes out and some form of 1.5.0-tags-v1-5-0-preview-6.1 where the real base branch is not properly detected

## How Has This Been Tested?
Changes are based off the original PR with some changes based on additional environment variables that exist in a Github Action Runner environment (event name, ref type, head ref, etc)

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
