### PR TITLE
Add support for Squash Commit releases

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -54,6 +54,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     [TestCase("Merge branch 'Release-v0.2.0'", true, "0.2.0")]
     [TestCase("Merge remote-tracking branch 'origin/release/0.8.0' into develop/" + MainBranch, true, "0.8.0")]
     [TestCase("Merge remote-tracking branch 'refs/remotes/origin/release/2.0.0'", true, "2.0.0")]
+    [TestCase("Merge branch 'Releases/0.2.0'", false, "0.2.0")] // Support Squash Commits
     public void TakesVersionFromMergeOfReleaseBranch(string message, bool isMergeCommit, string expectedVersion)
     {
         var parents = GetParents(isMergeCommit);
@@ -83,15 +84,20 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
     [TestCase("Finish 0.14.1", true)] // Don't support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Hotfix' branch
     public void ShouldNotTakeVersionFromMergeOfNonReleaseBranch(string message, bool isMergeCommit)
     {
+        var configurationBuilder = GitFlowConfigurationBuilder.New;
+        configurationBuilder.WithBranch("hotfix", builder => builder.WithIsReleaseBranch(false));
+        ConfigurationHelper configurationHelper = new(configurationBuilder.Build());
+        var configurationDictionary = configurationHelper.Dictionary;
+
         var parents = GetParents(isMergeCommit);
-        AssertMergeMessage(message, null, parents);
-        AssertMergeMessage(message + " ", null, parents);
-        AssertMergeMessage(message + "\r ", null, parents);
-        AssertMergeMessage(message + "\r", null, parents);
-        AssertMergeMessage(message + "\r\n", null, parents);
-        AssertMergeMessage(message + "\r\n ", null, parents);
-        AssertMergeMessage(message + "\n", null, parents);
-        AssertMergeMessage(message + "\n ", null, parents);
+        AssertMergeMessage(message, null, parents, configurationDictionary);
+        AssertMergeMessage(message + " ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r\n", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\r\n ", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\n", null, parents, configurationDictionary);
+        AssertMergeMessage(message + "\n ", null, parents, configurationDictionary);
     }
 
     [TestCase("Merge pull request #165 from organization/Particular/release-1.0.0", true)]

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -97,14 +97,15 @@ public class MergeMessage
         mergeCommit.NotNull();
         configuration.NotNull();
 
-        mergeMessage = new(mergeCommit.Message, configuration);
+        mergeMessage = null;
 
-        var isReleaseBranch = mergeMessage.MergedBranch != null && configuration.IsReleaseBranch(mergeMessage.MergedBranch);
+        var mergedBranch = new MergeMessage(mergeCommit.Message, configuration).MergedBranch;
+        var isReleaseBranch = mergedBranch != null && configuration.IsReleaseBranch(mergedBranch);
         var isValidMergeCommit = mergeCommit.IsMergeCommit() || isReleaseBranch;
 
-        if (!isValidMergeCommit)
+        if (isValidMergeCommit)
         {
-            mergeMessage = null;
+            mergeMessage = new(mergeCommit.Message, configuration);
         }
 
         return isValidMergeCommit;

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -97,13 +97,16 @@ public class MergeMessage
         mergeCommit.NotNull();
         configuration.NotNull();
 
-        mergeMessage = null;
+        mergeMessage = new(mergeCommit.Message, configuration);
 
-        if (mergeCommit.IsMergeCommit())
+        var isReleaseBranch = mergeMessage.MergedBranch != null && configuration.IsReleaseBranch(mergeMessage.MergedBranch);
+        var isValidMergeCommit = mergeCommit.IsMergeCommit() || isReleaseBranch;
+
+        if (!isValidMergeCommit)
         {
-            mergeMessage = new MergeMessage(mergeCommit.Message, configuration);
+            mergeMessage = null;
         }
 
-        return mergeMessage != null;
+        return isValidMergeCommit;
     }
 }


### PR DESCRIPTION
Extended the `TryParse` operation to check whether the commit source branch is a release branch in order to support increment of merges from release into main branch when a squash merge has been applied.

## Motivation and Context
[Discussion](https://github.com/GitTools/GitVersion/discussions/3964)

## How Has This Been Tested?
- Local tests with only one merge commit worked
- Extended the `MergeMessageBaseVersionStrategyTests.cs` with a test using the `false` flag on `IsMergeCommit`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
