### PR TITLE
Remove dependency on "git" executable

### DIFF
--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -82,16 +82,13 @@ internal class GitVersionExecutor(
             var error = $"An unexpected error occurred:{PathHelper.NewLine}{exception}";
             this.log.Error(error);
 
-            this.log.Info("Attempting to show the current git graph (please include in issue): ");
-            this.log.Info("Showing max of 100 commits");
-
             try
             {
-                GitExtensions.DumpGraph(gitVersionOptions.WorkingDirectory, mess => this.log.Info(mess), 100);
+                GitExtensions.DumpGraphLog(logMessage => this.log.Info(logMessage));
             }
             catch (Exception dumpGraphException)
             {
-                this.log.Error("Couldn't dump the git graph due to the following error: " + dumpGraphException);
+                this.log.Error($"Couldn't dump the git graph due to the following error: {dumpGraphException}");
             }
             return 1;
         }
@@ -131,8 +128,7 @@ internal class GitVersionExecutor(
         var workingDirectory = gitVersionOptions.WorkingDirectory;
         if (gitVersionOptions.Diag)
         {
-            this.log.Info("Dumping commit graph: ");
-            GitExtensions.DumpGraph(workingDirectory, mess => this.log.Info(mess), 100);
+            GitExtensions.DumpGraphLog(logMessage => this.log.Info(logMessage));
         }
 
         if (!Directory.Exists(workingDirectory))

--- a/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitToolsTestingExtensions.cs
@@ -30,6 +30,7 @@ public static class GitToolsTestingExtensions
         commit.When.Returns(when.AddSeconds(1));
         return commit;
     }
+
     public static IBranch CreateMockBranch(string name, params ICommit[] commits)
     {
         var branch = Substitute.For<IBranch>();
@@ -55,13 +56,13 @@ public static class GitToolsTestingExtensions
 
     public static IBranch FindBranch(this IGitRepository repository, string branchName)
         => repository.Branches.FirstOrDefault(branch => branch.Name.WithoutOrigin == branchName)
-            ?? throw new GitVersionException($"Branch {branchName} not found");
+           ?? throw new GitVersionException($"Branch {branchName} not found");
 
     public static void DumpGraph(this IGitRepository repository, Action<string>? writer = null, int? maxCommits = null)
-        => GitExtensions.DumpGraph(repository.Path, writer, maxCommits);
+        => DumpGraph(repository.Path, writer, maxCommits);
 
     public static void DumpGraph(this IRepository repository, Action<string>? writer = null, int? maxCommits = null)
-        => GitExtensions.DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
+        => DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
 
     public static GitVersionVariables GetVersion(this RepositoryFixtureBase fixture, IGitVersionConfiguration? configuration = null,
         IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
@@ -173,4 +174,7 @@ public static class GitToolsTestingExtensions
         servicesOverrides?.Invoke(services);
         return services.BuildServiceProvider();
     }
+
+    private static void DumpGraph(string workingDirectory, Action<string>? writer = null, int? maxCommits = null)
+        => GitTestExtensions.ExecuteGitCmd(GitExtensions.CreateGitLogArgs(maxCommits), workingDirectory, writer);
 }

--- a/src/GitVersion.Core/Core/GitVersionContextFactory.cs
+++ b/src/GitVersion.Core/Core/GitVersionContextFactory.cs
@@ -29,7 +29,8 @@ internal class GitVersionContextFactory(
             currentBranch, gitVersionOptions.RepositoryInfo.CommitId, configuration.Ignore
         );
 
