### PR TITLE
#4299 - add new schemas for 6.11.*

### DIFF
--- a/schemas/6.1/GitVersion.configuration.json
+++ b/schemas/6.1/GitVersion.configuration.json
@@ -1,0 +1,394 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gitversion.net/schemas/6.1/GitVersion.configuration.json",
+  "title": "GitVersion Configuration (6.1)",
+  "description": "GitVersion configuration schema (6.1)",
+  "type": "object",
+  "properties": {
+    "assembly-file-versioning-format": {
+      "description": "Specifies the format of AssemblyFileVersion and overwrites the value of assembly-file-versioning-scheme.",
+      "type": "string"
+    },
+    "assembly-file-versioning-scheme": {
+      "description": "The scheme to use when setting AssemblyFileVersion attribute. Can be 'MajorMinorPatchTag', 'MajorMinorPatch', 'MajorMinor', 'Major', 'None'. Defaults to 'MajorMinorPatch'.",
+      "default": "MajorMinorPatch",
+      "enum": [
+        "MajorMinorPatchTag",
+        "MajorMinorPatch",
+        "MajorMinor",
+        "Major",
+        "None"
+      ]
+    },
+    "assembly-informational-format": {
+      "description": "Specifies the format of AssemblyInformationalVersion. Defaults to '{InformationalVersion}'.",
+      "default": "'{InformationalVersion}'",
+      "type": "string"
+    },
+    "assembly-versioning-format": {
+      "description": "Specifies the format of AssemblyVersion and overwrites the value of assembly-versioning-scheme.",
+      "type": "string"
+    },
+    "assembly-versioning-scheme": {
+      "description": "The scheme to use when setting AssemblyVersion attribute. Can be 'MajorMinorPatchTag', 'MajorMinorPatch', 'MajorMinor', 'Major', 'None'. Defaults to 'MajorMinorPatch'.",
+      "default": "MajorMinorPatch",
+      "enum": [
+        "MajorMinorPatchTag",
+        "MajorMinorPatch",
+        "MajorMinor",
+        "Major",
+        "None"
+      ]
+    },
+    "branches": {
+      "description": "The header for all the individual branch configuration.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/branchConfiguration"
+      }
+    },
+    "commit-date-format": {
+      "description": "The format to use when calculating the commit date. Defaults to 'yyyy-MM-dd'. See [Standard Date and Time Format Strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings) and [Custom Date and Time Format Strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings).",
+      "default": "yyyy-MM-dd",
+      "type": "string"
+    },
+    "commit-message-incrementing": {
+      "$ref": "#/$defs/nullableOfCommitMessageIncrementMode"
+    },
+    "mode": {
+      "$ref": "#/$defs/nullableOfDeploymentMode"
+    },
+    "ignore": {
+      "description": "The header property for the ignore configuration.",
+      "type": "object",
+      "properties": {
+        "commits-before": {
+          "$ref": "#/$defs/string3"
+        },
+        "sha": {
+          "$ref": "#/$defs/hashSetOfString2"
+        }
+      }
+    },
+    "increment": {
+      "$ref": "#/$defs/incrementStrategy"
+    },
+    "is-main-branch": {
+      "$ref": "#/$defs/nullableOfBoolean"
+    },
+    "is-release-branch": {
+      "$ref": "#/$defs/nullableOfBoolean1"
+    },
+    "is-source-branch-for": {
+      "$ref": "#/$defs/hashSetOfString"
+    },
+    "label": {
+      "$ref": "#/$defs/string"
+    },
+    "label-number-pattern": {
+      "$ref": "#/$defs/string1"
+    },
+    "major-version-bump-message": {
+      "format": "regex",
+      "description": "The regular expression to match commit messages with to perform a major version increment. Defaults to '\\+semver:\\s?(breaking|major)'",
+      "default": "\\+semver:\\s?(breaking|major)",
+      "type": "string"
+    },
+    "merge-message-formats": {
+      "description": "Custom merge message formats to enable identification of merge messages that do not follow the built-in conventions.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "minor-version-bump-message": {
+      "format": "regex",
+      "description": "The regular expression to match commit messages with to perform a minor version increment. Defaults to '\\+semver:\\s?(feature|minor)'",
+      "default": "\\+semver:\\s?(feature|minor)",
+      "type": "string"
+    },
+    "next-version": {
+      "description": "Allows you to bump the next version explicitly. Useful for bumping main or a feature branch with breaking changes",
+      "type": "string"
+    },
+    "no-bump-message": {
+      "format": "regex",
+      "description": "Used to tell GitVersion not to increment when in Mainline development mode. Defaults to '\\+semver:\\s?(none|skip)'",
+      "default": "\\+semver:\\s?(none|skip)",
+      "type": "string"
+    },
+    "patch-version-bump-message": {
+      "format": "regex",
+      "description": "The regular expression to match commit messages with to perform a patch version increment. Defaults to '\\+semver:\\s?(fix|patch)'",
+      "default": "\\+semver:\\s?(fix|patch)",
+      "type": "string"
+    },
+    "pre-release-weight": {
+      "$ref": "#/$defs/nullableOfInt32"
+    },
+    "prevent-increment": {
+      "$ref": "#/$defs/preventIncrementConfiguration"
+    },
+    "regex": {
+      "$ref": "#/$defs/string2"
+    },
+    "semantic-version-format": {
+      "description": "Specifies the semantic version format that is used when parsing the string. Can be 'Strict' or 'Loose'. Defaults to 'Strict'.",
+      "default": "Strict",
+      "enum": [
+        "Strict",
+        "Loose"
+      ]
+    },
+    "source-branches": {
+      "$ref": "#/$defs/hashSetOfString1"
+    },
+    "tag-prefix": {
+      "format": "regex",
+      "description": "A regular expression which is used to trim Git tags before processing. Defaults to '[vV]?'",
+      "default": "[vV]?",
+      "type": "string"
+    },
+    "tag-pre-release-weight": {
+      "description": "The pre-release weight in case of tagged commits. Defaults to 60000.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "track-merge-message": {
+      "$ref": "#/$defs/nullableOfBoolean4"
+    },
+    "track-merge-target": {
+      "$ref": "#/$defs/nullableOfBoolean5"
+    },
+    "tracks-release-branches": {
+      "$ref": "#/$defs/nullableOfBoolean6"
+    },
+    "update-build-number": {
+      "description": "Whether to update the build number in the project file. Defaults to true.",
+      "default": "true",
+      "type": "boolean"
+    },
+    "version-in-branch-pattern": {
+      "format": "regex",
+      "description": "A regular expression which is used to determine the version number in the branch name or commit message (e.g., v1.0.0-LTS). Defaults to '(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*'.",
+      "default": "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*",
+      "type": "string"
+    },
+    "strategies": {
+      "description": "Specifies which version strategies (one or more) will be used to determine the next version. Following values are available: 'ConfiguredNextVersion', 'MergeMessage', 'TaggedCommit', 'TrackReleaseBranches', 'VersionInBranchName' and 'Mainline'.",
+      "type": "array",
+      "items": {
+        "description": "Specifies which version strategies (one or more) will be used to determine the next version. Following values are available: 'ConfiguredNextVersion', 'MergeMessage', 'TaggedCommit', 'TrackReleaseBranches', 'VersionInBranchName' and 'Mainline'.",
+        "enum": [
+          "None",
+          "Fallback",
+          "ConfiguredNextVersion",
+          "MergeMessage",
+          "TaggedCommit",
+          "TrackReleaseBranches",
+          "VersionInBranchName",
+          "Mainline"
+        ]
+      }
+    },
+    "workflow": {
+      "description": "The base template of the configuration to use. Possible values are: 'GitFlow/v1' or 'GitHubFlow/v1'",
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "branchConfiguration": {
+      "type": "object",
+      "properties": {
+        "commit-message-incrementing": {
+          "$ref": "#/$defs/nullableOfCommitMessageIncrementMode"
+        },
+        "mode": {
+          "$ref": "#/$defs/nullableOfDeploymentMode"
+        },
+        "increment": {
+          "$ref": "#/$defs/incrementStrategy"
+        },
+        "is-main-branch": {
+          "$ref": "#/$defs/nullableOfBoolean"
+        },
+        "is-release-branch": {
+          "$ref": "#/$defs/nullableOfBoolean1"
+        },
+        "is-source-branch-for": {
+          "$ref": "#/$defs/hashSetOfString"
+        },
+        "label": {
+          "$ref": "#/$defs/string"
+        },
+        "label-number-pattern": {
+          "$ref": "#/$defs/string1"
+        },
+        "pre-release-weight": {
+          "$ref": "#/$defs/nullableOfInt32"
+        },
+        "prevent-increment": {
+          "$ref": "#/$defs/preventIncrementConfiguration"
+        },
+        "regex": {
+          "$ref": "#/$defs/string2"
+        },
+        "source-branches": {
+          "$ref": "#/$defs/hashSetOfString1"
+        },
+        "track-merge-message": {
+          "$ref": "#/$defs/nullableOfBoolean4"
+        },
+        "track-merge-target": {
+          "$ref": "#/$defs/nullableOfBoolean5"
+        },
+        "tracks-release-branches": {
+          "$ref": "#/$defs/nullableOfBoolean6"
+        }
+      }
+    },
+    "nullableOfCommitMessageIncrementMode": {
+      "description": "Sets whether it should be possible to increment the version with special syntax in the commit message. Can be 'Disabled', 'Enabled' or 'MergeMessageOnly'.",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "MergeMessageOnly"
+      ]
+    },
+    "nullableOfDeploymentMode": {
+      "description": "The deployment mode for this branch. Can be 'ManualDeployment', 'ContinuousDelivery', 'ContinuousDeployment'.",
+      "enum": [
+        "ManualDeployment",
+        "ContinuousDelivery",
+        "ContinuousDeployment"
+      ]
+    },
+    "incrementStrategy": {
+      "description": "The increment strategy for this branch. Can be 'Inherit', 'Patch', 'Minor', 'Major', 'None'.",
+      "enum": [
+        "None",
+        "Major",
+        "Minor",
+        "Patch",
+        "Inherit"
+      ]
+    },
+    "nullableOfBoolean": {
+      "description": "When using Mainline mode, this indicates that this branch is a mainline. By default main and support/* are mainlines.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullableOfBoolean1": {
+      "description": "Indicates this branch configuration represents a release branch in GitFlow.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "hashSetOfString": {
+      "description": "The branches that this branch is a source branch.",
+      "type": "array",
+      "items": {
+        "description": "The branches that this branch is a source branch.",
+        "type": "string"
+      }
+    },
+    "string": {
+      "description": "The label to use for this branch. Use the value {BranchName} or similar as a placeholder to insert a named capture group from RegularExpression (fx. the branch name).",
+      "type": "string"
+    },
+    "string1": {
+      "format": "regex",
+      "description": "The regular expression pattern to use to extract the number from the branch name. Defaults to '[/-](?<number>\\d+)'.",
+      "default": "[/-](?<number>\\d+)",
+      "type": "string"
+    },
+    "nullableOfInt32": {
+      "description": "Provides a way to translate the PreReleaseLabel to a number.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "preventIncrementConfiguration": {
+      "description": "The prevent increment configuration section.",
+      "type": "object",
+      "properties": {
+        "of-merged-branch": {
+          "$ref": "#/$defs/nullableOfBoolean2"
+        },
+        "when-branch-merged": {
+          "$ref": "#/$defs/nullableOfBoolean2"
+        },
+        "when-current-commit-tagged": {
+          "$ref": "#/$defs/nullableOfBoolean3"
+        }
+      }
+    },
+    "nullableOfBoolean2": {
+      "description": "Prevent increment when branch merged.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullableOfBoolean3": {
+      "description": "This branch related property controls the behavior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "string2": {
+      "format": "regex",
+      "description": "The regular expression pattern to use to match this branch.",
+      "type": "string"
+    },
+    "hashSetOfString1": {
+      "description": "The source branches for this branch.",
+      "type": "array",
+      "items": {
+        "description": "The source branches for this branch.",
+        "type": "string"
+      }
+    },
+    "nullableOfBoolean4": {
+      "description": "This property is a branch related property and gives the user the possibility to control the behavior of whether the merge commit message will be interpreted as a next version or not.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullableOfBoolean5": {
+      "description": "Strategy which will look for tagged merge commits directly off the current branch.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullableOfBoolean6": {
+      "description": "Indicates this branch configuration represents develop in GitFlow.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "string3": {
+      "format": "date-time",
+      "description": "Commits before this date will be ignored. Format: yyyy-MM-ddTHH:mm:ss.",
+      "type": "string"
+    },
+    "hashSetOfString2": {
+      "description": "A sequence of SHAs to be excluded from the version calculations.",
+      "type": "array",
+      "items": {
+        "description": "A sequence of SHAs to be excluded from the version calculations.",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/6.1/GitVersion.json
+++ b/schemas/6.1/GitVersion.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gitversion.net/schemas/6.1/GitVersion.json",
+  "title": "GitVersion version variables output",
+  "description": "GitVersion output schema",
+  "type": "object",
+  "properties": {
+    "AssemblySemFileVer": {
+      "description": "Suitable for .NET AssemblyFileVersion. Defaults to Major.Minor.Patch.0.",
+      "type": "string"
+    },
+    "AssemblySemVer": {
+      "description": "Suitable for .NET AssemblyVersion. Defaults to Major.Minor.0.0",
+      "type": "string"
+    },
+    "BranchName": {
+      "description": "The name of the checked out Git branch.",
+      "type": "string"
+    },
+    "BuildMetaData": {
+      "description": "The build metadata, usually representing number of commits since the VersionSourceSha.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "CommitDate": {
+      "description": "The ISO-8601 formatted date of the commit identified by Sha.",
+      "type": "string"
+    },
+    "CommitsSinceVersionSource": {
+      "description": "The number of commits since the version source.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "EscapedBranchName": {
+      "description": "Equal to BranchName, but with / replaced with -.",
+      "type": "string"
+    },
+    "FullBuildMetaData": {
+      "description": "The BuildMetaData suffixed with BranchName and Sha.",
+      "type": "string"
+    },
+    "FullSemVer": {
+      "description": "The full, SemVer 2.0 compliant version number.",
+      "type": "string"
+    },
+    "InformationalVersion": {
+      "description": "Suitable for .NET AssemblyInformationalVersion. Defaults to FullSemVer suffixed by FullBuildMetaData.",
+      "type": "string"
+    },
+    "Major": {
+      "description": "The major version. Should be incremented on breaking changes.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "MajorMinorPatch": {
+      "description": "Major, Minor and Patch joined together, separated by '.'.",
+      "type": "string"
+    },
+    "Minor": {
+      "description": "The minor version. Should be incremented on new features.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "Patch": {
+      "description": "The patch version. Should be incremented on bug fixes.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "PreReleaseLabel": {
+      "description": "The pre-release label is the name of the pre-release.",
+      "type": "string"
+    },
+    "PreReleaseLabelWithDash": {
+      "description": "The pre-release label prefixed with a dash.",
+      "type": "string"
+    },
+    "PreReleaseNumber": {
+      "description": "The pre-release number is the number of commits since the last version bump.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "PreReleaseTag": {
+      "description": "The pre-release tag is the pre-release label suffixed by the PreReleaseNumber.",
+      "type": "string"
+    },
+    "PreReleaseTagWithDash": {
+      "description": "The pre-release tag prefixed with a dash.",
+      "type": "string"
+    },
+    "SemVer": {
+      "description": "The semantic version number, including PreReleaseTagWithDash for pre-release version numbers.",
+      "type": "string"
+    },
+    "Sha": {
+      "description": "The SHA of the Git commit.",
+      "type": "string"
+    },
+    "ShortSha": {
+      "description": "The Sha limited to 7 characters.",
+      "type": "string"
+    },
+    "UncommittedChanges": {
+      "description": "The number of uncommitted changes present in the repository.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "VersionSourceSha": {
+      "description": "The SHA of the commit used as version source.",
+      "type": "string"
+    },
+    "WeightedPreReleaseNumber": {
+      "description": "A summation of branch specific pre-release-weight and the PreReleaseNumber. Can be used to obtain a monotonically increasing version number across the branches.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  }
+}

--- a/src/GitVersion.Schema/Program.cs
+++ b/src/GitVersion.Schema/Program.cs
@@ -21,6 +21,15 @@ AttributeHandler.AddHandler<DescriptionAttributeHandler1>();
 AttributeHandler.AddHandler<DescriptionAttributeHandler2>();
 AttributeHandler.AddHandler<FormatAttributeHandler>();
 
+if (!Directory.Exists(schemasDirectory))
+{
+    Directory.CreateDirectory(schemasDirectory);
+}
+if (!Directory.Exists(Path.Combine(schemasDirectory, schemaVersion)))
+{
+    Directory.CreateDirectory(Path.Combine(schemasDirectory, schemaVersion));
+}
+
 var builder = new JsonSchemaBuilder();
 builder.Schema("http://json-schema.org/draft-07/schema#");
 builder.Id($"https://gitversion.net/schemas/{schemaVersion}/GitVersion.configuration.json");


### PR DESCRIPTION
This pull request adds new JSON schema files for GitVersion configuration and output, as well as updates to the `Program.cs` file to ensure the necessary directories exist before creating schemas.

### New JSON schema files:
* [`schemas/6.1/GitVersion.configuration.json`](diffhunk://#diff-9cf6090a77c7d56fda9f8dd6d8a312405aa28318494d1f49a0ebef09fb4a60f7R1-R394): Added schema for GitVersion configuration, detailing properties like `assembly-file-versioning-format`, `branches`, `commit-date-format`, and various version bump messages.
* [`schemas/6.1/GitVersion.json`](diffhunk://#diff-5b3427d5058a23985dda6bf216d79e22d35b62d5c110ad4fcc6ef5c02908db90R1-R133): Added schema for GitVersion output, defining properties such as `AssemblySemFileVer`, `BranchName`, `CommitDate`, `Major`, `Minor`, `Patch`, and `SemVer`.

### Directory checks in `Program.cs`:
* [`src/GitVersion.Schema/Program.cs`](diffhunk://#diff-b12fc97d54710d0e1fd4d2f6821bf0dbc6a2b850b09fa69ed21c97ebbfefe5e5R24-R32): Added checks to create `schemasDirectory` and its subdirectory for the schema version if they do not exist.