### PR TITLE
add link to docs version 5.12.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
       uses: chabad360/htmlproofer@master
       with:
         directory: ./artifacts/docs/preview
-        arguments: --ignore-urls /api/,/docs/ --allow-hash-href --allow-missing-href --assume-extension --disable-external --no-check_external_hash
+        arguments: --ignore-urls /api/,/docs/,/5.12.0/ --allow-hash-href --allow-missing-href --assume-extension --disable-external --no-check_external_hash
     -
       name: '[Reviewdog Reporter]'
       id: reporter

--- a/docs/input/_Navbar.cshtml
+++ b/docs/input/_Navbar.cshtml
@@ -1,0 +1,13 @@
+@{
+    List<Tuple<string, string>> pages = new List<Tuple<string, string>>
+    {
+        Tuple.Create("Documentation", Context.GetLink("docs")),
+        Tuple.Create("API", Context.GetLink("api")),
+        Tuple.Create("<i></i> 5.12.0", "/5.12.0/docs"),
+    };
+    foreach(Tuple<string, string> p in pages)
+    {
+        string active = Context.GetLink(Document).StartsWith(p.Item2) ? "active" : null;
+        <li class="@active"><a href="@p.Item2">@Html.Raw(p.Item1)</a></li>
+    }
+}


### PR DESCRIPTION
Adds the link to the older version of the docs at https://gitversion.net/5.12.0/docs/