### PR TITLE
refactor: update remote branch handling in tests

### DIFF
--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -65,6 +65,21 @@ public static class GitRepositoryTestingExtensions
     public static void DumpGraph(this IRepository repository, Action<string>? writer = null, int? maxCommits = null)
         => DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
 
+    public static void RenameRemote(this LibGit2Sharp.RemoteCollection remotes, string oldName, string newName)
+    {
+        if (oldName.IsEquivalentTo(newName)) return;
+        if (remotes.Any(remote => remote.Name == newName))
+        {
+            throw new InvalidOperationException($"A remote with the name '{newName}' already exists.");
+        }
+        if (!remotes.Any(remote => remote.Name == oldName))
+        {
+            throw new InvalidOperationException($"A remote with the name '{oldName}' does not exist.");
+        }
+        remotes.Add(newName, remotes[oldName].Url);
+        remotes.Remove(oldName);
+    }
+
     public static GitVersionVariables GetVersion(this RepositoryFixtureBase fixture, IGitVersionConfiguration? configuration = null,
         IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
     {

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -142,17 +142,12 @@ public class RemoteRepositoryScenarios : TestBase
     [TestCase("custom", "release/3.0.0", "0.1.0-alpha.5")]
     public void EnsureRemoteReleaseBranchesAreTracked(string origin, string branchName, string expectedVersion)
     {
-        if (SysEnv.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            Assert.Ignore("Test ignored on Windows - LibGitSharp 0.31.0 fails");
-        }
-
         using var fixture = new RemoteRepositoryFixture("develop");
 
         fixture.CreateBranch(branchName);
         fixture.MakeACommit();
 
-        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", origin);
+        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
         fixture.LocalRepositoryFixture.Fetch(origin);
         fixture.LocalRepositoryFixture.Checkout("develop");
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
@@ -54,12 +54,8 @@ public class VersionInCurrentBranchNameScenarios : TestBase
     [Test]
     public void DoesNotTakeVersionFromNameOfRemoteReleaseBranchInCustomRemote()
     {
-        if (SysEnv.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            Assert.Ignore("Test ignored on Windows - LibGitSharp 0.31.0 fails");
-        }
         using var fixture = new RemoteRepositoryFixture();
-        fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", "upstream");
+        fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", "upstream");
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
         Commands.Fetch(fixture.LocalRepositoryFixture.Repository, fixture.LocalRepositoryFixture.Repository.Network.Remotes.First().Name, [], new(), null);

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
@@ -70,12 +70,8 @@ public class VersionInMergedBranchNameScenarios : TestBase
     [Test]
     public void DoesNotTakeVersionFromNameOfRemoteReleaseBranchInCustomRemote()
     {
-        if (SysEnv.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            Assert.Ignore("Test ignored on Windows - LibGitSharp 0.31.0 fails");
-        }
         using var fixture = new RemoteRepositoryFixture();
-        fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", "upstream");
+        fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", "upstream");
         fixture.BranchTo("release/2.0.0");
         fixture.MakeACommit();
         fixture.LocalRepositoryFixture.Fetch("upstream");

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
@@ -98,14 +98,10 @@ public class VersionInBranchNameBaseVersionStrategyTests : TestBase
     [TestCase("origin", "release/3.0.0", "3.0.0")]
     public void CanTakeVersionFromNameOfRemoteReleaseBranch(string origin, string branchName, string expectedBaseVersion)
     {
-        if (SysEnv.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            Assert.Ignore("Test ignored on Windows - LibGitSharp 0.31.0 fails");
-        }
         using var fixture = new RemoteRepositoryFixture();
 
         fixture.CreateBranch(branchName);
-        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.Rename("origin", origin);
+        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
         fixture.LocalRepositoryFixture.Fetch(origin);
 
         var localRepository = fixture.LocalRepositoryFixture.Repository.ToGitRepository();


### PR DESCRIPTION
This pull request introduces a new helper method, `RenameRemote`, to simplify renaming Git remotes in tests and refactors existing test cases to use this method. Additionally, it removes platform-specific test skips for Windows, enabling broader test coverage.

### New Helper Method:

* Added a `RenameRemote` extension method to `LibGit2Sharp.RemoteCollection` for renaming Git remotes more concisely. (`src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs`)

### Refactoring Test Cases:

* Replaced calls to `Remotes.Rename` with the new `RenameRemote` method in multiple test cases to improve code readability and reuse. (`src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs`, `src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs`, `src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs`, `src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs`) [[1]](diffhunk://#diff-63a54d17bff09ba2f1ddccc297140b4107933768e4009be4d0375ce8bb990996L145-R150) [[2]](diffhunk://#diff-290c12fe8aa5a8b059cf3b3050e4c27248d8d043c92e3a5cf312fbe57d57283bL57-R58) [[3]](diffhunk://#diff-c8f930182b7271bee8ce8b36f09fc26bdfb946f0cfb5f73542358f5d5fdb1ac6L73-R74) [[4]](diffhunk://#diff-aa4dab4d03eee9598fe766fd3af87c1b08a10dab3f5233a246c984d0d894d03eL101-R104)

### Test Coverage Enhancements:

* Removed platform-specific skips for Windows in several test cases, allowing these tests to run on all platforms. (`src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs`, `src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs`, `src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs`, `src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs`) [[1]](diffhunk://#diff-63a54d17bff09ba2f1ddccc297140b4107933768e4009be4d0375ce8bb990996L145-R150) [[2]](diffhunk://#diff-290c12fe8aa5a8b059cf3b3050e4c27248d8d043c92e3a5cf312fbe57d57283bL57-R58) [[3]](diffhunk://#diff-c8f930182b7271bee8ce8b36f09fc26bdfb946f0cfb5f73542358f5d5fdb1ac6L73-R74) [[4]](diffhunk://#diff-aa4dab4d03eee9598fe766fd3af87c1b08a10dab3f5233a246c984d0d894d03eL101-R104)