### PR TITLE
Fix path separator for gitversion.dll in MSBuild task

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -8,10 +8,10 @@
         <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == 'true' And '$(GenerateGitVersionFiles)' == 'true' ">true</UpdateAssemblyInfo>
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' And '$(GenerateGitVersionFiles)' == 'true' ">true</GenerateGitVersionInformation>
 
-        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$(MSBuildThisFileDirectory)$(TargetFramework)/gitversion.dll&quot;</GitVersionFileExe>
-        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$(MSBuildThisFileDirectory)$(TargetFramework)/GitVersion.MsBuild.dll</GitVersionAssemblyFile>
+        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(TargetFramework)))gitversion.dll&quot;</GitVersionFileExe>
+        <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(TargetFramework)))GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
-    
+
     <UsingTask TaskName="GetVersion" AssemblyFile="$(GitVersionAssemblyFile)" />
     <UsingTask TaskName="GenerateGitVersionInformation" AssemblyFile="$(GitVersionAssemblyFile)" />
     <UsingTask TaskName="WriteVersionInfoToBuildLog" AssemblyFile="$(GitVersionAssemblyFile)" />


### PR DESCRIPTION
## Description
I looked at #2547 on how they solved the path seperator issue. The linked issue and I have still have the same issue and from looking at the code I think this can fix the issue. 

## Related Issue
https://github.com/GitTools/GitVersion/issues/2993

My error I'm trying to fix:
```
0>GitVersion.MsBuild.targets(9,9): Error MSB3073 : The command "dotnet --roll-forward Major "C:\Users\[REDACTED]\.nuget\packages\gitversion.msbuild\5.7.0\tools\netcoreapp3.1/gitversion.dll" "C:\src\[REDACTED]\[REDACTED]" -output file -outputfile obj\gitversion.json" exited with code 1.
```

## Motivation and Context
We should not hardcode path seperators as they are environment dependent.

## How Has This Been Tested?
Nothing has been tested. I can't figure out how to actually build it locally. The build.ps1 script gives me this error
```
----------------------------------------
Setup
----------------------------------------
Could not execute because the specified command or file was not found.

----------------------------------------
TearDown
----------------------------------------
Starting Teardown...
Target:               Default
Build Agent:          Local
OS:                   Windows
Pull Request:         False
Repository Name:
Original Repository:  False
Branch Name:          issue-4086
Main Branch:          False
Support Branch:       False
Tagged:               False
IsStableRelease:      False
IsTaggedPreRelease:   False
IsInternalPreRelease: False
Finished running tasks.
Error: GitVersion: Process returned an error (exit code 1).
```

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project. 
- [ ] My change requires a change to the documentation. -don't think need documentation change
- [ ] I have updated the documentation accordingly. -don't think need documentation change
- [ ] I have added tests to cover my changes. -did not find tests
- [x] All new and existing tests passed.
