### PR TITLE
The increment of the target branch will be ignored when prevent-increment is set to true on the source branch

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -40,6 +40,7 @@
     *   Default `RegularExpression` for feature branches is changed from `^features?[/-]` to `^features?[/-](?<BranchName>.+)` to support using `{BranchName}` out-of-the-box
     *   Default `RegularExpression` for unknown branches is changed from `.*` to `(?<BranchName>.+)` to support using `{BranchName}` out-of-the-box
 *   The `Mainline` mode and the related implementation has been removed completely. The new `TrunkBased` version strategy should be used instead.
+*   The `TrunkBased` workflow doesn't support downgrading the increment for calculating the next version. This is the case if e.g. a bump messages has been defined which is lower than the branch increment.
 *   The branch related property `is-mainline` in the configuration system has been renamed to `is-main-branch`
 *   The versioning mode has been renamed to deployment mode and consists of following values:
     *   ManualDeployment (previously ContinuousDelivery)
@@ -53,7 +54,7 @@
     *   VersionInBranchName
     *   TrunkBased
 *   The initialization wizard has been removed.
-*   On the `develop`, `release` and `hotfix` branch the introduced branch related property `prevent-increment-when-current-commit-tagged` has been set to `false` to get the incremented instead of the tagged semantic version.
+*   On the `develop`, `release` and `hotfix` branch the introduced branch related property `prevent-increment.when-current-commit-tagged` has been set to `false` to get the incremented instead of the tagged semantic version.
 
 ## v5.0.0
 

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -72,8 +72,8 @@ branches:
   develop:
     label: alpha
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     track-merge-target: true
     regex: ^dev(elop)?(ment)?$
     source-branches: []
@@ -85,7 +85,8 @@ branches:
   main:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches:
@@ -100,8 +101,9 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: None
-    prevent-increment-of-merged-branch-version: true
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
     track-merge-target: false
     regex: ^releases?[/-]
     source-branches:
@@ -118,6 +120,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: ^features?[/-](?<BranchName>.+)
     source-branches:
     - develop
@@ -132,6 +135,7 @@ branches:
     mode: ContinuousDelivery
     label: PullRequest
     increment: Inherit
+    prevent-increment: {}
     label-number-pattern: '[/-](?<number>\d+)'
     regex: ^(pull|pull\-requests|pr)[/-]
     source-branches:
@@ -147,7 +151,8 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: Inherit
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     regex: ^hotfix(es)?[/-]
     source-branches:
     - release
@@ -160,7 +165,8 @@ branches:
   support:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^support[/-]
     source-branches:
@@ -174,6 +180,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: (?<BranchName>.+)
     source-branches:
     - main
@@ -189,8 +196,10 @@ ignore:
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled
@@ -200,6 +209,7 @@ is-source-branch-for: []
 tracks-release-branches: false
 is-release-branch: false
 is-main-branch: false
+
 ```
 
 The supported built-in configuration for the `GitHubFlow` workflow (`workflow: GitHubFlow/v1`) looks like:
@@ -228,7 +238,8 @@ branches:
   main:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches:
@@ -242,8 +253,9 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: None
-    prevent-increment-of-merged-branch-version: true
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
     track-merge-target: false
     regex: ^releases?[/-]
     source-branches:
@@ -293,8 +305,10 @@ ignore:
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled
@@ -330,7 +344,8 @@ branches:
     mode: ContinuousDeployment
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches: []
@@ -341,14 +356,16 @@ branches:
   feature:
     increment: Minor
     regex: ^features?[/-](?<BranchName>.+)
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     source-branches:
     - main
     pre-release-weight: 30000
   hotfix:
     increment: Patch
     regex: ^hotfix(es)?[/-](?<BranchName>.+)
-    prevent-increment-when-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     source-branches:
     - main
     pre-release-weight: 30000
@@ -375,8 +392,10 @@ ignore:
 mode: ManualDeployment
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled
@@ -467,9 +486,7 @@ increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
 
 The special value `Inherit` means that GitVersion should find the parent branch
 (i.e. the branch where the current branch was branched from), and use its values
-for [increment](#increment),
-[prevent-increment-of-merged-branch-version](#prevent-increment-of-merged-branch-version)
-and [tracks-release-branches](#tracks-release-branches).
+for [increment](#increment) or other branch related properties.
 
 ### tag-prefix
 
@@ -791,7 +808,9 @@ Another example: branch `features/sc-12345/some-description` would become a pre-
 
 Same as for the [global configuration, explained above](#increment).
 
-### prevent-increment-of-merged-branch-version
+### prevent-increment-of-merged-branch
+
+The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when this branch related property is set to true on the target branch.
 
 When `release-2.0.0` is merged into main, we want main to build `2.0.0`. If
 `release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
