### PR TITLE
Fix tag normalization for Azure Pipelines

### DIFF
--- a/src/GitVersion.BuildAgents.Tests/Agents/AzurePipelinesTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/AzurePipelinesTests.cs
@@ -77,4 +77,43 @@ public class AzurePipelinesTests : TestBase
         var logMessage = this.buildServer.SetBuildNumber(vars);
         logMessage.ShouldBe(logPrefix + expectedBuildNumber);
     }
+
+    [Test]
+    public void GetCurrentBranchShouldHandleBranches()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", $"refs/heads/{MainBranch}");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBe($"refs/heads/{MainBranch}");
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldHandleTags()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/tags/1.0.0");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldHandlePullRequests()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/pull/1/merge");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBe("refs/pull/1/merge");
+    }
 }

--- a/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
@@ -17,8 +17,24 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
         $"##vso[task.setvariable variable=GitVersion.{name};isOutput=true]{value}"
     ];
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("GIT_BRANCH")
-        ?? Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {
+        var gitBranch = Environment.GetEnvironmentVariable("GIT_BRANCH");
+        if (gitBranch is not null)
+            return gitBranch;
+
+        var sourceBranch = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+
+        // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+        // BUILD_SOURCEBRANCH must be used only for "real" branches, not for tags.
+        // Azure Pipelines sets BUILD_SOURCEBRANCH to refs/tags/<tag> when the pipeline is triggered for a tag.
+        if (sourceBranch?.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return null;
+        }
+
+        return sourceBranch;
+    }
 
     public override bool PreventFetch() => true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the Azure Pipelines agent so it does not return tag names as branch names.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/GitTools/GitVersion/issues/4015
<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Motivation and Context
Azure Pipelines provides the name of the tag for which the pipeline has been triggered in `BUILD_SOURCEBRANCH` as
`refs/tags/<tag>`.  When we do not ignore the tags in the Azure Pipelines agent, the repository normalization will normalize
the tag name `refs/tags/<tag>` to the local branch name `tags/<tag>`. This leads to an incorrect calculation of prerelease labels
(e.g. `tags-v1.2.3-beta.1`) .

A similar issue has been fixed for GitHub Actions in https://github.com/GitTools/GitVersion/issues/2838.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests have been added for the Azure Pipelines agent.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
