### PR TITLE
(dependabot) Add .NET SDK to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+- package-ecosystem: dotnet-sdk
+  labels:
+      - "dependencies"
+  commit-message:
+      prefix: "(deps)"
+  directory: "/"
+  schedule:
+    interval: daily
 - package-ecosystem: nuget
   labels:
     - "dependencies"


### PR DESCRIPTION
This pull request includes an update to the `.github/dependabot.yml` file to add a new package ecosystem and improve the dependency management configuration.

Changes to dependency management configuration:

* Added `dotnet-sdk` as a new package ecosystem with daily update schedule and specific commit message prefix.