### PR TITLE
Move regex patterns to a common file

### DIFF
--- a/new-cli/GitVersion.Common/GitVersion.Common.csproj
+++ b/new-cli/GitVersion.Common/GitVersion.Common.csproj
@@ -6,6 +6,7 @@
     <Compile Include="..\..\src\GitVersion.Core\Core\Abstractions\IEnvironment.cs" Link="Infrastructure\%(Filename)%(Extension)" />
     <Compile Include="..\..\src\GitVersion.Core\Core\Abstractions\IFileSystem.cs" Link="Infrastructure\%(Filename)%(Extension)" />
     <Compile Include="..\..\src\GitVersion.Core\Core\Exceptions\WarningException.cs" Link="Exceptions\%(Filename)%(Extension)"/>
+    <Compile Include="..\..\src\GitVersion.Core\Core\RegexPatterns.cs" Link="%(Filename)%(Extension)" />
     <Compile Include="..\..\src\GitVersion.Core\Extensions\StringExtensions.cs" Link="Extensions\StringExtensions.cs" />
     <Compile Include="..\..\src\GitVersion.Core\Extensions\CommonExtensions.cs" Link="Extensions\CommonExtensions.cs" />
     <Compile Include="..\..\src\GitVersion.Core\Helpers\*.cs" Link="Helpers\%(Filename)%(Extension)" />

--- a/src/GitVersion.App/ArgumentParserExtensions.cs
+++ b/src/GitVersion.App/ArgumentParserExtensions.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Helpers;
 
 namespace GitVersion;
@@ -39,9 +39,13 @@ internal static class ArgumentParserExtensions
     }
 
     public static bool IsSwitchArgument(this string? value)
-        => value != null
-           && (value.StartsWith('-') || value.StartsWith('/'))
-           && !Regex.Match(value, @"/\w+:").Success; //Exclude msbuild & project parameters in form /blah:, which should be parsed as values, not switch names.
+    {
+        var patternRegex = RegexPatterns.Common.SwitchArgumentRegex;
+        return value != null
+               && (value.StartsWith('-') || value.StartsWith('/'))
+               && !patternRegex.Match(value).Success;
+        //Exclude msbuild & project parameters in form /blah:, which should be parsed as values, not switch names.
+    }
 
     public static bool IsSwitch(this string? value, string switchName)
     {

--- a/src/GitVersion.Configuration/BranchConfiguration.cs
+++ b/src/GitVersion.Configuration/BranchConfiguration.cs
@@ -90,7 +90,7 @@ internal record BranchConfiguration : IBranchConfiguration
             Increment = Increment == IncrementStrategy.Inherit ? configuration.Increment : Increment,
             DeploymentMode = DeploymentMode ?? configuration.DeploymentMode,
             Label = Label ?? configuration.Label,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = PreventIncrement.OfMergedBranch ?? configuration.PreventIncrement.OfMergedBranch,
                 WhenBranchMerged = PreventIncrement.WhenBranchMerged ?? configuration.PreventIncrement.WhenBranchMerged,
@@ -117,7 +117,7 @@ internal record BranchConfiguration : IBranchConfiguration
             Increment = Increment == IncrementStrategy.Inherit ? configuration.Increment : Increment,
             DeploymentMode = DeploymentMode ?? configuration.DeploymentMode,
             Label = Label ?? configuration.Label,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = PreventIncrement.OfMergedBranch ?? configuration.PreventIncrementOfMergedBranch,
                 WhenBranchMerged = PreventIncrement.WhenBranchMerged ?? configuration.PreventIncrementWhenBranchMerged,

--- a/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
@@ -177,7 +177,7 @@ internal class BranchConfigurationBuilder
         IsMainBranch = isMainBranch,
         IsReleaseBranch = isReleaseBranch,
         LabelNumberPattern = labelNumberPattern,
-        PreventIncrement = new PreventIncrementConfiguration()
+        PreventIncrement = new PreventIncrementConfiguration
         {
             OfMergedBranch = preventIncrementOfMergedBranch,
             WhenBranchMerged = preventIncrementWhenBranchMerged,

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -423,7 +423,7 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
             IsMainBranch = this.isMainBranch,
             IsReleaseBranch = this.isReleaseBranch,
             LabelNumberPattern = this.labelNumberPattern,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = this.preventIncrementOfMergedBranch,
                 WhenBranchMerged = this.preventIncrementWhenBranchMerged,

--- a/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
@@ -1,3 +1,4 @@
+using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;
@@ -13,10 +14,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             AssemblyFileVersioningScheme = ConfigurationConstants.DefaultAssemblyFileVersioningScheme,
             AssemblyVersioningScheme = ConfigurationConstants.DefaultAssemblyVersioningScheme,
             CommitDateFormat = ConfigurationConstants.DefaultCommitDateFormat,
-            MajorVersionBumpMessage = IncrementStrategyFinder.DefaultMajorPattern,
-            MinorVersionBumpMessage = IncrementStrategyFinder.DefaultMinorPattern,
-            NoBumpMessage = IncrementStrategyFinder.DefaultNoBumpPattern,
-            PatchVersionBumpMessage = IncrementStrategyFinder.DefaultPatchPattern,
+            MajorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMajorPattern,
+            MinorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMinorPattern,
+            NoBumpMessage = RegexPatterns.VersionCalculation.DefaultNoBumpPattern,
+            PatchVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultPatchPattern,
             SemanticVersionFormat = ConfigurationConstants.DefaultSemanticVersionFormat,
             VersionStrategies = ConfigurationConstants.DefaultVersionStrategies,
             TagPrefix = ConfigurationConstants.DefaultTagPrefix,
@@ -28,7 +29,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
             CommitMessageIncrementing = CommitMessageIncrementMode.Enabled,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = false,
                 WhenBranchMerged = false,
@@ -48,7 +49,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             RegularExpression = DevelopBranch.RegexPattern,
             SourceBranches = [this.MainBranch.Name],
             Label = "alpha",
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -66,7 +67,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             RegularExpression = MainBranch.RegexPattern,
             SourceBranches = [],
             Label = string.Empty,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true
             },
@@ -89,7 +90,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.SupportBranch.Name,
             ],
             Label = "beta",
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
@@ -115,7 +116,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.HotfixBranch.Name
             ],
             Label = ConfigurationConstants.BranchNamePlaceholder,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -139,7 +140,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.HotfixBranch.Name
             ],
             Label = "PullRequest",
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
@@ -154,7 +155,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             Increment = IncrementStrategy.Inherit,
             RegularExpression = HotfixBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ManualDeployment,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -175,7 +176,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             RegularExpression = SupportBranch.RegexPattern,
             SourceBranches = [this.MainBranch.Name],
             Label = string.Empty,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true
             },
