### PR TITLE
Switch to JSON for cache serialization and deserialization

### DIFF
--- a/.github/workflows/_artifacts_linux.yml
+++ b/.github/workflows/_artifacts_linux.yml
@@ -47,10 +47,6 @@ jobs:
       with:
         name: native-${{ runner.os }}
         path: ${{ github.workspace }}/artifacts/packages/native
-#    -
-#      name: Setup QEMU
-#      if: inputs.arch == 'arm64'
-#      uses: docker/setup-qemu-action@v3
     -
       name: Echo
       shell: pwsh

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -37,10 +37,6 @@ jobs:
       with:
         name: nuget
         path: ${{ github.workspace }}/artifacts/packages/nuget
-#    -
-#      name: Setup QEMU
-#      if: inputs.arch == 'arm64'
-#      uses: docker/setup-qemu-action@v3
     -
       name: Docker Test
       if: success() && github.event_name == 'pull_request' || github.repository_owner != 'GitTools'

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -114,7 +114,7 @@ public static class DockerContextExtensions
         var tags = context.GetDockerTags(dockerImage, dockerImage.Architecture);
         foreach (var tag in tags)
         {
-            context.DockerTestRun(tag, dockerImage.Architecture, "/repo", "/showvariable", "FullSemver");
+            context.DockerTestRun(tag, dockerImage.Architecture, "/repo", "/showvariable", "FullSemver", "/nocache");
         }
     }
 

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -92,31 +92,33 @@ public class GitVersionExecutorTests : TestBase
     public void CacheFileExistsOnDisk()
     {
         const string versionCacheFileContent = """
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
         """;
 
         var stringBuilder = new StringBuilder();
@@ -152,29 +154,31 @@ public class GitVersionExecutorTests : TestBase
     public void CacheFileExistsOnDiskWhenOverrideConfigIsSpecifiedVersionShouldBeDynamicallyCalculatedWithoutSavingInCache()
     {
         const string versionCacheFileContent = """
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
         """;
 
         using var fixture = new EmptyRepositoryFixture();
@@ -236,31 +240,33 @@ public class GitVersionExecutorTests : TestBase
     public void ConfigChangeInvalidatesCache(string configFileName)
     {
         const string versionCacheFileContent = """
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
         """;
 
         using var fixture = new EmptyRepositoryFixture();
@@ -296,31 +302,33 @@ public class GitVersionExecutorTests : TestBase
     public void NoCacheBypassesCache()
     {
         const string versionCacheFileContent = """
-        Major: 4
-        Minor: 10
-        Patch: 3
-        PreReleaseTag: test.19
-        PreReleaseTagWithDash: -test.19
-        PreReleaseLabel: test
-        PreReleaseLabelWithDash: -test
-        PreReleaseNumber: 19
-        WeightedPreReleaseNumber: 19
-        BuildMetaData:
-        FullBuildMetaData: Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        MajorMinorPatch: 4.10.3
-        SemVer: 4.10.3-test.19
-        AssemblySemVer: 4.10.3.0
-        AssemblySemFileVer: 4.10.3.0
-        FullSemVer: 4.10.3-test.19
-        InformationalVersion: 4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        BranchName: feature/test
-        EscapedBranchName: feature-test
-        Sha: dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f
-        ShortSha: dd2a29af
-        VersionSourceSha: 4.10.2
-        CommitsSinceVersionSource: 19
-        CommitDate: 2015-11-10
-        UncommittedChanges: 0
+        {
+          "Major": 4,
+          "Minor": 10,
+          "Patch": 3,
+          "PreReleaseTag": "test.19",
+          "PreReleaseTagWithDash": "-test.19",
+          "PreReleaseLabel": "test",
+          "PreReleaseLabelWithDash": "-test",
+          "PreReleaseNumber": 19,
+          "WeightedPreReleaseNumber": 19,
+          "BuildMetaData": null,
+          "FullBuildMetaData": "Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "MajorMinorPatch": "4.10.3",
+          "SemVer": "4.10.3-test.19",
+          "AssemblySemVer": "4.10.3.0",
+          "AssemblySemFileVer": "4.10.3.0",
+          "FullSemVer": "4.10.3-test.19",
+          "InformationalVersion": "4.10.3-test.19+Branch.feature/test.Sha.dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "BranchName": "feature/test",
+          "EscapedBranchName": "feature-test",
+          "Sha": "dd2a29aff0c948e1bdf3dabbe13e1576e70d5f9f",
+          "ShortSha": "dd2a29af",
+          "VersionSourceSha": "4.10.2",
+          "CommitsSinceVersionSource": 19,
+          "CommitDate": "2015-11-10T00:00:00.000Z",
+          "UncommittedChanges": 0
+        }
         """;
 
         using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersion.Output/GitVersion.Output.csproj
+++ b/src/GitVersion.Output/GitVersion.Output.csproj
@@ -8,11 +8,7 @@
         <EmbeddedResource Include="*\AddFormats\**\*.*" />
         <EmbeddedResource Include="*\Templates\**\*.*" />
     </ItemGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="YamlDotNet" />
-    </ItemGroup>
-    
+
     <ItemGroup>
         <InternalsVisibleTo Include="GitVersion.App.Tests" />
         <InternalsVisibleTo Include="GitVersion.Output.Tests" />

--- a/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
@@ -87,19 +87,14 @@ public class VersionVariableSerializer : IVersionVariableSerializer
 
     private GitVersionVariables FromFileInternal(string filePath)
     {
-        using var stream = fileSystem.OpenRead(filePath);
-        using var reader = new StreamReader(stream);
-        var dictionary = new YamlDotNet.Serialization.Deserializer().Deserialize<Dictionary<string, string>>(reader);
-        return FromDictionary(dictionary);
+        var json = fileSystem.ReadAllText(filePath);
+        return FromJson(json);
     }
 
     private void ToFileInternal(GitVersionVariables gitVersionVariables, string filePath)
     {
-        var dictionary = gitVersionVariables.ToDictionary(x => x.Key, x => x.Value);
-        using var stream = fileSystem.OpenWrite(filePath);
-        using var sw = new StreamWriter(stream);
-        var serializer = new YamlDotNet.Serialization.Serializer();
-        serializer.Serialize(sw, dictionary);
+        var json = ToJson(gitVersionVariables);
+        fileSystem.WriteAllText(filePath, json);
     }
 
     private static JsonSerializerOptions JsonSerializerOptions() => new() { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Converters = { new VersionVariablesJsonStringConverter() } };

--- a/tests/scripts/test-global-tool.sh
+++ b/tests/scripts/test-global-tool.sh
@@ -21,7 +21,7 @@ result=$(dotnet tool install GitVersion.Tool --version $version --tool-path /too
 status=$?
 if test $status -eq 0
 then
-    /tools/dotnet-gitversion $repoPath /showvariable FullSemver
+    /tools/dotnet-gitversion $repoPath /showvariable FullSemver /nocache
 else
     echo $result
 fi

--- a/tests/scripts/test-native-tool.sh
+++ b/tests/scripts/test-native-tool.sh
@@ -21,7 +21,7 @@ result=$(tar -xvpf /native/gitversion-$runtime-$version.tar.gz -C /native) # >/d
 status=$?
 if test $status -eq 0
 then
-    /native/gitversion $repoPath /showvariable FullSemver;
+    /native/gitversion $repoPath /showvariable FullSemver /nocache
 else
     echo $result
 fi


### PR DESCRIPTION
Replace YAML-based deserialization with JSON in VersionVariableSerializer. Redundant qemu setup in GitHub workflows has been removed. Further, GitVersion called with "/nocache" flag in DockerContextExtensions and various test scripts to bypass caching mechanism.

Rework of #3805 