### PR TITLE
Switch cache format from JSON back to YAML

### DIFF
--- a/.github/actions/docker-manifests/action.yml
+++ b/.github/actions/docker-manifests/action.yml
@@ -32,7 +32,7 @@ runs:
   -
     name: '[Docker Publish Manifests] DockerHub'
     shell: pwsh
-    run: dotnet run/docker.dll --target=DockerManifest --arch=amd64 --docker_dotnetversion=${{ inputs.targetFramework }} --docker_distro=${{ inputs.distro }} --docker_registry dockerhub
+    run: dotnet run/docker.dll --target=DockerManifest --arch=amd64 --arch=arm64 --docker_dotnetversion=${{ inputs.targetFramework }} --docker_distro=${{ inputs.distro }} --docker_registry dockerhub
   -
     name: Login to GitHub
     uses: docker/login-action@v2
@@ -43,4 +43,4 @@ runs:
   -
     name: '[Docker Publish Manifests] GitHub'
     shell: pwsh
-    run: dotnet run/docker.dll --target=DockerManifest --arch=amd64 --docker_dotnetversion=${{ inputs.targetFramework }} --docker_distro=${{ inputs.distro }} --docker_registry github
+    run: dotnet run/docker.dll --target=DockerManifest --arch=amd64 --arch=arm64 --docker_dotnetversion=${{ inputs.targetFramework }} --docker_distro=${{ inputs.distro }} --docker_registry github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ amd64 ]
+        arch: [ amd64, amd64 ]
 
     uses: ./.github/workflows/_artifacts_linux.yml
     with:
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ amd64 ]
+        arch: [ amd64, amd64 ]
 
     uses: ./.github/workflows/_docker.yml
     with:

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -92,33 +92,31 @@ public class GitVersionExecutorTests : TestBase
     public void CacheFileExistsOnDisk()
     {
         const string versionCacheFileContent = """
-        {
-          "Major": 4,
-          "Minor": 10,
-          "Patch": 3,
-          "PreReleaseTag": "test.19",
-          "PreReleaseTagWithDash": "-test.19",
-          "PreReleaseLabel": "test",
-          "PreReleaseLabelWithDash": "-test",
-          "PreReleaseNumber": 19,
-          "WeightedPreReleaseNumber": 19,
-          "BuildMetaData": null,
-          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "MajorMinorPatch": "4.10.3",
-          "SemVer": "4.10.3-test.19",
-          "AssemblySemVer": "4.10.3.0",
-          "AssemblySemFileVer": "4.10.3.0",
-          "FullSemVer": "4.10.3-test.19",
-          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "BranchName": "feature/test",
-          "EscapedBranchName": "feature-test",
-          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "ShortSha": "dd2a29af",
-          "VersionSourceSha": "4.10.2",
-          "CommitsSinceVersionSource": 19,
-          "CommitDate": "2015-11-10T00:00:00.000Z",
-          "UncommittedChanges": 0
-        }
+        Major: 4
+        Minor: 10
+        Patch: 3
+        PreReleaseTag: test.19
+        PreReleaseTagWithDash: -test.19
+        PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
+        PreReleaseNumber: 19
+        WeightedPreReleaseNumber: 19
+        BuildMetaData:
+        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        MajorMinorPatch: 4.10.3
+        SemVer: 4.10.3-test.19
+        AssemblySemVer: 4.10.3.0
+        AssemblySemFileVer: 4.10.3.0
+        FullSemVer: 4.10.3-test.19
+        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        BranchName: feature/test
+        EscapedBranchName: feature-test
+        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        ShortSha: dd2a29af
+        VersionSourceSha: 4.10.2
+        CommitsSinceVersionSource: 19
+        CommitDate: 2015-11-10
+        UncommittedChanges: 0
         """;
 
         var stringBuilder = new StringBuilder();
@@ -154,31 +152,29 @@ public class GitVersionExecutorTests : TestBase
     public void CacheFileExistsOnDiskWhenOverrideConfigIsSpecifiedVersionShouldBeDynamicallyCalculatedWithoutSavingInCache()
     {
         const string versionCacheFileContent = """
-        {
-          "Major": 4,
-          "Minor": 10,
-          "Patch": 3,
-          "PreReleaseTag": "test.19",
-          "PreReleaseTagWithDash": "-test.19",
-          "PreReleaseLabel": "test",
-          "PreReleaseLabelWithDash": "-test",
-          "PreReleaseNumber": 19,
-          "BuildMetaData": null,
-          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "MajorMinorPatch": "4.10.3",
-          "SemVer": "4.10.3-test.19",
-          "AssemblySemVer": "4.10.3.0",
-          "AssemblySemFileVer": "4.10.3.0",
-          "FullSemVer": "4.10.3-test.19",
-          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "BranchName": "feature/test",
-          "EscapedBranchName": "feature-test",
-          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "ShortSha": "dd2a29af",
-          "CommitsSinceVersionSource": 19,
-          "CommitDate": "2015-11-10T00:00:00.000Z",
-          "UncommittedChanges": 0
-        }
+        Major: 4
+        Minor: 10
+        Patch: 3
+        PreReleaseTag: test.19
+        PreReleaseTagWithDash: -test.19
+        PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
+        PreReleaseNumber: 19
+        BuildMetaData:
+        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        MajorMinorPatch: 4.10.3
+        SemVer: 4.10.3-test.19
+        AssemblySemVer: 4.10.3.0
+        AssemblySemFileVer: 4.10.3.0
+        FullSemVer: 4.10.3-test.19
+        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        BranchName: feature/test
+        EscapedBranchName: feature-test
+        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        ShortSha: dd2a29af
+        CommitsSinceVersionSource: 19
+        CommitDate: 2015-11-10
+        UncommittedChanges: 0
         """;
 
         using var fixture = new EmptyRepositoryFixture();
@@ -232,7 +228,7 @@ public class GitVersionExecutorTests : TestBase
         gitVersionCalculator.CalculateVersionVariables();
 
         var logsMessages = stringBuilder.ToString();
-        logsMessages.ShouldContain(".json not found", Case.Insensitive, logsMessages);
+        logsMessages.ShouldContain(".yml not found", Case.Insensitive, logsMessages);
     }
 
     [TestCase(ConfigurationFileLocator.DefaultFileName)]
@@ -240,33 +236,31 @@ public class GitVersionExecutorTests : TestBase
     public void ConfigChangeInvalidatesCache(string configFileName)
     {
         const string versionCacheFileContent = """
-        {
-          "Major": 4,
-          "Minor": 10,
-          "Patch": 3,
-          "PreReleaseTag": "test.19",
-          "PreReleaseTagWithDash": "-test.19",
-          "PreReleaseLabel": "test",
-          "PreReleaseLabelWithDash": "-test",
-          "PreReleaseNumber": 19,
-          "WeightedPreReleaseNumber": 19,
-          "BuildMetaData": null,
-          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "MajorMinorPatch": "4.10.3",
-          "SemVer": "4.10.3-test.19",
-          "AssemblySemVer": "4.10.3.0",
-          "AssemblySemFileVer": "4.10.3.0",
-          "FullSemVer": "4.10.3-test.19",
-          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "BranchName": "feature/test",
-          "EscapedBranchName": "feature-test",
-          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "ShortSha": "dd2a29af",
-          "VersionSourceSha": "4.10.2",
-          "CommitsSinceVersionSource": 19,
-          "CommitDate": "2015-11-10T00:00:00.000Z",
-          "UncommittedChanges": 0
-        }
+        Major: 4
+        Minor: 10
+        Patch: 3
+        PreReleaseTag: test.19
+        PreReleaseTagWithDash: -test.19
+        PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
+        PreReleaseNumber: 19
+        WeightedPreReleaseNumber: 19
+        BuildMetaData:
+        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        MajorMinorPatch: 4.10.3
+        SemVer: 4.10.3-test.19
+        AssemblySemVer: 4.10.3.0
+        AssemblySemFileVer: 4.10.3.0
+        FullSemVer: 4.10.3-test.19
+        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        BranchName: feature/test
+        EscapedBranchName: feature-test
+        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        ShortSha: dd2a29af
+        VersionSourceSha: 4.10.2
+        CommitsSinceVersionSource: 19
+        CommitDate: 2015-11-10
+        UncommittedChanges: 0
         """;
 
         using var fixture = new EmptyRepositoryFixture();
@@ -302,33 +296,31 @@ public class GitVersionExecutorTests : TestBase
     public void NoCacheBypassesCache()
     {
         const string versionCacheFileContent = """
-        {
-          "Major": 4,
-          "Minor": 10,
-          "Patch": 3,
-          "PreReleaseTag": "test.19",
-          "PreReleaseTagWithDash": "-test.19",
-          "PreReleaseLabel": "test",
-          "PreReleaseLabelWithDash": "-test",
-          "PreReleaseNumber": 19,
-          "WeightedPreReleaseNumber": 19,
-          "BuildMetaData": null,
-          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "MajorMinorPatch": "4.10.3",
-          "SemVer": "4.10.3-test.19",
-          "AssemblySemVer": "4.10.3.0",
-          "AssemblySemFileVer": "4.10.3.0",
-          "FullSemVer": "4.10.3-test.19",
-          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "BranchName": "feature/test",
-          "EscapedBranchName": "feature-test",
-          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
-          "ShortSha": "dd2a29af",
-          "VersionSourceSha": "4.10.2",
-          "CommitsSinceVersionSource": 19,
-          "CommitDate": "2015-11-10T00:00:00.000Z",
-          "UncommittedChanges": 0
-        }
+        Major: 4
+        Minor: 10
+        Patch: 3
+        PreReleaseTag: test.19
+        PreReleaseTagWithDash: -test.19
+        PreReleaseLabel: test
+        PreReleaseLabelWithDash: -test
+        PreReleaseNumber: 19
+        WeightedPreReleaseNumber: 19
+        BuildMetaData:
+        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        MajorMinorPatch: 4.10.3
+        SemVer: 4.10.3-test.19
+        AssemblySemVer: 4.10.3.0
+        AssemblySemFileVer: 4.10.3.0
+        FullSemVer: 4.10.3-test.19
+        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        BranchName: feature/test
+        EscapedBranchName: feature-test
+        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
+        ShortSha: dd2a29af
+        VersionSourceSha: 4.10.2
+        CommitsSinceVersionSource: 19
+        CommitDate: 2015-11-10
+        UncommittedChanges: 0
         """;
 
         using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCache.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCache.cs
@@ -91,5 +91,5 @@ public class GitVersionCache : IGitVersionCache
         return cacheDir;
     }
 
-    private static string GetCacheFileName(GitVersionCacheKey key, string cacheDir) => PathHelper.Combine(cacheDir, string.Concat(key.Value, ".json"));
+    private static string GetCacheFileName(GitVersionCacheKey key, string cacheDir) => PathHelper.Combine(cacheDir, string.Concat(key.Value, ".yml"));
 }

--- a/src/GitVersion.Output/GitVersion.Output.csproj
+++ b/src/GitVersion.Output/GitVersion.Output.csproj
@@ -8,7 +8,11 @@
         <EmbeddedResource Include="*\AddFormats\**\*.*" />
         <EmbeddedResource Include="*\Templates\**\*.*" />
     </ItemGroup>
-
+    
+    <ItemGroup>
+        <PackageReference Include="YamlDotNet" />
+    </ItemGroup>
+    
     <ItemGroup>
         <InternalsVisibleTo Include="GitVersion.App.Tests" />
         <InternalsVisibleTo Include="GitVersion.Output.Tests" />

--- a/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
@@ -87,14 +87,19 @@ public class VersionVariableSerializer : IVersionVariableSerializer
 
     private GitVersionVariables FromFileInternal(string filePath)
     {
-        var json = fileSystem.ReadAllText(filePath);
-        return FromJson(json);
+        using var stream = fileSystem.OpenRead(filePath);
+        using var reader = new StreamReader(stream);
+        var dictionary = new YamlDotNet.Serialization.Deserializer().Deserialize<Dictionary<string, string>>(reader);
+        return FromDictionary(dictionary);
     }
 
     private void ToFileInternal(GitVersionVariables gitVersionVariables, string filePath)
     {
-        var json = ToJson(gitVersionVariables);
-        fileSystem.WriteAllText(filePath, json);
+        var dictionary = gitVersionVariables.ToDictionary(x => x.Key, x => x.Value);
+        using var stream = fileSystem.OpenWrite(filePath);
+        using var sw = new StreamWriter(stream);
+        var serializer = new YamlDotNet.Serialization.Serializer();
+        serializer.Serialize(sw, dictionary);
     }
 
     private static JsonSerializerOptions JsonSerializerOptions() => new() { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Converters = { new VersionVariablesJsonStringConverter() } };


### PR DESCRIPTION
The cache format for version variables has been changed from JSON to YAML in `GitVersionCache` and `VersionVariableSerializer` classes, to provide more readable and easily editable files. Code changes also include updates in the test files reflect.

This is intended to fix the arm64 support that was broken. For some reason the serialization as json for the cache isn't working. We need more investigation, so reverting back to yaml, but taking in consideration the recent changes. The YamlDotnet will be a dependency on GitVersion.Output and not GitVersion.Core