@@ -202,7 +203,7 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
                 this.SupportBranch.Name
             ],
             Label = ConfigurationConstants.BranchNamePlaceholder,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = true
             },

--- a/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
@@ -1,3 +1,4 @@
+using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;
@@ -13,10 +14,10 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             AssemblyFileVersioningScheme = ConfigurationConstants.DefaultAssemblyFileVersioningScheme,
             AssemblyVersioningScheme = ConfigurationConstants.DefaultAssemblyVersioningScheme,
             CommitDateFormat = ConfigurationConstants.DefaultCommitDateFormat,
-            MajorVersionBumpMessage = IncrementStrategyFinder.DefaultMajorPattern,
-            MinorVersionBumpMessage = IncrementStrategyFinder.DefaultMinorPattern,
-            NoBumpMessage = IncrementStrategyFinder.DefaultNoBumpPattern,
-            PatchVersionBumpMessage = IncrementStrategyFinder.DefaultPatchPattern,
+            MajorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMajorPattern,
+            MinorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMinorPattern,
+            NoBumpMessage = RegexPatterns.VersionCalculation.DefaultNoBumpPattern,
+            PatchVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultPatchPattern,
             SemanticVersionFormat = ConfigurationConstants.DefaultSemanticVersionFormat,
             VersionStrategies = ConfigurationConstants.DefaultVersionStrategies,
             TagPrefix = ConfigurationConstants.DefaultTagPrefix,
@@ -26,7 +27,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = false,
                 WhenBranchMerged = false,
@@ -45,7 +46,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
         {
             Label = string.Empty,
             Increment = IncrementStrategy.Patch,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true
             },
@@ -64,7 +65,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = "beta",
             Increment = IncrementStrategy.Patch,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true,
                 WhenBranchMerged = false,
@@ -88,7 +89,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -108,7 +109,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = "PullRequest",
             Increment = IncrementStrategy.Inherit,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
@@ -130,7 +131,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },

