### PR TITLE
Replace C# extension with official C# Dev Kit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
             },
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
-                "ms-dotnettools.csharp",
+                "ms-dotnettools.csdevkit",
                 "EditorConfig.EditorConfig",
                 "streetsidesoftware.code-spell-checker"
             ]


### PR DESCRIPTION
## Description
Replace the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) with the better [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) for the devcontainer of VS Code.  
Hint: Had to run `dotnet test src` once so that tests appear in the Testing area of VS Code.

## Motivation and Context
From [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit):

> C# Dev Kit helps you manage your code with a solution explorer and test your code with integrated unit test discovery and execution, elevating your C# development experience wherever you like to develop (Windows, macOS, Linux, and even in a Codespace).
This extension builds on top of the great C# language capabilities provided by the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and enhances your C# environment by adding a set of powerful tools and utilities that integrate natively with VS Code to help C# developers write, debug, and maintain their code faster and with fewer errors. Some of this new tooling includes but is not limited to:
> - C# project and solution management via an integrated solution explorer
> - Native testing environment to run and debug tests using the Test Explorer
> - Roslyn-powered language service for best in-class C# language features such as code navigation, refactoring, semantic awareness, and more

## Checklist:

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
