### PR TITLE
Normalization of GitVersionTargetFramework and fallback scenario

### DIFF
--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -8,7 +8,11 @@
         <UpdateAssemblyInfo Condition=" '$(UpdateAssemblyInfo)' == 'true' And '$(GenerateGitVersionFiles)' == 'true' ">true</UpdateAssemblyInfo>
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' And '$(GenerateGitVersionFiles)' == 'true' ">true</GenerateGitVersionInformation>
 
-        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == ''">$(TargetFramework)</GitVersionTargetFramework>
+        <!-- Validates the target framework and sets the GitVersionTargetFramework property to the target framework that is compatible with the target framework of the project -->
+        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0')) == 'true'">net8.0</GitVersionTargetFramework>
+        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net6.0')) == 'true'">net6.0</GitVersionTargetFramework>
+        <!-- Fall back to net8.0 if the target framework is not compatible with net6.0 and net8.0 -->
+        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == ''">net8.0</GitVersionTargetFramework>
         <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))gitversion.dll&quot;</GitVersionFileExe>
         <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>


### PR DESCRIPTION
This is about making sure that compatible target frameworks are treated equally. The previous solution tried to use the TargetFramework, which led to an error when we used `net8.0-windows`.

## Description
<!--- Describe your changes in detail -->

The solution here normalizes `net8.0-windows` and all other platform-specific TargetFrameworks to  
`net8.0`. It also accounts for `net9.0` or higher. If the TargetFramework isn't compatible with `net8.0`, it checks for compatibility with `net6.0`. If that doesn't work, it falls back to `net8.0`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4192

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.

In this case not necessary, i think.
- [ ] My change requires a change to the documentation. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
