### PR TITLE
Update the commit-message behavior docs

### DIFF
--- a/docs/input/docs/reference/version-increments.md
+++ b/docs/input/docs/reference/version-increments.md
@@ -83,11 +83,6 @@ If the incrementing `mode` is set to `MergeMessageOnly` you can add this
 information when merging a pull request. This prevents commits within a PR to
 bump the version number.
 
-One thing to be aware of: If the current version is an alpha-version (i.e.
-`0.x.y`.), attempting to bump the major version will merely bump the minor (eg
-from `0.2.0` to `0.3.0` instead of `1.0.0`). Once the current version is greater
-than `1.0.0`, bumping the major version works as expected.
-
 #### Conventional commit messages
 
 If you want to use the [Conventional Commits][conventional-commits] standard,


### PR DESCRIPTION
This pull request includes a documentation update to the version increments reference. The most important change is the removal of a section explaining the behavior of version bumping for alpha versions.

Documentation update:

* Removed the explanation about major version bumping behavior for alpha versions from `docs/input/docs/reference/version-increments.md`.

Related to https://github.com/GitTools/GitVersion/issues/4184 and https://github.com/GitTools/GitVersion/pull/4185