### PR TITLE
update docker distros

### DIFF
--- a/.github/actions/docker-test/action.yml
+++ b/.github/actions/docker-test/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 'amd64'
   distro:
     description: 'Linux Distro'
-    default: 'debian.11'
+    default: 'debian.12'
   targetFramework:
     description: '.net version'
     default: '8.0'

--- a/.github/workflows/_artifacts_linux.yml
+++ b/.github/workflows/_artifacts_linux.yml
@@ -20,15 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - alpine.3.17
-          - alpine.3.18
-          - centos.stream.8
-          - debian.11
-          - fedora.37
+          - alpine.3.19
+          - alpine.3.20
+          - centos.stream.9
+          - debian.12
+          - fedora.40
           - ubuntu.20.04
           - ubuntu.22.04
           - ubuntu.24.04
-        targetFramework: [ '6.0', '8.0' ]
+        targetFramework: [ '8.0', '6.0' ]
 
     steps:
     -

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -20,15 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - alpine.3.17
-          - alpine.3.18
-          - centos.stream.8
-          - debian.11
-          - fedora.37
+          - alpine.3.19
+          - alpine.3.20
+          - centos.stream.9
+          - debian.12
+          - fedora.40
           - ubuntu.20.04
           - ubuntu.22.04
           - ubuntu.24.04
-        targetFramework: [ '6.0', '8.0' ]
+        targetFramework: [ '8.0', '6.0' ]
 
     steps:
     -

--- a/.github/workflows/_docker_manifests.yml
+++ b/.github/workflows/_docker_manifests.yml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - alpine.3.17
-          - alpine.3.18
-          - centos.stream.8
-          - debian.11
-          - fedora.37
+          - alpine.3.19
+          - alpine.3.20
+          - centos.stream.9
+          - debian.12
+          - fedora.40
           - ubuntu.20.04
           - ubuntu.22.04
           - ubuntu.24.04
