### PR TITLE
Replace underscores in branch specific labels

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -185,6 +185,7 @@ public class FeatureBranchScenarios : TestBase
     [TestCase("alpha", "JIRA-123", "^features?[/-](?<BranchName>.+)", "alpha")]
     [TestCase($"alpha.{ConfigurationConstants.BranchNamePlaceholder}", "JIRA-123", "^features?[/-](?<BranchName>.+)", "alpha.JIRA-123")]
     [TestCase("{BranchName}-of-task-number-{TaskNumber}", "4711_this-is-a-feature", "^features?[/-](?<TaskNumber>\\d+)_(?<BranchName>.+)", "this-is-a-feature-of-task-number-4711")]
+    [TestCase("{BranchName}", "4711_this-is-a-feature", "^features?[/-](?<BranchName>.+)", "4711-this-is-a-feature")]
     public void ShouldUseConfiguredLabel(string label, string featureName, string regularExpression, string preReleaseLabelName)
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -103,6 +103,8 @@ internal static class ConfigurationExtensions
                 {
                     label = label.Replace("{" + groupName + "}", match.Groups[groupName].Value);
                 }
+
+                label = label.Replace('_', '-');
             }
         }
 


### PR DESCRIPTION
## Description
Replace underscores in branch specific labels that may have been included through regex group matches.

## Related Issue
#4110

## Motivation and Context
The underscore is outputted into the SemVer value and elsewhere, but underscores are not valid SemVer characters.

## How Has This Been Tested?
Added integration test case.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
