### PR TITLE
Remove System.Net.Requests package reference

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,7 +30,6 @@
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.6.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Polly" Version="8.2.0" />
-    <PackageVersion Include="System.Net.Requests" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -13,7 +13,6 @@
 
     <ItemGroup>
         <PackageReference Include="Polly" />
-        <PackageReference Include="System.Net.Requests" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="YamlDotNet" />


### PR DESCRIPTION
The reference to 'System.Net.Requests' package has been deleted from both Directory.Packages.props and GitVersion.Core.csproj files. This package was no longer in use or no necessary dependencies relied on it, making the removal a clean up operation.
