### PR TITLE
Fix typo in track-merge-target and track-merge-message

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -245,8 +245,8 @@ branches:
     increment: Patch
     prevent-increment:
       of-merged-branch: true
-    tracks-merge-target: false
-    tracks-merge-message: true
+    track-merge-target: false
+    track-merge-message: true
     regex: ^master$|^main$
     source-branches: []
     is-source-branch-for: []

--- a/schemas/6.0/GitVersion.configuration.json
+++ b/schemas/6.0/GitVersion.configuration.json
@@ -337,7 +337,7 @@
       ]
     },
     "nullableOfBoolean3": {
-      "description": "This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.",
+      "description": "This branch related property controls the behavior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.",
       "type": [
         "boolean",
         "null"

--- a/src/GitVersion.Configuration/Workflows/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration/Workflows/GitHubFlow/v1.yml
@@ -24,8 +24,8 @@ branches:
     increment: Patch
     prevent-increment:
       of-merged-branch: true
-    tracks-merge-target: false
-    tracks-merge-message: true
+    track-merge-target: false
+    track-merge-message: true
     regex: ^master$|^main$
     source-branches: []
     is-source-branch-for: []


### PR DESCRIPTION
Fix typo in track-merge-target and track-merge-message

## Description
Due to the default configuration of the GitHubFlow/v1 having a typo, the GitVersion task fails with an unkown property.
`Could not build the configuration instance because following exception occurred: 'Property 'tracks-merge-target' not found on type 'GitVersion.Configuration.BranchConfiguration'.' Please ensure that the /overrideconfig parameters are correct and the configuration file is in the correct format.`

## Related Issue
https://github.com/GitTools/GitVersion/releases/tag/6.0.0-rc.1

## Motivation and Context
Fix the GitVersion task for GitHubFlow/v1.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