@@ -801,6 +820,10 @@ In a GitFlow-based repository, setting this option can have implications on the
 `CommitsSinceVersionSource` output variable. It can rule out a potentially
 better version source proposed by the `MergeMessageBaseVersionStrategy`. For
 more details and an in-depth analysis, please see [the discussion][2506].
+
+### prevent-increment-when-branch-merged
+
+The increment of the merged branch will be ignored when this branch related property is set to `true` on the source branch.
 
 ### prevent-increment-when-current-commit-tagged
 

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -21,8 +21,8 @@ branches:
   develop:
     label: alpha
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     track-merge-target: true
     regex: ^dev(elop)?(ment)?$
     source-branches: []
@@ -34,7 +34,8 @@ branches:
   main:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches:
@@ -49,8 +50,9 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: None
-    prevent-increment-of-merged-branch-version: true
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
     track-merge-target: false
     regex: ^releases?[/-]
     source-branches:
@@ -67,6 +69,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: ^features?[/-](?<BranchName>.+)
     source-branches:
     - develop
@@ -81,6 +84,7 @@ branches:
     mode: ContinuousDelivery
     label: PullRequest
     increment: Inherit
+    prevent-increment: {}
     label-number-pattern: '[/-](?<number>\d+)'
     regex: ^(pull|pull\-requests|pr)[/-]
     source-branches:
@@ -96,7 +100,8 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: Inherit
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     regex: ^hotfix(es)?[/-]
     source-branches:
     - release
@@ -109,7 +114,8 @@ branches:
   support:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^support[/-]
     source-branches:
@@ -123,6 +129,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: (?<BranchName>.+)
     source-branches:
     - main
@@ -138,8 +145,10 @@ ignore:
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-current-commit-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled

--- a/src/GitVersion.Configuration/BranchConfiguration.cs
+++ b/src/GitVersion.Configuration/BranchConfiguration.cs
@@ -18,13 +18,12 @@ internal record BranchConfiguration : IBranchConfiguration
     [JsonPropertyDescription("The increment strategy for this branch. Can be 'Inherit', 'Patch', 'Minor', 'Major', 'None'.")]
     public IncrementStrategy Increment { get; internal set; }
 
-    [JsonPropertyName("prevent-increment-of-merged-branch-version")]
-    [JsonPropertyDescription("Prevent increment of merged branch version.")]
-    public bool? PreventIncrementOfMergedBranchVersion { get; internal set; }
+    [JsonIgnore]
+    IPreventIncrementConfiguration IBranchConfiguration.PreventIncrement => PreventIncrement;
 
-    [JsonPropertyName("prevent-increment-when-current-commit-tagged")]
-    [JsonPropertyDescription("This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.")]
-    public bool? PreventIncrementWhenCurrentCommitTagged { get; internal set; }
+    [JsonPropertyName("prevent-increment")]
+    [JsonPropertyDescription("The prevent increment configuration section.")]
+    public PreventIncrementConfiguration PreventIncrement { get; internal set; } = new();
 
     [JsonPropertyName("label-number-pattern")]
     [JsonPropertyDescription($"The regular expression pattern to use to extract the number from the branch name. Defaults to '{ConfigurationConstants.DefaultLabelNumberPattern}'.")]
@@ -91,10 +90,12 @@ internal record BranchConfiguration : IBranchConfiguration
             Increment = Increment == IncrementStrategy.Inherit ? configuration.Increment : Increment,
             DeploymentMode = DeploymentMode ?? configuration.DeploymentMode,
             Label = Label ?? configuration.Label,
-            PreventIncrementOfMergedBranchVersion = PreventIncrementOfMergedBranchVersion
-                ?? configuration.PreventIncrementOfMergedBranchVersion,
-            PreventIncrementWhenCurrentCommitTagged = PreventIncrementWhenCurrentCommitTagged
-            ?? configuration.PreventIncrementWhenCurrentCommitTagged,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = PreventIncrement.OfMergedBranch ?? configuration.PreventIncrement.OfMergedBranch,
+                WhenBranchMerged = PreventIncrement.WhenBranchMerged ?? configuration.PreventIncrement.WhenBranchMerged,
+                WhenCurrentCommitTagged = PreventIncrement.WhenCurrentCommitTagged ?? configuration.PreventIncrement.WhenCurrentCommitTagged
+            },
             LabelNumberPattern = LabelNumberPattern ?? configuration.LabelNumberPattern,
             TrackMergeTarget = TrackMergeTarget ?? configuration.TrackMergeTarget,
             TrackMergeMessage = TrackMergeMessage ?? configuration.TrackMergeMessage,

