### PR TITLE
Support for dotted versions of the GitVersion config files by default

### DIFF
--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -41,9 +41,9 @@ GitVersion [path]
                     E.g. /output json /format {SemVer} - will output `1.2.3+beta.4`
                          /output json /format {Major}.{Minor} - will output `1.2`
     /l              Path to logfile.
-    /config         Path to config file (defaults to GitVersion.yml or GitVersion.yaml)
+    /config         Path to config file (defaults to GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml)
     /showconfig     Outputs the effective GitVersion config (defaults + custom
-                    from GitVersion.yml or GitVersion.yaml) in yaml format
+                    from GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml) in yaml format
     /overrideconfig Overrides GitVersion config values inline (semicolon-
                     separated key value pairs e.g. /overrideconfig
                     tag-prefix=Foo)
@@ -97,7 +97,7 @@ GitVersion [path]
 
 ## Override config
 
-`/overrideconfig [key=value]` will override appropriate `key` from 'GitVersion.yml' or 'GitVersion.yaml'.
+`/overrideconfig [key=value]` will override appropriate `key` from 'GitVersion.yml', 'GitVersion.yaml', '.GitVersion.yml' or '.GitVersion.yaml'.
 
 To specify multiple options add multiple `/overrideconfig [key=value]` entries:
 `/overrideconfig key1=value1 /overrideconfig key2=value2`.
@@ -129,7 +129,7 @@ Following options are supported:
 
 Read more about [Configuration](/docs/reference/configuration).
 
-Using `override-config` on the command line will not change the contents of the config file `GitVersion.yml` or `GitVersion.yaml`.
+Using `override-config` on the command line will not change the contents of the config file `GitVersion.yml`, `GitVersion.yaml`, `.GitVersion.yml` or `.GitVersion.yaml`.
 
 ### Example: How to override configuration option 'tag-prefix' to use prefix 'custom'
 

--- a/src/GitVersion.App/OverrideConfigurationOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigurationOptionParser.cs
@@ -18,7 +18,7 @@ internal class OverrideConfigurationOptionParser
     /// </summary>
     /// <returns></returns>
     /// <remarks>
