### PR TITLE
mark dependencies as private assets for msbuild

### DIFF
--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -14,16 +14,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Win32.Registry" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" />
+        <PackageReference Include="Microsoft.Win32.Registry" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
+        <PackageReference Update="@(PackageReference)" PrivateAssets="All"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" PrivateAssets="All" />
-        <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" PrivateAssets="All" />
-        <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" PrivateAssets="All" />
-        <ProjectReference Include="..\GitVersion.Output\GitVersion.Output.csproj" PrivateAssets="All" />
+        <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" />
+        <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />
+        <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
+        <ProjectReference Include="..\GitVersion.Output\GitVersion.Output.csproj" />
+        <ProjectReference Update="@(ProjectReference)" PrivateAssets="All"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -38,7 +41,6 @@
         <None Include="$(ExePublishPath)/net6.0/publish/**/*;$(BinPath)/net6.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net6.0" />
         <None Include="$(ExePublishPath)/net7.0/publish/**/*;$(BinPath)/net7.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net7.0" />
         <None Include="$(ExePublishPath)/net8.0/publish/**/*;$(BinPath)/net8.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net8.0" />
-
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change that all references of the msbuild package are marked as private assets, so they don't get added as dependency to the nuget package.

The dependecies field of the nuspec before the change:
```xml
<dependencies>
  <group targetFramework="net6.0">
    <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
  </group>
  <group targetFramework="net7.0">
    <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
  </group>
  <group targetFramework="net8.0">
    <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
  </group>
</dependencies>
```

and afer the change the dependencies of the nuspec look like this:
```xml
<dependencies>
  <group targetFramework="net6.0" />
  <group targetFramework="net7.0" />
  <group targetFramework="net8.0" />
</dependencies>
```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No, so far, happy to create one if the pr is not enough

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The dependencies cause extra dll's to be published, for build only dependencies (`PrivateAssets="All"`). This problem seems to be cause by the change to the ceontral package management, where `System.Text.Json` was promoted to be included in the [`Directory.Build.props`](https://github.com/GitTools/GitVersion/blob/main/src/Directory.Build.props#L44)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build locally and checked the generated nuspec file in the outpur directory.

## Screenshots (if appropriate):
![grafik](https://github.com/GitTools/GitVersion/assets/16615577/60a47098-9200-4513-ad14-9e5d56ef9116)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
