### PR TITLE
(build) - fix dockerhub readme publish

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -76,12 +76,3 @@ jobs:
         docker_registry_password: ${{ secrets.DOCKER_PASSWORD }}
         github_registry_username: ${{ github.repository_owner }}
         github_registry_password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
-    -
-      name: DockerHub Publish Readme
-      if: success() && github.event_name != 'pull_request' && github.repository_owner == 'GitTools' && github.ref_name == 'main'
-      shell: pwsh
-      run: dotnet run/docker.dll --target=DockerHubReadmePublish
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,14 @@ jobs:
       if: ${{ github.event_name == 'repository_dispatch' }}
       uses: ./.github/actions/artifacts-attest
     -
+      name: DockerHub Publish Readme
+      if: ${{ github.event_name == 'repository_dispatch' }}
+      shell: pwsh
+      run: dotnet run/docker.dll --target=DockerHubReadmePublish
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    -
       name: '[Release]'
       shell: pwsh
       run: dotnet run/release.dll --target=PublishRelease


### PR DESCRIPTION
This pull request includes several changes to the DockerHub README publishing process, mainly focusing on workflow adjustments and code refactoring for asynchronous operations.

Workflow adjustments:

* [`.github/workflows/_docker.yml`](diffhunk://#diff-5286568d5ab47872eab83c204289a43d337706010b384c37f9eafbc6203cabc3L79-L87): Removed the `DockerHub Publish Readme` job from the Docker workflow.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR140-R147): Added the `DockerHub Publish Readme` job to the CI workflow, triggered by the `repository_dispatch` event.

Code refactoring:

* [`build/docker/Tasks/DockerHubReadmePublish.cs`](diffhunk://#diff-6c137eda2ccf354f73f6868abf104d3e5206e3eba0854a914360d9f5c1e4dbb9L14-R14): Changed the `DockerHubReadmePublishInternal` class to inherit from `AsyncFrostingTask` instead of `FrostingTask` and updated the `Run` method to `RunAsync` for asynchronous execution. [[1]](diffhunk://#diff-6c137eda2ccf354f73f6868abf104d3e5206e3eba0854a914360d9f5c1e4dbb9L14-R14) [[2]](diffhunk://#diff-6c137eda2ccf354f73f6868abf104d3e5206e3eba0854a914360d9f5c1e4dbb9L27-R43)
* [`build/docker/Tasks/DockerHubReadmePublish.cs`](diffhunk://#diff-6c137eda2ccf354f73f6868abf104d3e5206e3eba0854a914360d9f5c1e4dbb9R52): Added logging statements to provide more detailed information during the execution of the `RunAsync` method.