### PR TITLE
Arm64 - disable testing the artifacts as well as the docker images for Arm64

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -38,6 +38,16 @@ jobs:
         name: nuget
         path: ${{ github.workspace }}/artifacts/packages/nuget
     -
+      name: Setup QEMU
+      if: inputs.arch == 'arm64'
+      uses: docker/setup-qemu-action@v3
+    -
+      name: Setup Docker Buildx
+      if: inputs.arch == 'arm64'
+      uses: docker/setup-buildx-action@v3
+      with:
+        install: true      
+    -
       name: Docker Test
       if: success() && github.event_name == 'pull_request' || github.repository_owner != 'GitTools'
       uses: ./.github/actions/docker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ amd64, amd64 ]
+        arch: [ amd64, arm64 ]
 
     uses: ./.github/workflows/_artifacts_linux.yml
     with:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ amd64, amd64 ]
+        arch: [ amd64, arm64 ]
 
     uses: ./.github/workflows/_docker.yml
     with:

--- a/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
+++ b/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
@@ -27,7 +27,7 @@ public class ArtifactsDotnetToolTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForArtifacts(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage)) continue;
 
             var cmd = $"{rootPrefix}/scripts/test-global-tool.sh --version {version} --nugetPath {rootPrefix}/nuget --repoPath {rootPrefix}/repo";
 

--- a/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
@@ -26,7 +26,7 @@ public class ArtifactsMsBuildCoreTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForArtifacts(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage)) continue;
 
             var framework = dockerImage.TargetFramework;
 

--- a/build/artifacts/Tasks/ArtifactsNativeTest.cs
+++ b/build/artifacts/Tasks/ArtifactsNativeTest.cs
@@ -27,7 +27,7 @@ public class ArtifactsNativeTest : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForArtifacts(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage)) continue;
 
             var runtime = "linux";
             if (dockerImage.Distro.StartsWith("alpine"))

--- a/build/artifacts/Tasks/ArtifactsPrepare.cs
+++ b/build/artifacts/Tasks/ArtifactsPrepare.cs
@@ -21,7 +21,7 @@ public class ArtifactsPrepare : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForArtifacts(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage)) continue;
             context.DockerPullImage(dockerImage);
         }
     }

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -22,9 +22,6 @@ public class Constants
     public static readonly string[] VersionsToBuild = [Version60, Version70, Version80];
     public static readonly string[] Frameworks = [NetVersion60, NetVersion70, NetVersion80];
 
-    public static readonly string[] DistrosToSkipForArtifacts = [];
-    public static readonly string[] DistrosToSkipForDocker = [];
-
     public const string DockerBaseImageName = "gittools/build-images";
     public const string DockerImageName = "gittools/gitversion";
 

--- a/build/common/Utilities/ContextExtensions.cs
+++ b/build/common/Utilities/ContextExtensions.cs
@@ -1,5 +1,7 @@
+using System.Runtime.InteropServices;
 using Cake.Common.Build.AzurePipelines;
 using Xunit;
+using ProcessArchitecture = System.Runtime.InteropServices.Architecture;
 
 namespace Common.Utilities;
 
@@ -12,6 +14,7 @@ public static class ContextExtensions
         {
             processSettings.WorkingDirectory = workDir;
         }
+
         context.StartProcess(exe, processSettings, out var redirectedOutput);
         return redirectedOutput.ToList();
     }
@@ -79,6 +82,12 @@ public static class ContextExtensions
         return string.Empty;
     }
 
+    public static bool IsRunningOnAmd64(this ICakeContext _)
+        => RuntimeInformation.ProcessArchitecture == ProcessArchitecture.X64;
+
+    public static bool IsRunningOnArm64(this ICakeContext _) =>
+        RuntimeInformation.ProcessArchitecture == ProcessArchitecture.Arm64;
+
     public static string GetBuildAgent(this ICakeContext context)
     {
         var buildSystem = context.BuildSystem();
@@ -142,6 +151,7 @@ public static class ContextExtensions
         {
             repositoryBranch = buildSystem.GitHubActions.Environment.Workflow.Ref.Replace("refs/heads/", "");
         }
+
         return repositoryBranch;
     }
 
