### PR TITLE
Make sure custom configuration file path is returned when custom configuration is set

### DIFF
--- a/src/GitVersion.Core/Configuration/IConfigurationFileLocator.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationFileLocator.cs
@@ -3,5 +3,5 @@ namespace GitVersion.Configuration;
 public interface IConfigurationFileLocator
 {
     void Verify(string? workingDirectory, string? projectRootDirectory);
-    string? GetConfigurationFile(string? directory);
+    string? GetConfigurationFile(string? directoryPath);
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -113,7 +113,7 @@ GitVersion.Configuration.IConfigurationBuilder
 GitVersion.Configuration.IConfigurationBuilder.AddOverride(System.Collections.Generic.IReadOnlyDictionary<object!, object?>! value) -> void
 GitVersion.Configuration.IConfigurationBuilder.Build() -> GitVersion.Configuration.IGitVersionConfiguration!
 GitVersion.Configuration.IConfigurationFileLocator
-GitVersion.Configuration.IConfigurationFileLocator.GetConfigurationFile(string? directory) -> string?
+GitVersion.Configuration.IConfigurationFileLocator.GetConfigurationFile(string? directoryPath) -> string?
 GitVersion.Configuration.IConfigurationFileLocator.Verify(string? workingDirectory, string? projectRootDirectory) -> void
 GitVersion.Configuration.IConfigurationProvider
 GitVersion.Configuration.IConfigurationProvider.Provide(System.Collections.Generic.IReadOnlyDictionary<object!, object?>? overrideConfiguration = null) -> GitVersion.Configuration.IGitVersionConfiguration!


### PR DESCRIPTION
## Description

In this pr, `/config` argument usage controlled and issue when using it fixed.

- Introduce a new test method `ReturnConfigurationFilePathIfCustomConfigurationIsSet` in `ConfigurationFileLocatorTests.cs` to 
verify custom config file handling.
- Update `GitVersion.Configuration.Tests.csproj` to copy `Configuration/CustomConfig.yaml` to the output directory.
- Enhance `GetConfigurationFile` method in `ConfigurationFileLocator.cs` to return the custom config file path if set and exists.
- Add `CustomConfig.yaml` with various versioning settings.

## Related Issue

Resolves #4480 

## Motivation and Context

This bugfix resolves #4480 issue. In earlier changes there is a change to how should tool locating configuration files. It cause a problem if `/config` arguments is used. Now if its used and configuration file is presents, locator returns custom configuration file path directly.

This isn't a problem before [this change](https://github.com/GitTools/GitVersion/pull/4452/files#diff-698746acc424792fb49b9893dfe1d64685618dc599f54c8c8063c79af7262abb) merged. In dotnet Path.Combine method handles if path is rooted automatically. But with this pr, tool stops using Path.Combine and starts directly looking under givin directory path. For further information, you can check [this Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.combine?view=net-9.0#system-io-path-combine(system-string-system-string)). In this documentation; we are interested with combine method's examples section - path1 and path3 combine example -. 

## How Has This Been Tested?

All existing tests pass.
New tests added.

## Checklist:

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
