### PR TITLE
Refactor caching system in GitVersion

### DIFF
--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -91,33 +91,35 @@ public class GitVersionExecutorTests : TestBase
     [Test]
     public void CacheFileExistsOnDisk()
     {
-        const string versionCacheFileContent = @"
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
-        ";
+        const string versionCacheFileContent = """
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
+        """;
 
         var stringBuilder = new StringBuilder();
         void Action(string s) => stringBuilder.AppendLine(s);
@@ -145,37 +147,39 @@ public class GitVersionExecutorTests : TestBase
 
         var logsMessages = stringBuilder.ToString();
 
-        logsMessages.ShouldContain("Deserializing version variables from cache file", Case.Insensitive, logsMessages);
+        logsMessages.ShouldContain("Loading version variables from disk cache file", Case.Insensitive, logsMessages);
     }
 
     [Test]
     public void CacheFileExistsOnDiskWhenOverrideConfigIsSpecifiedVersionShouldBeDynamicallyCalculatedWithoutSavingInCache()
     {
-        const string versionCacheFileContent = @"
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
-        ";
+        const string versionCacheFileContent = """
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
+        """;
 
         using var fixture = new EmptyRepositoryFixture();
         fixture.Repository.MakeACommit();
@@ -228,40 +232,42 @@ public class GitVersionExecutorTests : TestBase
         gitVersionCalculator.CalculateVersionVariables();
 
         var logsMessages = stringBuilder.ToString();
-        logsMessages.ShouldContain("yml not found", Case.Insensitive, logsMessages);
+        logsMessages.ShouldContain(".json not found", Case.Insensitive, logsMessages);
     }
 
     [TestCase(ConfigurationFileLocator.DefaultFileName)]
     [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName)]
     public void ConfigChangeInvalidatesCache(string configFileName)
     {
-        const string versionCacheFileContent = @"
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
-        ";
+        const string versionCacheFileContent = """
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
+        """;
 
         using var fixture = new EmptyRepositoryFixture();
 
@@ -295,33 +301,35 @@ public class GitVersionExecutorTests : TestBase
     [Test]
     public void NoCacheBypassesCache()
     {
-        const string versionCacheFileContent = @"
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
-        ";
+        const string versionCacheFileContent = """
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
+        """;
 
         using var fixture = new EmptyRepositoryFixture();
 

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -15,7 +15,6 @@
         <PackageReference Include="Polly" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
-        <PackageReference Include="YamlDotNet" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -865,6 +865,7 @@ static GitVersion.Logging.LogExtensions.Warning(this GitVersion.Logging.ILog! lo
 static GitVersion.Logging.LogExtensions.Write(this GitVersion.Logging.ILog! log, GitVersion.Logging.LogLevel level, string! format, params object![]! args) -> void
 static GitVersion.OutputVariables.VersionVariablesHelper.FromFile(string! filePath, GitVersion.IFileSystem! fileSystem) -> GitVersion.OutputVariables.GitVersionVariables!
 static GitVersion.OutputVariables.VersionVariablesHelper.FromJson(string! json) -> GitVersion.OutputVariables.GitVersionVariables!
+static GitVersion.OutputVariables.VersionVariablesHelper.ToFile(GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables, string! filePath, GitVersion.IFileSystem! fileSystem) -> void
 static GitVersion.OutputVariables.VersionVariablesHelper.ToJson(this GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables) -> string!
 static GitVersion.ReferenceName.FromBranchName(string! branchName) -> GitVersion.ReferenceName!
 static GitVersion.ReferenceName.Parse(string! canonicalName) -> GitVersion.ReferenceName!

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -35,17 +35,19 @@ internal sealed class OutputGenerator : IOutputGenerator
         {
             this.buildAgent.WriteIntegration(this.console.WriteLine, variables, context.UpdateBuildNumber ?? true);
         }
+
+        var json = variables.ToJson();
         if (gitVersionOptions.Output.Contains(OutputType.File))
         {
             var retryOperation = new RetryAction<IOException>();
-            retryOperation.Execute(() => this.fileSystem.WriteAllText(context.OutputFile, variables.ToJson()));
+            retryOperation.Execute(() => this.fileSystem.WriteAllText(context.OutputFile, json));
         }
 
         if (!gitVersionOptions.Output.Contains(OutputType.Json)) return;
 
         if (gitVersionOptions.ShowVariable is null && gitVersionOptions.Format is null)
         {
-            this.console.WriteLine(variables.ToJson());
+            this.console.WriteLine(json);
             return;
         }
 


### PR DESCRIPTION
Recreated from #3797

Changes include updating cache file format from YML to JSON, removing unused methods, and optimizing file write/read operations. This allows to remove dependency on YamlDotNet. Various changes were also made to use more appropriate method identifiers and improve handling of cache file exceptions.