### PR TITLE
Support for Dotenv output format

### DIFF
--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -30,7 +30,7 @@ GitVersion [path]
 
     /targetpath     Same as 'path', but not positional
     /output         Determines the output to the console. Can be either 'json',
-                    'file' or 'buildserver', will default to 'json'.
+                    'file', 'buildserver' or 'dotenv', will default to 'json'.
     /outputfile     Path to output file. It is used in combination with /output
                     'file'.
     /showvariable   Used in conjunction with /output json, will output just a

--- a/docs/input/docs/usage/cli/output.md
+++ b/docs/input/docs/usage/cli/output.md
@@ -14,3 +14,10 @@ out the variables to whatever build server it is running in. You can then use
 those variables in your build scripts or run different tools to create versioned
 NuGet packages or whatever you would like to do. See [build
 servers](/docs/reference/build-servers) for more information about this.
+
+You can even store the [variables](/docs/reference/variables) in a Dotenv file
+and load it to have the variables available in your environment.
+For that you have to run `GitVersion.exe /output dotenv` and store the output
+into e.g. a `gitversion.env` file. These files can also be passed around in CI environments
+like [GitHub](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#passing-values-between-steps-and-jobs-in-a-workflow)
+or [GitLab](https://docs.gitlab.com/ee/ci/variables/#pass-an-environment-variable-to-another-job).

--- a/docs/input/docs/usage/cli/output.md
+++ b/docs/input/docs/usage/cli/output.md
@@ -21,3 +21,17 @@ For that you have to run `GitVersion.exe /output dotenv` and store the output
 into e.g. a `gitversion.env` file. These files can also be passed around in CI environments
 like [GitHub](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#passing-values-between-steps-and-jobs-in-a-workflow)
 or [GitLab](https://docs.gitlab.com/ee/ci/variables/#pass-an-environment-variable-to-another-job).
+Below are some examples of using the Dotenv format in the Unix command line:
+```bash
+# Output version variables in Dotenv format
+gitversion /output dotenv
+
+# Show only a subset of the version variables in Dotenv format
+gitversion /output dotenv | grep -i "prerelease"
+
+# Show only a subset of the version variables that match the regex in Dotenv format
+gitversion /output dotenv | grep -iE "major|sha=|_prerelease"
+
+# Write version variables in Dotenv format into a file
+gitversion /output dotenv > gitversion.env
+```

--- a/new-cli/command.md
+++ b/new-cli/command.md
@@ -53,6 +53,18 @@ cat gitversion.json | gitversion output buildserver
 # Read version variables from stdin and write to Jenkins.
 cat gitversion.json | gitversion output buildserver --buildserver Jenkins
 
+# Output version variables in Dotenv format
+gitversion /output dotenv
+
+# Show only a subset of the version variables in Dotenv format (Unix syntax)
+gitversion /output dotenv | grep -i "prerelease"
+
+# Show only a subset of the version variables that match the regex in Dotenv format (Unix syntax)
+gitversion /output dotenv | grep -iE "major|sha=|_prerelease"
+
+# Write version variables in Dotenv format into a file
+gitversion /output dotenv > gitversion.env
+
 # Read version variables from stdin and write to globbed .wxi files.
 cat gitversion.json | gitversion output wix --path ./**/*.wxi
 

--- a/new-cli/command.md
+++ b/new-cli/command.md
@@ -53,18 +53,6 @@ cat gitversion.json | gitversion output buildserver
 # Read version variables from stdin and write to Jenkins.
 cat gitversion.json | gitversion output buildserver --buildserver Jenkins
 
-# Output version variables in Dotenv format
-gitversion /output dotenv
-
-# Show only a subset of the version variables in Dotenv format (Unix syntax)
-gitversion /output dotenv | grep -i "prerelease"
-
-# Show only a subset of the version variables that match the regex in Dotenv format (Unix syntax)
-gitversion /output dotenv | grep -iE "major|sha=|_prerelease"
-
-# Write version variables in Dotenv format into a file
-gitversion /output dotenv > gitversion.env
-
 # Read version variables from stdin and write to globbed .wxi files.
 cat gitversion.json | gitversion output wix --path ./**/*.wxi
 

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -103,7 +103,7 @@ public class ArgumentParserTests : TestBase
     {
         var exception = Assert.Throws<WarningException>(() => this.argumentParser.ParseArguments("targetDirectoryPath -output invalid_value"));
         exception.ShouldNotBeNull();
-        exception.Message.ShouldBe("Value 'invalid_value' cannot be parsed as output type, please use 'json', 'file' or 'buildserver'");
+        exception.Message.ShouldBe("Value 'invalid_value' cannot be parsed as output type, please use 'json', 'file', 'buildserver' or 'dotenv'");
     }
 
     [Test]

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -432,7 +432,7 @@ internal class ArgumentParser(IEnvironment environment,
         {
             if (!Enum.TryParse(v, true, out OutputType outputType))
             {
-                throw new WarningException($"Value '{v}' cannot be parsed as output type, please use 'json', 'file' or 'buildserver'");
+                throw new WarningException($"Value '{v}' cannot be parsed as output type, please use 'json', 'file', 'buildserver' or 'dotenv'");
             }
 
             arguments.Output.Add(outputType);

--- a/src/GitVersion.Core/Options/OutputType.cs
+++ b/src/GitVersion.Core/Options/OutputType.cs
@@ -4,5 +4,6 @@ public enum OutputType
 {
     BuildServer,
     Json,
-    File
+    File,
+    DotEnv
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -417,6 +417,7 @@ GitVersion.OutputType
 GitVersion.OutputType.BuildServer = 0 -> GitVersion.OutputType
 GitVersion.OutputType.File = 2 -> GitVersion.OutputType
 GitVersion.OutputType.Json = 1 -> GitVersion.OutputType
+GitVersion.OutputType.DotEnv = 3 -> GitVersion.OutputType
 GitVersion.OutputVariables.GitVersionVariables
 GitVersion.OutputVariables.GitVersionVariables.AssemblySemFileVer.get -> string?
 GitVersion.OutputVariables.GitVersionVariables.AssemblySemFileVer.init -> void

--- a/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
+++ b/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
@@ -68,13 +68,13 @@ public class FormatArgumentTests : TestBase
         output.ShouldBeEquivalentTo(expectedValue);
     }
 
-    [TestCase("Major", "1")]
-    [TestCase("MajorMinorPatch", "1.1.0")]
-    [TestCase("SemVer", "1.1.0-foo.1")]
-    [TestCase("PreReleaseTagWithDash", "-foo.1")]
-    [TestCase("AssemblySemFileVer", "1.1.0.0")]
-    [TestCase("BranchName", "feature/foo")]
-    [TestCase("FullSemVer", "1.1.0-foo.1+1")]
+    [TestCase("Major", "'1'")]
+    [TestCase("MajorMinorPatch", "'1.1.0'")]
+    [TestCase("SemVer", "'1.1.0-foo.1'")]
+    [TestCase("PreReleaseTagWithDash", "'-foo.1'")]
+    [TestCase("AssemblySemFileVer", "'1.1.0.0'")]
+    [TestCase("BranchName", "'feature/foo'")]
+    [TestCase("FullSemVer", "'1.1.0-foo.1+1'")]
     public void ShouldOutputDotEnvEntries(string variableName, string expectedValue)
     {
         var fixture = CreateTestRepository();
@@ -127,13 +127,13 @@ public class FormatArgumentTests : TestBase
         Assert.That(totalOutputLines, Is.EqualTo(versionVariables.Count()));
     }
 
-    [TestCase("Major", "0")]
-    [TestCase("MajorMinorPatch", "0.0.1")]
-    [TestCase("SemVer", "0.0.1-1")]
+    [TestCase("Major", "'0'")]
+    [TestCase("MajorMinorPatch", "'0.0.1'")]
+    [TestCase("SemVer", "'0.0.1-1'")]
     [TestCase("BuildMetaData", "''")]
-    [TestCase("AssemblySemVer", "0.0.1.0")]
-    [TestCase("PreReleaseTagWithDash", "-1")]
-    [TestCase("BranchName", "main")]
+    [TestCase("AssemblySemVer", "'0.0.1.0'")]
+    [TestCase("PreReleaseTagWithDash", "'-1'")]
+    [TestCase("BranchName", "'main'")]
     [TestCase("PreReleaseLabel", "''")]
     [TestCase("PreReleaseLabelWithDash", "''")]
     public void ShouldOutputAllDotEnvEntriesEvenForMinimalRepositories(string variableName, string expectedValue)

--- a/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
+++ b/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
@@ -97,7 +97,7 @@ public class FormatArgumentTests : TestBase
 
         outputGenerator.Execute(versionVariables, new());
         var output = consoleBuilder.ToString();
-        output.ShouldContain("GitVersion_" + variableName + "=" + expectedValue + "\n");
+        output.ShouldContain($"GitVersion_{variableName}={expectedValue}{SysEnv.NewLine}");
     }
 
     [TestCase]
@@ -123,7 +123,7 @@ public class FormatArgumentTests : TestBase
 
         outputGenerator.Execute(versionVariables, new());
         var output = consoleBuilder.ToString();
-        var totalOutputLines = output.Split("\n").Length - 1; // ignore last item that also ends with \n
+        var totalOutputLines = output.Split(SysEnv.NewLine).Length - 1; // ignore last item that also ends with the newline string
         Assert.That(totalOutputLines, Is.EqualTo(versionVariables.Count()));
     }
 
@@ -158,7 +158,7 @@ public class FormatArgumentTests : TestBase
 
         outputGenerator.Execute(versionVariables, new());
         var output = consoleBuilder.ToString();
-        output.ShouldContain("GitVersion_" + variableName + "=" + expectedValue + "\n");
+        output.ShouldContain($"GitVersion_{variableName}={expectedValue}{SysEnv.NewLine}");
     }
 
     [TestCase]
@@ -184,7 +184,7 @@ public class FormatArgumentTests : TestBase
 
         outputGenerator.Execute(versionVariables, new());
         var output = consoleBuilder.ToString();
-        var totalOutputLines = output.Split("\n").Length - 1; // ignore last item that also ends with \n
+        var totalOutputLines = output.Split(SysEnv.NewLine).Length - 1; // ignore last item that also ends with the newline string
         Assert.That(totalOutputLines, Is.EqualTo(versionVariables.Count()));
     }
 

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -48,7 +48,7 @@ internal sealed class OutputGenerator(
                 dotEnvEntries.Add(prefixedKey + "=" + environmentValue);
             }
 
-            foreach(var dotEnvEntry in dotEnvEntries)
+            foreach (var dotEnvEntry in dotEnvEntries)
             {
                 this.console.WriteLine(dotEnvEntry);
             }

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -28,9 +28,32 @@ internal sealed class OutputGenerator(
     public void Execute(GitVersionVariables variables, OutputContext context)
     {
         var gitVersionOptions = this.options.Value;
+
         if (gitVersionOptions.Output.Contains(OutputType.BuildServer))
         {
             this.buildAgent.WriteIntegration(this.console.WriteLine, variables, context.UpdateBuildNumber ?? true);
+        }
+
+        if (gitVersionOptions.Output.Contains(OutputType.DotEnv))
+        {
+            List<string> dotEnvEntries = [];
+            foreach (var (key, value) in variables.OrderBy(x => x.Key))
+            {
+                string prefixedKey = "GitVersion_" + key;
+                string environmentValue = "''";
+                if (!value.IsNullOrEmpty())
+                {
+                    environmentValue = value;
+                }
+                dotEnvEntries.Add(prefixedKey + "=" + environmentValue);
+            }
+
+            foreach(var dotEnvEntry in dotEnvEntries)
+            {
+                this.console.WriteLine(dotEnvEntry);
+            }
+
+            return;
         }
 
         var json = this.serializer.ToJson(variables);

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -40,12 +40,12 @@ internal sealed class OutputGenerator(
             foreach (var (key, value) in variables.OrderBy(x => x.Key))
             {
                 string prefixedKey = "GitVersion_" + key;
-                string environmentValue = "''";
+                string environmentValue = "";
                 if (!value.IsNullOrEmpty())
                 {
                     environmentValue = value;
                 }
-                dotEnvEntries.Add(prefixedKey + "=" + environmentValue);
+                dotEnvEntries.Add($"{prefixedKey}='{environmentValue}'");
             }
 
             foreach (var dotEnvEntry in dotEnvEntries)


### PR DESCRIPTION
## Description
This PR implements the functionality to export the GitVersion variables in the Dotenv format that can be consumed by your environment.

## Related Issue
Closes #4174

## Motivation and Context
Exporting the variables in the Dotenv format provides a simple mechanism to use the GitVersion variables in your shell environment. Additonallty some CI systems like GitHub or GitLab allow to pass around and expanding the jobs environment with artifacts in the Dotenv format.

It can be discussed how the output should look like e.g. wrap all values in `'<value>'`, write nothing for empty lines or use `''` (that's what I've decided for). The parsing rules for nodejs projects are [here](https://github.com/motdotla/dotenv?tab=readme-ov-file#what-rules-does-the-parsing-engine-follow) while the ones for GitLab CI can be found [here](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv).

## How Has This Been Tested?
With the provided unit tests as well as with a Python script and a library for handling Dotenv files (see Examples section below).

## Examples:
Running the following commands
```bash
git init --initial-branch=main
touch text.txt
git add test.txt 
git commit -m "test"
gitversion /output dotenv > gitversion.env
```
results in a `gitversion.env` file with the following content
```
GitVersion_AssemblySemFileVer=0.0.1.0
GitVersion_AssemblySemVer=0.0.1.0
GitVersion_BranchName=main
GitVersion_BuildMetaData=''
GitVersion_CommitDate=2025-02-08
GitVersion_CommitsSinceVersionSource=1
GitVersion_EscapedBranchName=main
GitVersion_FullBuildMetaData=Branch.main.Sha.2501b1440f9823abca9f9100f3776e42a3d730c3
GitVersion_FullSemVer=0.0.1-1
GitVersion_InformationalVersion=0.0.1-1+Branch.main.Sha.2501b1440f9823abca9f9100f3776e42a3d730c3
GitVersion_Major=0
GitVersion_MajorMinorPatch=0.0.1
GitVersion_Minor=0
GitVersion_Patch=1
GitVersion_PreReleaseLabel=''
GitVersion_PreReleaseLabelWithDash=''
GitVersion_PreReleaseNumber=1
GitVersion_PreReleaseTag=1
GitVersion_PreReleaseTagWithDash=-1
GitVersion_SemVer=0.0.1-1
GitVersion_Sha=2501b1440f9823abca9f9100f3776e42a3d730c3
GitVersion_ShortSha=2501b14
GitVersion_UncommittedChanges=1519
GitVersion_VersionSourceSha=''
GitVersion_WeightedPreReleaseNumber=55001
```

Loading that file in Python (`pip install python-dotenv`) with the following script
```py
import dotenv
import os

dotenv_file = dotenv.find_dotenv('gitversion.env')
dotenv.load_dotenv(dotenv_file)

print("-- output loaded values as example --")
print(os.environ["GitVersion_MajorMinorPatch"])  # 0.0.1
print(os.environ['GitVersion_VersionSourceSha'])  # empty

print("-- manipulate a loaded value --")
os.environ["GitVersion_MajorMinorPatch"] = ""
print(os.environ['GitVersion_MajorMinorPatch'])  # empty

print("-- write changes to env file --")
dotenv.set_key("python_gitversion.env", "GitVersion_Major", os.environ["GitVersion_Major"])
dotenv.set_key("python_gitversion.env", "GitVersion_FullSemVer", os.environ["GitVersion_FullSemVer"])
dotenv.set_key("python_gitversion.env", "GitVersion_MajorMinorPatch", os.environ["GitVersion_MajorMinorPatch"])
dotenv.set_key("python_gitversion.env", "GitVersion_VersionSourceSha", os.environ["GitVersion_VersionSourceSha"])
```
writes 
```
-- output loaded values as example --
0.0.1

-- manipulate a loaded value --

-- write changes to env file --
```
to the console (and thus proves it can load/understand the generated Dotenv format from GitVersion) and results in a `python_gitversion.env` file with the content
```
GitVersion_MajorMinorPatch=''
GitVersion_VersionSourceSha=''
GitVersion_Major='0'
GitVersion_FullSemVer='0.0.1-1'
```

## Checklist:

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