--- a/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
@@ -1,3 +1,4 @@
+using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;
@@ -8,15 +9,15 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
 
     private TrunkBasedConfigurationBuilder()
     {
-        WithConfiguration(new GitVersionConfiguration()
+        WithConfiguration(new GitVersionConfiguration
         {
             AssemblyFileVersioningScheme = ConfigurationConstants.DefaultAssemblyFileVersioningScheme,
             AssemblyVersioningScheme = ConfigurationConstants.DefaultAssemblyVersioningScheme,
             CommitDateFormat = ConfigurationConstants.DefaultCommitDateFormat,
-            MajorVersionBumpMessage = IncrementStrategyFinder.DefaultMajorPattern,
-            MinorVersionBumpMessage = IncrementStrategyFinder.DefaultMinorPattern,
-            NoBumpMessage = IncrementStrategyFinder.DefaultNoBumpPattern,
-            PatchVersionBumpMessage = IncrementStrategyFinder.DefaultPatchPattern,
+            MajorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMajorPattern,
+            MinorVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultMinorPattern,
+            NoBumpMessage = RegexPatterns.VersionCalculation.DefaultNoBumpPattern,
+            PatchVersionBumpMessage = RegexPatterns.VersionCalculation.DefaultPatchPattern,
             SemanticVersionFormat = ConfigurationConstants.DefaultSemanticVersionFormat,
             VersionStrategies = [
                 VersionStrategies.ConfiguredNextVersion,
@@ -31,7 +32,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Inherit,
             CommitMessageIncrementing = CommitMessageIncrementMode.Enabled,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = false,
                 WhenBranchMerged = false,
@@ -44,12 +45,12 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             IsMainBranch = false
         });
 
-        WithBranch(MainBranch.Name).WithConfiguration(new BranchConfiguration()
+        WithBranch(MainBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDeployment,
             Label = string.Empty,
             Increment = IncrementStrategy.Patch,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true
             },
@@ -63,12 +64,12 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 55000
         });
 
-        WithBranch(FeatureBranch.Name).WithConfiguration(new BranchConfiguration()
+        WithBranch(FeatureBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Minor,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -82,12 +83,12 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(HotfixBranch.Name).WithConfiguration(new BranchConfiguration()
+        WithBranch(HotfixBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = ConfigurationConstants.BranchNamePlaceholder,
             Increment = IncrementStrategy.Patch,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
@@ -106,7 +107,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = "PullRequest",
             Increment = IncrementStrategy.Inherit,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
@@ -126,7 +127,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
         WithBranch(UnknownBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Patch,
-            PreventIncrement = new PreventIncrementConfiguration()
+            PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },

--- a/src/GitVersion.Configuration/GitVersionConfiguration.cs
+++ b/src/GitVersion.Configuration/GitVersionConfiguration.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using GitVersion.Configuration.Attributes;
+using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.VersionCalculation;
 using static GitVersion.Configuration.ConfigurationConstants;
@@ -49,7 +50,7 @@ internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersio
     public string? VersionInBranchPattern { get; internal set; }
 
     [JsonIgnore]
-    public Regex VersionInBranchRegex => versionInBranchRegex ??= new Regex(GetVersionInBranchPattern(), RegexOptions.Compiled);
+    public Regex VersionInBranchRegex => versionInBranchRegex ??= new(GetVersionInBranchPattern(), RegexOptions.Compiled);
     private Regex? versionInBranchRegex;
 
     private string GetVersionInBranchPattern()
@@ -72,26 +73,26 @@ internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersio
     private string? nextVersion;
 
     [JsonPropertyName("major-version-bump-message")]
-    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a major version increment. Defaults to '{IncrementStrategyFinder.DefaultMajorPattern}'")]
-    [JsonPropertyDefault(IncrementStrategyFinder.DefaultMajorPattern)]
+    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a major version increment. Defaults to '{RegexPatterns.VersionCalculation.DefaultMajorPattern}'")]
+    [JsonPropertyDefault(RegexPatterns.VersionCalculation.DefaultMajorPattern)]
     [JsonPropertyFormat(Format.Regex)]
     public string? MajorVersionBumpMessage { get; internal set; }
 
     [JsonPropertyName("minor-version-bump-message")]
-    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a minor version increment. Defaults to '{IncrementStrategyFinder.DefaultMinorPattern}'")]
-    [JsonPropertyDefault(IncrementStrategyFinder.DefaultMinorPattern)]
+    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a minor version increment. Defaults to '{RegexPatterns.VersionCalculation.DefaultMinorPattern}'")]
+    [JsonPropertyDefault(RegexPatterns.VersionCalculation.DefaultMinorPattern)]
     [JsonPropertyFormat(Format.Regex)]
     public string? MinorVersionBumpMessage { get; internal set; }
 
     [JsonPropertyName("patch-version-bump-message")]
-    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a patch version increment. Defaults to '{IncrementStrategyFinder.DefaultPatchPattern}'")]
-    [JsonPropertyDefault(IncrementStrategyFinder.DefaultPatchPattern)]
+    [JsonPropertyDescription($"The regular expression to match commit messages with to perform a patch version increment. Defaults to '{RegexPatterns.VersionCalculation.DefaultPatchPattern}'")]
+    [JsonPropertyDefault(RegexPatterns.VersionCalculation.DefaultPatchPattern)]
     [JsonPropertyFormat(Format.Regex)]
     public string? PatchVersionBumpMessage { get; internal set; }
 
     [JsonPropertyName("no-bump-message")]
-    [JsonPropertyDescription($"Used to tell GitVersion not to increment when in Mainline development mode. Defaults to '{IncrementStrategyFinder.DefaultNoBumpPattern}'")]
-    [JsonPropertyDefault(IncrementStrategyFinder.DefaultNoBumpPattern)]
+    [JsonPropertyDescription($"Used to tell GitVersion not to increment when in Mainline development mode. Defaults to '{RegexPatterns.VersionCalculation.DefaultNoBumpPattern}'")]
+    [JsonPropertyDefault(RegexPatterns.VersionCalculation.DefaultNoBumpPattern)]
     [JsonPropertyFormat(Format.Regex)]
     public string? NoBumpMessage { get; internal set; }
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
@@ -63,7 +63,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -81,7 +81,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -98,7 +98,7 @@ public class IgnoreCommitScenarios : TestBase
         var commitC = fixture.Repository.MakeACommit("C");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitC.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitC.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -117,7 +117,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitC.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitC.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -136,7 +136,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Before = commitC.Committer.When })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Before = commitC.Committer.When })
             .Build();
 
         // ✅ succeeds as expected
@@ -155,7 +155,7 @@ public class IgnoreCommitScenarios : TestBase
         var commitB = fixture.Repository.MakeACommit("B");
 
         var configuration = TrunkBasedConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .WithBranch("main", b => b.WithIncrement(IncrementStrategy.Patch)
                 .WithPreventIncrementWhenCurrentCommitTagged(preventIncrementWhenCurrentCommitTagged)
                 .WithDeploymentMode(GitVersion.VersionCalculation.DeploymentMode.ContinuousDelivery)
@@ -213,7 +213,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -231,7 +231,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -248,7 +248,7 @@ public class IgnoreCommitScenarios : TestBase
         var commitC = fixture.Repository.MakeACommit("C");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitC.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitC.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -267,7 +267,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitC.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitC.Sha] })
             .Build();
 
         // ✅ succeeds as expected