--- a/src/GitVersion.Configuration/BranchConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/BranchConfigurationBuilder.cs
@@ -9,7 +9,8 @@ internal class BranchConfigurationBuilder
     private DeploymentMode? deploymentMode;
     private string? label;
     private IncrementStrategy increment;
-    private bool? preventIncrementOfMergedBranchVersion;
+    private bool? preventIncrementOfMergedBranch;
+    private bool? preventIncrementWhenBranchMerged;
     private bool? preventIncrementWhenCurrentCommitTagged;
     private string? labelNumberPattern;
     private bool? trackMergeTarget;
@@ -45,9 +46,15 @@ internal class BranchConfigurationBuilder
         return this;
     }
 
-    public virtual BranchConfigurationBuilder WithPreventIncrementOfMergedBranchVersion(bool? value)
+    public virtual BranchConfigurationBuilder WithPreventIncrementOfMergedBranch(bool? value)
     {
-        this.preventIncrementOfMergedBranchVersion = value;
+        this.preventIncrementOfMergedBranch = value;
+        return this;
+    }
+
+    public virtual BranchConfigurationBuilder WithPreventIncrementWhenBranchMerged(bool? value)
+    {
+        this.preventIncrementWhenBranchMerged = value;
         return this;
     }
 
@@ -140,8 +147,9 @@ internal class BranchConfigurationBuilder
         WithDeploymentMode(value.DeploymentMode);
         WithLabel(value.Label);
         WithIncrement(value.Increment);
-        WithPreventIncrementOfMergedBranchVersion(value.PreventIncrementOfMergedBranchVersion);
-        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrementWhenCurrentCommitTagged);
+        WithPreventIncrementOfMergedBranch(value.PreventIncrement.OfMergedBranch);
+        WithPreventIncrementWhenBranchMerged(value.PreventIncrement.WhenBranchMerged);
+        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrement.WhenCurrentCommitTagged);
         WithLabelNumberPattern(value.LabelNumberPattern);
         WithTrackMergeTarget(value.TrackMergeTarget);
         WithTrackMergeMessage(value.TrackMergeMessage);
@@ -169,8 +177,12 @@ internal class BranchConfigurationBuilder
         IsMainBranch = isMainBranch,
         IsReleaseBranch = isReleaseBranch,
         LabelNumberPattern = labelNumberPattern,
-        PreventIncrementOfMergedBranchVersion = preventIncrementOfMergedBranchVersion,
-        PreventIncrementWhenCurrentCommitTagged = preventIncrementWhenCurrentCommitTagged,
+        PreventIncrement = new PreventIncrementConfiguration()
+        {
+            OfMergedBranch = preventIncrementOfMergedBranch,
+            WhenBranchMerged = preventIncrementWhenBranchMerged,
+            WhenCurrentCommitTagged = preventIncrementWhenCurrentCommitTagged
+        },
         PreReleaseWeight = preReleaseWeight,
         SourceBranches = sourceBranches,
         IsSourceBranchFor = isSourceBranchFor

--- a/src/GitVersion.Configuration/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/ConfigurationBuilderBase.cs
@@ -31,7 +31,8 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
     private DeploymentMode? versioningMode;
     private string? label;
     private IncrementStrategy increment = IncrementStrategy.Inherit;
-    private bool? preventIncrementOfMergedBranchVersion;
+    private bool? preventIncrementOfMergedBranch;
+    private bool? preventIncrementWhenBranchMerged;
     private bool? preventIncrementWhenCurrentCommitTagged;
     private string? labelNumberPattern;
     private bool? trackMergeTarget;
@@ -250,9 +251,15 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
         return (TConfigurationBuilder)this;
     }
 
-    public virtual TConfigurationBuilder WithPreventIncrementOfMergedBranchVersion(bool? value)
+    public virtual TConfigurationBuilder WithPreventIncrementOfMergedBranch(bool? value)
     {
-        this.preventIncrementOfMergedBranchVersion = value;
+        this.preventIncrementOfMergedBranch = value;
+        return (TConfigurationBuilder)this;
+    }
+
+    public virtual TConfigurationBuilder WithPreventIncrementWhenBranchMerged(bool? value)
+    {
+        this.preventIncrementWhenBranchMerged = value;
         return (TConfigurationBuilder)this;
     }
 
@@ -344,8 +351,9 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
         WithDeploymentMode(value.DeploymentMode);
         WithLabel(value.Label);
         WithIncrement(value.Increment);
