### PR TITLE
Docker documentation (v5)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/pwsh
+#!/usr/bin/env pwsh
 <#
 .PARAMETER Stage
 The build stage to execute.

--- a/docs/input/docs/usage/docker.md
+++ b/docs/input/docs/usage/docker.md
@@ -1,0 +1,27 @@
+---
+Order: 50
+Title: Docker
+Description: |
+    Use GitVersion through one of its many published Docker containers.
+---
+
+GitVersion can be used through one of its many published Docker
+containers. The list of available containers can be found on
+[Docker Hub][docker-hub]. Once you've found the image you want to use,
+you can run it like this:
+
+```shell
+docker run --rm --volume "$(pwd):/repo" gittools/gitversion:6.0.0-beta.3-fedora.36-6.0-arm64 /repo
+```
+
+The above command will run GitVersion with the current directory
+mapped to `/repo` inside the container (the `--volume "$(pwd):/repo"`
+part). The `/repo` directory is then passed in as the argument
+GitVersion should use to calculate the version.
+
+The `--rm` flag will remove the container after it has finished
+running.
+
+[Explore GitVersion on Docker Hub][docker-hub]{.btn .btn-primary}
+
+[docker-hub]: https://hub.docker.com/r/gittools/gitversion

--- a/docs/input/docs/usage/library.md
+++ b/docs/input/docs/usage/library.md
@@ -15,9 +15,9 @@ patch releases, it's a useful option to some.
 
 :::{.alert .alert-warning}
 **Warning**
-
-We are not semantically versioning this library and it should be considered
-unstable.
+The library API is not stable and does not follow the semantic versioning
+of the GitVersion tool. A patch release of the tool may break the library
+and we will refactor and change the library API without notice.
 :::
 
 <a href="/api" class="btn btn-primary">Explore the GitVersion library API</a>

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -17,26 +17,36 @@ expected.
 
 ## Serving the documentation locally
 
-To serve up the documentation locally, you need to run the `build.ps1` script
-with the arguments `-Target Preview-Documentation`.
+To serve up the documentation locally, you need to run the following
+commands:
+
+```shell
+./build.ps1 -Stage build -Target PrepareBuild
+./build.ps1 -Stage build -Target Build
+./build.ps1 -Stage docs -Target PreviewDocs
+```
 
 ### On Windows
 
-On Windows, you need to run the following build command in a PowerShell
+On Windows, you need to run the following commands in a PowerShell
 terminal:
 
 ```shell
-.\build.ps1 -Target Preview-Documentation
+./build.ps1 -Stage build -Target PrepareBuild
+./build.ps1 -Stage build -Target Build
+./build.ps1 -Stage docs -Target PreviewDocs
 ```
 
 ### On Unix
 
 First you need to [install PowerShell on macOS][ps-mac] or [Linux][ps-linux],
-then execute the following command:
+then execute the following commands:
 
 ```shell
-pwsh build.ps1 -Target Preview-Documentation
-```
+./build.ps1 -Stage build -Target PrepareBuild
+./build.ps1 -Stage build -Target Build
+./build.ps1 -Stage docs -Target PreviewDocs
+ ```
 
 After pressing enter, the documentation will be generated and then served under
 a local web server.  Information about the URL that can be used to view the docs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add documentation for Docker usage (rebased version of #3858).

## Motivation and Context
It's currently not documented how to use GitVersion through Docker.

## How Has This Been Tested?
I've executed the docs build locally.

## Screenshots (if appropriate):
<img width="1242" alt="Docker usage documentation" src="https://github.com/GitTools/GitVersion/assets/12283/a74ae84c-fdcf-495a-a3b8-efa1d9d0f66c">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
