### PR TITLE
(deps): Bump MSBuild.ProjectCreation to 13.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="Polly" Version="8.4.2" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.8" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.12.8" />
@@ -20,7 +21,7 @@
     <PackageVersion Include="Buildalyzer" Version="7.0.2" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="4.5.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
-    <PackageVersion Include="MSBuild.ProjectCreation" Version="12.0.1" />
+    <PackageVersion Include="MSBuild.ProjectCreation" Version="13.0.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
@@ -35,6 +36,8 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="YamlDotNet" Version="16.1.3" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />

--- a/src/GitVersion.Configuration/GitVersion.Configuration.csproj
+++ b/src/GitVersion.Configuration/GitVersion.Configuration.csproj
@@ -9,7 +9,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="YamlDotNet" />
     </ItemGroup>
 

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -10,7 +10,11 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.IO.Redist" />
         <PackageReference Include="MSBuild.ProjectCreation" />
+        <PackageReference Include="System.Drawing.Common" />
+        <PackageReference Include="System.Security.Cryptography.Xml" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.Output/GitVersion.Output.csproj
+++ b/src/GitVersion.Output/GitVersion.Output.csproj
@@ -7,10 +7,6 @@
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="System.Text.Json"/>
-    </ItemGroup>
     
     <ItemGroup>
         <Compile Remove="*\AddFormats\**\*.*" />

--- a/src/GitVersion.Schema/GitVersion.Schema.csproj
+++ b/src/GitVersion.Schema/GitVersion.Schema.csproj
@@ -6,6 +6,7 @@
     <ItemGroup>
         <PackageReference Include="JsonSchema.Net.Generation" />
         <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />


### PR DESCRIPTION
This pull request includes several updates to package references across multiple project files. The most significant changes involve adding new package references and updating existing ones to newer versions.

### Package Updates:

* Updated `MSBuild.ProjectCreation` to version `13.0.0` in `src/Directory.Packages.props`.

### New Package References:

* Added `Microsoft.IO.Redist` version `6.0.1` in `src/Directory.Packages.props`.
* Added `System.Drawing.Common` version `8.0.10` and `System.Security.Cryptography.Xml` version `8.0.2` in `src/Directory.Packages.props`.
* Added `Microsoft.IO.Redist`, `System.Drawing.Common`, `System.Security.Cryptography.Xml`, and `System.Text.Json` in `src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj`.
* Added `System.Text.Json` in `src/GitVersion.Schema/GitVersion.Schema.csproj`.

### Package Removals:

* Removed `System.Text.Json` from `src/GitVersion.Configuration/GitVersion.Configuration.csproj`.
* Removed `System.Text.Json` from `src/GitVersion.Output/GitVersion.Output.csproj`.