-        WithPreventIncrementOfMergedBranchVersion(value.PreventIncrementOfMergedBranchVersion);
-        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrementWhenCurrentCommitTagged);
+        WithPreventIncrementOfMergedBranch(value.PreventIncrement.OfMergedBranch);
+        WithPreventIncrementWhenBranchMerged(value.PreventIncrement.WhenBranchMerged);
+        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrement.WhenCurrentCommitTagged);
         WithLabelNumberPattern(value.LabelNumberPattern);
         WithTrackMergeTarget(value.TrackMergeTarget);
         WithTrackMergeMessage(value.TrackMergeMessage);
@@ -411,8 +419,12 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
             IsMainBranch = this.isMainBranch,
             IsReleaseBranch = this.isReleaseBranch,
             LabelNumberPattern = this.labelNumberPattern,
-            PreventIncrementOfMergedBranchVersion = this.preventIncrementOfMergedBranchVersion,
-            PreventIncrementWhenCurrentCommitTagged = this.preventIncrementWhenCurrentCommitTagged,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = this.preventIncrementOfMergedBranch,
+                WhenBranchMerged = this.preventIncrementWhenBranchMerged,
+                WhenCurrentCommitTagged = this.preventIncrementWhenCurrentCommitTagged,
+            },
             PreReleaseWeight = this.preReleaseWeight
         };
 

--- a/src/GitVersion.Configuration/GitFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/GitFlowConfigurationBuilder.cs
@@ -28,8 +28,12 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
             CommitMessageIncrementing = CommitMessageIncrementMode.Enabled,
-            PreventIncrementOfMergedBranchVersion = false,
-            PreventIncrementWhenCurrentCommitTagged = true,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = false,
+                WhenBranchMerged = false,
+                WhenCurrentCommitTagged = true
+            },
             TrackMergeTarget = false,
             TrackMergeMessage = true,
             TracksReleaseBranches = false,
@@ -43,8 +47,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             RegularExpression = DevelopBranch.RegexPattern,
             SourceBranches = [],
             Label = "alpha",
-            PreventIncrementOfMergedBranchVersion = false,
-            PreventIncrementWhenCurrentCommitTagged = false,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                WhenCurrentCommitTagged = false
+            },
             TrackMergeTarget = true,
             TracksReleaseBranches = true,
             IsMainBranch = false,
@@ -62,7 +68,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.ReleaseBranch.Name
             ],
             Label = string.Empty,
-            PreventIncrementOfMergedBranchVersion = true,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = true
+            },
             TrackMergeTarget = false,
             TracksReleaseBranches = false,
             IsMainBranch = true,
@@ -83,8 +92,11 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.ReleaseBranch.Name
             ],
             Label = "beta",
-            PreventIncrementOfMergedBranchVersion = true,
-            PreventIncrementWhenCurrentCommitTagged = false,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = true,
+                WhenCurrentCommitTagged = false
+            },
             TrackMergeTarget = false,
             TracksReleaseBranches = false,
             IsMainBranch = false,
@@ -134,7 +146,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             Increment = IncrementStrategy.Inherit,
             RegularExpression = HotfixBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ManualDeployment,
-            PreventIncrementWhenCurrentCommitTagged = false,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                WhenCurrentCommitTagged = false
+            },
             SourceBranches =
             [
                 this.ReleaseBranch.Name,
@@ -153,7 +168,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             RegularExpression = SupportBranch.RegexPattern,
             SourceBranches = [this.MainBranch.Name],
             Label = string.Empty,
-            PreventIncrementOfMergedBranchVersion = true,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = true
+            },
             TrackMergeTarget = false,
             TracksReleaseBranches = false,
             IsMainBranch = true,

--- a/src/GitVersion.Configuration/GitHubFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/GitHubFlowConfigurationBuilder.cs
@@ -28,8 +28,12 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
             CommitMessageIncrementing = CommitMessageIncrementMode.Enabled,
-            PreventIncrementOfMergedBranchVersion = false,
-            PreventIncrementWhenCurrentCommitTagged = true,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = false,
+                WhenBranchMerged = false,
+                WhenCurrentCommitTagged = true
+            },
             TrackMergeTarget = false,
             TrackMergeMessage = true,
             TracksReleaseBranches = false,
@@ -43,7 +47,10 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             RegularExpression = MainBranch.RegexPattern,
             SourceBranches = [this.ReleaseBranch.Name],
             Label = string.Empty,
-            PreventIncrementOfMergedBranchVersion = true,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = true
+            },
             TrackMergeTarget = false,
             TracksReleaseBranches = false,
             IsMainBranch = true,
@@ -62,8 +69,11 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
                 this.ReleaseBranch.Name
             ],
             Label = "beta",
