### PR TITLE
Feature/merge message releases

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -52,6 +52,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     [TestCase("Merge branch 'Release-v0.2.0'", true, "0.2.0")]
     [TestCase("Merge remote-tracking branch 'origin/release/0.8.0' into develop/" + MainBranch, true, "0.8.0")]
     [TestCase("Merge remote-tracking branch 'refs/remotes/origin/release/2.0.0'", true, "2.0.0")]
+    [TestCase("Merge branch 'Releases/0.2.0'", false, "0.2.0")] // Support Squash Commits
     public void TakesVersionFromMergeOfReleaseBranch(string message, bool isMergeCommit, string expectedVersion)
     {
         var parents = GetParents(isMergeCommit);

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -66,7 +66,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
         AssertMergeMessage(message + "\n ", expectedVersion, parents);
     }
 
-    [TestCase("Merge branch 'hotfix-0.1.5'", false)]
+    // [TestCase("Merge branch 'hotfix-0.1.5'", false)] this is somehow configured as a release branch
     [TestCase("Merge branch 'develop' of github.com:Particular/NServiceBus into develop", true)]
     [TestCase("Merge branch '4.0.3'", true)]
     [TestCase("Merge branch 's'", true)]

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -66,7 +66,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
         AssertMergeMessage(message + "\n ", expectedVersion, parents);
     }
 
-    // [TestCase("Merge branch 'hotfix-0.1.5'", false)] this is somehow configured as a release branch
+    [TestCase("Merge branch 'hotfix-0.1.5'", false)]
     [TestCase("Merge branch 'develop' of github.com:Particular/NServiceBus into develop", true)]
     [TestCase("Merge branch '4.0.3'", true)]
     [TestCase("Merge branch 's'", true)]
@@ -82,15 +82,19 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     [TestCase("Finish 0.14.1", true)] // Don't support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Hotfix' branch
     public void ShouldNotTakeVersionFromMergeOfNonReleaseBranch(string message, bool isMergeCommit)
     {
+        var configurationBuilder = GitFlowConfigurationBuilder.New;
+        configurationBuilder.WithBranch("hotfix", builder => builder.WithIsReleaseBranch(false));
+        ConfigurationHelper configurationHelper = new(configurationBuilder.Build());
+        var configurationDictionary = configurationHelper.Dictionary;
         var parents = GetParents(isMergeCommit);
-        AssertMergeMessage(message, null, parents);
-        AssertMergeMessage(message + " ", null, parents);
-        AssertMergeMessage(message + "\r ", null, parents);
-        AssertMergeMessage(message + "\r", null, parents);
-        AssertMergeMessage(message + "\r\n", null, parents);
-        AssertMergeMessage(message + "\r\n ", null, parents);
-        AssertMergeMessage(message + "\n", null, parents);
-        AssertMergeMessage(message + "\n ", null, parents);
+        AssertMergeMessage(message, null, parents, configurationDictionary);
+        AssertMergeMessage(message + " ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r\n", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r\n ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\n", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\n ", null, parents, configurationDictionary);
     }
 
     [TestCase("Merge pull request #165 from organization/Particular/release-1.0.0", true)]

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -99,7 +99,13 @@ public class MergeMessage
         mergeMessage = new(mergeCommit.Message, configuration);
 
         var isReleaseBranch = mergeMessage.MergedBranch != null && configuration.IsReleaseBranch(mergeMessage.MergedBranch);
+        var isValidMergeCommit = mergeCommit.IsMergeCommit || isReleaseBranch;
 
-        return mergeCommit.IsMergeCommit || isReleaseBranch;
+        if (!isValidMergeCommit)
+        {
+            mergeMessage = null;
+        }
+
+        return isValidMergeCommit;
     }
 }

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -96,17 +96,10 @@ public class MergeMessage
         mergeCommit.NotNull();
         configuration.NotNull();
 
-        mergeMessage = null;
+        mergeMessage = new(mergeCommit.Message, configuration);
 
-        var mergeMessageFormats = DefaultFormats.Union(
-                configuration.MergeMessageFormats
-                    .Select(n => new MergeMessageFormat(n.Key, n.Value)));
+        var isReleaseBranch = mergeMessage.MergedBranch != null && configuration.IsReleaseBranch(mergeMessage.MergedBranch);
 
-        if (mergeCommit.IsMergeCommit || mergeMessageFormats.Any(format => format.Pattern.IsMatch(mergeCommit.Message)))
-        {
-            mergeMessage = new(mergeCommit.Message, configuration);
-        }
-
-        return mergeMessage != null;
+        return mergeCommit.IsMergeCommit || isReleaseBranch;
     }
 }

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -98,7 +98,11 @@ public class MergeMessage
 
         mergeMessage = null;
 
-        if (mergeCommit.IsMergeCommit)
+        var mergeMessageFormats = DefaultFormats.Union(
+                configuration.MergeMessageFormats
+                    .Select(n => new MergeMessageFormat(n.Key, n.Value)));
+
+        if (mergeCommit.IsMergeCommit || mergeMessageFormats.Any(format => format.Pattern.IsMatch(mergeCommit.Message)))
         {
             mergeMessage = new(mergeCommit.Message, configuration);
         }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -67,14 +67,8 @@ internal class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionContext> ver
         return mergeMessage != null;
     }
 
-    private static MergeMessage? Inner(ICommit mergeCommit, GitVersionContext context)
-    {
-        if (mergeCommit.Parents.Count() < 2)
-        {
-            return null;
-        }
-
-        var mergeMessage = new MergeMessage(mergeCommit.Message, context.Configuration);
-        return mergeMessage;
-    }
+    private static MergeMessage? Inner(ICommit mergeCommit, GitVersionContext context) =>
+        MergeMessage.TryParse(mergeCommit, context.Configuration, out MergeMessage? mergeMessage)
+            ? mergeMessage
+            : null;
 }


### PR DESCRIPTION
Extended the `TryParse` operation to check whether the commit source branch is a release branch in order to support increment of merges from release into main branch when a squash merge has been applied.

## Motivation and Context
[Discussion](https://github.com/GitTools/GitVersion/discussions/3964)

## How Has This Been Tested?
- Local tests with only one merge commit worked
- Extended the `MergeMessageBaseVersionStrategyTests.cs` with a test using the `false` flag on `IsMergeCommit`

❗ I had to comment one test, as the `hotfix-0.1.5` branch was somehow configured as a release branch and thus, the version was taken into respect. Would appreciate some feedback here!

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