-        targetFramework: [ '6.0', '8.0' ]
+        targetFramework: [ '8.0', '6.0' ]
 
     steps:
     -

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        targetFramework: [ '6.0', '8.0' ]
+        targetFramework: [ '8.0', '6.0' ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/build/.run/Artifacts DotnetTool Test.run.xml
+++ b/build/.run/Artifacts DotnetTool Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts DotnetTool Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsDotnetToolTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.17" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsDotnetToolTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.19" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts MsBuildCore Test.run.xml
+++ b/build/.run/Artifacts MsBuildCore Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts MsBuildCore Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsMsBuildCoreTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.17" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsMsBuildCoreTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.19" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Native Test.run.xml
+++ b/build/.run/Artifacts Native Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Native Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsNativeTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.17" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsNativeTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=alpine.3.19" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Prepare.run.xml
+++ b/build/.run/Artifacts Prepare.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Prepare" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsPrepare --docker_dotnetversion=8.0 --docker_distro=alpine.3.17" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsPrepare --docker_dotnetversion=8.0 --docker_distro=alpine.3.19" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Test.run.xml
+++ b/build/.run/Artifacts Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsTest --docker_dotnetversion=8.0 --docker_distro=alpine.3.17" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsTest --docker_dotnetversion=8.0 --docker_distro=alpine.3.19" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Docker Build.run.xml
+++ b/build/.run/Docker Build.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Docker Build" type="DotNetProject" factoryName=".NET Project" folderName="Docker">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/docker.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=DockerBuild --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.11 --verbosity=diagnostic" />
+    <option name="PROGRAM_PARAMETERS" value="--target=DockerBuild --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.12 --verbosity=diagnostic" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Docker Manifest.run.xml
+++ b/build/.run/Docker Manifest.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Docker Manifest" type="DotNetProject" factoryName=".NET Project" folderName="Docker">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/docker.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=DockerManifest --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.11" />
+    <option name="PROGRAM_PARAMETERS" value="--target=DockerManifest --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.12" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Docker Publish.run.xml
+++ b/build/.run/Docker Publish.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Docker Publish" type="DotNetProject" factoryName=".NET Project" folderName="Docker">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/docker.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=DockerPublish --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.11 --verbosity=diagnostic" />
+    <option name="PROGRAM_PARAMETERS" value="--target=DockerPublish --arch=amd64 --arch=arm64 --docker_dotnetversion=8.0 --docker_distro=debian.12 --verbosity=diagnostic" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Docker Test.run.xml
+++ b/build/.run/Docker Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Docker Test" type="DotNetProject" factoryName=".NET Project" folderName="Docker">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/docker.exe" />
-    <option name="PROGRAM_PARAMETERS" value="--target=DockerTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=debian.11" />
+    <option name="PROGRAM_PARAMETERS" value="--target=DockerTest --arch=amd64 --docker_dotnetversion=8.0 --docker_distro=debian.12" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -26,26 +26,24 @@ public class Constants
     public const string Arm64 = "arm64";
     public const string Amd64 = "amd64";
 
-    public const string Alpine317 = "alpine.3.17";
-    public const string Alpine318 = "alpine.3.18";
-    public const string CentosStream8 = "centos.stream.8";
-    public const string Debian11 = "debian.11";
-    public const string Fedora37 = "fedora.37";
+    public const string AlpineMin = "alpine.3.19";
+    public const string AlpineLatest = "alpine.3.20";
+    public const string CentosStreamLatest = "centos.stream.9";
+    public const string DebianLatest = "debian.12";
+    public const string FedoraLatest = "fedora.40";
     public const string Ubuntu2004 = "ubuntu.20.04";
     public const string Ubuntu2204 = "ubuntu.22.04";
     public const string Ubuntu2404 = "ubuntu.24.04";
-    public const string DockerDistroLatest = Debian11;
-    public const string DebianLatest = Debian11;
+    public const string DockerDistroLatest = DebianLatest;
     public const string UbuntuLatest = Ubuntu2404;
-    public const string AlpineLatest = Alpine318;
 
     public static readonly string[] DockerDistrosToBuild =
     [
-        Alpine317,
-        Alpine318,
-        CentosStream8,
-        Debian11,
-        Fedora37,
+        AlpineMin,
+        AlpineLatest,
+        CentosStreamLatest,
+        DebianLatest,
+        FedoraLatest,
         Ubuntu2004,
         Ubuntu2204,
         Ubuntu2404

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY='docker.io'
-ARG DISTRO='debian.11'
+ARG DISTRO='debian.12'
 ARG DOTNET_VERSION='8.0'
 ARG VERSION='5.12.0'
 


### PR DESCRIPTION
This pull request includes updates to various configuration files to use newer versions of Linux distributions and .NET framework. The most important changes include updating the default Linux distribution and target frameworks across multiple workflow and configuration files.

### Updates to Linux Distributions and Target Frameworks:

* [`.github/actions/docker-test/action.yml`](diffhunk://#diff-16fa8792c589ad765a257180228958a9294395331c5674be4eccfbb8454cf4beL9-R9): Updated the default Linux distribution from `debian.11` to `debian.12`.

* `.github/workflows/_artifacts_linux.yml`, `.github/workflows/_docker.yml`, `.github/workflows/_docker_manifests.yml`, `.github/workflows/_unit_tests.yml`: Updated the matrix of Linux distributions to include newer versions such as `alpine.3.19`, `alpine.3.20`, `centos.stream.9`, `debian.12`, and `fedora.40`. Also reordered the target frameworks to `['8.0', '6.0']`. [[1]](diffhunk://#diff-d361cbf432f44016d6915dd08925ededa5d3814529c576dbd7b1649e5b7c5363L23-R31) [[2]](diffhunk://#diff-5286568d5ab47872eab83c204289a43d337706010b384c37f9eafbc6203cabc3L23-R31) [[3]](diffhunk://#diff-f6f8bffd600a46606ee2c3305dbf33252854bee1ea3b50d85cc960e21397674dL16-R24) [[4]](diffhunk://#diff-52209bb21199fb684f5badc86471fc2e35c2431c151ca1f39aef67654782085cL17-R17)

* [`build/.run/*`](diffhunk://#diff-41cd7968d23ad2a6ee9ea49e049f4802da7d5e3de2f3ca88f026375be85f8702L4-R4): Updated the `PROGRAM_PARAMETERS` in multiple run configuration files to use newer Linux distributions, changing from `alpine.3.17` to `alpine.3.19` and from `debian.11` to `debian.12`. [[1]](diffhunk://#diff-41cd7968d23ad2a6ee9ea49e049f4802da7d5e3de2f3ca88f026375be85f8702L4-R4) [[2]](diffhunk://#diff-0b33c289214674b91f4b55f486965349469c376dadb6ba04317055d230f7cab2L4-R4) [[3]](diffhunk://#diff-0a48c99493b63a2e8d02c668ad9f4d50ac5ce8e670d98ddf00d0d2fb1ecb2b77L4-R4) [[4]](diffhunk://#diff-43fbcf31151d3f102b0f742983105abad661dbeb01a977818f0629321a61f8ebL4-R4) [[5]](diffhunk://#diff-8727733586e43c9725b7f232ab404fd91427e16b43a0707ba2f805afbee436cfL4-R4) [[6]](diffhunk://#diff-7561a08ea09cdc73e53b70ede5d86a8409f3a0b97771d3e8c290ce7248dd5c62L4-R4) [[7]](diffhunk://#diff-83c3bce9c62199c5b88ef055a3b7e76c771c5ec2570325ce697bf9fdc61643ceL4-R4) [[8]](diffhunk://#diff-129d5ba9725fc26a4ebbcbac3a662cae3e575f5865fff379fde4a87bd78fbeb0L4-R4) [[9]](diffhunk://#diff-a3344c2ba0632f2ed24394bf5d46dd6890e269d003aa0a1e26ee737e88c670a5L4-R4)

* [`build/common/Utilities/Constants.cs`](diffhunk://#diff-7e25693b603a6c8dac707b84658365cdbbf7fe3024ed6e59ae10627e7992c028L29-R46): Updated constants to reflect the new versions of Linux distributions.

* [`build/docker/Dockerfile`](diffhunk://#diff-2e245700d3161b3c801e7beced5e460a3f240958ef7d55d21d1740cea569ec52L2-R2): Changed the default Linux distribution argument from `debian.11` to `debian.12`.