### PR TITLE
(build) use sdk 9.0.100

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,6 @@
     "src"
   ],
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
-    "allowPrerelease": true
+    "version": "9.0.100"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `global.json` file. The change updates the SDK version to the stable release version.

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL8-R8): Updated SDK version from `9.0.100-rc.2.24474.11` to `9.0.100` and removed the `allowPrerelease` property.