### PR TITLE
Refactor GitVersion.Core for clear, maintainable methods

### DIFF
--- a/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
+++ b/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
@@ -19,8 +19,8 @@ public class ExecutionResults
     {
         get
         {
-            var jsonStartIndex = Output.IndexOf("{", StringComparison.Ordinal);
-            var jsonEndIndex = Output.IndexOf("}", StringComparison.Ordinal);
+            var jsonStartIndex = Output.IndexOf('{');
+            var jsonEndIndex = Output.IndexOf('}');
             var json = Output.Substring(jsonStartIndex, jsonEndIndex - jsonStartIndex + 1);
 
             return VersionVariablesHelper.FromJson(json);

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -16,7 +16,7 @@ public class GitVersionExecutorTests : TestBase
 {
     private IFileSystem fileSystem;
     private ILog log;
-    private IGitVersionCache gitVersionCache;
+    private GitVersionCache gitVersionCache;
     private IServiceProvider sp;
 
     [Test]
@@ -571,7 +571,7 @@ public class GitVersionExecutorTests : TestBase
 
         this.fileSystem = this.sp.GetRequiredService<IFileSystem>();
         this.log = this.sp.GetRequiredService<ILog>();
-        this.gitVersionCache = this.sp.GetRequiredService<IGitVersionCache>();
+        this.gitVersionCache = (GitVersionCache)this.sp.GetRequiredService<IGitVersionCache>();
 
         return this.sp.GetRequiredService<IGitVersionCalculateTool>();
     }

--- a/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
@@ -108,7 +108,7 @@ public static class GitToolsTestingExtensions
 
         using var stream = File.Open(versionFile, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
         using var writer = new StreamWriter(stream);
-        writer.Write(versionVariables.ToJsonString());
+        writer.Write(versionVariables.ToJson());
     }
 
     public static void AssertFullSemver(this RepositoryFixtureBase fixture, string fullSemver,

--- a/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
@@ -29,6 +29,6 @@ public class JsonVersionBuilderTests : TestBase
 
         var variableProvider = serviceProvider.GetRequiredService<IVariableProvider>();
         var variables = variableProvider.GetVariablesFor(semanticVersion, configuration, null);
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
@@ -51,7 +51,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("unstable"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -77,7 +77,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("unstable"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -101,7 +101,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("develop"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -127,7 +127,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("develop"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -153,7 +153,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("develop"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, SemanticVersion.Empty);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("develop"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -254,7 +254,7 @@ public class VariableProviderTests : TestBase
             .Build().GetEffectiveConfiguration(ReferenceName.FromBranchName("develop"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(c => c.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(c => c.SubFolder("Approved"));
     }
 
     [Test]
@@ -281,6 +281,6 @@ public class VariableProviderTests : TestBase
             .GetEffectiveConfiguration(ReferenceName.FromBranchName("main"));
         var variables = this.variableProvider.GetVariablesFor(semanticVersion, configuration, null);
 
-        variables.ToJsonString().ShouldMatchApproved(_ => _.SubFolder("Approved"));
+        variables.ToJson().ShouldMatchApproved(_ => _.SubFolder("Approved"));
     }
 }

--- a/src/GitVersion.Core/OutputVariables/VersionVariablesHelper.cs
+++ b/src/GitVersion.Core/OutputVariables/VersionVariablesHelper.cs
@@ -14,6 +14,22 @@ public static class VersionVariablesHelper
         return FromDictionary(variablePairs);
     }
 
+    public static string ToJson(this GitVersionVariables gitVersionVariables)
+    {
+        var variablesType = typeof(VersionVariablesJsonModel);
+        var variables = new VersionVariablesJsonModel();
+
+        foreach (var (key, value) in gitVersionVariables.OrderBy(x => x.Key))
+        {
+            var propertyInfo = variablesType.GetProperty(key);
+            propertyInfo?.SetValue(variables, ChangeType(value, propertyInfo.PropertyType));
+        }
+
+        var serializeOptions = JsonSerializerOptions();
+
+        return JsonSerializer.Serialize(variables, serializeOptions);
+    }
+
     public static GitVersionVariables FromFile(string filePath, IFileSystem fileSystem)
     {
         try
@@ -31,22 +47,6 @@ public static class VersionVariablesHelper
 
             throw;
         }
-    }
-
-    public static string ToJsonString(this GitVersionVariables gitVersionVariables)
-    {
-        var variablesType = typeof(VersionVariablesJsonModel);
-        var variables = new VersionVariablesJsonModel();
-
-        foreach (var (key, value) in gitVersionVariables.OrderBy(x => x.Key))
-        {
-            var propertyInfo = variablesType.GetProperty(key);
-            propertyInfo?.SetValue(variables, ChangeType(value, propertyInfo.PropertyType));
-        }
-
-        var serializeOptions = JsonSerializerOptions();
-
-        return JsonSerializer.Serialize(variables, serializeOptions);
     }
 
     private static GitVersionVariables FromDictionary(IEnumerable<KeyValuePair<string, string>>? properties)
@@ -72,11 +72,7 @@ public static class VersionVariablesHelper
         return versionVariables;
     }
 
-    private static JsonSerializerOptions JsonSerializerOptions()
-    {
-        var serializeOptions = new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Converters = { new VersionVariablesJsonStringConverter() } };
-        return serializeOptions;
-    }
+    private static JsonSerializerOptions JsonSerializerOptions() => new() { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Converters = { new VersionVariablesJsonStringConverter() } };
 
     private static object? ChangeType(object? value, Type type)
     {

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -688,19 +688,15 @@ GitVersion.VersionCalculation.BaseVersion.ShouldIncrement.init -> void
 GitVersion.VersionCalculation.BaseVersion.Source.get -> string!
 GitVersion.VersionCalculation.BaseVersion.Source.init -> void
 GitVersion.VersionCalculation.Caching.GitVersionCache
-GitVersion.VersionCalculation.Caching.GitVersionCache.GetCacheDirectory() -> string!
-GitVersion.VersionCalculation.Caching.GitVersionCache.GetCacheFileName(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey) -> string!
 GitVersion.VersionCalculation.Caching.GitVersionCache.GitVersionCache(GitVersion.IFileSystem! fileSystem, GitVersion.Logging.ILog! log, GitVersion.IGitRepositoryInfo! repositoryInfo) -> void
-GitVersion.VersionCalculation.Caching.GitVersionCache.LoadVersionVariablesFromDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! key) -> GitVersion.OutputVariables.GitVersionVariables?
-GitVersion.VersionCalculation.Caching.GitVersionCache.WriteVariablesToDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey, GitVersion.OutputVariables.GitVersionVariables! variablesFromCache) -> void
+GitVersion.VersionCalculation.Caching.GitVersionCache.LoadVersionVariablesFromDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey) -> GitVersion.OutputVariables.GitVersionVariables?
+GitVersion.VersionCalculation.Caching.GitVersionCache.WriteVariablesToDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey, GitVersion.OutputVariables.GitVersionVariables! versionVariables) -> void
 GitVersion.VersionCalculation.Caching.GitVersionCacheKey
 GitVersion.VersionCalculation.Caching.GitVersionCacheKey.GitVersionCacheKey(string! value) -> void
 GitVersion.VersionCalculation.Caching.GitVersionCacheKey.Value.get -> string!
 GitVersion.VersionCalculation.Caching.IGitVersionCache
-GitVersion.VersionCalculation.Caching.IGitVersionCache.GetCacheDirectory() -> string!
-GitVersion.VersionCalculation.Caching.IGitVersionCache.GetCacheFileName(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey) -> string!
-GitVersion.VersionCalculation.Caching.IGitVersionCache.LoadVersionVariablesFromDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! key) -> GitVersion.OutputVariables.GitVersionVariables?
-GitVersion.VersionCalculation.Caching.IGitVersionCache.WriteVariablesToDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey, GitVersion.OutputVariables.GitVersionVariables! variablesFromCache) -> void
+GitVersion.VersionCalculation.Caching.IGitVersionCache.LoadVersionVariablesFromDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey) -> GitVersion.OutputVariables.GitVersionVariables?
+GitVersion.VersionCalculation.Caching.IGitVersionCache.WriteVariablesToDiskCache(GitVersion.VersionCalculation.Caching.GitVersionCacheKey! cacheKey, GitVersion.OutputVariables.GitVersionVariables! versionVariables) -> void
 GitVersion.VersionCalculation.CommitMessageIncrementMode
 GitVersion.VersionCalculation.CommitMessageIncrementMode.Disabled = 1 -> GitVersion.VersionCalculation.CommitMessageIncrementMode
 GitVersion.VersionCalculation.CommitMessageIncrementMode.Enabled = 0 -> GitVersion.VersionCalculation.CommitMessageIncrementMode