@@ -161,6 +171,7 @@ public static class ContextExtensions
         {
             repositoryName = buildSystem.GitHubActions.Environment.Workflow.Repository;
         }
+
         return repositoryName;
     }
 
@@ -172,6 +183,7 @@ public static class ContextExtensions
         context.GetFiles($"src/GitVersion.App/bin/{Constants.DefaultConfiguration}/{Constants.NetVersionLatest}/gitversion.dll").SingleOrDefault();
     public static FilePath? GetGitVersionDotnetToolLocation(this ICakeContext context) =>
         context.MakeAbsolute(Paths.Tools.Combine("gitversion").CombineWithFilePath("gitversion.dll"));
+
     public static FilePath? GetSchemaDotnetToolLocation(this ICakeContext context) =>
         context.MakeAbsolute(Paths.Tools.Combine("schema").CombineWithFilePath("schema.dll"));
 }

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -10,26 +10,19 @@ public enum Architecture
 
 public static class DockerContextExtensions
 {
-    public static bool SkipImageForArtifacts(this ICakeContext context, DockerImage dockerImage)
+    public static bool SkipImageTesting(this ICakeContext context, DockerImage dockerImage)
     {
         var (distro, targetFramework, architecture, _, _) = dockerImage;
 
-        if (architecture == Architecture.Amd64) return false;
-        if (!Constants.DistrosToSkipForArtifacts.Contains(distro)) return false;
-
-        context.Information($"Skipping Target: {targetFramework}, Distro: {distro}, Arch: {architecture}");
-        return true;
-    }
-
-    public static bool SkipImageForDocker(this ICakeContext context, DockerImage dockerImage)
-    {
-        var (distro, targetFramework, architecture, _, _) = dockerImage;
-
-        if (architecture == Architecture.Amd64) return false;
-        if (!Constants.DistrosToSkipForDocker.Contains(distro)) return false;
-
-        context.Information($"Skipping Target: {targetFramework}, Distro: {distro}, Arch: {architecture}");
-        return true;
+        switch (architecture)
+        {
+            case Architecture.Amd64:
+            case Architecture.Arm64 when context.IsRunningOnArm64():
+                return false;
+            default:
+                context.Information($"Skipping Target: {targetFramework}, Distro: {distro}, Arch: {architecture}");
+                return true;
+        }
     }
 
     public static void DockerBuildImage(this BuildContextBase context, DockerImage dockerImage)

--- a/build/docker/Tasks/DockerBuild.cs
+++ b/build/docker/Tasks/DockerBuild.cs
@@ -27,7 +27,6 @@ public class DockerBuild : FrostingTask<BuildContext>
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForDocker(dockerImage)) continue;
             context.DockerBuildImage(dockerImage);
         }
     }

--- a/build/docker/Tasks/DockerPublish.cs
+++ b/build/docker/Tasks/DockerPublish.cs
@@ -45,7 +45,6 @@ public class DockerPublishInternal : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForDocker(dockerImage)) continue;
             context.DockerPushImage(dockerImage);
         }
     }

--- a/build/docker/Tasks/DockerTest.cs
+++ b/build/docker/Tasks/DockerTest.cs
@@ -23,7 +23,7 @@ public class DockerTest : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageForDocker(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage)) continue;
             context.DockerTestImage(dockerImage);
         }
     }


### PR DESCRIPTION
Currently running the docker images with QEMU for the Arm64 images in order to test the artifacts and the docker images it's not possible for [.net70](https://github.com/dotnet/core/blob/main/release-notes/7.0/supported-os.md#qemu) and[ .net80](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#qemu). This will be disabled until the GH Runners will [support Arm64 for Linux](https://github.com/actions/runner-images/issues/8439#issuecomment-1755601587)