### PR TITLE
Feature: Support ignoring (filtering) paths in git tree

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -191,6 +191,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
@@ -208,7 +209,7 @@ tracks-release-branches: false
 is-release-branch: false
 is-main-branch: false
 ```
-<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The supported built-in configuration for the `GitHubFlow` workflow (`workflow: GitHubFlow/v1`) looks like:
@@ -315,6 +316,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
@@ -332,7 +334,7 @@ tracks-release-branches: false
 is-release-branch: false
 is-main-branch: false
 ```
-<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The preview built-in configuration (experimental usage only) for the `TrunkBased` workflow (`workflow: TrunkBased/preview1`) looks like:
@@ -424,6 +426,7 @@ branches:
     pre-release-weight: 30000
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit
@@ -441,7 +444,7 @@ tracks-release-branches: false
 is-release-branch: false
 is-main-branch: false
 ```
-<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The details of the available options are as follows:
@@ -620,6 +623,44 @@ ignore:
 Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 2015-10-23T12:23:15`) to setup an exclusion range. Effectively any commit before
 `commits-before` will be ignored.
+
+#### paths
+A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
+```yaml
+ignore:
+  paths:
+    - ^docs\/
+```
+##### *Monorepo*
+This ignore config can be used to filter only those commits that belong to a specific project in a monorepo. 
+As an example, consider a monorepo consisting of subdirectories for `ProjectA`, `ProjectB` and a shared `LibraryC`. For GitVersion to consider only commits that are part of `projectA` and shared library `LibraryC`, a regex that matches all paths except those starting with `ProjectA` or `LibraryC` can be used. Either one of the following configs would filter out `ProjectB`.
+* Specific match on `/ProjectB/*`:
+```yaml
+ignore:
+  paths:
+    - `^\/ProductB\/.*`
+```
+* Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
+```yaml
+ignore:
+  paths:
+    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+```
+A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
+* `/ProductA/*`
+* `/LibraryC/*`
+* `/ProductA/*` and  `/LibraryC/*`
+* `/ProductA/*` and `/ProductB/*`
+* `/LibraryC/*` and `/ProductB/*`
+* `/ProductA/*` and `/ProductB/*` and `/LibraryC/*`
+
+:::
+Note: The `ignore.paths` configuration is case-sensitive. This can lead to unexpected behavior on case-insensitive file systems, such as Windows. To ensure consistent matching regardless of case, you can prefix your regular expressions with the case-insensitive flag `(?i)`. For example, `(?i)^docs\/` will match both `docs/` and `Docs/`. 
+:::
+
+::: {.alert .alert-warning}
+A commit is ignored by the `ignore.paths` configuration only if **all paths** changed in that commit match one or more of the specified regular expressions. If a path in a commit does not match any one of the ignore patterns, that commit will be included in version calculations.
+:::
 
 ### merge-message-formats
 

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -225,6 +225,44 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 2015-10-23T12:23:15`) to setup an exclusion range. Effectively any commit before
 `commits-before` will be ignored.
 
+#### paths
+A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
+```yaml
+ignore:
+  paths:
+    - ^docs\/
+```
+##### *Monorepo*
+This ignore config can be used to filter only those commits that belong to a specific project in a monorepo. 
+As an example, consider a monorepo consisting of subdirectories for `ProjectA`, `ProjectB` and a shared `LibraryC`. For GitVersion to consider only commits that are part of `projectA` and shared library `LibraryC`, a regex that matches all paths except those starting with `ProjectA` or `LibraryC` can be used. Either one of the following configs would filter out `ProjectB`.
+* Specific match on `/ProjectB/*`:
+```yaml
+ignore:
+  paths:
+    - `^\/ProductB\/.*`
+```
+* Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
+```yaml
+ignore:
+  paths:
+    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+```
+A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
+* `/ProductA/*`
+* `/LibraryC/*`
+* `/ProductA/*` and  `/LibraryC/*`
+* `/ProductA/*` and `/ProductB/*`
+* `/LibraryC/*` and `/ProductB/*`
+* `/ProductA/*` and `/ProductB/*` and `/LibraryC/*`
+
+:::
+Note: The `ignore.paths` configuration is case-sensitive. This can lead to unexpected behavior on case-insensitive file systems, such as Windows. To ensure consistent matching regardless of case, you can prefix your regular expressions with the case-insensitive flag `(?i)`. For example, `(?i)^docs\/` will match both `docs/` and `Docs/`. 
+:::
+
+::: {.alert .alert-warning}
+A commit is ignored by the `ignore.paths` configuration only if **all paths** changed in that commit match one or more of the specified regular expressions. If a path in a commit does not match any one of the ignore patterns, that commit will be included in version calculations.
+:::
+
 ### merge-message-formats
 
 Custom merge message formats to enable identification of merge messages that do not

--- a/docs/input/docs/workflows/GitFlow/v1.yml
+++ b/docs/input/docs/workflows/GitFlow/v1.yml
@@ -148,6 +148,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/docs/input/docs/workflows/GitHubFlow/v1.yml
+++ b/docs/input/docs/workflows/GitHubFlow/v1.yml
@@ -97,6 +97,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/docs/input/docs/workflows/TrunkBased/preview1.yml
+++ b/docs/input/docs/workflows/TrunkBased/preview1.yml
@@ -82,6 +82,7 @@ branches:
     pre-release-weight: 30000
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/new-cli/GitVersion.Core.Libgit2Sharp/GitVersion.Core.Libgit2Sharp.csproj
+++ b/new-cli/GitVersion.Core.Libgit2Sharp/GitVersion.Core.Libgit2Sharp.csproj
@@ -57,6 +57,9 @@
       <Compile Include="..\..\src\GitVersion.LibGit2Sharp\Git\TagCollection.cs">
         <Link>Git\TagCollection.cs</Link>
       </Compile>
+	  <Compile Include="..\..\src\GitVersion.LibGit2Sharp\Git\TreeChanges.cs">
+        <Link>Git\TreeChanges.cs</Link>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -148,6 +148,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
@@ -148,6 +148,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
@@ -97,6 +97,7 @@ branches:
     is-main-branch: false
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
@@ -82,6 +82,7 @@ branches:
     pre-release-weight: 30000
 ignore:
   sha: []
+  paths: []
 mode: ContinuousDelivery
 label: '{BranchName}'
 increment: Inherit

--- a/src/GitVersion.Configuration/IgnoreConfiguration.cs
+++ b/src/GitVersion.Configuration/IgnoreConfiguration.cs
@@ -24,12 +24,12 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
     [JsonPropertyDescription("A sequence of SHAs to be excluded from the version calculations.")]
     public HashSet<string> Shas { get; init; } = [];
 
-    [JsonIgnore]
-    public bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
-
     IReadOnlyCollection<string> IIgnoreConfiguration.Paths => Paths;
 
     [JsonPropertyName("paths")]
     [JsonPropertyDescription("A sequence of file paths to be excluded from the version calculations.")]
     public Collection<string> Paths { get; init; } = [];
+
+    [JsonIgnore]
+    public bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
 }

--- a/src/GitVersion.Configuration/IgnoreConfiguration.cs
+++ b/src/GitVersion.Configuration/IgnoreConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using GitVersion.Configuration.Attributes;
 
 namespace GitVersion.Configuration;
@@ -24,5 +25,11 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
     public HashSet<string> Shas { get; init; } = [];
 
     [JsonIgnore]
-    public bool IsEmpty => Before == null && Shas.Count == 0;
+    public bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
+
+    IReadOnlyCollection<string> IIgnoreConfiguration.Paths => Paths;
+
+    [JsonPropertyName("paths")]
+    [JsonPropertyDescription("A sequence of file paths to be excluded from the version calculations.")]
+    public Collection<string> Paths { get; init; } = [];
 }

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -32,6 +32,13 @@ public static class GitRepositoryTestingExtensions
         return commit;
     }
 
+    public static ICommit CreateMockCommit(List<string> diffPaths)
+    {
+        var commit = CreateMockCommit();
+        commit.DiffPaths.Returns(diffPaths);
+        return commit;
+    }
+
     public static IBranch CreateMockBranch(string name, params ICommit[] commits)
     {
         var branch = Substitute.For<IBranch>();

--- a/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
@@ -12,7 +12,7 @@ public class MinDateVersionFilterTests : TestBase
         var dummy = DateTimeOffset.UtcNow.AddSeconds(1.0);
         var sut = new MinDateVersionFilter(dummy);
 
-        Should.Throw<ArgumentNullException>(() => sut.Exclude(null!, out _));
+        Should.Throw<ArgumentNullException>(() => sut.Exclude((IBaseVersion)null!, out _));
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
@@ -7,5 +7,42 @@ namespace GitVersion.Core.Tests;
 public class PathFilterTests : TestBase
 {
     [Test]
-    public void VerifyNullGuard() => Should.Throw<ArgumentNullException>(() => new PathFilter(null!));
+    public void VerifyNullGuard()
+    {
+        var sut = new PathFilter([]);
+
+        Should.Throw<ArgumentNullException>(() => sut.Exclude((IBaseVersion)null!, out _));
+    }
+
+    [Test]
+    public void WhenPathMatchShouldExcludeWithReason()
+    {
+        var commit = GitRepositoryTestingExtensions.CreateMockCommit(["/path"]);
+        BaseVersion version = new("dummy", new SemanticVersion(1), commit);
+        var sut = new PathFilter(commit.DiffPaths);
+
+        sut.Exclude(version, out var reason).ShouldBeTrue();
+        reason.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void WhenPathMismatchShouldNotExclude()
+    {
+        var commit = GitRepositoryTestingExtensions.CreateMockCommit(["/path"]);
+        BaseVersion version = new("dummy", new SemanticVersion(1), commit);
+        var sut = new PathFilter(["/another_path"]);
+
+        sut.Exclude(version, out var reason).ShouldBeFalse();
+        reason.ShouldBeNull();
+    }
+
+    [Test]
+    public void ExcludeShouldAcceptVersionWithNullCommit()
+    {
+        BaseVersion version = new("dummy", new SemanticVersion(1));
+        var sut = new PathFilter(["/path"]);
+
+        sut.Exclude(version, out var reason).ShouldBeFalse();
+        reason.ShouldBeNull();
+    }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
@@ -1,0 +1,11 @@
+using GitVersion.Core.Tests.Helpers;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Core.Tests;
+
+[TestFixture]
+public class PathFilterTests : TestBase
+{
+    [Test]
+    public void VerifyNullGuard() => Should.Throw<ArgumentNullException>(() => new PathFilter(null!));
+}

--- a/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
@@ -12,7 +12,7 @@ public class ShaVersionFilterTests : TestBase
         var commit = GitRepositoryTestingExtensions.CreateMockCommit();
         var sut = new ShaVersionFilter([commit.Sha]);
 
-        Should.Throw<ArgumentNullException>(() => sut.Exclude(null!, out _));
+        Should.Throw<ArgumentNullException>(() => sut.Exclude((IBaseVersion)null!, out _));
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -204,7 +204,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
         public IObjectId Id => throw new NotImplementedException();
         public string Sha => throw new NotImplementedException();
         public IReadOnlyList<ICommit> Parents => throw new NotImplementedException();
-        public IEnumerable<string> DiffPaths => throw new NotImplementedException();
+        public IReadOnlyList<string> DiffPaths => throw new NotImplementedException();
         public DateTimeOffset When => throw new NotImplementedException();
         public string Message => throw new NotImplementedException();
     }

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -204,6 +204,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
         public IObjectId Id => throw new NotImplementedException();
         public string Sha => throw new NotImplementedException();
         public IReadOnlyList<ICommit> Parents => throw new NotImplementedException();
+        public IEnumerable<string> DiffPaths => throw new NotImplementedException();
         public DateTimeOffset When => throw new NotImplementedException();
         public string Message => throw new NotImplementedException();
     }

--- a/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
@@ -68,7 +68,6 @@ public record EffectiveConfiguration
         PatchVersionBumpMessage = configuration.PatchVersionBumpMessage;
         NoBumpMessage = configuration.NoBumpMessage;
         CommitMessageIncrementing = branchConfiguration.CommitMessageIncrementing.Value;
-        VersionFilters = configuration.Ignore.ToFilters();
         Ignore = configuration.Ignore;
         TracksReleaseBranches = branchConfiguration.TracksReleaseBranches ?? false;
         IsReleaseBranch = branchConfiguration.IsReleaseBranch ?? false;
@@ -123,8 +122,6 @@ public record EffectiveConfiguration
     public string? NoBumpMessage { get; }
 
     public CommitMessageIncrementMode CommitMessageIncrementing { get; }
-
-    public IEnumerable<IVersionFilter> VersionFilters { get; }
 
     public IIgnoreConfiguration Ignore { get; }
 

--- a/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
@@ -8,5 +8,5 @@ public interface IIgnoreConfiguration
 
     IReadOnlyCollection<string> Paths { get; }
 
-    bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
+    bool IsEmpty { get; }
 }

--- a/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
@@ -6,5 +6,7 @@ public interface IIgnoreConfiguration
 
     IReadOnlySet<string> Shas { get; }
 
-    bool IsEmpty { get; }
+    IReadOnlyCollection<string> Paths { get; }
+
+    bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
 }

--- a/src/GitVersion.Core/Configuration/IgnoreConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Configuration/IgnoreConfigurationExtensions.cs
@@ -22,5 +22,5 @@ internal static class IgnoreConfigurationExtensions
     }
 
     private static bool ShouldBeIgnored(ICommit commit, IIgnoreConfiguration ignore)
-        => !(commit.When <= ignore.Before) && !ignore.Shas.Contains(commit.Sha);
+        => !ignore.ToFilters().Any(filter => filter.Exclude(commit, out var _));
 }

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -25,7 +25,7 @@ internal static class ConfigurationExtensions
         {
             fallbackConfiguration = parentConfiguration;
         }
-        return new EffectiveConfiguration(configuration, branchConfiguration, fallbackConfiguration);
+        return new EffectiveConfiguration(configuration, branchConfiguration, fallbackConfiguration: fallbackConfiguration);
     }
 
     public static IBranchConfiguration GetBranchConfiguration(this IGitVersionConfiguration configuration, IBranch branch)
@@ -44,6 +44,7 @@ internal static class ConfigurationExtensions
 
         if (source.Shas.Count != 0) yield return new ShaVersionFilter(source.Shas);
         if (source.Before.HasValue) yield return new MinDateVersionFilter(source.Before.Value);
+        if (source.Paths.Count != 0) yield return new PathFilter(source.Paths);
     }
 
     private static IEnumerable<IBranchConfiguration> GetBranchConfigurations(IGitVersionConfiguration configuration, string branchName)

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -25,7 +25,7 @@ internal static class ConfigurationExtensions
         {
             fallbackConfiguration = parentConfiguration;
         }
-        return new EffectiveConfiguration(configuration, branchConfiguration, fallbackConfiguration: fallbackConfiguration);
+        return new EffectiveConfiguration(configuration, branchConfiguration, fallbackConfiguration);
     }
 
     public static IBranchConfiguration GetBranchConfiguration(this IGitVersionConfiguration configuration, IBranch branch)
@@ -44,7 +44,7 @@ internal static class ConfigurationExtensions
 
         if (source.Shas.Count != 0) yield return new ShaVersionFilter(source.Shas);
         if (source.Before.HasValue) yield return new MinDateVersionFilter(source.Before.Value);
-        if (source.Paths.Count != 0) yield return new PathFilter(source.Paths);
+        if (source.Paths.Count != 0) yield return new PathFilter(source.Paths.ToList());
     }
 
     private static IEnumerable<IBranchConfiguration> GetBranchConfigurations(IGitVersionConfiguration configuration, string branchName)

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -7,5 +7,6 @@ public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, IGitObjec
     DateTimeOffset When { get; }
 
     string Message { get; }
+
     IReadOnlyList<string> DiffPaths { get; }
 }

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -7,5 +7,5 @@ public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, IGitObjec
     DateTimeOffset When { get; }
 
     string Message { get; }
-    IEnumerable<string> DiffPaths { get; }
+    IReadOnlyList<string> DiffPaths { get; }
 }

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -7,4 +7,5 @@ public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, IGitObjec
     DateTimeOffset When { get; }
 
     string Message { get; }
+    IEnumerable<string> DiffPaths { get; }
 }

--- a/src/GitVersion.Core/Git/ITreeChanges.cs
+++ b/src/GitVersion.Core/Git/ITreeChanges.cs
@@ -2,5 +2,5 @@ namespace GitVersion.Git;
 
 public interface ITreeChanges
 {
-    IEnumerable<string> Paths { get; }
+    IReadOnlyList<string> Paths { get; }
 }

--- a/src/GitVersion.Core/Git/ITreeChanges.cs
+++ b/src/GitVersion.Core/Git/ITreeChanges.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.Git;
+
+public interface ITreeChanges
+{
+    IEnumerable<string> Paths { get; }
+}

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -87,7 +87,6 @@ GitVersion.Configuration.EffectiveConfiguration.TrackMergeMessage.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.TrackMergeTarget.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.TracksReleaseBranches.get -> bool
 GitVersion.Configuration.EffectiveConfiguration.UpdateBuildNumber.get -> bool
-GitVersion.Configuration.EffectiveConfiguration.VersionFilters.get -> System.Collections.Generic.IEnumerable<GitVersion.VersionCalculation.IVersionFilter!>!
 GitVersion.Configuration.EffectiveConfiguration.VersionInBranchPattern.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionStrategy.get -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.Configuration.IBranchConfiguration

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -146,3 +146,8 @@ virtual GitVersion.WixInfo.<Clone>$() -> GitVersion.WixInfo!
 virtual GitVersion.WixInfo.EqualityContract.get -> System.Type!
 virtual GitVersion.WixInfo.Equals(GitVersion.WixInfo? other) -> bool
 virtual GitVersion.WixInfo.PrintMembers(System.Text.StringBuilder! builder) -> bool
+GitVersion.Configuration.IIgnoreConfiguration.Paths.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+GitVersion.Git.ICommit.DiffPaths.get -> System.Collections.Generic.IEnumerable<string!>!
+GitVersion.Git.ITreeChanges
+GitVersion.Git.ITreeChanges.Paths.get -> System.Collections.Generic.IEnumerable<string!>!
+GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.Git.ICommit! commit, out string? reason) -> bool

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -147,7 +147,7 @@ virtual GitVersion.WixInfo.EqualityContract.get -> System.Type!
 virtual GitVersion.WixInfo.Equals(GitVersion.WixInfo? other) -> bool
 virtual GitVersion.WixInfo.PrintMembers(System.Text.StringBuilder! builder) -> bool
 GitVersion.Configuration.IIgnoreConfiguration.Paths.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
-GitVersion.Git.ICommit.DiffPaths.get -> System.Collections.Generic.IEnumerable<string!>!
+GitVersion.Git.ICommit.DiffPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 GitVersion.Git.ITreeChanges
-GitVersion.Git.ITreeChanges.Paths.get -> System.Collections.Generic.IEnumerable<string!>!
+GitVersion.Git.ITreeChanges.Paths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 GitVersion.VersionCalculation.IVersionFilter.Exclude(GitVersion.Git.ICommit! commit, out string? reason) -> bool

--- a/src/GitVersion.Core/VersionCalculation/Abstractions/IVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/Abstractions/IVersionFilter.cs
@@ -1,6 +1,9 @@
+using GitVersion.Git;
+
 namespace GitVersion.VersionCalculation;
 
 public interface IVersionFilter
 {
     bool Exclude(IBaseVersion baseVersion, out string? reason);
+    bool Exclude(ICommit commit, out string? reason);
 }

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -7,7 +7,9 @@ using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation;
 
-internal class IncrementStrategyFinder(IRepositoryStore repositoryStore, ITaggedSemanticVersionRepository taggedSemanticVersionRepository)
+internal class IncrementStrategyFinder(
+    IRepositoryStore repositoryStore,
+    ITaggedSemanticVersionRepository taggedSemanticVersionRepository)
     : IIncrementStrategyFinder
 {
     private readonly Dictionary<string, VersionField?> commitIncrementCache = [];

--- a/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using GitVersion.Extensions;
+using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation;
 
@@ -12,6 +13,17 @@ internal class MinDateVersionFilter(DateTimeOffset minimum) : IVersionFilter
         reason = null;
 
         if (baseVersion.BaseVersionSource == null || baseVersion.BaseVersionSource.When >= minimum)
+            return false;
+
+        reason = "Source was ignored due to commit date being outside of configured range";
+        return true;
+    }
+
+    public bool Exclude(ICommit commit, [NotNullWhen(true)] out string? reason)
+    {
+        reason = null;
+
+        if (commit == null || commit.When >= minimum)
             return false;
 
         reason = "Source was ignored due to commit date being outside of configured range";

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -35,21 +35,22 @@ internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = Pat
     public bool Exclude(ICommit? commit, [NotNullWhen(true)] out string? reason)
     {
         reason = null;
-
-        if (commit != null)
+        if (commit == null)
         {
-            switch (mode)
-            {
-                case PathFilterMode.Inclusive:
+            return false;
+        }
+
+        switch (mode)
+        {
+            case PathFilterMode.Inclusive:
+                {
+                    if (commit.DiffPaths.All(this.IsMatch))
                     {
-                        if (commit.DiffPaths.All(this.IsMatch))
-                        {
-                            reason = "Source was ignored due to all commit paths matching ignore regex";
-                            return true;
-                        }
-                        break;
+                        reason = "Source was ignored due to all commit paths matching ignore regex";
+                        return true;
                     }
-            }
+                    break;
+                }
         }
 
         return false;

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -7,16 +7,12 @@ namespace GitVersion.VersionCalculation;
 
 internal class PathFilter(IReadOnlyList<string> paths) : IVersionFilter
 {
-    private readonly List<Regex> pathsRegexes = [.. paths.Select(path => new Regex(path, RegexOptions.IgnoreCase | RegexOptions.Compiled))];
+    private readonly List<Regex> pathsRegexes = [.. paths.Select(path => new Regex(path, RegexOptions.Compiled))];
     private readonly ConcurrentDictionary<string, bool> pathMatchCache = [];
 
     public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)
     {
         ArgumentNullException.ThrowIfNull(baseVersion);
-
-        reason = null;
-        if (baseVersion.Source.StartsWith("Fallback") || baseVersion.Source.StartsWith("Git tag") || baseVersion.Source.StartsWith("NextVersion")) return false;
-
         return Exclude(baseVersion.BaseVersionSource, out reason);
     }
 
@@ -26,9 +22,7 @@ internal class PathFilter(IReadOnlyList<string> paths) : IVersionFilter
 
         if (commit != null)
         {
-            var patchPaths = commit.DiffPaths;
-
-            foreach (var path in patchPaths)
+            foreach (var path in commit.DiffPaths)
             {
                 if (!pathMatchCache.TryGetValue(path, out var isMatch))
                 {

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using GitVersion.Git;
+
+namespace GitVersion.VersionCalculation;
+
+internal class PathFilter( IEnumerable<string> paths) : IVersionFilter
+{
+    private readonly List<Regex> pathsRegexes = paths.Select(path => new Regex(path, RegexOptions.IgnoreCase | RegexOptions.Compiled)).ToList();
+    private readonly Dictionary<string, bool> pathMatchCache = [];
+
+    public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)
+    {
+        ArgumentNullException.ThrowIfNull(baseVersion);
+
+        reason = null;
+        if (baseVersion.Source.StartsWith("Fallback") || baseVersion.Source.StartsWith("Git tag") || baseVersion.Source.StartsWith("NextVersion")) return false;
+
+        return Exclude(baseVersion.BaseVersionSource, out reason);
+    }
+
+    public bool Exclude(ICommit? commit, [NotNullWhen(true)] out string? reason)
+    {
+        reason = null;
+
+        if (commit != null)
+        {
+            var patchPaths = commit.DiffPaths;
+
+            if (patchPaths != null)
+            {
+                foreach (var path in patchPaths)
+                {
+                    if (!pathMatchCache.TryGetValue(path, out var isMatch))
+                    {
+                        isMatch = this.pathsRegexes.Any(regex => regex.IsMatch(path));
+                        pathMatchCache[path] = isMatch;
+                    }
+
+                    if (isMatch)
+                    {
+                        reason = "Source was ignored due to commit path matching ignore regex";
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -5,9 +5,15 @@ using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation;
 
-internal class PathFilter(IReadOnlyList<string> paths) : IVersionFilter
+internal enum PathFilterMode
 {
-    private readonly List<Regex> pathsRegexes = [.. paths.Select(path => new Regex(path, RegexOptions.Compiled))];
+    Inclusive,  // All commit paths must match for commit to be excluded
+    //Exclusive // Any commit path must match for commit to be excluded
+}
+
+internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = PathFilterMode.Inclusive) : IVersionFilter
+{
+    private readonly IReadOnlyList<Regex> pathsRegexes = [.. paths.Select(path => new Regex(path, RegexOptions.Compiled))];
     private readonly ConcurrentDictionary<string, bool> pathMatchCache = [];
 
     public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)
@@ -16,25 +22,33 @@ internal class PathFilter(IReadOnlyList<string> paths) : IVersionFilter
         return Exclude(baseVersion.BaseVersionSource, out reason);
     }
 
+    private bool IsMatch(string path)
+    {
+        if (!pathMatchCache.TryGetValue(path, out var isMatch))
+        {
+            isMatch = this.pathsRegexes.Any(regex => regex.IsMatch(path));
+            pathMatchCache[path] = isMatch;
+        }
+        return isMatch;
+    }
+
     public bool Exclude(ICommit? commit, [NotNullWhen(true)] out string? reason)
     {
         reason = null;
 
         if (commit != null)
         {
-            foreach (var path in commit.DiffPaths)
+            switch (mode)
             {
-                if (!pathMatchCache.TryGetValue(path, out var isMatch))
-                {
-                    isMatch = this.pathsRegexes.Any(regex => regex.IsMatch(path));
-                    pathMatchCache[path] = isMatch;
-                }
-
-                if (isMatch)
-                {
-                    reason = "Source was ignored due to commit path matching ignore regex";
-                    return true;
-                }
+                case PathFilterMode.Inclusive:
+                    {
+                        if (commit.DiffPaths.All(this.IsMatch))
+                        {
+                            reason = "Source was ignored due to all commit paths matching ignore regex";
+                            return true;
+                        }
+                        break;
+                    }
             }
         }
 

--- a/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/ShaVersionFilter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using GitVersion.Extensions;
+using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation;
 
@@ -20,6 +21,18 @@ internal class ShaVersionFilter(IEnumerable<string> shaList) : IVersionFilter
         }
 
         reason = $"Sha {baseVersion.BaseVersionSource} was ignored due to commit having been excluded by configuration";
+        return true;
+    }
+
+    public bool Exclude(ICommit commit, [NotNullWhen(true)] out string? reason)
+    {
+        reason = null;
+
+        if (commit == null
+            || !this.shaList.Any(sha => commit.Sha.StartsWith(sha, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        reason = $"Sha {commit} was ignored due to commit having been excluded by configuration";
         return true;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -18,7 +18,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
     {
         configuration.NotNull();
 
-        if (!this.Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.ConfiguredNextVersion))
+        if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.ConfiguredNextVersion))
             yield break;
 
         var nextVersion = Context.Configuration.NextVersion;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -18,7 +18,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
     {
         configuration.NotNull();
 
-        if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.ConfiguredNextVersion))
+        if (!this.Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.ConfiguredNextVersion))
             yield break;
 
         var nextVersion = Context.Configuration.NextVersion;

--- a/src/GitVersion.LibGit2Sharp/Git/Branch.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Branch.cs
@@ -10,16 +10,16 @@ internal sealed class Branch : IBranch
 
     private readonly LibGit2Sharp.Branch innerBranch;
 
-    internal Branch(LibGit2Sharp.Branch branch)
+    internal Branch(LibGit2Sharp.Branch branch, LibGit2Sharp.Diff diff)
     {
         this.innerBranch = branch.NotNull();
         Name = new(branch.CanonicalName);
 
         var commit = this.innerBranch.Tip;
-        Tip = commit is null ? null : new Commit(commit);
+        Tip = commit is null ? null : new Commit(commit, diff);
 
         var commits = this.innerBranch.Commits;
-        Commits = new CommitCollection(commits);
+        Commits = new CommitCollection(commits, diff);
     }
 
     public ReferenceName Name { get; }

--- a/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
@@ -7,11 +7,13 @@ internal sealed class BranchCollection : IBranchCollection
 {
     private readonly LibGit2Sharp.BranchCollection innerCollection;
     private readonly Lazy<IReadOnlyCollection<IBranch>> branches;
+    private readonly LibGit2Sharp.Diff diff;
 
-    internal BranchCollection(LibGit2Sharp.BranchCollection collection)
+    internal BranchCollection(LibGit2Sharp.BranchCollection collection, LibGit2Sharp.Diff diff)
     {
         this.innerCollection = collection.NotNull();
-        this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => new Branch(branch))]);
+this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => new Branch(branch, diff))]);
+        this.diff = diff.NotNull();
     }
 
     public IEnumerator<IBranch> GetEnumerator()
@@ -25,7 +27,7 @@ internal sealed class BranchCollection : IBranchCollection
         {
             name = name.NotNull();
             var branch = this.innerCollection[name];
-            return branch is null ? null : new Branch(branch);
+            return branch is null ? null : new Branch(branch, this.diff);
         }
     }
 

--- a/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
@@ -12,7 +12,7 @@ internal sealed class BranchCollection : IBranchCollection
     internal BranchCollection(LibGit2Sharp.BranchCollection collection, LibGit2Sharp.Diff diff)
     {
         this.innerCollection = collection.NotNull();
-this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => new Branch(branch, diff))]);
+        this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => new Branch(branch, diff))]);
         this.diff = diff.NotNull();
     }
 

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -27,7 +27,6 @@ internal sealed class Commit : GitObject, ICommit
     public IReadOnlyList<ICommit> Parents => this.parentsLazy.Value;
     public DateTimeOffset When { get; }
     public string Message => this.innerCommit.Message;
-    // TODO implement tag prefix filtering before returning the paths.
     public IReadOnlyList<string> DiffPaths
     {
         get

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -44,5 +44,5 @@ internal sealed class Commit : GitObject, ICommit
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => $"'{Id.ToString(7)}' - {this.innerCommit.MessageShort}";
     public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
-    private TreeChanges CommitChanges => new TreeChanges(this.repoDiff.Compare<LibGit2Sharp.TreeChanges>(this.innerCommit.Tree, this.innerCommit.Parents.FirstOrDefault()?.Tree));
+    private TreeChanges CommitChanges => new(this.repoDiff.Compare<LibGit2Sharp.TreeChanges>(this.innerCommit.Tree, this.innerCommit.Parents.FirstOrDefault()?.Tree));
 }

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 
@@ -5,17 +6,20 @@ namespace GitVersion.Git;
 
 internal sealed class Commit : GitObject, ICommit
 {
+    private static readonly ConcurrentDictionary<string, IReadOnlyList<string>> pathsCache = new();
     private static readonly LambdaEqualityHelper<ICommit> equalityHelper = new(x => x.Id);
     private static readonly LambdaKeyComparer<ICommit, string> comparerHelper = new(x => x.Sha);
     private readonly Lazy<IReadOnlyList<ICommit>> parentsLazy;
 
     private readonly LibGit2Sharp.Commit innerCommit;
+    private readonly LibGit2Sharp.Diff repoDiff;
 
-    internal Commit(LibGit2Sharp.Commit innerCommit) : base(innerCommit)
+    internal Commit(LibGit2Sharp.Commit innerCommit, LibGit2Sharp.Diff repoDiff) : base(innerCommit)
     {
         this.innerCommit = innerCommit.NotNull();
-        this.parentsLazy = new(() => innerCommit.Parents.Select(parent => new Commit(parent)).ToList());
+        this.parentsLazy = new(() => innerCommit.Parents.Select(parent => new Commit(parent, repoDiff)).ToList());
         When = innerCommit.Committer.When;
+        this.repoDiff = repoDiff;
     }
 
     public int CompareTo(ICommit? other) => comparerHelper.Compare(this, other);
@@ -23,8 +27,20 @@ internal sealed class Commit : GitObject, ICommit
     public IReadOnlyList<ICommit> Parents => this.parentsLazy.Value;
     public DateTimeOffset When { get; }
     public string Message => this.innerCommit.Message;
+    // TODO implement tag prefix filtering before returning the paths.
+    public IEnumerable<string> DiffPaths
+    {
+        get
+        {
+            if (pathsCache.TryGetValue(this.Sha, out var paths))
+                return paths;
+            else
+                return this.CommitChanges?.Paths ?? [];
+        }
+    }
     public override bool Equals(object? obj) => Equals(obj as ICommit);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => $"'{Id.ToString(7)}' - {this.innerCommit.MessageShort}";
     public static implicit operator LibGit2Sharp.Commit(Commit d) => d.innerCommit;
+    private ITreeChanges CommitChanges => new TreeChanges(this.repoDiff.Compare<LibGit2Sharp.TreeChanges>(this.innerCommit.Tree, this.innerCommit.Parents.FirstOrDefault()?.Tree));
 }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using LibGit2Sharp;
@@ -8,7 +7,6 @@ namespace GitVersion.Git;
 internal sealed partial class GitRepository
 {
     private Lazy<IRepository>? repositoryLazy;
-    private readonly ConcurrentDictionary<string, IReadOnlyList<string>?> patchPathsCache = new();
 
     private IRepository RepositoryInstance
     {

--- a/src/GitVersion.LibGit2Sharp/Git/Tag.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Tag.cs
@@ -9,12 +9,14 @@ internal sealed class Tag : ITag
     private static readonly LambdaEqualityHelper<ITag> equalityHelper = new(x => x.Name.Canonical);
     private static readonly LambdaKeyComparer<ITag, string> comparerHelper = new(x => x.Name.Canonical);
     private readonly LibGit2Sharp.Tag innerTag;
+    private readonly LibGit2Sharp.Diff diff;
     private readonly Lazy<ICommit?> commitLazy;
 
-    internal Tag(LibGit2Sharp.Tag tag)
+    internal Tag(LibGit2Sharp.Tag tag, LibGit2Sharp.Diff diff)
     {
         this.innerTag = tag.NotNull();
         this.commitLazy = new(PeeledTargetCommit);
+        this.diff = diff.NotNull();
         Name = new(this.innerTag.CanonicalName);
     }
 
@@ -33,7 +35,7 @@ internal sealed class Tag : ITag
             target = annotation.Target;
         }
 
-        return target is LibGit2Sharp.Commit commit ? new Commit(commit) : null;
+        return target is LibGit2Sharp.Commit commit ? new Commit(commit, this.diff) : null;
     }
 
     public override bool Equals(object? obj) => Equals(obj as ITag);

--- a/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
@@ -6,10 +6,10 @@ internal sealed class TagCollection : ITagCollection
 {
     private readonly Lazy<IReadOnlyCollection<ITag>> tags;
 
-    internal TagCollection(LibGit2Sharp.TagCollection collection)
+    internal TagCollection(LibGit2Sharp.TagCollection collection, LibGit2Sharp.Diff diff)
     {
         collection = collection.NotNull();
-        this.tags = new Lazy<IReadOnlyCollection<ITag>>(() => [.. collection.Select(tag => new Tag(tag))]);
+        this.tags = new Lazy<IReadOnlyCollection<ITag>>(() => [.. collection.Select(tag => new Tag(tag, diff))]);
     }
 
     public IEnumerator<ITag> GetEnumerator()

--- a/src/GitVersion.LibGit2Sharp/Git/TreeChanges.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TreeChanges.cs
@@ -1,0 +1,8 @@
+namespace GitVersion.Git;
+
+internal sealed class TreeChanges(LibGit2Sharp.TreeChanges innerTreeChanges) : ITreeChanges
+{
+    private readonly LibGit2Sharp.TreeChanges innerTreeChanges = innerTreeChanges ?? throw new ArgumentNullException(nameof(innerTreeChanges));
+
+    public IEnumerable<string> Paths => this.innerTreeChanges.Select(element => element.Path);
+}

--- a/src/GitVersion.LibGit2Sharp/Git/TreeChanges.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TreeChanges.cs
@@ -4,5 +4,5 @@ internal sealed class TreeChanges(LibGit2Sharp.TreeChanges innerTreeChanges) : I
 {
     private readonly LibGit2Sharp.TreeChanges innerTreeChanges = innerTreeChanges ?? throw new ArgumentNullException(nameof(innerTreeChanges));
 
-    public IEnumerable<string> Paths => this.innerTreeChanges.Select(element => element.Path);
+    public IReadOnlyList<string> Paths => [.. this.innerTreeChanges.Select(element => element.Path)];
 }


### PR DESCRIPTION
## Description

This PR adds a new option to the git version config, allowing users to filter specific paths in the directory tree using the "ignore/paths" config.

## Related Issue

Resolves #2436 

## Motivation and Context
This feature enables better versioning capability when using GitVersion in a *monorepo*, where different components need to be versioned independently. 
It is based on work done previously and mentioned in the related issue #2436. See discussion for more info.

## How Has This Been Tested?
All existing tests pass. 
New sanity tests were added and passed.
Additional tests will be included before closing this PR.

## Checklist:

* \[X] My code follows the code style of this project.
* \[X] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
