### PR TITLE
Remove JetBrains.Annotations dependency

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -62,7 +62,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
 
-        <PackageReference Include="JetBrains.Annotations" PrivateAssets="All"/>
         <PackageReference Include="NSubstitute"/>
 
         <PackageReference Include="NUnit"/>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="FluentDateTime" Version="2.1.0" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="3.5.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.28.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.8.3" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -14,8 +14,6 @@
     <ItemGroup>
         <PackageReference Include="Polly" />
         <PackageReference Include="System.Net.Requests" />
-
-        <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="YamlDotNet" />

--- a/src/GitVersion.Testing/Helpers/StringBuilderExtensions.cs
+++ b/src/GitVersion.Testing/Helpers/StringBuilderExtensions.cs
@@ -1,11 +1,17 @@
-using JetBrains.Annotations;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace GitVersion.Testing.Internal;
 
 internal static class StringBuilderExtensions
 {
-    [StringFormatMethod("format")]
-    public static void AppendLineFormat(this StringBuilder stringBuilder, string format, params object?[] args)
+    public static void AppendLineFormat(this StringBuilder stringBuilder,
+#if NET7_0_OR_GREATER
+                                        [StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+#endif
+                                        string format,
+                                        params object?[] args)
     {
         stringBuilder.AppendFormat(format, args);
         stringBuilder.AppendLine();


### PR DESCRIPTION
The JetBrains.Annotations package and its reference usage are removed from the code. This changes the AppendLineFormat function in the StringBuilderExtensions class and removes any related package references in the Directory.Packages.props and GitVersion.Core.csproj files.
