### PR TITLE
Better Bitbucket support for gitversion /output buildserver for Powershell

### DIFF
--- a/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
@@ -9,37 +9,58 @@ internal class BitBucketPipelines : BuildAgentBase
     public const string BranchEnvironmentVariableName = "BITBUCKET_BRANCH";
     public const string TagEnvironmentVariableName = "BITBUCKET_TAG";
     public const string PullRequestEnvironmentVariableName = "BITBUCKET_PR_ID";
-    private string? file;
+    private string? propertyFile;
+    private string? ps1File;
 
-    public BitBucketPipelines(IEnvironment environment, ILog log) : base(environment, log) => WithPropertyFile("gitversion.properties");
+    public BitBucketPipelines(IEnvironment environment, ILog log) : base(environment, log)
+    {
+        WithPropertyFile("gitversion.properties");
+        WithPowershellFile("gitversion.ps1");
+    }
 
     protected override string EnvironmentVariable => EnvironmentVariableName;
 
     public override string GenerateSetVersionMessage(GitVersionVariables variables) => variables.FullSemVer;
 
-    public void WithPropertyFile(string propertiesFileName) => this.file = propertiesFileName;
+    public void WithPropertyFile(string propertiesFileName) => this.propertyFile = propertiesFileName;
+
+    public void WithPowershellFile(string powershellFileName) => this.ps1File = powershellFileName;
 
     public override string[] GenerateSetParameterMessage(string name, string? value) => new[] { $"GITVERSION_{name.ToUpperInvariant()}={value}" };
 
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
     {
-        if (this.file is null)
+        if (this.propertyFile is null || this.ps1File is null)
             return;
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
-        writer($"Outputting variables to '{this.file}' ... ");
+        writer($"Outputting variables to '{this.propertyFile}' for Bash,");
+        writer($"and to '{this.ps1File}' for Powershell ... ");
         writer("To import the file into your build environment, add the following line to your build step:");
-        writer($"  - source {this.file}");
+        writer($"Bash:");
+        writer($"  - source {this.propertyFile}");
+        writer($"Powershell:");
+        writer($"  - . .\\{this.ps1File}");
         writer("");
         writer("To reuse the file across build steps, add the file as a build artifact:");
+        writer($"Bash:");
         writer("  artifacts:");
-        writer($"    - {this.file}");
+        writer($"    - {this.propertyFile}");
+        writer($"Powershell:");
+        writer("  artifacts:");
+        writer($"    - {this.ps1File}");
 
         var exports = variables
             .Select(variable => $"export GITVERSION_{variable.Key.ToUpperInvariant()}={variable.Value}")
             .ToList();
 
-        File.WriteAllLines(this.file, exports);
+        File.WriteAllLines(this.propertyFile, exports);
+
+        var psExports = variables
+            .Select(variable => $"$GITVERSION_{variable.Key.ToUpperInvariant()} = \"{variable.Value}\"")
+            .ToList();
+
+        File.WriteAllLines(this.ps1File, psExports);
     }
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)


### PR DESCRIPTION
## Description
When running gitversion in Bitbucket Pipeline in Windows Powershell environment, `gitversion.ps1` file is also written, in addition to the original `gitversion.properties` for Bash (not changed).

## Related Issue
https://github.com/GitTools/GitVersion/issues/3831

## Motivation and Context
Getting the gitversion output variables into Powershell session requires now only one command:
`. .\gitversion.ps1`

Old way was to parse `gitversion.properties` file:
```
Get-Content .\gitversion.properties | % {$_ -replace "export ",""} | Out-File new.properties
$GitVerProps = ConvertFrom-StringData (Get-Content .\new.properties -raw)
```

## How Has This Been Tested?
Included checks to existing tests. 
I have tested this manually in our Bitbucket Pipelines and I haven't found any issues.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