@@ -286,7 +286,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("D");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Before = commitC.Committer.When })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Before = commitC.Committer.When })
             .Build();
 
         // ✅ succeeds as expected
@@ -305,7 +305,7 @@ public class IgnoreCommitScenarios : TestBase
         var commitB = fixture.Repository.MakeACommit("B");
 
         var configuration = GitHubFlowConfigurationBuilder.New
-            .WithIgnoreConfiguration(new IgnoreConfiguration() { Shas = [commitB.Sha] })
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [commitB.Sha] })
             .WithBranch("main", b => b.WithPreventIncrementWhenCurrentCommitTagged(preventIncrementWhenCurrentCommitTagged))
             .Build();
 

--- a/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -30,7 +30,7 @@ public class NextVersionCalculatorTests : TestBase
     {
         using var contextBuilder = new GitVersionContextBuilder();
 
-        var overrideConfiguration = new Dictionary<object, object?>()
+        var overrideConfiguration = new Dictionary<object, object?>
         {
             { "next-version", "1.0.0" }
         };

--- a/src/GitVersion.Core/Core/RegexPatterns.cs
+++ b/src/GitVersion.Core/Core/RegexPatterns.cs
@@ -1,0 +1,83 @@
+using System.Text.RegularExpressions;
+
+namespace GitVersion.Core;
+
+internal static class RegexPatterns
+{
+    internal static class Common
+    {
+        public static readonly Regex SwitchArgumentRegex = new(@"/\w+:", RegexOptions.Compiled);
+        public static readonly Regex ObscurePasswordRegex = new("(https?://)(.+)(:.+@)", RegexOptions.Compiled);
+
+        // This regex matches an expression to replace.
+        // - env:ENV name OR a member name
+        // - optional fallback value after " ?? "
+        // - the fallback value should be a quoted string, but simple unquoted text is allowed for back compat
+        public static readonly Regex ExpandTokensRegex = new("""{((env:(?<envvar>\w+))|(?<member>\w+))(\s+(\?\?)??\s+((?<fallback>\w+)|"(?<fallback>.*)"))??}""", RegexOptions.Compiled);
+    }
+
+    internal static class MergeMessage
+    {
+        public static readonly Regex DefaultMergeMessageRegex = new(@"^Merge (branch|tag) '(?<SourceBranch>[^']*)'(?: into (?<TargetBranch>[^\s]*))*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex SmartGitMergeMessageRegex = new(@"^Finish (?<SourceBranch>[^\s]*)(?: into (?<TargetBranch>[^\s]*))*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex BitBucketPullMergeMessageRegex = new(@"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex BitBucketPullv7MergeMessageRegex = new(@"^Pull request #(?<PullRequestNumber>\d+).*\r?\n\r?\nMerge in (?<Source>.*) from (?<SourceBranch>[^\s]*) to (?<TargetBranch>[^\s]*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex BitBucketCloudPullMergeMessageRegex = new(@"^Merged in (?<SourceBranch>[^\s]*) \(pull request #(?<PullRequestNumber>\d+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex GitHubPullMergeMessageRegex = new(@"^Merge pull request #(?<PullRequestNumber>\d+) (from|in) (?:[^\s\/]+\/)?(?<SourceBranch>[^\s]*)(?: into (?<TargetBranch>[^\s]*))*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex RemoteTrackingMergeMessageRegex = new(@"^Merge remote-tracking branch '(?<SourceBranch>[^\s]*)'(?: into (?<TargetBranch>[^\s]*))*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex AzureDevOpsPullMergeMessageRegex = new(@"^Merge pull request (?<PullRequestNumber>\d+) from (?<SourceBranch>[^\s]*) into (?<TargetBranch>[^\s]*)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    }
+
+    internal static class Output
+    {
+        public static readonly Regex AssemblyVersionRegex = new(@"AssemblyVersion(Attribute)?\s*\(.*\)\s*");
+        public static readonly Regex AssemblyInfoVersionRegex = new(@"AssemblyInformationalVersion(Attribute)?\s*\(.*\)\s*");
+        public static readonly Regex AssemblyFileVersionRegex = new(@"AssemblyFileVersion(Attribute)?\s*\(.*\)\s*");
+        public static readonly Regex CsharpAssemblyAttributeRegex = new(@"(\s*\[\s*assembly:\s*(?:.*)\s*\]\s*$(\r?\n)?)", RegexOptions.Multiline);
+        public static readonly Regex FsharpAssemblyAttributeRegex = new(@"(\s*\[\s*\<assembly:\s*(?:.*)\>\s*\]\s*$(\r?\n)?)", RegexOptions.Multiline);
+        public static readonly Regex VisualBasicAssemblyAttributeRegex = new(@"(\s*\<Assembly:\s*(?:.*)\>\s*$(\r?\n)?)", RegexOptions.Multiline);
+    }
+
+    internal static class VersionCalculation
+    {
+        //language=regexp
+        public const string DefaultMajorPattern = @"\+semver:\s?(breaking|major)";
+
+        //language=regexp
+        public const string DefaultMinorPattern = @"\+semver:\s?(feature|minor)";
+
+        //language=regexp
+        public const string DefaultPatchPattern = @"\+semver:\s?(fix|patch)";
+
+        //language=regexp
+        public const string DefaultNoBumpPattern = @"\+semver:\s?(none|skip)";
+
+        public static readonly Regex DefaultMajorPatternRegex = new(DefaultMajorPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex DefaultMinorPatternRegex = new(DefaultMinorPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex DefaultPatchPatternRegex = new(DefaultPatchPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex DefaultNoBumpPatternRegex = new(DefaultNoBumpPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+
+    internal static class SemanticVersion
+    {
+        // uses the git-semver spec https://github.com/semver/semver/blob/master/semver.md
+        public static readonly Regex ParseStrictRegex = new(
+            @"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static readonly Regex ParseLooseRegex = new(
+            @"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static readonly Regex ParseBuildMetaDataRegex = new(
+            @"(?<BuildNumber>\d+)?(\.?Branch(Name)?\.(?<BranchName>[^\.]+))?(\.?Sha?\.(?<Sha>[^\.]+))?(?<Other>.*)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static readonly Regex FormatBuildMetaDataRegex = new("[^0-9A-Za-z-.]",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static readonly Regex ParsePreReleaseTagRegex = new(
+            @"(?<name>.*?)\.?(?<number>\d+)?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+}

--- a/src/GitVersion.Core/Helpers/StringFormatWith.cs
+++ b/src/GitVersion.Core/Helpers/StringFormatWith.cs
@@ -1,16 +1,11 @@
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+using GitVersion.Core;
 
 namespace GitVersion.Helpers;
 
 internal static class StringFormatWithExtension
 {
-    // This regex matches an expression to replace.
-    // - env:ENV name OR a member name
-    // - optional fallback value after " ?? "
-    // - the fallback value should be a quoted string, but simple unquoted text is allowed for back compat
-    private static readonly Regex TokensRegex = new(@"{((env:(?<envvar>\w+))|(?<member>\w+))(\s+(\?\?)??\s+((?<fallback>\w+)|""(?<fallback>.*)""))??}", RegexOptions.Compiled);
-
     /// <summary>
     /// Formats the <paramref name="template"/>, replacing each expression wrapped in curly braces
     /// with the corresponding property from the <paramref name="source"/> or <paramref name="environment"/>.
@@ -45,7 +40,7 @@ internal static class StringFormatWithExtension
             throw new ArgumentNullException(nameof(source));
         }
 
-        foreach (Match match in TokensRegex.Matches(template).Cast<Match>())
+        foreach (Match match in RegexPatterns.Common.ExpandTokensRegex.Matches(template).Cast<Match>())
         {
             string propertyValue;
             string? fallback = match.Groups["fallback"].Success ? match.Groups["fallback"].Value : null;

--- a/src/GitVersion.Core/Logging/Log.cs
+++ b/src/GitVersion.Core/Logging/Log.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Helpers;
 
 namespace GitVersion.Logging;
@@ -7,7 +7,6 @@ namespace GitVersion.Logging;
 internal sealed class Log(params ILogAppender[] appenders) : ILog
 {
     private IEnumerable<ILogAppender> appenders = appenders;
-    private readonly Regex obscurePasswordRegex = new("(https?://)(.+)(:.+@)", RegexOptions.Compiled);
     private readonly StringBuilder sb = new();
     private string currentIndentation = string.Empty;
     private const string Indentation = "  ";
@@ -59,7 +58,7 @@ internal sealed class Log(params ILogAppender[] appenders) : ILog
 
     private string FormatMessage(string message, string level)
     {
-        var obscuredMessage = this.obscurePasswordRegex.Replace(message, "$1$2:*******@");
+        var obscuredMessage = RegexPatterns.Common.ObscurePasswordRegex.Replace(message, "$1$2:*******@");
         var timestamp = $"{DateTime.Now:yy-MM-dd H:mm:ss:ff}";
         return string.Format(CultureInfo.InvariantCulture, "{0}{1} [{2}] {3}", this.currentIndentation, level, timestamp, obscuredMessage);
     }

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion;
@@ -8,15 +9,6 @@ namespace GitVersion;
 public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEquatable<SemanticVersion?>
 {
     public static readonly SemanticVersion Empty = new();
-
-    // uses the git-semver spec https://github.com/semver/semver/blob/master/semver.md
-    private static readonly Regex ParseSemVerStrict = new(
-        @"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    private static readonly Regex ParseSemVerLoose = new(
-        @"^(?<SemVer>(?<Major>\d+)(\.(?<Minor>\d+))?(\.(?<Patch>\d+))?)(\.(?<FourthPart>\d+))?(-(?<Tag>[^\+]*))?(\+(?<BuildMetaData>.*))?$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public long Major { get; init; }
 
@@ -176,7 +168,7 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
 
     private static bool TryParseStrict(string version, [NotNullWhen(true)] out SemanticVersion? semanticVersion)
     {
-        var parsed = ParseSemVerStrict.Match(version);
+        var parsed = RegexPatterns.SemanticVersion.ParseStrictRegex.Match(version);
 
         if (!parsed.Success)
         {
@@ -198,7 +190,7 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
 
     private static bool TryParseLoose(string version, [NotNullWhen(true)] out SemanticVersion? semanticVersion)
     {
-        var parsed = ParseSemVerLoose.Match(version);
+        var parsed = RegexPatterns.SemanticVersion.ParseLooseRegex.Match(version);
 
         if (!parsed.Success)
         {

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 
@@ -8,10 +8,6 @@ namespace GitVersion;
 public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVersionBuildMetaData?>
 {
     public static readonly SemanticVersionBuildMetaData Empty = new();
-
-    private static readonly Regex ParseRegex = new(
-        @"(?<BuildNumber>\d+)?(\.?Branch(Name)?\.(?<BranchName>[^\.]+))?(\.?Sha?\.(?<Sha>[^\.]+))?(?<Other>.*)",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly LambdaEqualityHelper<SemanticVersionBuildMetaData> EqualityHelper =
         new(x => x.CommitsSinceTag, x => x.Branch, x => x.Sha);
@@ -115,7 +111,7 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
         if (buildMetaData.IsNullOrEmpty())
             return Empty;
 
-        var parsed = ParseRegex.Match(buildMetaData);
+        var parsed = RegexPatterns.SemanticVersion.ParseBuildMetaDataRegex.Match(buildMetaData);
 
         long? buildMetaDataCommitsSinceTag = null;
         long? buildMetaDataCommitsSinceVersionSource = null;
@@ -151,7 +147,7 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
     private static string FormatMetaDataPart(string value)
     {
         if (!value.IsNullOrEmpty())
-            value = Regex.Replace(value, "[^0-9A-Za-z-.]", "-");
+            value = RegexPatterns.SemanticVersion.FormatBuildMetaDataRegex.Replace(value, "-");
         return value;
     }
 }

--- a/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 
@@ -10,10 +10,6 @@ public sealed class SemanticVersionPreReleaseTag :
 {
     private static readonly StringComparer IgnoreCaseComparer = StringComparer.InvariantCultureIgnoreCase;
     public static readonly SemanticVersionPreReleaseTag Empty = new();
-
-    private static readonly Regex ParseRegex = new(
-        @"(?<name>.*?)\.?(?<number>\d+)?$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly LambdaEqualityHelper<SemanticVersionPreReleaseTag> EqualityHelper =
         new(x => x.Name, x => x.Number);
@@ -74,7 +70,7 @@ public sealed class SemanticVersionPreReleaseTag :
     {
         if (preReleaseTag.IsNullOrEmpty()) return Empty;
 
-        var match = ParseRegex.Match(preReleaseTag);
+        var match = RegexPatterns.SemanticVersion.ParsePreReleaseTagRegex.Match(preReleaseTag);
         if (!match.Success)
         {
             // TODO check how to log this

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -10,20 +10,10 @@ namespace GitVersion.VersionCalculation;
 internal class IncrementStrategyFinder(IGitRepository repository, ITaggedSemanticVersionRepository taggedSemanticVersionRepository)
     : IIncrementStrategyFinder
 {
-    public const string DefaultMajorPattern = @"\+semver:\s?(breaking|major)";
-    public const string DefaultMinorPattern = @"\+semver:\s?(feature|minor)";
-    public const string DefaultPatchPattern = @"\+semver:\s?(fix|patch)";
-    public const string DefaultNoBumpPattern = @"\+semver:\s?(none|skip)";
-
     private static readonly ConcurrentDictionary<string, Regex> CompiledRegexCache = new();
     private readonly Dictionary<string, VersionField?> commitIncrementCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
-
-    private static readonly Regex DefaultMajorPatternRegex = new(DefaultMajorPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex DefaultMinorPatternRegex = new(DefaultMinorPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex DefaultPatchPatternRegex = new(DefaultPatchPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex DefaultNoBumpPatternRegex = new(DefaultNoBumpPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private readonly IGitRepository repository = repository.NotNull();
     private readonly ITaggedSemanticVersionRepository taggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
@@ -59,10 +49,10 @@ internal class IncrementStrategyFinder(IGitRepository repository, ITaggedSemanti
     {
         commits.NotNull();
 
-        var majorRegex = TryGetRegexOrDefault(majorVersionBumpMessage, DefaultMajorPatternRegex);
-        var minorRegex = TryGetRegexOrDefault(minorVersionBumpMessage, DefaultMinorPatternRegex);
-        var patchRegex = TryGetRegexOrDefault(patchVersionBumpMessage, DefaultPatchPatternRegex);
-        var none = TryGetRegexOrDefault(noBumpMessage, DefaultNoBumpPatternRegex);
+        var majorRegex = TryGetRegexOrDefault(majorVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultMajorPatternRegex);
+        var minorRegex = TryGetRegexOrDefault(minorVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultMinorPatternRegex);
+        var patchRegex = TryGetRegexOrDefault(patchVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultPatchPatternRegex);
+        var none = TryGetRegexOrDefault(noBumpMessage, RegexPatterns.VersionCalculation.DefaultNoBumpPatternRegex);
 
         var increments = commits
             .Select(c => GetIncrementFromCommit(c, majorRegex, minorRegex, patchRegex, none))
@@ -93,7 +83,7 @@ internal class IncrementStrategyFinder(IGitRepository repository, ITaggedSemanti
 
         if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
         {
-            commits = commits.Where(c => c.Parents.Count() > 1);
+            commits = commits.Where(c => c.Parents.Count > 1);
         }
 
         return GetIncrementForCommits(
@@ -242,10 +232,10 @@ internal class IncrementStrategyFinder(IGitRepository repository, ITaggedSemanti
         commit.NotNull();
         configuration.NotNull();
 
-        var majorRegex = TryGetRegexOrDefault(configuration.MajorVersionBumpMessage, DefaultMajorPatternRegex);
-        var minorRegex = TryGetRegexOrDefault(configuration.MinorVersionBumpMessage, DefaultMinorPatternRegex);
-        var patchRegex = TryGetRegexOrDefault(configuration.PatchVersionBumpMessage, DefaultPatchPatternRegex);
-        var none = TryGetRegexOrDefault(configuration.NoBumpMessage, DefaultNoBumpPatternRegex);
+        var majorRegex = TryGetRegexOrDefault(configuration.MajorVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultMajorPatternRegex);
+        var minorRegex = TryGetRegexOrDefault(configuration.MinorVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultMinorPatternRegex);
+        var patchRegex = TryGetRegexOrDefault(configuration.PatchVersionBumpMessage, RegexPatterns.VersionCalculation.DefaultPatchPatternRegex);
+        var none = TryGetRegexOrDefault(configuration.NoBumpMessage, RegexPatterns.VersionCalculation.DefaultNoBumpPatternRegex);
 
         return GetIncrementFromCommit(commit, majorRegex, minorRegex, patchRegex, none) ?? VersionField.None;
     }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
@@ -26,7 +26,7 @@ internal sealed class CommitOnNonTrunk : IIncrementer
 
         if (commit.Successor is null)
         {
-            yield return new BaseVersionOperator()
+            yield return new BaseVersionOperator
             {
                 Source = GetType().Name,
                 BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
@@ -24,7 +24,7 @@ internal abstract class CommitOnNonTrunkBranchedBase : IIncrementer
         context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
         context.ForceIncrement = true;
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = null,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
@@ -15,7 +15,7 @@ internal abstract class CommitOnNonTrunkWithPreReleaseTagBase : IIncrementer
     {
         context.BaseVersionSource = commit.Value;
 
-        yield return new BaseVersionOperand()
+        yield return new BaseVersionOperand
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
@@ -15,7 +15,7 @@ internal abstract class CommitOnNonTrunkWithStableTagBase : IIncrementer
     {
         context.BaseVersionSource = commit.Value;
 
-        yield return new BaseVersionOperand()
+        yield return new BaseVersionOperand
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastCommitOnNonTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastCommitOnNonTrunkWithPreReleaseTag.cs
@@ -16,7 +16,7 @@ internal sealed class LastCommitOnNonTrunkWithPreReleaseTag : CommitOnNonTrunkWi
             yield return item;
         }
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastCommitOnNonTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastCommitOnNonTrunkWithStableTag.cs
@@ -16,7 +16,7 @@ internal sealed class LastCommitOnNonTrunkWithStableTag : CommitOnNonTrunkWithSt
             yield return item;
         }
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastMergeCommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/LastMergeCommitOnNonTrunk.cs
@@ -17,7 +17,7 @@ internal sealed class LastMergeCommitOnNonTrunk : MergeCommitOnNonTrunkBase
             yield return item;
         }
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
@@ -24,7 +24,7 @@ internal sealed class CommitOnTrunk : IIncrementer
         context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
         context.ForceIncrement = true;
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
@@ -31,7 +31,7 @@ internal abstract class CommitOnTrunkBranchedBase : IIncrementer
         context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
         context.ForceIncrement = true;
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithPreReleaseTagBase.cs
@@ -13,7 +13,7 @@ internal abstract class CommitOnTrunkWithPreReleaseTagBase : IIncrementer
     {
         context.BaseVersionSource = commit.Value;
 
-        yield return new BaseVersionOperand()
+        yield return new BaseVersionOperand
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
@@ -14,7 +14,7 @@ internal abstract class CommitOnTrunkWithStableTagBase : IIncrementer
     {
         context.BaseVersionSource = commit.Value;
 
-        yield return new BaseVersionOperand()
+        yield return new BaseVersionOperand
         {
             Source = GetType().Name,
             SemanticVersion = context.SemanticVersion.NotNull(),

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
@@ -26,7 +26,7 @@ internal sealed class LastCommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreR
             context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
             context.ForceIncrement = false;
 
-            yield return new BaseVersionOperator()
+            yield return new BaseVersionOperator
             {
                 Source = GetType().Name,
                 BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithStableTag.cs
@@ -20,7 +20,7 @@ internal sealed class LastCommitOnTrunkWithStableTag : CommitOnTrunkWithStableTa
         {
             context.ForceIncrement = true;
 
-            yield return new BaseVersionOperator()
+            yield return new BaseVersionOperator
             {
                 Source = GetType().Name,
                 BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -52,7 +52,7 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
 
         if (context.SemanticVersion is not null)
         {
-            yield return new BaseVersionOperand()
+            yield return new BaseVersionOperand
             {
                 Source = GetType().Name,
                 BaseVersionSource = context.BaseVersionSource,
@@ -60,7 +60,7 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
             };
         }
 
-        yield return new BaseVersionOperator()
+        yield return new BaseVersionOperator
         {
             Source = GetType().Name,
             BaseVersionSource = context.BaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -202,7 +202,7 @@ internal class NextVersionCalculator(
 
         BaseVersion calculatedBase = new()
         {
-            Operand = new BaseVersionOperand()
+            Operand = new BaseVersionOperand
             {
                 Source = maxVersion.BaseVersion.Source,
                 BaseVersionSource = latestBaseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -34,7 +34,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
                 BaseVersionOperator? operation = null;
                 if (!semanticVersion.IsPreRelease || label is not null && semanticVersion.PreReleaseTag.Name != label)
                 {
-                    operation = new BaseVersionOperator()
+                    operation = new BaseVersionOperator
                     {
                         Increment = VersionField.None,
                         ForceIncrement = false,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
@@ -49,9 +49,9 @@ internal sealed class FallbackVersionStrategy(
             label: label
         );
 
-        yield return new BaseVersion()
+        yield return new BaseVersion
         {
-            Operator = new BaseVersionOperator()
+            Operator = new BaseVersionOperator
             {
                 Source = "Fallback base version",
                 BaseVersionSource = baseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -62,7 +62,7 @@ internal sealed class TaggedCommitVersionStrategy(
             yield return new BaseVersion(
                 $"Git tag '{semanticVersionWithTag.Tag.Name.Friendly}'", semanticVersionWithTag.Value, baseVersionSource)
             {
-                Operator = new BaseVersionOperator()
+                Operator = new BaseVersionOperator
                 {
                     Increment = increment,
                     ForceIncrement = false,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -63,7 +63,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
             result = new BaseVersion(
                 "Release branch exists -> " + baseVersion.Source, baseVersion.SemanticVersion, baseVersionSource)
             {
-                Operator = new BaseVersionOperator()
+                Operator = new BaseVersionOperator
                 {
                     Increment = increment,
                     ForceIncrement = false,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -49,7 +49,7 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
 
                 baseVersion = new BaseVersion("Version in branch name", result.Value)
                 {
-                    Operator = new BaseVersionOperator()
+                    Operator = new BaseVersionOperator
                     {
                         Increment = VersionField.None,
                         ForceIncrement = false,

--- a/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Logging;
@@ -13,16 +14,12 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
     private readonly List<Action> restoreBackupTasks = [];
     private readonly List<Action> cleanupBackupTasks = [];
 
-    private readonly IDictionary<string, Regex> assemblyAttributeRegexes = new Dictionary<string, Regex>
+    private readonly Dictionary<string, Regex> assemblyAttributeRegexes = new()
     {
-        {".cs", new Regex( @"(\s*\[\s*assembly:\s*(?:.*)\s*\]\s*$(\r?\n)?)", RegexOptions.Multiline) },
-        {".fs", new Regex( @"(\s*\[\s*\<assembly:\s*(?:.*)\>\s*\]\s*$(\r?\n)?)", RegexOptions.Multiline) },
-        {".vb", new Regex( @"(\s*\<Assembly:\s*(?:.*)\>\s*$(\r?\n)?)", RegexOptions.Multiline) }
+        {".cs", RegexPatterns.Output.CsharpAssemblyAttributeRegex },
+        {".fs", RegexPatterns.Output.FsharpAssemblyAttributeRegex },
+        {".vb", RegexPatterns.Output.VisualBasicAssemblyAttributeRegex }
     };
-
-    private readonly Regex assemblyVersionRegex = new(@"AssemblyVersion(Attribute)?\s*\(.*\)\s*");
-    private readonly Regex assemblyInfoVersionRegex = new(@"AssemblyInformationalVersion(Attribute)?\s*\(.*\)\s*");
-    private readonly Regex assemblyFileVersionRegex = new(@"AssemblyFileVersion(Attribute)?\s*\(.*\)\s*");
 
     private const string NewLine = "\r\n";
 
@@ -67,17 +64,17 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
 
             if (!assemblyVersion.IsNullOrWhiteSpace())
             {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(this.assemblyVersionRegex, fileContents, assemblyVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
+                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyVersionRegex, fileContents, assemblyVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
             }
 
             if (!assemblyFileVersion.IsNullOrWhiteSpace())
             {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(this.assemblyFileVersionRegex, fileContents, assemblyFileVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
+                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyFileVersionRegex, fileContents, assemblyFileVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
             }
 
             if (!assemblyInfoVersion.IsNullOrWhiteSpace())
             {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(this.assemblyInfoVersionRegex, fileContents, assemblyInfoVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
+                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyInfoVersionRegex, fileContents, assemblyInfoVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
             }
 
             if (appendedAttributes)


### PR DESCRIPTION
This PR moves most of Regex patterns to `RegexPatterns` in preparation to dropping .net60 support and start using `GeneratedRegexAttribute`