### PR TITLE
Disable GitVersion task when running with MsBuild on .NET Framework (including Visual Studio)

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -24,6 +24,12 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <!-- The GitVersion task is explicitly disabled when running on the .NET Framework because it's no longer supported. 
+        If a project that uses GitVersion.MsBuild is opened in Visual Studio, 
+        the task will be turned off because Visual Studio operates on the .NET Framework's version of MSBuild. 
+        However, you can still execute GitVersion.MsBuild as part of the `dotnet build` or `dotnet msbuild` commands. -->
+        <DisableGitVersionTask Condition=" '$(MSBuildRuntimeType)' != 'Core' ">true</DisableGitVersionTask>
+        
         <DisableGitVersionTask Condition=" '$(DisableGitVersionTask)' == '' ">false</DisableGitVersionTask>
 
         <!-- Property that enables WriteVersionInfoToBuildLog -->


### PR DESCRIPTION
Close  #3787 