### PR TITLE
Mention new config parameter `semantic-version-format`

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -98,6 +98,9 @@
 
 * If you have a tag `1.0.0` on `main` and branch from `main` to `release/1.0.1` then the next version number will be `1.1.0` when using the `GitFlow` workflow. This behavior is expected (but different compared to the `GitHubFlow` workflow) because on the `GitFlow` workflow you have an addition branch configuration with name hotfix where `is-release-branch` is set to `true`. That means if you want `1.0.1` as a next version you need to branch to `hotfix/1.0.1` or `hotfix/next`.  On the other hand if you use the `GitHubFlow` workflow the next version number will be `1.0.1` because the increment on the `release` branch is set to `Patch`.
 
+* There is a new configuration parameter `semantic-version-format` with default of `Strict`. The behavoir of `Strict` is, that every possible non-semver version e.g. `1.2.3.4` is ignored when trying to calculate the next version. So, if you have three-part and four-part version numbers mixed, it will compute the next version on basis of the last found three-part version number, ignoring all four-part numbers.
+This is different compared to v5 where per default it was a `Loose` comparison.
+
 ### Legacy Output Variables
 
 The following legacy output variables have been removed in this version:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add some explanation for the new config parameter `semantic-version-format`. I ran into an issue, where four-part version numbers were ignored, and I cannot find anything in the docs about this breaking behavior between v5 <==> v6.

## Related Issue

https://github.com/GitTools/GitVersion/discussions/4287
<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!--- Drag and drop screenshots here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[ ] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