@@ -869,7 +865,7 @@ static GitVersion.Logging.LogExtensions.Warning(this GitVersion.Logging.ILog! lo
 static GitVersion.Logging.LogExtensions.Write(this GitVersion.Logging.ILog! log, GitVersion.Logging.LogLevel level, string! format, params object![]! args) -> void
 static GitVersion.OutputVariables.VersionVariablesHelper.FromFile(string! filePath, GitVersion.IFileSystem! fileSystem) -> GitVersion.OutputVariables.GitVersionVariables!
 static GitVersion.OutputVariables.VersionVariablesHelper.FromJson(string! json) -> GitVersion.OutputVariables.GitVersionVariables!
-static GitVersion.OutputVariables.VersionVariablesHelper.ToJsonString(this GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables) -> string!
+static GitVersion.OutputVariables.VersionVariablesHelper.ToJson(this GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables) -> string!
 static GitVersion.ReferenceName.FromBranchName(string! branchName) -> GitVersion.ReferenceName!
 static GitVersion.ReferenceName.Parse(string! canonicalName) -> GitVersion.ReferenceName!
 static GitVersion.ReferenceName.TryParse(out GitVersion.ReferenceName? value, string! canonicalName) -> bool

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCache.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCache.cs
@@ -19,14 +19,14 @@ public class GitVersionCache : IGitVersionCache
         this.repositoryInfo = repositoryInfo.NotNull();
     }
 
