### PR TITLE
#4060 - removed the `init` from the help

### DIFF
--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -23,7 +23,6 @@ GitVersion [path]
 
     path            The directory containing .git. If not defined current
                     directory is used. (Must be first argument)
-    init            Configuration utility for gitversion
     /version        Displays the version of GitVersion
     /diag           Runs GitVersion with additional diagnostic information
                     (requires git.exe to be installed)
@@ -94,8 +93,6 @@ GitVersion [path]
                     Use this switch to override
     /nofetch        Disables 'git fetch' during version calculation. Might cause
                     GitVersion to not calculate your version as expected.
-
-gitversion init     Configuration utility for gitversion
 ```
 
 ## Override config

--- a/src/GitVersion.App/ArgumentParserExtensions.cs
+++ b/src/GitVersion.App/ArgumentParserExtensions.cs
@@ -65,7 +65,7 @@ internal static class ArgumentParserExtensions
 
     public static bool ArgumentRequiresValue(this string argument, int argumentIndex)
     {
-        var booleanArguments = new[] { "init", "updateassemblyinfo", "ensureassemblyinfo", "nofetch", "nonormalize", "nocache" };
+        var booleanArguments = new[] { "updateassemblyinfo", "ensureassemblyinfo", "nofetch", "nonormalize", "nocache" };
 
         var argumentMightRequireValue = !booleanArguments.Contains(argument[1..], StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Fixes #4060