### PR TITLE
Extend MergeMessageVersionStrategy to support squash commits

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -52,6 +52,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     [TestCase("Merge branch 'Release-v0.2.0'", true, "0.2.0")]
     [TestCase("Merge remote-tracking branch 'origin/release/0.8.0' into develop/" + MainBranch, true, "0.8.0")]
     [TestCase("Merge remote-tracking branch 'refs/remotes/origin/release/2.0.0'", true, "2.0.0")]
+    [TestCase("Merge branch 'Releases/0.2.0'", false, "0.2.0")] // Support Squash Commits
     public void TakesVersionFromMergeOfReleaseBranch(string message, bool isMergeCommit, string expectedVersion)
     {
         var parents = GetParents(isMergeCommit);

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -98,7 +98,11 @@ public class MergeMessage
 
         mergeMessage = null;
 
-        if (mergeCommit.IsMergeCommit)
+        var mergeMessageFormats = DefaultFormats.Union(
+                configuration.MergeMessageFormats
+                    .Select(n => new MergeMessageFormat(n.Key, n.Value)));
+
+        if (mergeCommit.IsMergeCommit || mergeMessageFormats.Any(format => format.Pattern.IsMatch(mergeCommit.Message)))
         {
             mergeMessage = new(mergeCommit.Message, configuration);
         }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -67,14 +67,8 @@ internal class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionContext> ver
         return mergeMessage != null;
     }
 
-    private static MergeMessage? Inner(ICommit mergeCommit, GitVersionContext context)
-    {
-        if (mergeCommit.Parents.Count() < 2)
-        {
-            return null;
-        }
-
-        var mergeMessage = new MergeMessage(mergeCommit.Message, context.Configuration);
-        return mergeMessage;
-    }
+    private static MergeMessage? Inner(ICommit mergeCommit, GitVersionContext context) =>
+        MergeMessage.TryParse(mergeCommit, context.Configuration, out MergeMessage? mergeMessage)
+            ? mergeMessage
+            : null;
 }


### PR DESCRIPTION
Extended the `TryParse` operation to include a regex check whether the commit message contains one of the specified CommitMessageFormats in order to support increment of merges from release into main branch when a squash merge has been applied.

## Motivation and Context
[Discussion](https://github.com/GitTools/GitVersion/discussions/3964)

## How Has This Been Tested?
- Local tests with only one merge commit worked
- Extended the `MergeMessageBaseVersionStrategyTests.cs` with a test using the `false` flag on `IsMergeCommit`


## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