-    /// Lookup keys are created from <see cref="System.Text.Json.Serialization.JsonPropertyNameAttribute"/> to match 'GitVersion.yml' or 'GitVersion.yaml' file
+    /// Lookup keys are created from <see cref="System.Text.Json.Serialization.JsonPropertyNameAttribute"/> to match 'GitVersion.yml', 'GitVersion.yaml', '.GitVersion.yml' or '.GitVersion.yaml' file
     /// options as close as possible.
     /// </remarks>
     private static ILookup<string?, PropertyInfo> GetSupportedProperties() => typeof(GitVersionConfiguration).GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -37,8 +37,20 @@ public static class ConfigurationFileLocatorTests
 
         [TestCase(ConfigurationFileLocator.DefaultFileName, ConfigurationFileLocator.DefaultFileName)]
         [TestCase(ConfigurationFileLocator.DefaultFileName, ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultFileName, ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultFileName, ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
         [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName, ConfigurationFileLocator.DefaultFileName)]
         [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName, ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName, ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName, ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted, ConfigurationFileLocator.DefaultFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted, ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted, ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted, ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted, ConfigurationFileLocator.DefaultFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted, ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted, ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted, ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
         public void ThrowsExceptionOnAmbiguousConfigFileLocation(string repoConfigFile, string workingConfigFile)
         {
             using var repositoryConfigFilePath = this.fileSystem.SetupConfigFile(path: this.repoPath, fileName: repoConfigFile);
@@ -52,6 +64,8 @@ public static class ConfigurationFileLocatorTests
 
         [TestCase(ConfigurationFileLocator.DefaultFileName)]
         [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
         public void NoWarnOnGitVersionYmlFile(string configurationFile)
         {
             using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, fileName: configurationFile);

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -73,6 +73,18 @@ public static class ConfigurationFileLocatorTests
             Should.NotThrow(() => this.configurationProvider.ProvideForDirectory(this.repoPath));
         }
 
+        [TestCase(ConfigurationFileLocator.DefaultFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName)]
+        [TestCase(ConfigurationFileLocator.DefaultFileNameDotted)]
+        [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
+        public void NoWarnOnLowercasedGitVersionYmlFile(string configurationFile)
+        {
+            var lowercasedConfigurationFile = configurationFile.ToLower();
+            using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, fileName: lowercasedConfigurationFile);
+
+            Should.NotThrow(() => this.configurationProvider.ProvideForDirectory(this.repoPath));
+        }
+
         [Test]
         public void NoWarnOnNoGitVersionYmlFile() => Should.NotThrow(() => this.configurationProvider.ProvideForDirectory(this.repoPath));
     }

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -74,7 +74,7 @@ internal class ConfigurationFileLocator(
 
         if (!hasConfigInProjectRootDirectory && !hasConfigInWorkingDirectory)
         {
-            if (!SupportedConfigFileNames.Any(entry => entry.Equals(this.ConfigurationFile)))
+            if (!SupportedConfigFileNames.Any(entry => entry.Equals(this.ConfigurationFile, StringComparison.OrdinalIgnoreCase)))
             {
                 workingConfigFile = PathHelper.Combine(workingDirectory, this.ConfigurationFile);
                 projectRootConfigFile = PathHelper.Combine(projectRootDirectory, this.ConfigurationFile);

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -15,7 +15,7 @@ internal class ConfigurationFileLocator(
     public const string DefaultAlternativeFileName = "GitVersion.yaml";
     public const string DefaultFileNameDotted = $".{DefaultFileName}";
     public const string DefaultAlternativeFileNameDotted = $".{DefaultAlternativeFileName}";
-    public List<string> PossibleConfigFileNames = [DefaultFileName, DefaultAlternativeFileName, DefaultFileNameDotted, DefaultAlternativeFileNameDotted];
+    public List<string> SupportedConfigFileNames = [DefaultFileName, DefaultAlternativeFileName, DefaultFileNameDotted, DefaultAlternativeFileNameDotted];
 
     private readonly IFileSystem fileSystem = fileSystem.NotNull();
     private readonly ILog log = log.NotNull();
@@ -33,7 +33,7 @@ internal class ConfigurationFileLocator(
     public string? GetConfigurationFile(string? directory)
     {
         if (directory is null) return null;
-        var candidateList = new List<string>(PossibleConfigFileNames);
+        var candidateList = new List<string>(SupportedConfigFileNames);
         if (!this.ConfigurationFile.IsNullOrEmpty())
         {
             // give configuration value the highest priority
@@ -74,7 +74,7 @@ internal class ConfigurationFileLocator(
 
         if (!hasConfigInProjectRootDirectory && !hasConfigInWorkingDirectory)
         {
-            if (!PossibleConfigFileNames.Any(entry => entry.Equals(this.ConfigurationFile)))
+            if (!SupportedConfigFileNames.Any(entry => entry.Equals(this.ConfigurationFile)))
             {
                 workingConfigFile = PathHelper.Combine(workingDirectory, this.ConfigurationFile);
                 projectRootConfigFile = PathHelper.Combine(projectRootDirectory, this.ConfigurationFile);

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -33,17 +33,12 @@ internal class ConfigurationFileLocator(
     public string? GetConfigurationFile(string? directory)
     {
         if (directory is null) return null;
-        var candidateList = new List<string>(SupportedConfigFileNames);
-        if (!this.ConfigurationFile.IsNullOrEmpty())
-        {
-            // give configuration value the highest priority
-            candidateList.Insert(0, this.ConfigurationFile);
-        }
 
-        var candidatePaths = candidateList
-            .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
-            .Select(candidate => PathHelper.Combine(directory, candidate))
-            .ToList();
+        string?[] candidates = [this.ConfigurationFile, ..SupportedConfigFileNames];
+        var candidatePaths =
+            from candidate in candidates
+            where !candidate.IsNullOrWhiteSpace()
+            select PathHelper.Combine(directory, candidate);
 
         foreach (var candidatePath in candidatePaths)
         {

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -34,7 +34,7 @@ internal class ConfigurationFileLocator(
     {
         if (directory is null) return null;
 
-        string?[] candidates = [this.ConfigurationFile, ..SupportedConfigFileNames];
+        string?[] candidates = [this.ConfigurationFile, .. SupportedConfigFileNames];
         var candidatePaths =
             from candidate in candidates
             where !candidate.IsNullOrWhiteSpace()

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -243,6 +243,8 @@ public class GitVersionExecutorTests : TestBase
 
     [TestCase(ConfigurationFileLocator.DefaultFileName)]
     [TestCase(ConfigurationFileLocator.DefaultAlternativeFileName)]
+    [TestCase(ConfigurationFileLocator.DefaultFileNameDotted)]
+    [TestCase(ConfigurationFileLocator.DefaultAlternativeFileNameDotted)]
     public void ConfigChangeInvalidatesCache(string configFileName)
     {
         const string versionCacheFileContent = """


### PR DESCRIPTION
## Description
Follow the convention of many other tools which use a leading dot for their configuration files, e.g. `.gitignore`, `.editorconfig`, `.gitattributes`, etc.

## Related Issue
Closes #4431 

## Motivation and Context
With this change GitVersion will look for the following configuration files by default:  
`GitVersion.yml`, `GitVersion.yaml`, `.GitVersion.yml` and `.GitVersion.yaml` (in this order)

## How Has This Been Tested?
By extending the unit tests.

## Checklist:

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