-        if (currentCommit is null) throw new GitVersionException("No commits found on the current branch.");
+        if (currentCommit is null)
+            throw new GitVersionException("No commits found on the current branch.");
 
         if (currentBranch.IsDetachedHead)
         {

--- a/src/GitVersion.Core/Extensions/GitExtensions.cs
+++ b/src/GitVersion.Core/Extensions/GitExtensions.cs
@@ -1,28 +1,11 @@
-using GitVersion.Helpers;
-
 namespace GitVersion.Extensions;
 
 public static class GitExtensions
 {
-    public static void DumpGraph(string workingDirectory, Action<string>? writer = null, int? maxCommits = null)
+    public static void DumpGraphLog(Action<string>? writer = null, int? maxCommits = null)
     {
         var output = new StringBuilder();
-        try
-        {
-            ProcessHelper.Run(
-                o => output.AppendLine(o),
-                e => output.AppendLineFormat("ERROR: {0}", e),
-                null,
-                "git",
-                CreateGitLogArgs(maxCommits),
-                workingDirectory);
-        }
-        catch (FileNotFoundException exception) when (exception.FileName == "git")
-        {
-            output.AppendLine("Could not execute 'git log' due to the following error:");
-            output.AppendLine(exception.ToString());
-        }
-
+        output.AppendLine($"Please run `git {CreateGitLogArgs(maxCommits)}` to see the git graph. This can help you troubleshoot any issues.");
         if (writer != null)
         {
             writer(output.ToString());
@@ -36,6 +19,6 @@ public static class GitExtensions
     public static string CreateGitLogArgs(int? maxCommits)
     {
         var commits = maxCommits != null ? $" -n {maxCommits}" : null;
-        return $@"log --graph --format=""%h %cr %d"" --decorate --date=relative --all --remotes=*{commits}";
+        return $"""log --graph --format="%h %cr %d" --decorate --date=relative --all --remotes=*{commits}""";
     }
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -753,7 +753,7 @@ static GitVersion.Extensions.EnumerableExtensions.AddRange<T>(this System.Collec
 static GitVersion.Extensions.EnumerableExtensions.OnlyOrDefault<T>(this System.Collections.Generic.IEnumerable<T>! source) -> T?
 static GitVersion.Extensions.EnumerableExtensions.SingleOfType<T>(this System.Collections.IEnumerable! source) -> T
 static GitVersion.Extensions.GitExtensions.CreateGitLogArgs(int? maxCommits) -> string!
-static GitVersion.Extensions.GitExtensions.DumpGraph(string! workingDirectory, System.Action<string!>? writer = null, int? maxCommits = null) -> void
+static GitVersion.Extensions.GitExtensions.DumpGraphLog(System.Action<string!>? writer = null, int? maxCommits = null) -> void
 static GitVersion.Extensions.IncrementStrategyExtensions.ToVersionField(this GitVersion.IncrementStrategy strategy) -> GitVersion.VersionField
 static GitVersion.Extensions.ReadEmbeddedResourceExtensions.ReadAsStringFromEmbeddedResource(this string! resourceName, System.Reflection.Assembly! assembly) -> string!
 static GitVersion.Extensions.ReadEmbeddedResourceExtensions.ReadAsStringFromEmbeddedResource<T>(this string! resourceName) -> string!

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -73,7 +73,7 @@ public abstract class RepositoryFixtureBase : IDisposable
         SequenceDiagram.Destroy(branch);
     }
 
-    public static void Init(string path, string branchName = "main") => GitTestExtensions.ExecuteGitCmd($"init {path} -b {branchName}");
+    public static void Init(string path, string branchName = "main") => GitTestExtensions.ExecuteGitCmd($"init {path} -b {branchName}", ".");
 
     public string MakeATaggedCommit(string tag)
     {
@@ -165,8 +165,8 @@ public abstract class RepositoryFixtureBase : IDisposable
     /// </summary>
     public void MakeShallow()
     {
-        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} pull --depth 1");
-        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} gc --prune=all");
+        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} pull --depth 1", ".");
+        GitTestExtensions.ExecuteGitCmd($"-C {RepositoryPath} gc --prune=all", ".");
     }
 
     public void Fetch(string remote, FetchOptions? options = null)

--- a/src/GitVersion.Testing/GitTestExtensions.cs
+++ b/src/GitVersion.Testing/GitTestExtensions.cs
@@ -69,7 +69,7 @@ public static class GitTestExtensions
         return commit;
     }
 
-    public static void ExecuteGitCmd(string gitCmd, Action<string>? writer = null)
+    public static void ExecuteGitCmd(string gitCmd, string workingDirectory, Action<string>? writer = null)
     {
         var output = new StringBuilder();
         try
@@ -80,7 +80,7 @@ public static class GitTestExtensions
                 null,
                 "git",
                 gitCmd,
-                ".");
+                workingDirectory);
         }
         catch (FileNotFoundException exception) when (exception.FileName == "git")
         {

--- a/src/GitVersion.Testing/GitVersion.Testing.csproj
+++ b/src/GitVersion.Testing/GitVersion.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
@@ -7,6 +7,5 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="..\GitVersion.Core\Helpers\PathHelper.cs" Link="Helpers\PathHelper.cs" />
-        <Compile Include="..\GitVersion.Core\Helpers\ProcessHelper.cs" Link="Helpers\ProcessHelper.cs" />
     </ItemGroup>
 </Project>

--- a/src/GitVersion.Testing/Helpers/ProcessHelper.cs
+++ b/src/GitVersion.Testing/Helpers/ProcessHelper.cs
@@ -1,9 +1,9 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
-namespace GitVersion.Helpers;
+namespace GitVersion.Testing;
 
-internal static class ProcessHelper
+public static class ProcessHelper
 {
     private static readonly object LockObject = new();
 

--- a/src/mark-shipped.ps1
+++ b/src/mark-shipped.ps1
@@ -1,3 +1,5 @@
+#! /usr/bin/env pwsh
+
 [CmdletBinding(PositionalBinding = $false)]
 param ()
 


### PR DESCRIPTION
This will simplify the publishing to winget, as well as there is no reason to depend on git executable only to be able to do the dump of the git graph.

This is changed by providing the exact commit command that needs to be run to get the git graph, instead of running the git executable but gitversion