### PR TITLE
#4244 - remove explicit version on cli install

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-| Version   | Supported          |
-| --------: | :----------------: |
-| 5.x       | :white\_check\_mark: |
-| ⋜ 5.x     | :x:                |
+| Version |      Supported       |
+|--------:|:--------------------:|
+|     6.x | :white\_check\_mark: |
+|   < 6.x |         :x:          |
 
 ## Reporting Security Issues
 

--- a/docs/input/docs/reference/build-servers/bitbucket-pipelines.md
+++ b/docs/input/docs/reference/build-servers/bitbucket-pipelines.md
@@ -27,7 +27,7 @@ pipelines:
       name: Version and build
       script:
         - export PATH="$PATH:/root/.dotnet/tools"
-        - dotnet tool install --global GitVersion.Tool --version 5.*
+        - dotnet tool install --global GitVersion.Tool
         - dotnet-gitversion /output buildserver
         - source gitversion.properties
         - echo Building with semver $GITVERSION_FULLSEMVER
@@ -61,7 +61,7 @@ pipelines:
       name: Version
       script:
         - export PATH="$PATH:/root/.dotnet/tools"
-        - dotnet tool install --global GitVersion.Tool --version 5.*
+        - dotnet tool install --global GitVersion.Tool
         - dotnet-gitversion /output buildserver
       artifacts:
         - gitversion.properties

--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -13,8 +13,14 @@ GitVersion can be installed as a [.NET global tool][dotnet-tool] under the name
 [`GitVersion.Tool`][tool] by executing the following in a terminal:
 
 ```shell
-dotnet tool install --global GitVersion.Tool --version 5.*
+dotnet tool install --global GitVersion.Tool
 ```
+
+:::{.alert .alert-info}
+**Hint:** To install an older version of GitVersion.Tools, use the --version flag of dotnet tool install
+
+Example: `dotnet tool install GitVersion.Tool --global --version 5.*`
+:::
 
 If you want to pin to a specific version of GitVersion, you can find the available
 versions of [`GitVersion.Tool` on NuGet](https://www.nuget.org/packages/GitVersion.Tool/).
@@ -62,15 +68,15 @@ without installing any other dependencies. To use the Docker image, execute
 the following:
 
 ```shell
-docker run --rm -v "$(pwd):/repo" gittools/gitversion:5.6.6 /repo
+docker run --rm -v "$(pwd):/repo" gittools/gitversion:latest-debian.12 /repo
 ```
 
 The important arguments here are:
 
 |                    Argument | Description                                                                                                  |
-| --------------------------: | :----------------------------------------------------------------------------------------------------------- |
+|----------------------------:|:-------------------------------------------------------------------------------------------------------------|
 |            `"$(pwd):/repo"` | Maps the output of `pwd` (the working directory) to the `/repo` directory within the Docker container.       |
-| `gittools/gitversion:5.6.6` | The name and tag of the GitVersion container to use.                                                         |
+| `gittools/gitversion:{tag}` | The name and tag of the GitVersion container to use.                                                         |
 |                     `/repo` | The directory within the Docker container GitVersion should use as its working directory. Don't change this. |
 
 :::{.alert .alert-warning}


### PR DESCRIPTION
This pull request includes updates to documentation and configuration files to ensure compatibility with the latest versions of tools and improve clarity. The most important changes include updating the supported versions in the `SECURITY.md` file, removing version constraints for the `GitVersion.Tool` installation commands, and updating Docker image tags in the installation instructions.

Updates to supported versions:

* [`SECURITY.md`](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L6-R8): Updated the supported versions table to reflect support for version 6.x and deprecation of versions below 6.x.

Tool installation updates:

* [`docs/input/docs/reference/build-servers/bitbucket-pipelines.md`](diffhunk://#diff-90eb0f0a1a527a1fd3792f476955cb0337a3b25fef1d9ece8f8a19b46bb75199L30-R30): Removed version constraints for the `dotnet tool install` command to always install the latest version of `GitVersion.Tool`. [[1]](diffhunk://#diff-90eb0f0a1a527a1fd3792f476955cb0337a3b25fef1d9ece8f8a19b46bb75199L30-R30) [[2]](diffhunk://#diff-90eb0f0a1a527a1fd3792f476955cb0337a3b25fef1d9ece8f8a19b46bb75199L64-R64)
* [`docs/input/docs/usage/cli/installation.md`](diffhunk://#diff-bd41bb546fb6ad4c8aa212d60cbc1a9e54e12453074fe96d3f27db5cdb63b7b4L16-R24): Updated the `dotnet tool install` command to remove version constraints and added a hint for installing older versions.

Docker image updates:

* [`docs/input/docs/usage/cli/installation.md`](diffhunk://#diff-bd41bb546fb6ad4c8aa212d60cbc1a9e54e12453074fe96d3f27db5cdb63b7b4L65-R79): Updated the Docker run command to use the latest Debian-based image tag for `gittools/gitversion`.