-            PreventIncrementOfMergedBranchVersion = true,
-            PreventIncrementWhenCurrentCommitTagged = false,
+            PreventIncrement = new PreventIncrementConfiguration()
+            {
+                OfMergedBranch = true,
+                WhenCurrentCommitTagged = false
+            },
             TrackMergeTarget = false,
             TracksReleaseBranches = false,
             IsMainBranch = false,

--- a/src/GitVersion.Configuration/PreventIncrementConfiguration.cs
+++ b/src/GitVersion.Configuration/PreventIncrementConfiguration.cs
@@ -1,0 +1,18 @@
+using GitVersion.Attributes;
+
+namespace GitVersion.Configuration;
+
+internal class PreventIncrementConfiguration : IPreventIncrementConfiguration
+{
+    [JsonPropertyName("of-merged-branch")]
+    [JsonPropertyDescription("Prevent increment when branch merged.")]
+    public bool? OfMergedBranch { get; set; }
+
+    [JsonPropertyName("when-branch-merged")]
+    [JsonPropertyDescription("Prevent increment when branch merged.")]
+    public bool? WhenBranchMerged { get; set; }
+
+    [JsonPropertyName("when-current-commit-tagged")]
+    [JsonPropertyDescription("This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.")]
+    public bool? WhenCurrentCommitTagged { get; set; }
+}

--- a/src/GitVersion.Configuration/SupportedWorkflows/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration/SupportedWorkflows/GitFlow/v1.yml
@@ -21,8 +21,8 @@ branches:
   develop:
     label: alpha
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     track-merge-target: true
     regex: ^dev(elop)?(ment)?$
     source-branches: []
@@ -34,7 +34,8 @@ branches:
   main:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches:
@@ -49,8 +50,9 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: None
-    prevent-increment-of-merged-branch-version: true
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
     track-merge-target: false
     regex: ^releases?[/-]
     source-branches:
@@ -67,6 +69,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: ^features?[/-](?<BranchName>.+)
     source-branches:
     - develop
@@ -81,6 +84,7 @@ branches:
     mode: ContinuousDelivery
     label: PullRequest
     increment: Inherit
+    prevent-increment: {}
     label-number-pattern: '[/-](?<number>\d+)'
     regex: ^(pull|pull\-requests|pr)[/-]
     source-branches:
@@ -96,7 +100,8 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: Inherit
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     regex: ^hotfix(es)?[/-]
     source-branches:
     - release
@@ -109,7 +114,8 @@ branches:
   support:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^support[/-]
     source-branches:
@@ -123,6 +129,7 @@ branches:
     mode: ManualDeployment
     label: '{BranchName}'
     increment: Inherit
+    prevent-increment: {}
     regex: (?<BranchName>.+)
     source-branches:
     - main
@@ -138,8 +145,10 @@ ignore:
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-current-commit-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled

--- a/src/GitVersion.Configuration/SupportedWorkflows/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration/SupportedWorkflows/GitHubFlow/v1.yml
@@ -21,7 +21,8 @@ branches:
   main:
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches:
@@ -35,8 +36,9 @@ branches:
     mode: ManualDeployment
     label: beta
     increment: None
-    prevent-increment-of-merged-branch-version: true
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
     track-merge-target: false
     regex: ^releases?[/-]
     source-branches:
@@ -86,8 +88,10 @@ ignore:
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-current-commit-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled

--- a/src/GitVersion.Configuration/SupportedWorkflows/TrunkBased/v1.yml
+++ b/src/GitVersion.Configuration/SupportedWorkflows/TrunkBased/v1.yml
@@ -19,7 +19,8 @@ branches:
     mode: ContinuousDeployment
     label: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     regex: ^master$|^main$
     source-branches: []
@@ -30,14 +31,16 @@ branches:
   feature:
     increment: Minor
     regex: ^features?[/-](?<BranchName>.+)
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     source-branches:
     - main
     pre-release-weight: 30000
   hotfix:
     increment: Patch
     regex: ^hotfix(es)?[/-](?<BranchName>.+)
-    prevent-increment-when-current-commit-tagged: false
+    prevent-increment:
+      when-current-commit-tagged: false
     source-branches:
     - main
     pre-release-weight: 30000
@@ -64,8 +67,10 @@ ignore:
 mode: ManualDeployment
 label: '{BranchName}'
 increment: Inherit
-prevent-increment-of-merged-branch-version: false
-prevent-increment-when-current-commit-tagged: true
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
 track-merge-target: false
 track-merge-message: true
 commit-message-incrementing: Enabled

