### PR TITLE
Add test for commit bump during 0.x

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -115,4 +115,17 @@ public class VersionBumpingScenarios : TestBase
 
         fixture.AssertFullSemver("2.0.1-1");
     }
+
+    [Theory]
+    [TestCase("Breaking change\n\n+semver:breaking", "0.2.0-1")]
+    [TestCase("Minor change\n\n+semver:minor", "0.1.1-1")]
+    [TestCase("Patch change\n\n+semver:patch", "0.1.1-1")]
+    public void BumpsCorrectPartDuringInitialDevelopment(string commitMessage, string expectedVersion)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.MakeATaggedCommit("0.1.0");
+        fixture.Repository.MakeACommit(commitMessage);
+        fixture.AssertFullSemver(expectedVersion);
+    }
 }


### PR DESCRIPTION
This test verifies issue #4184.

## Description
As [described in the documentation](https://gitversion.net/docs/reference/version-increments#commit-messages), bumping the major version during the 0.x phase should bump the minor version instead.

However, this does not currently work. This test sets up that scenario.

## Related Issue
#4184 

## Motivation and Context
This test will make sure the bump behaviour stays as intended.

## How Has This Been Tested?
I have run the test locally on my machine and it behaves as expected (currently failing of course).

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (The new test fails by design)
