### PR TITLE
attempt to fix performance issues with a cache

### DIFF
--- a/src/GitVersion.Core/Configuration/IgnoreConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Configuration/IgnoreConfigurationExtensions.cs
@@ -5,28 +5,20 @@ namespace GitVersion.Configuration;
 
 internal static class IgnoreConfigurationExtensions
 {
-    public static IEnumerable<ITag> Filter(this IIgnoreConfiguration ignore, IEnumerable<ITag> source)
+    public static IEnumerable<ITag> Filter(this IIgnoreConfiguration ignore, ITag[] source)
     {
         ignore.NotNull();
         source.NotNull();
 
-        if (!ignore.IsEmpty)
-        {
-            return source.Where(element => ShouldBeIgnored(element.Commit, ignore));
-        }
-        return source;
+        return !ignore.IsEmpty ? source.Where(element => ShouldBeIgnored(element.Commit, ignore)) : source;
     }
 
-    public static IEnumerable<ICommit> Filter(this IIgnoreConfiguration ignore, IEnumerable<ICommit> source)
+    public static IEnumerable<ICommit> Filter(this IIgnoreConfiguration ignore, ICommit[] source)
     {
         ignore.NotNull();
         source.NotNull();
 
-        if (!ignore.IsEmpty)
-        {
-            return source.Where(element => ShouldBeIgnored(element, ignore));
-        }
-        return source;
+        return !ignore.IsEmpty ? source.Where(element => ShouldBeIgnored(element, ignore)) : source;
     }
 
     private static bool ShouldBeIgnored(ICommit commit, IIgnoreConfiguration ignore)

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -219,7 +219,7 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
             SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
         };
 
-        var commits = this.repository.Commits.QueryBy(filter).ToArray();
+        var commits = this.repository.Commits.QueryBy(filter);
 
         return ignore.Filter(commits).ToList();
     }

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
@@ -49,7 +49,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
             {
                 var semanticVersions = GetTaggedSemanticVersions(tagPrefix, format, ignore);
 
-                foreach (var commit in ignore.Filter(branch.Commits))
+                foreach (var commit in ignore.Filter(branch.Commits.ToArray()))
                 {
                     foreach (var semanticVersion in semanticVersions[commit])
                     {
@@ -88,7 +88,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
             using (this.log.IndentLog($"Getting tagged semantic versions by track merge target '{branch.Name.Canonical}'. " +
                                       $"TagPrefix: {tagPrefix} and Format: {format}"))
             {
-                var shaHashSet = new HashSet<string>(ignore.Filter(branch.Commits).Select(element => element.Id.Sha));
+                var shaHashSet = new HashSet<string>(ignore.Filter(branch.Commits.ToArray()).Select(element => element.Id.Sha));
 
                 foreach (var semanticVersion in GetTaggedSemanticVersions(tagPrefix, format, ignore).SelectMany(v => v))
                 {
@@ -124,7 +124,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
         {
             this.log.Info($"Getting tagged semantic versions. TagPrefix: {tagPrefix} and Format: {format}");
 
-            foreach (var tag in ignore.Filter(this.repositoryStore.Tags))
+            foreach (var tag in ignore.Filter(this.repositoryStore.Tags.ToArray()))
             {
                 if (SemanticVersion.TryParse(tag.Name.Friendly, tagPrefix, out var semanticVersion, format))
                 {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -82,7 +82,7 @@ internal sealed class MainlineVersionStrategy(
             configuration: branchConfiguration
         );
 
-        var commitsInReverseOrder = Context.Configuration.Ignore.Filter(Context.CurrentBranchCommits);
+        var commitsInReverseOrder = Context.Configuration.Ignore.Filter(Context.CurrentBranchCommits.ToArray());
 
         TaggedSemanticVersions taggedSemanticVersion = TaggedSemanticVersions.OfBranch;
         if (branchConfiguration.TrackMergeTarget == true) taggedSemanticVersion |= TaggedSemanticVersions.OfMergeTargets;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -33,7 +33,7 @@ internal sealed class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionConte
                 || !configuration.Value.TrackMergeMessage)
             yield break;
 
-        foreach (var commit in configuration.Value.Ignore.Filter(Context.CurrentBranchCommits))
+        foreach (var commit in configuration.Value.Ignore.Filter(Context.CurrentBranchCommits.ToArray()))
         {
             if (MergeMessage.TryParse(commit, Context.Configuration, out var mergeMessage)
                 && mergeMessage.Version is not null

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpecCollection.cs
@@ -4,11 +4,14 @@ namespace GitVersion.Git;
 
 internal sealed class RefSpecCollection : IRefSpecCollection
 {
-    private readonly LibGit2Sharp.RefSpecCollection innerCollection;
+    private readonly Lazy<IReadOnlyCollection<IRefSpec>> refSpecs;
 
     internal RefSpecCollection(LibGit2Sharp.RefSpecCollection collection)
-        => this.innerCollection = collection.NotNull();
+    {
+        collection = collection.NotNull();
+        this.refSpecs = new Lazy<IReadOnlyCollection<IRefSpec>>(() => collection.Select(tag => new RefSpec(tag)).ToArray());
+    }
 
-    public IEnumerator<IRefSpec> GetEnumerator() => this.innerCollection.Select(tag => new RefSpec(tag)).GetEnumerator();
+    public IEnumerator<IRefSpec> GetEnumerator() => this.refSpecs.Value.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
@@ -4,13 +4,16 @@ namespace GitVersion.Git;
 
 internal sealed class TagCollection : ITagCollection
 {
-    private readonly LibGit2Sharp.TagCollection innerCollection;
+    private readonly Lazy<IReadOnlyCollection<ITag>> tags;
 
     internal TagCollection(LibGit2Sharp.TagCollection collection)
-        => this.innerCollection = collection.NotNull();
+    {
+        collection = collection.NotNull();
+        this.tags = new Lazy<IReadOnlyCollection<ITag>>(() => collection.Select(tag => new Tag(tag)).ToArray());
+    }
 
     public IEnumerator<ITag> GetEnumerator()
-        => this.innerCollection.Select(tag => new Tag(tag)).GetEnumerator();
+        => this.tags.Value.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is an attempt to fix some of the performance problems (see #4159).  As best I can tell each time that the commits are requested from a given `IBranch` the git library appears to enumerate again and again.

## Related Issue
https://github.com/GitTools/GitVersion/issues/4159

## Motivation and Context
1.5 minutes to compute a version is a lot! 😄 

## How Has This Been Tested?
Best way I was able to test, was use the current version (6.0.2) and then compare to the results after caching.  The difference in performance was 1 and a half minutes on my machine to 10 seconds.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