--- a/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
@@ -307,7 +307,7 @@ public class DevelopScenarios : TestBase
             .WithBranch("main", builder => builder.WithDeploymentMode(DeploymentMode.ContinuousDelivery))
             .WithBranch("develop", builder => builder
                 .WithDeploymentMode(DeploymentMode.ContinuousDelivery)
-                .WithPreventIncrementOfMergedBranchVersion(false)
+                .WithPreventIncrementOfMergedBranch(false)
             )
             .WithBranch("release", builder => builder.WithDeploymentMode(DeploymentMode.ContinuousDelivery))
             .Build();
@@ -350,7 +350,7 @@ public class DevelopScenarios : TestBase
     {
         var configuration = GitFlowConfigurationBuilder.New
             .WithDeploymentMode(DeploymentMode.ContinuousDelivery)
-            .WithBranch("develop", builder => builder.WithPreventIncrementOfMergedBranchVersion(true))
+            .WithBranch("develop", builder => builder.WithPreventIncrementOfMergedBranch(true))
             .Build();
 
         using var fixture = new EmptyRepositoryFixture();
@@ -391,10 +391,10 @@ public class DevelopScenarios : TestBase
     {
         var configuration = GitFlowConfigurationBuilder.New
             .WithBranch("develop", builder => builder
-                .WithPreventIncrementOfMergedBranchVersion(false)
+                .WithPreventIncrementOfMergedBranch(false)
             )
             .WithBranch("hotfix", builder => builder
-                .WithPreventIncrementOfMergedBranchVersion(true)
+                .WithPreventIncrementOfMergedBranch(true)
                 .WithRegularExpression("^(origin/)?hotfix[/-]")
             )
             .Build();

--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -454,7 +454,7 @@ public class FeatureBranchScenarios : TestBase
             .WithAssemblyVersioningScheme(AssemblyVersioningScheme.Major)
             .WithAssemblyFileVersioningFormat("{MajorMinorPatch}.{env:WeightedPreReleaseNumber ?? 0}")
             .WithBranch("main", builder => builder.WithDeploymentMode(DeploymentMode.ContinuousDelivery))
-            .WithBranch("develop", builder => builder.WithPreventIncrementOfMergedBranchVersion(true))
+            .WithBranch("develop", builder => builder.WithPreventIncrementOfMergedBranch(true))
             .WithBranch("feature", builder => builder
                 .WithLabel($"feat-{ConfigurationConstants.BranchNamePlaceholder}")
                 .WithDeploymentMode(DeploymentMode.ContinuousDelivery)

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
@@ -226,7 +226,7 @@ internal partial class TrunkBasedScenariosWithAGitFlow
             IncrementStrategy increment, IncrementStrategy incrementOnFeature, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(increment).WithLabel(label).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(increment).WithLabel(label).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(incrementOnFeature))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
@@ -259,7 +259,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -488,7 +488,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -717,7 +717,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -946,7 +946,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
@@ -258,7 +258,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -486,7 +486,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -713,7 +713,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -940,7 +940,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
@@ -258,7 +258,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -485,7 +485,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -712,7 +712,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -939,7 +939,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
@@ -258,7 +258,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -485,7 +485,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -712,7 +712,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -939,7 +939,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
@@ -258,7 +258,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -485,7 +485,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -712,7 +712,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -939,7 +939,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
@@ -264,7 +264,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -493,7 +493,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -722,7 +722,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -951,7 +951,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
@@ -263,7 +263,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -492,7 +492,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -721,7 +721,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -950,7 +950,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/TrunkBased/TrunkBasedScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
@@ -261,7 +261,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(null).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -490,7 +490,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel(string.Empty).WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -719,7 +719,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("foo").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 
@@ -948,7 +948,7 @@ internal partial class TrunkBasedScenariosWithAGitHubFlow
             IncrementStrategy incrementOnMain, IncrementStrategy increment, string? label)
         {
             IGitVersionConfiguration trunkBased = TrunkBasedBuilder
-                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranchVersion(false))
+                .WithBranch("main", _ => _.WithIncrement(incrementOnMain).WithLabel("bar").WithPreventIncrementOfMergedBranch(false))
                 .WithBranch("feature", _ => _.WithIncrement(increment).WithLabel(label))
                 .Build();
 

--- a/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
@@ -154,28 +154,14 @@ public class EffectiveBranchConfigurationFinderTests
     {
         // Arrange
         var releaseBranchMock = GitToolsTestingExtensions.CreateMockBranch(branchName, GitToolsTestingExtensions.CreateMockCommit());
-        var branchConfiguration = new BranchConfiguration
-        {
-            Increment = IncrementStrategy.None,
-            PreventIncrementOfMergedBranchVersion = false,
-            TrackMergeTarget = false,
-            TracksReleaseBranches = false,
-            IsReleaseBranch = false,
-            SourceBranches = new()
-        };
-
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
             .WithBranch("release/latest", builder => builder
-                .WithConfiguration(branchConfiguration)
-                .WithDeploymentMode(DeploymentMode.ContinuousDeployment)
                 .WithIncrement(IncrementStrategy.None)
                 .WithLabel("latest")
                 .WithRegularExpression("release/latest")
             )
             .WithBranch("release", builder => builder
-                .WithConfiguration(branchConfiguration)
-                .WithDeploymentMode(DeploymentMode.ContinuousDeployment)
                 .WithIncrement(IncrementStrategy.Patch)
                 .WithLabel("not-latest")
                 .WithRegularExpression("releases?[/-]")

--- a/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
@@ -48,8 +48,9 @@ public record EffectiveConfiguration
         NextVersion = configuration.NextVersion;
         Increment = branchConfiguration.Increment;
         RegularExpression = branchConfiguration.RegularExpression;
-        PreventIncrementOfMergedBranchVersion = branchConfiguration.PreventIncrementOfMergedBranchVersion ?? false;
-        PreventIncrementWhenCurrentCommitTagged = branchConfiguration.PreventIncrementWhenCurrentCommitTagged ?? true;
+        PreventIncrementOfMergedBranch = branchConfiguration.PreventIncrement.OfMergedBranch ?? false;
+        PreventIncrementWhenBranchMerged = branchConfiguration.PreventIncrement.WhenBranchMerged ?? false;
+        PreventIncrementWhenCurrentCommitTagged = branchConfiguration.PreventIncrement.WhenCurrentCommitTagged ?? true;
         LabelNumberPattern = branchConfiguration.LabelNumberPattern;
         TrackMergeTarget = branchConfiguration.TrackMergeTarget ?? false;
         TrackMergeMessage = branchConfiguration.TrackMergeMessage ?? true;
@@ -98,7 +99,9 @@ public record EffectiveConfiguration
 
     public string? RegularExpression { get; }
 
-    public bool PreventIncrementOfMergedBranchVersion { get; }
+    public bool PreventIncrementOfMergedBranch { get; }
+
+    public bool PreventIncrementWhenBranchMerged { get; }
 
     public bool PreventIncrementWhenCurrentCommitTagged { get; }
 

--- a/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
@@ -11,9 +11,7 @@ public interface IBranchConfiguration
 
     IncrementStrategy Increment { get; }
 
-    bool? PreventIncrementOfMergedBranchVersion { get; }
-
-    bool? PreventIncrementWhenCurrentCommitTagged { get; }
+    IPreventIncrementConfiguration PreventIncrement { get; }
 
     string? LabelNumberPattern { get; }
 

--- a/src/GitVersion.Core/Configuration/IPreventIncrementConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IPreventIncrementConfiguration.cs
@@ -1,0 +1,10 @@
+namespace GitVersion.Configuration;
+
+public interface IPreventIncrementConfiguration
+{
+    public bool? OfMergedBranch { get; }
+
+    public bool? WhenBranchMerged { get; }
+
+    public bool? WhenCurrentCommitTagged { get; }
+}

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -117,6 +117,8 @@ GitVersion.Configuration.EffectiveConfiguration.AssemblyVersioningFormat.get -> 
 GitVersion.Configuration.EffectiveConfiguration.AssemblyVersioningScheme.get -> GitVersion.Extensions.AssemblyVersioningScheme
 GitVersion.Configuration.EffectiveConfiguration.DeploymentMode.get -> GitVersion.VersionCalculation.DeploymentMode
 GitVersion.Configuration.EffectiveConfiguration.EffectiveConfiguration(GitVersion.Configuration.IGitVersionConfiguration! configuration, GitVersion.Configuration.IBranchConfiguration! branchConfiguration) -> void
+GitVersion.Configuration.EffectiveConfiguration.PreventIncrementOfMergedBranch.get -> bool
+GitVersion.Configuration.EffectiveConfiguration.PreventIncrementWhenBranchMerged.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.PreventIncrementWhenCurrentCommitTagged.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.RegularExpression.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.CommitDateFormat.get -> string?
@@ -134,7 +136,6 @@ GitVersion.Configuration.EffectiveConfiguration.NextVersion.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.NoBumpMessage.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.PatchVersionBumpMessage.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.PreReleaseWeight.get -> int
-GitVersion.Configuration.EffectiveConfiguration.PreventIncrementOfMergedBranchVersion.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.SemanticVersionFormat.get -> GitVersion.SemanticVersionFormat
 GitVersion.Configuration.EffectiveConfiguration.TrackMergeMessage.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.TrackMergeTarget.get -> bool
@@ -156,8 +157,7 @@ GitVersion.Configuration.IBranchConfiguration.IsSourceBranchFor.get -> System.Co
 GitVersion.Configuration.IBranchConfiguration.Label.get -> string?
 GitVersion.Configuration.IBranchConfiguration.LabelNumberPattern.get -> string?
 GitVersion.Configuration.IBranchConfiguration.PreReleaseWeight.get -> int?
-GitVersion.Configuration.IBranchConfiguration.PreventIncrementOfMergedBranchVersion.get -> bool?
-GitVersion.Configuration.IBranchConfiguration.PreventIncrementWhenCurrentCommitTagged.get -> bool?
+GitVersion.Configuration.IBranchConfiguration.PreventIncrement.get -> GitVersion.Configuration.IPreventIncrementConfiguration!
 GitVersion.Configuration.IBranchConfiguration.RegularExpression.get -> string?
 GitVersion.Configuration.IBranchConfiguration.SourceBranches.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 GitVersion.Configuration.IBranchConfiguration.TrackMergeMessage.get -> bool?
@@ -198,6 +198,10 @@ GitVersion.Configuration.IIgnoreConfiguration
 GitVersion.Configuration.IIgnoreConfiguration.Before.get -> System.DateTimeOffset?
 GitVersion.Configuration.IIgnoreConfiguration.IsEmpty.get -> bool
 GitVersion.Configuration.IIgnoreConfiguration.Shas.get -> System.Collections.Generic.IReadOnlySet<string!>!
+GitVersion.Configuration.IPreventIncrementConfiguration
+GitVersion.Configuration.IPreventIncrementConfiguration.OfMergedBranch.get -> bool?
+GitVersion.Configuration.IPreventIncrementConfiguration.WhenBranchMerged.get -> bool?
+GitVersion.Configuration.IPreventIncrementConfiguration.WhenCurrentCommitTagged.get -> bool?
 GitVersion.ConfigurationInfo
 GitVersion.ConfigurationInfo.ConfigurationFile -> string?
 GitVersion.ConfigurationInfo.ConfigurationInfo() -> void

--- a/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/TrunkBased/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -9,21 +9,29 @@ internal abstract class MergeCommitOnNonTrunkBase : ITrunkBasedIncrementer
 
     public virtual IEnumerable<BaseVersionV2> GetIncrements(TrunkBasedIteration iteration, TrunkBasedCommit commit, TrunkBasedContext context)
     {
+        if (commit.ChildIteration is null) throw new InvalidOperationException("The commit child iteration is null.");
+
         var baseVersion = TrunkBasedVersionStrategy.DetermineBaseVersionRecursive(
-           iteration: commit.ChildIteration!,
+           iteration: commit.ChildIteration,
            targetLabel: context.TargetLabel
        );
 
         context.Label ??= baseVersion.Label;
 
-        if (commit.Configuration.PreventIncrementOfMergedBranchVersion)
-            context.Increment = baseVersion.Increment;
-        else
+        var increment = VersionField.None;
+        if (!commit.Configuration.PreventIncrementOfMergedBranch)
         {
-            context.Increment = context.Increment.Consolidate(baseVersion.Increment);
+            increment = increment.Consolidate(context.Increment);
+        }
+        if (!commit.ChildIteration.Configuration.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(baseVersion.Increment);
         }
         if (commit.Configuration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
-            context.Increment = context.Increment.Consolidate(commit.Increment);
+        {
+            increment = increment.Consolidate(commit.Increment);
+        }
+        context.Increment = increment;
 
         if (baseVersion.BaseVersionSource is not null)
         {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -30,7 +30,7 @@ internal class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionContext> ver
                     && Context.Configuration.IsReleaseBranch(mergeMessage.MergedBranch!))
                 {
                     this.log.Info($"Found commit [{commit}] matching merge message format: {mergeMessage.FormatName}");
-                    var shouldIncrement = !configuration.Value.PreventIncrementOfMergedBranchVersion;
+                    var shouldIncrement = !configuration.Value.PreventIncrementOfMergedBranch;
 
                     var message = commit.Message.Trim();
 


### PR DESCRIPTION
## Detailed Description

Introduce a new branch related property of name `prevent-increment-when-branch-merged`. This property can be used like the `prevent-increment-of-merged-branch` property to control the behavior of how to increment the version when a branch has been merged.

The configuration could be look like as following:
```yaml
prevent-increment:
  of-merged-branch: false
  when-branch-merged: false # new branch related property
  when-current-commit-tagged: true
```

## Context

Following business statements applying:

- The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when `prevent-increment-of-merged-branch` is set to true on the target branch
- The increment of the merged branch will be ignored when `prevent-increment-when-branch-merged` is set to true on the source branch

Close #3922

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
