### PR TITLE
Fixes to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:dev-8.0
+FROM mcr.microsoft.com/devcontainers/dotnet:dev-9.0
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
             "upgradePackages": "true"
         },
 		"ghcr.io/devcontainers/features/git:1": {
-            "version": "latest",
+            "version": "os-provided",
             "ppa": "false"
         },
         "ghcr.io/devcontainers/features/powershell:1": {


### PR DESCRIPTION
## Description

One change avoids compiling git from source since the version provided by the OS is fine and can be installed quickly (compared to compiling git). The other one addresses the problem that the `dotnet:dev-8.0` doesn't work out-of-the-box because the `global.json` defines SDK 9.0 (not sure if this is the problem but my changes fixed the issue and got the devcontainer running) so that you need `dotnet:dev-9.0`.

## Motivation and Context
Better out-of-the-box experience.

## How Has This Been Tested?
Setting up the project in VS Code and running the testsuite with `dotnet test --framework net9.0 src/`

## Checklist:
* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
