### PR TITLE
Do not return the tag as branch name for GitLab CI

### DIFF
--- a/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
@@ -21,7 +21,18 @@ internal class GitLabCi : BuildAgentBase
         $"GitVersion_{name}={value}"
     ];
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {
+        // CI_COMMIT_REF_NAME can contain either the branch or the tag
+        // See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+
+        // CI_COMMIT_TAG is only available in tag pipelines,
+        // so we can exit if CI_COMMIT_REF_NAME would return the tag
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI_COMMIT_TAG")))
+            return null;
+
+        return Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
+    }
 
     public override bool PreventFetch() => true;
 


### PR DESCRIPTION
In case of a tag pipeline, return null as branch name instead of the tag

## Description
For tag pipelines (triggered by tagging a commit), do not return CI_COMMIT_REF_NAME as the current branch because in this case it contains the new tag instead of a branch.

## Related Issue
Fixes #4186

## Motivation and Context
Bugfix

## How Has This Been Tested?
Manually tested the following scenarios on GitLab CI:
- Commit
- Tag
- Branches
- Merge requests

Also ran the tests in the solution.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