-    public void WriteVariablesToDiskCache(GitVersionCacheKey cacheKey, GitVersionVariables variablesFromCache)
+    public void WriteVariablesToDiskCache(GitVersionCacheKey cacheKey, GitVersionVariables versionVariables)
     {
         var cacheFileName = GetCacheFileName(cacheKey);
 
         Dictionary<string, string?> dictionary;
         using (this.log.IndentLog("Creating dictionary"))
         {
-            dictionary = variablesFromCache.ToDictionary(x => x.Key, x => x.Value);
+            dictionary = versionVariables.ToDictionary(x => x.Key, x => x.Value);
         }
 
         void WriteCacheOperation()
@@ -44,26 +44,11 @@ public class GitVersionCache : IGitVersionCache
         retryOperation.Execute(WriteCacheOperation);
     }
 
-    public string GetCacheFileName(GitVersionCacheKey cacheKey)
-    {
-        var cacheDir = PrepareCacheDirectory();
-        var cacheFileName = GetCacheFileName(cacheKey, cacheDir);
-        return cacheFileName;
-    }
-
-    public string GetCacheDirectory()
-    {
-        var gitDir = this.repositoryInfo.DotGitDirectory;
-        return PathHelper.Combine(gitDir, "gitversion_cache");
-    }
-
-    public GitVersionVariables? LoadVersionVariablesFromDiskCache(GitVersionCacheKey key)
+    public GitVersionVariables? LoadVersionVariablesFromDiskCache(GitVersionCacheKey cacheKey)
     {
         using (this.log.IndentLog("Loading version variables from disk cache"))
         {
-            var cacheDir = PrepareCacheDirectory();
-
-            var cacheFileName = GetCacheFileName(key, cacheDir);
+            var cacheFileName = GetCacheFileName(cacheKey);
             if (!this.fileSystem.Exists(cacheFileName))
             {
                 this.log.Info("Cache file " + cacheFileName + " not found.");
@@ -94,6 +79,18 @@ public class GitVersionCache : IGitVersionCache
                 }
             }
         }
+    }
+
+    internal string GetCacheFileName(GitVersionCacheKey cacheKey)
+    {
+        var cacheDir = PrepareCacheDirectory();
+        return GetCacheFileName(cacheKey, cacheDir);
+    }
+
+    internal string GetCacheDirectory()
+    {
+        var gitDir = this.repositoryInfo.DotGitDirectory;
+        return PathHelper.Combine(gitDir, "gitversion_cache");
     }
 
     private string PrepareCacheDirectory()

--- a/src/GitVersion.Core/VersionCalculation/Caching/IGitVersionCache.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/IGitVersionCache.cs
@@ -4,8 +4,6 @@ namespace GitVersion.VersionCalculation.Caching;
 
 public interface IGitVersionCache
 {
-    void WriteVariablesToDiskCache(GitVersionCacheKey cacheKey, GitVersionVariables variablesFromCache);
-    string GetCacheDirectory();
-    GitVersionVariables? LoadVersionVariablesFromDiskCache(GitVersionCacheKey key);
-    string GetCacheFileName(GitVersionCacheKey cacheKey);
+    void WriteVariablesToDiskCache(GitVersionCacheKey cacheKey, GitVersionVariables versionVariables);
+    GitVersionVariables? LoadVersionVariablesFromDiskCache(GitVersionCacheKey cacheKey);
 }

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -38,14 +38,14 @@ internal sealed class OutputGenerator : IOutputGenerator
         if (gitVersionOptions.Output.Contains(OutputType.File))
         {
             var retryOperation = new RetryAction<IOException>();
-            retryOperation.Execute(() => this.fileSystem.WriteAllText(context.OutputFile, variables.ToJsonString()));
+            retryOperation.Execute(() => this.fileSystem.WriteAllText(context.OutputFile, variables.ToJson()));
         }
 
         if (!gitVersionOptions.Output.Contains(OutputType.Json)) return;
 
         if (gitVersionOptions.ShowVariable is null && gitVersionOptions.Format is null)
         {
-            this.console.WriteLine(variables.ToJsonString());
+            this.console.WriteLine(variables.ToJson());
             return;
         }
 

--- a/src/GitVersion.sln.DotSettings
+++ b/src/GitVersion.sln.DotSettings
@@ -700,4 +700,6 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=asbjornu/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gitversion/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reacheable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This commit refactors several methods within GitVersion.Core and its associated test files for better clarity and maintainability. Apart from renaming variables for clearer intent, it also streamlines the use of JsonSerializerOptions and simplifies the use of the 'toJson' method throughout the codebase. Moreover, it adjusts the accessibility of certain methods, modifying them from public to internal where appropriate.