### PR TITLE
Replace the version mode Mainline in 6.x (Part I.B)

### DIFF
--- a/src/GitVersion.Core/Core/ITaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/ITaggedSemanticVersionRepository.cs
@@ -4,9 +4,7 @@ namespace GitVersion.Core;
 
 internal interface ITaggedSemanticVersionRepository
 {
-    ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(IBranch branch, EffectiveConfiguration configuration);
-
-    ILookup<ICommit, SemanticVersionWithTag> GetAllTaggedSemanticVersions(string? tagPrefix, SemanticVersionFormat format);
+    ILookup<ICommit, SemanticVersionWithTag> GetAllTaggedSemanticVersions(IBranch branch, EffectiveConfiguration configuration);
 
     ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfBranch(
         IBranch branch,

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
@@ -24,7 +24,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
         this.branchRepository = branchRepository.NotNull();
     }
 
-    public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(IBranch branch, EffectiveConfiguration configuration)
+    public ILookup<ICommit, SemanticVersionWithTag> GetAllTaggedSemanticVersions(IBranch branch, EffectiveConfiguration configuration)
     {
         configuration.NotNull();
 
@@ -102,42 +102,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
             }
         }
 
-        return GetElements().ToLookup(element => element.Key, element => element.Value);
-    }
-
-    private readonly ConcurrentDictionary<(string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
-        allTaggedSemanticVersionsCache = new();
-
-    public ILookup<ICommit, SemanticVersionWithTag> GetAllTaggedSemanticVersions(string? tagPrefix, SemanticVersionFormat format)
-    {
-        tagPrefix ??= string.Empty;
-
-        IEnumerable<SemanticVersionWithTag> GetElements()
-        {
-            this.log.Info($"Getting tagged semantic versions. TagPrefix: {tagPrefix} and Format: {format}");
-
-            foreach (var tag in this.gitRepository.Tags)
-            {
-                if (SemanticVersion.TryParse(tag.Name.Friendly, tagPrefix, out var semanticVersion, format))
-                {
-                    yield return new SemanticVersionWithTag(semanticVersion, tag);
-                }
-            }
-        }
-
-        bool isCached = true;
-        var result = allTaggedSemanticVersionsCache.GetOrAdd(new(tagPrefix, format), _ =>
-        {
-            isCached = false;
-            return GetElements().ToLookup(element => element.Tag.Commit, element => element);
-        });
-
-        if (isCached)
-        {
-            this.log.Debug($"Returning cached tagged semantic versions. TagPrefix: {tagPrefix} and Format: {format}");
-        }
-
-        return result;
+        return GetElements().Distinct().ToLookup(element => element.Key, element => element.Value);
     }
 
     private readonly ConcurrentDictionary<(IBranch, string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
@@ -154,8 +119,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
             using (this.log.IndentLog($"Getting tagged semantic versions on branch '{branch.Name.Canonical}'. " +
                 $"TagPrefix: {tagPrefix} and Format: {format}"))
             {
-                var semanticVersions = GetAllTaggedSemanticVersions(tagPrefix, format);
-
+                var semanticVersions = GetTaggedSemanticVersions(tagPrefix, format);
                 foreach (var commit in branch.Commits)
                 {
                     foreach (var semanticVersion in semanticVersions[commit])
@@ -170,8 +134,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
         var result = taggedSemanticVersionsOfBranchCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
         {
             isCached = false;
-            var semanticVersions = GetElements();
-            return semanticVersions.ToLookup(element => element.Tag.Commit, element => element);
+            return GetElements().Distinct().ToLookup(element => element.Tag.Commit, element => element);
         });
 
         if (isCached)
@@ -201,7 +164,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
             {
                 var shaHashSet = new HashSet<string>(branch.Commits.Select(element => element.Id.Sha));
 
-                foreach (var semanticVersion in GetAllTaggedSemanticVersions(tagPrefix, format).SelectMany(_ => _))
+                foreach (var semanticVersion in GetTaggedSemanticVersions(tagPrefix, format).SelectMany(_ => _))
                 {
                     foreach (var commit in semanticVersion.Tag.Commit.Parents.Where(element => shaHashSet.Contains(element.Id.Sha)))
                     {
@@ -215,7 +178,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
         var result = taggedSemanticVersionsOfMergeTargetCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
         {
             isCached = false;
-            return GetElements().ToLookup(element => element.Item1, element => element.Item2);
+            return GetElements().Distinct().ToLookup(element => element.Item1, element => element.Item2);
         });
 
         if (isCached)
@@ -250,7 +213,7 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
             }
         }
 
-        return GetElements().ToLookup(element => element.Tag.Commit, element => element);
+        return GetElements().Distinct().ToLookup(element => element.Tag.Commit, element => element);
     }
 
     public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfReleaseBranches(
@@ -274,6 +237,41 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
             }
         }
 
-        return GetElements().ToLookup(element => element.Tag.Commit, element => element);
+        return GetElements().Distinct().ToLookup(element => element.Tag.Commit, element => element);
+    }
+
+    private readonly ConcurrentDictionary<(string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
+        taggedSemanticVersionsCache = new();
+
+    private ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(string? tagPrefix, SemanticVersionFormat format)
+    {
+        tagPrefix ??= string.Empty;
+
+        IEnumerable<SemanticVersionWithTag> GetElements()
+        {
+            this.log.Info($"Getting tagged semantic versions. TagPrefix: {tagPrefix} and Format: {format}");
+
+            foreach (var tag in this.gitRepository.Tags)
+            {
+                if (SemanticVersion.TryParse(tag.Name.Friendly, tagPrefix, out var semanticVersion, format))
+                {
+                    yield return new SemanticVersionWithTag(semanticVersion, tag);
+                }
+            }
+        }
+
+        bool isCached = true;
+        var result = taggedSemanticVersionsCache.GetOrAdd(new(tagPrefix, format), _ =>
+        {
+            isCached = false;
+            return GetElements().ToLookup(element => element.Tag.Commit, element => element);
+        });
+
+        if (isCached)
+        {
+            this.log.Debug($"Returning cached tagged semantic versions. TagPrefix: {tagPrefix} and Format: {format}");
+        }
+
+        return result;
     }
 }

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
@@ -7,6 +7,12 @@ namespace GitVersion.Core;
 
 internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRepository
 {
+    private readonly ConcurrentDictionary<(IBranch, string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
+        taggedSemanticVersionsOfBranchCache = new();
+    private readonly ConcurrentDictionary<(IBranch, string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
+        taggedSemanticVersionsOfMergeTargetCache = new();
+    private readonly ConcurrentDictionary<(string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
+        taggedSemanticVersionsCache = new();
     private readonly ILog log;
 
     private GitVersionContext VersionContext => this.versionContextLazy.Value;
@@ -105,9 +111,6 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
         return GetElements().Distinct().ToLookup(element => element.Key, element => element.Value);
     }
 
-    private readonly ConcurrentDictionary<(IBranch, string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
-        taggedSemanticVersionsOfBranchCache = new();
-
     public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfBranch(
         IBranch branch, string? tagPrefix, SemanticVersionFormat format)
     {
@@ -147,9 +150,6 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
 
         return result;
     }
-
-    private readonly ConcurrentDictionary<(IBranch, string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
-        taggedSemanticVersionsOfMergeTargetCache = new();
 
     public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfMergeTarget(
         IBranch branch, string? tagPrefix, SemanticVersionFormat format)
@@ -239,9 +239,6 @@ internal sealed class TaggedSemanticVersionRepository : ITaggedSemanticVersionRe
 
         return GetElements().Distinct().ToLookup(element => element.Tag.Commit, element => element);
     }
-
-    private readonly ConcurrentDictionary<(string, SemanticVersionFormat), ILookup<ICommit, SemanticVersionWithTag>>
-        taggedSemanticVersionsCache = new();
 
     private ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(string? tagPrefix, SemanticVersionFormat format)
     {

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/EnrichIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/EnrichIncrement.cs
@@ -1,0 +1,22 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal sealed class EnrichIncrement : ITrunkBasedContextPreEnricher
+{
+    public void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        var incrementForcedByBranch = commit.GetIncrementForcedByBranch();
+        var incrementForcedByCommit = commit.Increment;
+        context.Increment = context.Increment.Consolidate(incrementForcedByBranch, incrementForcedByCommit);
+
+        if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+            context.Label = null;
+        context.Label ??= commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+
+        if (commit.Configuration.IsMainline)
+            context.BaseVersionSource = commit.Predecessor?.Value;
+        context.ForceIncrement |= commit.Configuration.IsMainline || commit.IsPredecessorTheLastCommitOnTrunk;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/EnrichSemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/EnrichSemanticVersion.cs
@@ -1,0 +1,20 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal sealed class EnrichSemanticVersion : ITrunkBasedContextPreEnricher
+{
+    public void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        var branchSpecificLabel = context.TargetLabel;
+        branchSpecificLabel ??= iteration.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+        branchSpecificLabel ??= commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+
+        var semanticVersions = commit.SemanticVersions.Where(
+            element => element.IsMatchForBranchSpecificLabel(branchSpecificLabel)
+        ).ToList();
+        context.AlternativeSemanticVersions.AddRange(commit.SemanticVersions.Except(semanticVersions));
+        context.SemanticVersion = semanticVersions.Max();
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedContextPostEnricher.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedContextPostEnricher.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal interface ITrunkBasedContextPostEnricher
+{
+    void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context);
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedContextPreEnricher.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedContextPreEnricher.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal interface ITrunkBasedContextPreEnricher
+{
+    void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context);
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedIncrementer.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/ITrunkBasedIncrementer.cs
@@ -1,0 +1,8 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal interface ITrunkBasedIncrementer
+{
+    bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context);
+
+    IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context);
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunk.cs
@@ -1,0 +1,36 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class CommitOnNonTrunk : ITrunkBasedIncrementer
+{
+    // B  57 minutes ago  (HEAD -> feature/foo)
+    // A  58 minutes ago <<--
+
+    // B  57 minutes ago  (HEAD -> feature/foo) <<--
+    // A  58 minutes ago
+
+    public bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.ChildIteration is null && !commit.Configuration.IsMainline && context.SemanticVersion is null;
+
+    public IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+            context.Label = null;
+        context.Label ??= commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+
+        if (commit.Successor is null)
+        {
+            yield return BaseVersionV2.ShouldIncrementTrue(
+                source: GetType().Name,
+                baseVersionSource: context.BaseVersionSource,
+                increment: context.Increment,
+                label: context.Label,
+                forceIncrement: context.ForceIncrement,
+                alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+            );
+
+            context.BaseVersionSource = commit.Value;
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedBase.cs
@@ -1,0 +1,29 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal abstract class CommitOnNonTrunkBranchedBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => !commit.Configuration.IsMainline && commit.BranchName != iteration.BranchName && commit.Successor is null;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        var incrementForcedByBranch = iteration.Configuration.Increment == IncrementStrategy.Inherit
+            ? commit.GetIncrementForcedByBranch() : iteration.Configuration.Increment.ToVersionField();
+        context.Increment = context.Increment.Consolidate(incrementForcedByBranch);
+
+        context.Label = iteration.Configuration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
+        context.ForceIncrement = true;
+
+        yield return BaseVersionV2.ShouldIncrementFalse(
+            source: GetType().Name,
+            baseVersionSource: null,
+            label: context.Label,
+            alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+        );
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedToNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedToNonTrunk.cs
@@ -1,0 +1,18 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class CommitOnNonTrunkBranchedToNonTrunk : CommitOnNonTrunkBranchedBase
+{
+    // B  51 minutes ago  (HEAD -> feature/foo, main) <<--
+    // A  59 minutes ago
+
+    // B  58 minutes ago  (main)
+    // A  59 minutes ago  (HEAD -> feature/foo) <<--
+
+    // *  54 minutes ago  (main)
+    // | B  56 minutes ago  (HEAD -> feature/foo)
+    // |/
+    // A  58 minutes ago <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && !iteration.Configuration.IsMainline;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedToTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkBranchedToTrunk.cs
@@ -1,0 +1,18 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class CommitOnNonTrunkBranchedToTrunk : CommitOnNonTrunkBranchedBase
+{
+    // B  51 minutes ago  (HEAD -> release/1.0.x, main) <<--
+    // A  59 minutes ago
+
+    // B  58 minutes ago  (main)
+    // A  59 minutes ago  (HEAD -> release/1.0.x) <<--
+
+    // *  54 minutes ago  (main)
+    // | B  56 minutes ago  (HEAD -> release/1.0.x)
+    // |/
+    // A  58 minutes ago <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && iteration.Configuration.IsMainline;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithPreReleaseTag.cs
@@ -1,0 +1,10 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class CommitOnNonTrunkWithPreReleaseTag : CommitOnNonTrunkWithPreReleaseTagBase
+{
+    // B 57 minutes ago  (HEAD -> feature/foo)
+    // A 58 minutes ago  (tag 1.2.3-1) <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
@@ -1,0 +1,25 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal abstract class CommitOnNonTrunkWithPreReleaseTagBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.ChildIteration is null && !commit.Configuration.IsMainline
+            && context.SemanticVersion is not null && context.SemanticVersion.IsPreRelease;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        yield return BaseVersionV2.ShouldIncrementFalse(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            semanticVersion: context.SemanticVersion.NotNull()
+        );
+
+        context.Increment = commit.GetIncrementForcedByBranch();
+        context.Label = commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithStableTag.cs
@@ -1,0 +1,10 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class CommitOnNonTrunkWithStableTag : CommitOnNonTrunkWithStableTagBase
+{
+    // B 57 minutes ago  (HEAD -> feature/foo)
+    // A 58 minutes ago  (tag 1.2.3) <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
@@ -1,0 +1,25 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal abstract class CommitOnNonTrunkWithStableTagBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => !commit.Configuration.IsMainline && commit.ChildIteration is null
+            && context.SemanticVersion is not null && !context.SemanticVersion.IsPreRelease;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        yield return BaseVersionV2.ShouldIncrementFalse(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            semanticVersion: context.SemanticVersion.NotNull()
+        );
+
+        context.Increment = commit.GetIncrementForcedByBranch();
+        context.Label = commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastCommitOnNonTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastCommitOnNonTrunkWithPreReleaseTag.cs
@@ -1,0 +1,26 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class LastCommitOnNonTrunkWithPreReleaseTag : CommitOnNonTrunkWithPreReleaseTagBase
+{
+    // B 57 minutes ago  (HEAD -> feature/foo) (tag 1.2.3-1) <<--
+    // A 58 minutes ago
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+
+    public override IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        foreach (var item in base.GetIncrements(iteration, commit, context))
+        {
+            yield return item;
+        }
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.Label,
+            forceIncrement: false
+        );
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastCommitOnNonTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastCommitOnNonTrunkWithStableTag.cs
@@ -1,0 +1,26 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class LastCommitOnNonTrunkWithStableTag : CommitOnNonTrunkWithStableTagBase
+{
+    // B 57 minutes ago  (HEAD -> feature/foo) (tag 1.2.3) <<--
+    // A 58 minutes ago
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+
+    public override IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        foreach (var item in base.GetIncrements(iteration, commit, context))
+        {
+            yield return item;
+        }
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.Label,
+            forceIncrement: true
+        );
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastMergeCommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/LastMergeCommitOnNonTrunk.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class LastMergeCommitOnNonTrunk : MergeCommitOnNonTrunkBase
+{
+    // *  55 minutes ago  (HEAD -> develop) <<--
+    // |\
+    // | B  56 minutes ago  (feature/foo)
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+
+    public override IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        foreach (var item in base.GetIncrements(iteration, commit, context))
+        {
+            yield return item;
+        }
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.TargetLabel ?? context.Label,
+            forceIncrement: context.ForceIncrement,
+            alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+        );
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunk.cs
@@ -1,0 +1,12 @@
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal sealed class MergeCommitOnNonTrunk : MergeCommitOnNonTrunkBase
+{
+    // C  53 minutes ago  (HEAD -> develop)
+    // *  55 minutes ago <<--
+    // |\
+    // | B  56 minutes ago  (feature/foo)
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -1,0 +1,40 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+
+internal abstract class MergeCommitOnNonTrunkBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.ChildIteration is not null && !commit.Configuration.IsMainline && context.SemanticVersion is null;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        var baseVersion = TrunkBasedVersionStrategy.DetermineBaseVersionRecursive(
+           iteration: commit.ChildIteration!,
+           targetLabel: context.TargetLabel
+       );
+
+        context.Label ??= baseVersion.Label;
+
+        if (commit.Configuration.PreventIncrementOfMergedBranchVersion)
+            context.Increment = baseVersion.Increment;
+        else
+        {
+            context.Increment = context.Increment.Consolidate(baseVersion.Increment);
+        }
+        if (commit.Configuration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+            context.Increment = context.Increment.Consolidate(commit.Increment);
+
+        if (baseVersion.BaseVersionSource is not null)
+        {
+            context.BaseVersionSource = baseVersion.BaseVersionSource;
+            context.SemanticVersion = baseVersion.GetSemanticVersion();
+        }
+        else if (baseVersion.AlternativeSemanticVersion is not null)
+        {
+            context.AlternativeSemanticVersions.Add(baseVersion.AlternativeSemanticVersion);
+        }
+
+        yield break;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/RemoveIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/RemoveIncrement.cs
@@ -1,0 +1,14 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal sealed class RemoveIncrement : ITrunkBasedContextPostEnricher
+{
+    public void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        if (commit.Configuration.IsMainline)
+        {
+            context.Increment = VersionField.None;
+            context.Label = null;
+            context.AlternativeSemanticVersions.Clear();
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/RemoveSemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/RemoveSemanticVersion.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal sealed class RemoveSemanticVersion : ITrunkBasedContextPostEnricher
+{
+    public void Enrich(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context) => context.SemanticVersion = null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunk.cs
@@ -1,0 +1,36 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class CommitOnTrunk : ITrunkBasedIncrementer
+{
+    // B  57 minutes ago (HEAD -> main) <<--
+    // A  58 minutes ago
+
+    // B  57 minutes ago (HEAD -> main)
+    // A  58 minutes ago <<--
+
+    public bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.ChildIteration is null && commit.Configuration.IsMainline && context.SemanticVersion is null;
+
+    public IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+            context.Label = null;
+        context.Label ??= commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.ForceIncrement = true;
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.Label,
+            forceIncrement: context.ForceIncrement,
+            alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+        );
+
+        context.BaseVersionSource = commit.Value;
+        context.Increment = VersionField.None;
+        context.Label = null;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedBase.cs
@@ -1,0 +1,31 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal abstract class CommitOnTrunkBranchedBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.Configuration.IsMainline && commit.BranchName != iteration.BranchName && commit.Successor is null;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        var incrementForcedByBranch = iteration.Configuration.Increment == IncrementStrategy.Inherit
+            ? commit.GetIncrementForcedByBranch() : iteration.Configuration.Increment.ToVersionField();
+        context.Increment = context.Increment.Consolidate(incrementForcedByBranch);
+
+        context.Label = iteration.Configuration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
+        context.ForceIncrement = true;
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.Label,
+            forceIncrement: context.ForceIncrement,
+            alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+        );
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedToNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedToNonTrunk.cs
@@ -1,0 +1,18 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class CommitOnTrunkBranchedToNonTrunk : CommitOnTrunkBranchedBase
+{
+    // B  51 minutes ago  (HEAD -> feature/foo, main) <<--
+    // A  59 minutes ago
+
+    // B  58 minutes ago  (main)
+    // A  59 minutes ago  (HEAD -> feature/foo) <<--
+
+    // *  54 minutes ago  (main)
+    // | B  56 minutes ago  (HEAD -> feature/foo)
+    // |/
+    // A  58 minutes ago <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && !iteration.Configuration.IsMainline;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedToTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkBranchedToTrunk.cs
@@ -1,0 +1,18 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class CommitOnTrunkBranchedToTrunk : CommitOnTrunkBranchedBase
+{
+    // B  51 minutes ago  (HEAD -> release/1.0.x, main) <<--
+    // A  59 minutes ago
+
+    // B  58 minutes ago  (main)
+    // A  59 minutes ago  (HEAD -> release/1.0.x) <<--
+
+    // *  54 minutes ago  (main)
+    // | B  56 minutes ago  (HEAD -> release/1.0.x)
+    // |/
+    // A  58 minutes ago <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && iteration.Configuration.IsMainline;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithPreReleaseTag.cs
@@ -1,0 +1,10 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class CommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreReleaseTagBase
+{
+    // B 58 minutes ago (HEAD -> main)
+    // A 59 minutes ago (tag 0.2.0-1) <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithPreReleaseTagBase.cs
@@ -1,0 +1,23 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal abstract class CommitOnTrunkWithPreReleaseTagBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.Configuration.IsMainline && commit.ChildIteration is null
+            && context.SemanticVersion is not null && context.SemanticVersion.IsPreRelease;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        yield return BaseVersionV2.ShouldIncrementFalse(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            semanticVersion: context.SemanticVersion.NotNull()
+        );
+
+        context.Increment = VersionField.None;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithStableTag.cs
@@ -1,0 +1,10 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class CommitOnTrunkWithStableTag : CommitOnTrunkWithStableTagBase
+{
+    // B  58 minutes ago  (HEAD -> main)
+    // A  59 minutes ago  (tag 0.2.0) <<--
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/CommitOnTrunkWithStableTagBase.cs
@@ -1,0 +1,25 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal abstract class CommitOnTrunkWithStableTagBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.Configuration.IsMainline && commit.ChildIteration is null
+            && context.SemanticVersion is not null && !context.SemanticVersion.IsPreRelease;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        context.BaseVersionSource = commit.Value;
+
+        yield return BaseVersionV2.ShouldIncrementFalse(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            semanticVersion: context.SemanticVersion.NotNull()
+        );
+
+        context.Increment = VersionField.None;
+        context.Label = commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
@@ -1,0 +1,38 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class LastCommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreReleaseTagBase
+{
+    // B 58 minutes ago (HEAD -> main) (tag 0.2.0-1) <<--
+    // A 59 minutes ago
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+
+    public override IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        foreach (var item in base.GetIncrements(iteration, commit, context))
+        {
+            yield return item;
+        }
+
+        if (iteration.Configuration.IsMainline)
+        {
+            context.Increment = commit.GetIncrementForcedByBranch();
+            context.Label = commit.Configuration.GetBranchSpecificLabel(commit.BranchName, null);
+            context.ForceIncrement = false;
+
+            yield return BaseVersionV2.ShouldIncrementTrue(
+                source: GetType().Name,
+                baseVersionSource: context.BaseVersionSource,
+                increment: context.Increment,
+                label: context.Label,
+                forceIncrement: context.ForceIncrement
+            );
+
+            context.Increment = VersionField.None;
+            context.Label = null;
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastCommitOnTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastCommitOnTrunkWithStableTag.cs
@@ -1,0 +1,34 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class LastCommitOnTrunkWithStableTag : CommitOnTrunkWithStableTagBase
+{
+    // B  58 minutes ago  (HEAD -> main) (tag 0.2.0) <<--
+    // A  59 minutes ago
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+
+    public override IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        foreach (var item in base.GetIncrements(iteration, commit, context))
+        {
+            yield return item;
+        }
+
+        if (iteration.Configuration.IsMainline)
+        {
+            context.ForceIncrement = true;
+
+            yield return BaseVersionV2.ShouldIncrementTrue(
+                source: GetType().Name,
+                baseVersionSource: context.BaseVersionSource,
+                increment: context.Increment,
+                label: context.Label,
+                forceIncrement: context.ForceIncrement
+            );
+
+            context.Increment = VersionField.None;
+            context.Label = null;
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastMergeCommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/LastMergeCommitOnTrunk.cs
@@ -1,0 +1,11 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class LastMergeCommitOnTrunk : MergeCommitOnTrunkBase
+{
+    // *  55 minutes ago  (HEAD -> main) <<--
+    // |\
+    // | B  56 minutes ago  (feature/foo)
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/MergeCommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/MergeCommitOnTrunk.cs
@@ -1,0 +1,12 @@
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal sealed class MergeCommitOnTrunk : MergeCommitOnTrunkBase
+{
+    // C  53 minutes ago  (HEAD -> main)
+    // *  55 minutes ago <<--
+    // |\
+    // | B  56 minutes ago  (feature/foo)
+
+    public override bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => base.MatchPrecondition(iteration, commit, context) && commit.Successor is not null;
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/Trunk/MergeCommitOnTrunkBase.cs
@@ -1,0 +1,61 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+internal abstract class MergeCommitOnTrunkBase : ITrunkBasedIncrementer
+{
+    public virtual bool MatchPrecondition(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+        => commit.ChildIteration is not null && commit.Configuration.IsMainline && context.SemanticVersion is null;
+
+    public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
+    {
+        var baseVersion = TrunkBasedVersionStrategy.DetermineBaseVersionRecursive(
+           iteration: commit.ChildIteration!,
+           targetLabel: context.TargetLabel
+       );
+
+        context.Label ??= baseVersion.Label;
+
+        if (commit.Configuration.PreventIncrementOfMergedBranchVersion)
+            context.Increment = baseVersion.Increment;
+        else
+        {
+            context.Increment = context.Increment.Consolidate(baseVersion.Increment);
+        }
+        if (commit.Configuration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+            context.Increment = context.Increment.Consolidate(commit.Increment);
+
+        if (baseVersion.BaseVersionSource is not null)
+        {
+            context.BaseVersionSource = baseVersion.BaseVersionSource;
+            context.SemanticVersion = baseVersion.GetSemanticVersion();
+            context.ForceIncrement = baseVersion.ForceIncrement;
+        }
+        else if (baseVersion.AlternativeSemanticVersion is not null)
+        {
+            context.AlternativeSemanticVersions.Add(baseVersion.AlternativeSemanticVersion);
+        }
+
+        if (context.SemanticVersion is not null)
+        {
+            yield return BaseVersionV2.ShouldIncrementFalse(
+                source: GetType().Name,
+                baseVersionSource: context.BaseVersionSource,
+                semanticVersion: context.SemanticVersion.NotNull()
+            );
+        }
+
+        yield return BaseVersionV2.ShouldIncrementTrue(
+            source: GetType().Name,
+            baseVersionSource: context.BaseVersionSource,
+            increment: context.Increment,
+            label: context.Label,
+            forceIncrement: context.ForceIncrement,
+            alternativeSemanticVersion: context.AlternativeSemanticVersions.Max()
+        );
+
+        context.BaseVersionSource = commit.Value;
+        context.Increment = VersionField.None;
+        context.Label = null;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedCommit.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedCommit.cs
@@ -1,0 +1,103 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+[DebuggerDisplay(
+    @"\{ BranchName = {" + nameof(BranchName) + "}, Increment = {" + nameof(Increment) + "}, " +
+    "HasSuccessor = {" + nameof(HasSuccessor) + "}, HasPredecessor = {" + nameof(HasPredecessor) + "}, " +
+    "HasChildIteration = {" + nameof(HasChildIteration) + "}, Message = {" + nameof(Message) + @"} \}"
+)]
+internal record class TrunkBasedCommit
+{
+    public bool IsPredecessorTheLastCommitOnTrunk
+        => !Configuration.IsMainline && Predecessor is not null && Predecessor.Configuration.IsMainline;
+
+    public TrunkBasedIteration Iteration { get; }
+
+    public ReferenceName BranchName { get; }
+
+    public EffectiveConfiguration Configuration { get; }
+
+    public bool HasSuccessor => Successor is not null;
+
+    public TrunkBasedCommit? Successor { get; private set; }
+
+    public bool HasPredecessor => Predecessor is not null;
+
+    public TrunkBasedCommit? Predecessor { get; private set; }
+
+    public VersionField Increment { get; }
+
+    public ICommit Value { get; }
+
+    public string Message => Value.Message;
+
+    public TrunkBasedIteration? ChildIteration { get; private set; }
+
+    public bool HasChildIteration => ChildIteration is not null;
+
+    public IReadOnlyCollection<SemanticVersion> SemanticVersions => semanticVersions;
+
+    private readonly HashSet<SemanticVersion> semanticVersions = new();
+
+    public VersionField GetIncrementForcedByBranch()
+    {
+        ICommit lastCommit = null!;
+        for (var i = this; i is not null; i = i.Predecessor)
+        {
+            if (i.Configuration.Increment != IncrementStrategy.Inherit)
+                return i.Configuration.Increment.ToVersionField();
+            lastCommit = i.Value;
+        }
+
+        if (Iteration.Parent is not null && lastCommit.Parents.FirstOrDefault() is ICommit commit)
+        {
+            var trunkCommit = Iteration.Parent.FindCommit(commit);
+            if (trunkCommit is not null)
+                return trunkCommit.GetIncrementForcedByBranch();
+        }
+
+        for (var i = Iteration; i is not null; i = i.Parent)
+        {
+            if (i.Configuration.Increment != IncrementStrategy.Inherit)
+                return i.Configuration.Increment.ToVersionField();
+        }
+
+        return VersionField.None;
+    }
+
+    public TrunkBasedCommit(TrunkBasedIteration iteration, ICommit value, ReferenceName branchName, EffectiveConfiguration configuration, VersionField increment)
+    {
+        Iteration = iteration.NotNull();
+        BranchName = branchName.NotNull();
+        Configuration = configuration.NotNull();
+        Value = value.NotNull();
+        Increment = increment;
+    }
+
+    public void AddSemanticVersions(params SemanticVersion[] values)
+        => AddSemanticVersions((IEnumerable<SemanticVersion>)values);
+
+    public void AddSemanticVersions(IEnumerable<SemanticVersion> values)
+    {
+        foreach (var semanticVersion in values.NotNull())
+        {
+            semanticVersions.Add(semanticVersion);
+        }
+    }
+
+    public void AddChildIteration(TrunkBasedIteration iteration) => ChildIteration = iteration.NotNull();
+
+    public TrunkBasedCommit Append(
+        ICommit value, ReferenceName branchName, EffectiveConfiguration configuration, VersionField increment)
+    {
+        if (HasPredecessor) throw new InvalidOperationException();
+
+        TrunkBasedCommit commit = new(Iteration, value, branchName, configuration, increment);
+        Predecessor = commit;
+        commit.Successor = this;
+
+        return commit;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedContext.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedContext.cs
@@ -1,0 +1,18 @@
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+internal record class TrunkBasedContext
+{
+    public string? TargetLabel { get; init; }
+
+    public SemanticVersion? SemanticVersion { get; set; }
+
+    public string? Label { get; set; }
+
+    public VersionField Increment { get; set; }
+
+    public ICommit? BaseVersionSource { get; set; }
+
+    public HashSet<SemanticVersion> AlternativeSemanticVersions { get; } = new();
+
+    public bool ForceIncrement { get; set; }
+}

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedIteration.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/TrunkBasedIteration.cs
@@ -1,0 +1,60 @@
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion.VersionCalculation.TrunkBased;
+
+[DebuggerDisplay(
+    @"\{ Id = {" + nameof(Id) + "}, BranchName = {" + nameof(BranchName) + "}, Depth = {" + nameof(Depth) + "}, NumberOfCommits = {" + nameof(NumberOfCommits) + "}" + @"} \}"
+)]
+internal record class TrunkBasedIteration
+{
+    public EffectiveConfiguration Configuration { get; }
+
+    public TrunkBasedIteration? Parent { get; }
+
+    public string Id { get; }
+
+    public ReferenceName BranchName { get; }
+
+    public int Depth { get; }
+
+    public int NumberOfCommits => commits.Count;
+
+    public IReadOnlyCollection<TrunkBasedCommit> Commits => commits;
+    private readonly Stack<TrunkBasedCommit> commits = new();
+
+    private readonly Dictionary<ICommit, TrunkBasedCommit> commitLookup = new();
+
+    public TrunkBasedIteration(string id, ReferenceName branchName, EffectiveConfiguration configuration, TrunkBasedIteration? parent)
+    {
+        Id = id.NotNullOrEmpty();
+        Depth = parent?.Depth ?? 0 + 1;
+        BranchName = branchName.NotNull();
+        Configuration = configuration.NotNull();
+        Parent = parent;
+    }
+
+    public TrunkBasedCommit CreateCommit(
+        ICommit value, ReferenceName branchName, EffectiveConfiguration configuration, VersionField increment)
+    {
+        TrunkBasedCommit commit;
+        if (commits.Any())
+            commit = commits.Peek().Append(value, branchName, configuration, increment);
+        else
+        {
+            commit = new TrunkBasedCommit(this, value, branchName, configuration, increment);
+        }
+        commits.Push(commit);
+        commitLookup.Add(value, commit);
+
+        return commit;
+    }
+
+    public TrunkBasedCommit? FindCommit(ICommit commit)
+    {
+        commit.NotNull();
+
+        commitLookup.TryGetValue(commit, out var result);
+        return result;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -25,8 +25,11 @@ internal sealed class TaggedCommitVersionStrategy : VersionStrategyBase
         configuration.NotNull();
 
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
-        foreach (var semanticVersion in taggedSemanticVersionRepository
-            .GetTaggedSemanticVersions(Context.CurrentBranch, configuration.Value).SelectMany(element => element))
+        var taggedSemanticVersions = taggedSemanticVersionRepository
+            .GetAllTaggedSemanticVersions(Context.CurrentBranch, configuration.Value).SelectMany(element => element)
+            .Distinct().ToArray();
+
+        foreach (var semanticVersion in taggedSemanticVersions)
         {
             if (semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
             {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrunkBasedVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrunkBasedVersionStrategy.cs
@@ -34,7 +34,7 @@ internal sealed class TrunkBasedVersionStrategy : VersionStrategyBase
 
         var iteration = CreateIteration(branchName: Context.CurrentBranch.Name, configuration: configuration.Value);
 
-        var taggedSemanticVersions = TaggedSemanticVersionRepository.GetTaggedSemanticVersions(
+        var taggedSemanticVersions = TaggedSemanticVersionRepository.GetAllTaggedSemanticVersions(
             Context.CurrentBranch, configuration.Value
         );
 
@@ -83,7 +83,7 @@ internal sealed class TrunkBasedVersionStrategy : VersionStrategyBase
             {
                 configuration = effectiveConfigurationWasBranchedFrom.Value;
                 branchName = effectiveConfigurationWasBranchedFrom.Branch.Name;
-                taggedSemanticVersions = TaggedSemanticVersionRepository.GetTaggedSemanticVersions(
+                taggedSemanticVersions = TaggedSemanticVersionRepository.GetAllTaggedSemanticVersions(
                     effectiveConfigurationWasBranchedFrom.Branch, effectiveConfigurationWasBranchedFrom.Value
                 );
             }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrunkBasedVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrunkBasedVersionStrategy.cs
@@ -1,0 +1,335 @@
+using System.ComponentModel;
+using GitVersion.Common;
+using GitVersion.Configuration;
+using GitVersion.Core;
+using GitVersion.Extensions;
+using GitVersion.VersionCalculation.TrunkBased;
+using GitVersion.VersionCalculation.TrunkBased.NonTrunk;
+using GitVersion.VersionCalculation.TrunkBased.Trunk;
+
+namespace GitVersion.VersionCalculation;
+
+internal sealed class TrunkBasedVersionStrategy : VersionStrategyBase
+{
+    private volatile int IterationCounter;
+
+    private ITaggedSemanticVersionRepository TaggedSemanticVersionRepository { get; }
+
+    private IRepositoryStore RepositoryStore { get; }
+
+    private IIncrementStrategyFinder IncrementStrategyFinder { get; }
+
+    public TrunkBasedVersionStrategy(Lazy<GitVersionContext> context, IRepositoryStore repositoryStore,
+        ITaggedSemanticVersionRepository taggedSemanticVersionRepository, IIncrementStrategyFinder incrementStrategyFinder
+    ) : base(context)
+    {
+        RepositoryStore = repositoryStore.NotNull();
+        TaggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
+        IncrementStrategyFinder = incrementStrategyFinder.NotNull();
+    }
+
+    public override IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
+    {
+        if (Context.Configuration.VersioningMode != VersioningMode.TrunkBased) yield break;
+
+        var iteration = CreateIteration(branchName: Context.CurrentBranch.Name, configuration: configuration.Value);
+
+        var taggedSemanticVersions = TaggedSemanticVersionRepository.GetTaggedSemanticVersions(
+            Context.CurrentBranch, configuration.Value
+        );
+
+        var targetLabel = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        IterateOverCommitsRecursive(
+            commitsInReverseOrder: Context.CurrentBranch.Commits,
+            iteration: iteration,
+            targetLabel: targetLabel,
+            taggedSemanticVersions: taggedSemanticVersions
+        );
+
+        yield return DetermineBaseVersion(iteration, targetLabel);
+    }
+
+    private TrunkBasedIteration CreateIteration(
+        ReferenceName branchName, EffectiveConfiguration configuration, TrunkBasedIteration? parent = null)
+    {
+        var iterationCount = Interlocked.Increment(ref IterationCounter);
+        return new TrunkBasedIteration(
+            id: $"#{iterationCount}",
+            branchName: branchName,
+            configuration: configuration,
+            parent: parent
+        );
+    }
+
+    private bool IterateOverCommitsRecursive(
+        IEnumerable<ICommit> commitsInReverseOrder, TrunkBasedIteration iteration, string? targetLabel,
+        ILookup<ICommit, SemanticVersionWithTag> taggedSemanticVersions, HashSet<ICommit>? traversedCommits = null)
+    {
+        traversedCommits ??= new HashSet<ICommit>();
+
+        Lazy<IReadOnlyDictionary<ICommit, EffectiveBranchConfiguration>> commitsWasBranchedFromLazy = new(
+            () => GetCommitsWasBranchedFrom(branchName: iteration.BranchName)
+        );
+
+        var configuration = iteration.Configuration;
+        var branchName = iteration.BranchName;
+
+        foreach (var item in commitsInReverseOrder)
+        {
+            if (!traversedCommits.Add(item)) continue;
+
+            if (commitsWasBranchedFromLazy.Value.TryGetValue(item, out var effectiveConfigurationWasBranchedFrom)
+                && (!configuration.IsMainline || effectiveConfigurationWasBranchedFrom.Value.IsMainline))
+            {
+                configuration = effectiveConfigurationWasBranchedFrom.Value;
+                branchName = effectiveConfigurationWasBranchedFrom.Branch.Name;
+                taggedSemanticVersions = TaggedSemanticVersionRepository.GetTaggedSemanticVersions(
+                    effectiveConfigurationWasBranchedFrom.Branch, effectiveConfigurationWasBranchedFrom.Value
+                );
+            }
+
+            var incrementForcedByCommit = GetIncrementForcedByCommit(item, configuration);
+            var commit = iteration.CreateCommit(item, branchName, configuration, incrementForcedByCommit);
+
+            var semanticVersions = taggedSemanticVersions[item].ToArray();
+            commit.AddSemanticVersions(semanticVersions.Select(element => element.Value));
+
+            var label = targetLabel ?? configuration.GetBranchSpecificLabel(branchName, null);
+            foreach (var semanticVersion in semanticVersions)
+            {
+                if (semanticVersion.Value.IsMatchForBranchSpecificLabel(label)) return true;
+            }
+
+            if (item.IsMergeCommit)
+            {
+                Lazy<IReadOnlyCollection<ICommit>> mergedCommitsInReverseOrderLazy = new(
+                    () => IncrementStrategyFinder.GetMergedCommits(item, 1).Reverse().ToList()
+                );
+
+                if (configuration.TrackMergeMessage
+                    && MergeMessage.TryParse(item, Context.Configuration, out var mergeMessage))
+                {
+                    if (mergeMessage.Version is not null)
+                    {
+                        commit.AddSemanticVersions(mergeMessage.Version);
+                        return true;
+                    }
+
+                    if (mergeMessage.MergedBranch is not null)
+                    {
+                        var childConfiguration = Context.Configuration.GetEffectiveConfiguration(
+                            mergeMessage.MergedBranch
+                        );
+
+                        if (childConfiguration.IsMainline)
+                        {
+                            if (configuration.IsMainline) throw new NotImplementedException();
+                            mergedCommitsInReverseOrderLazy = new(
+                                () => IncrementStrategyFinder.GetMergedCommits(item, 0).Reverse().ToList()
+                            );
+                            childConfiguration = configuration;
+                        }
+
+                        var childIteration = CreateIteration(
+                            branchName: mergeMessage.MergedBranch,
+                            configuration: childConfiguration,
+                            parent: iteration
+                        );
+
+                        var done = IterateOverCommitsRecursive(
+                            commitsInReverseOrder: mergedCommitsInReverseOrderLazy.Value,
+                            iteration: childIteration,
+                            targetLabel: targetLabel,
+                            traversedCommits: traversedCommits,
+                            taggedSemanticVersions: taggedSemanticVersions
+                        );
+
+                        commit.AddChildIteration(childIteration);
+                        if (done) return true;
+                    }
+
+                    traversedCommits.AddRange(mergedCommitsInReverseOrderLazy.Value);
+                }
+            }
+        }
+        return false;
+    }
+
+    private VersionField GetIncrementForcedByCommit(ICommit commit, EffectiveConfiguration configuration)
+    {
+        commit.NotNull();
+        configuration.NotNull();
+
+        return configuration.CommitMessageIncrementing switch
+        {
+            CommitMessageIncrementMode.Enabled => IncrementStrategyFinder.GetIncrementForcedByCommit(commit, configuration),
+            CommitMessageIncrementMode.Disabled => VersionField.None,
+            CommitMessageIncrementMode.MergeMessageOnly => commit.IsMergeCommit
+                ? IncrementStrategyFinder.GetIncrementForcedByCommit(commit, configuration) : VersionField.None,
+            _ => throw new InvalidEnumArgumentException(
+                nameof(configuration.CommitMessageIncrementing), (int)configuration.CommitMessageIncrementing, typeof(CommitMessageIncrementMode)
+            )
+        };
+    }
+
+    private IReadOnlyDictionary<ICommit, EffectiveBranchConfiguration> GetCommitsWasBranchedFrom(ReferenceName branchName)
+    {
+        Dictionary<ICommit, EffectiveBranchConfiguration> result = new();
+
+        var branch = RepositoryStore.FindBranch(branchName);
+        if (branch is null) return result;
+
+        var branchCommits = RepositoryStore.FindCommitBranchesWasBranchedFrom(
+            branch, Context.Configuration
+        ).ToList();
+
+        var branchCommitDictionary = branchCommits.ToDictionary(
+            element => element.Branch, element => element.Commit
+        );
+        foreach (var item in branchCommitDictionary.Keys)
+        {
+            var branchConfiguration = Context.Configuration.GetBranchConfiguration(item);
+            if (branchConfiguration.Increment == IncrementStrategy.Inherit) continue;
+
+            if (result.ContainsKey(branchCommitDictionary[item]))
+            {
+                if ((branchConfiguration.IsMainline ?? Context.Configuration.IsMainline) == true
+                    && !result[branchCommitDictionary[item]].Value.IsMainline)
+                {
+                    result[branchCommitDictionary[item]]
+                        = new(new EffectiveConfiguration(Context.Configuration, branchConfiguration), item);
+                }
+            }
+            else
+            {
+                result.Add(
+                    key: branchCommitDictionary[item],
+                    value: new(new EffectiveConfiguration(Context.Configuration, branchConfiguration), item)
+                );
+            }
+        }
+        return result;
+    }
+
+    private static BaseVersionV2 DetermineBaseVersion(TrunkBasedIteration iteration, string? targetLabel)
+        => DetermineBaseVersionRecursive(iteration, targetLabel);
+
+    internal static BaseVersionV2 DetermineBaseVersionRecursive(TrunkBasedIteration iteration, string? targetLabel)
+    {
+        iteration.NotNull();
+
+        var incrementSteps = GetIncrementSteps(iteration, targetLabel).ToArray();
+
+        var semanticVersion = SemanticVersion.Empty;
+
+        for (var i = 0; i < incrementSteps.Length; i++)
+        {
+            var incrementStep = incrementSteps[i];
+            if (incrementStep.SemanticVersion is not null)
+                semanticVersion = incrementStep.SemanticVersion;
+
+            if (i + 1 < incrementSteps.Length)
+            {
+                if (incrementStep.ShouldIncrement)
+                {
+                    semanticVersion = semanticVersion.Increment(
+                        incrementStep.Increment, incrementStep.Label, incrementStep.ForceIncrement
+                    );
+                    if (semanticVersion.IsLessThan(incrementStep.AlternativeSemanticVersion, includePreRelease: false))
+                    {
+                        semanticVersion = new SemanticVersion(semanticVersion)
+                        {
+                            Major = incrementStep.AlternativeSemanticVersion!.Major,
+                            Minor = incrementStep.AlternativeSemanticVersion.Minor,
+                            Patch = incrementStep.AlternativeSemanticVersion.Patch
+                        };
+                    }
+                }
+            }
+            else
+            {
+                return new BaseVersionV2(nameof(TrunkBasedVersionStrategy), incrementStep.ShouldIncrement, semanticVersion, incrementStep.BaseVersionSource, null)
+                {
+                    Increment = incrementStep.Increment,
+                    Label = incrementStep.Label,
+                    ForceIncrement = incrementStep.ForceIncrement,
+                    AlternativeSemanticVersion = incrementStep.AlternativeSemanticVersion
+                };
+            }
+        }
+
+        throw new InvalidOperationException();
+    }
+
+    private static IEnumerable<BaseVersionV2> GetIncrementSteps(TrunkBasedIteration iteration, string? targetLabel)
+    {
+        TrunkBasedContext context = new()
+        {
+            TargetLabel = targetLabel,
+        };
+
+        foreach (var commit in iteration.Commits)
+        {
+            foreach (var item in TrunkContextPreEnricherCollection)
+            {
+                item.Enrich(iteration, commit, context);
+            }
+
+            foreach (var incrementer in TrunkIncrementerCollection
+                .Where(element => element.MatchPrecondition(iteration, commit, context)))
+            {
+                foreach (var item in incrementer.GetIncrements(iteration, commit, context))
+                {
+                    yield return item;
+                }
+            }
+
+            foreach (var item in TrunkContextPostEnricherCollection)
+            {
+                item.Enrich(iteration, commit, context);
+            }
+        }
+    }
+
+    private static readonly IReadOnlyCollection<ITrunkBasedContextPreEnricher> TrunkContextPreEnricherCollection = new ITrunkBasedContextPreEnricher[]
+    {
+        new EnrichSemanticVersion(),
+        new EnrichIncrement()
+    };
+    private static readonly IReadOnlyCollection<ITrunkBasedContextPostEnricher> TrunkContextPostEnricherCollection = new ITrunkBasedContextPostEnricher[]
+    {
+        new RemoveSemanticVersion(),
+        new RemoveIncrement()
+    };
+    private static readonly IReadOnlyCollection<ITrunkBasedIncrementer> TrunkIncrementerCollection = new ITrunkBasedIncrementer[]
+    {
+        // Trunk
+        new CommitOnTrunk(),
+
+        new CommitOnTrunkWithPreReleaseTag(),
+        new LastCommitOnTrunkWithPreReleaseTag(),
+
+        new CommitOnTrunkWithStableTag(),
+        new LastCommitOnTrunkWithStableTag(),
+
+        new MergeCommitOnTrunk(),
+        new LastMergeCommitOnTrunk(),
+
+        new CommitOnTrunkBranchedToTrunk(),
+        new CommitOnTrunkBranchedToNonTrunk(),
+
+        // NonTrunk
+        new CommitOnNonTrunk(),
+        new CommitOnNonTrunkWithPreReleaseTag(),
+        new LastCommitOnNonTrunkWithPreReleaseTag(),
+
+        new CommitOnNonTrunkWithStableTag(),
+        new LastCommitOnNonTrunkWithStableTag(),
+
+        new MergeCommitOnNonTrunk(),
+        new LastMergeCommitOnNonTrunk(),
+
+        new CommitOnNonTrunkBranchedToTrunk(),
+        new CommitOnNonTrunkBranchedToNonTrunk()
+    };
+}


### PR DESCRIPTION
## Description
Create TrunkBasedVersionStrategy implementation and replace the version mode Mainline in 6.x.

For more detail please see the following ADR:
- #3601

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
