### PR TITLE
Feature: Support shallow cloning of git repositories

### DIFF
--- a/docs/input/docs/reference/requirements.md
+++ b/docs/input/docs/reference/requirements.md
@@ -14,8 +14,9 @@ build server, needs to adhere to the below requirements.
 
 ### Unshallow
 
-The repository needs to be an [unshallow][git-unshallow] clone. This means
-that the `fetch-depth` in GitHub Actions needs to be set to `0`, for instance.
+The repository should be an [unshallow][git-unshallow] clone. This means
+that the `fetch-depth` in GitHub Actions should set to `0`, unless
+the `allowshallow` flag is used.
 Check with your [build server][build-servers] to see how it can be configured
 appropriately.
 

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -50,6 +50,10 @@ GitVersion [path]
                     Currently supported config overrides: tag-prefix
     /nocache        Bypasses the cache, result will not be written to the cache.
     /nonormalize    Disables normalize step on a build server.
+    /allowshallow   Allows GitVersion to run on a shallow clone.
+                    This is not recommended, but can be used if you are sure
+                    that the shallow clone contains all the information needed
+                    to calculate the version.
     /verbosity      Specifies the amount of information to be displayed.
                     (Quiet, Minimal, Normal, Verbose, Diagnostic)
                     Default is Normal

--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -18,8 +18,8 @@ version information that is compiled into the resulting artifact.
 Since version 6.0 only MSBuild running on .NET Core (`dotnet msbuild`) is supported.
 
 Unfortunately, up until at least Visual Studio 2022 17.11, Visual Studio runs all builds
-using the .NET Framework version of MSBuild, and therefore **Visual Studio is not supported**. 
-For more information see [this discussion](https://github.com/GitTools/GitVersion/discussions/4130).  
+using the .NET Framework version of MSBuild, and therefore **Visual Studio is not supported**.
+For more information see [this discussion](https://github.com/GitTools/GitVersion/discussions/4130).
 
 ## TL;DR
 
@@ -261,7 +261,9 @@ There are properties that correspond to certain
 In particular, setting `GitVersion_NoFetchEnabled` to `true` disables `git fetch`
 during version calculation, setting `GitVersion_NoNormalizeEnabled` to `true` disables
 normalize step on a build server, setting `GitVersion_NoCacheEnabled` to `true`
-makes GetVersion ignore cache. All the rest command line arguments can be passed via
+makes GetVersion ignore cache, setting `GitVersion_AllowShallowEnabled` to `true`
+does not mandate a full clone of the repository to determine the version.
+All the rest command line arguments can be passed via
 `GitVersion_CommandLineArguments` variable.
 
 ## My Git repository requires authentication. What should I do?

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -630,6 +630,13 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void AllowshallowTrueWhenDefined()
+    {
+        var arguments = this.argumentParser.ParseArguments("-allowshallow");
+        arguments.AllowShallow.ShouldBe(true);
+    }
+
+    [Test]
     public void OtherArgumentsCanBeParsedBeforeNofetch()
     {
         var arguments = this.argumentParser.ParseArguments("targetpath -nofetch ");
@@ -653,18 +660,45 @@ public class ArgumentParserTests : TestBase
         arguments.NoCache.ShouldBe(true);
     }
 
-    [TestCase("-nofetch -nonormalize -nocache")]
-    [TestCase("-nofetch -nocache -nonormalize")]
-    [TestCase("-nocache -nofetch -nonormalize")]
-    [TestCase("-nocache -nonormalize -nofetch")]
-    [TestCase("-nonormalize -nocache -nofetch")]
-    [TestCase("-nonormalize -nofetch -nocache")]
+    [Test]
+    public void OtherArgumentsCanBeParsedBeforeAllowshallow()
+    {
+        var arguments = this.argumentParser.ParseArguments("targetpath -allowshallow");
+        arguments.TargetPath.ShouldBe("targetpath");
+        arguments.AllowShallow.ShouldBe(true);
+    }
+
+    [TestCase("-nofetch -nonormalize -nocache -allowshallow")]
+    [TestCase("-nofetch -nonormalize -allowshallow -nocache")]
+    [TestCase("-nofetch -nocache -nonormalize -allowshallow")]
+    [TestCase("-nofetch -nocache -allowshallow -nonormalize")]
+    [TestCase("-nofetch -allowshallow -nonormalize -nocache")]
+    [TestCase("-nofetch -allowshallow -nocache -nonormalize")]
+    [TestCase("-nonormalize -nofetch -nocache -allowshallow")]
+    [TestCase("-nonormalize -nofetch -allowshallow -nocache")]
+    [TestCase("-nonormalize -nocache -nofetch -allowshallow")]
+    [TestCase("-nonormalize -nocache -allowshallow -nofetch")]
+    [TestCase("-nonormalize -allowshallow -nofetch -nocache")]
+    [TestCase("-nonormalize -allowshallow -nocache -nofetch")]
+    [TestCase("-nocache -nofetch -nonormalize -allowshallow")]
+    [TestCase("-nocache -nofetch -allowshallow -nonormalize")]
+    [TestCase("-nocache -nonormalize -nofetch -allowshallow")]
+    [TestCase("-nocache -nonormalize -allowshallow -nofetch")]
+    [TestCase("-nocache -allowshallow -nofetch -nonormalize")]
+    [TestCase("-nocache -allowshallow -nonormalize -nofetch")]
+    [TestCase("-allowshallow -nofetch -nonormalize -nocache")]
+    [TestCase("-allowshallow -nofetch -nocache -nonormalize")]
+    [TestCase("-allowshallow -nonormalize -nofetch -nocache")]
+    [TestCase("-allowshallow -nonormalize -nocache -nofetch")]
+    [TestCase("-allowshallow -nocache -nofetch -nonormalize")]
+    [TestCase("-allowshallow -nocache -nonormalize -nofetch")]
     public void SeveralSwitchesCanBeParsed(string commandLineArgs)
     {
         var arguments = this.argumentParser.ParseArguments(commandLineArgs);
         arguments.NoCache.ShouldBe(true);
         arguments.NoNormalize.ShouldBe(true);
         arguments.NoFetch.ShouldBe(true);
+        arguments.AllowShallow.ShouldBe(true);
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -46,6 +46,7 @@ public class HelpWriterTests : TestBase
             { nameof(Arguments.NoCache), "/nocache" },
             { nameof(Arguments.NoFetch), "/nofetch" },
             { nameof(Arguments.NoNormalize), "/nonormalize" },
+            { nameof(Arguments.AllowShallow), "/allowshallow" },
         };
         var helpText = string.Empty;
 

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -281,6 +281,12 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
+        if (name.IsSwitch("allowshallow"))
+        {
+            arguments.AllowShallow = true;
+            return true;
+        }
+
         if (name.IsSwitch("verbosity"))
         {
             ParseVerbosity(arguments, value);

--- a/src/GitVersion.App/ArgumentParserExtensions.cs
+++ b/src/GitVersion.App/ArgumentParserExtensions.cs
@@ -69,7 +69,7 @@ internal static class ArgumentParserExtensions
 
     public static bool ArgumentRequiresValue(this string argument, int argumentIndex)
     {
-        var booleanArguments = new[] { "updateassemblyinfo", "ensureassemblyinfo", "nofetch", "nonormalize", "nocache" };
+        var booleanArguments = new[] { "updateassemblyinfo", "ensureassemblyinfo", "nofetch", "nonormalize", "nocache", "allowshallow" };
 
         var argumentMightRequireValue = !booleanArguments.Contains(argument[1..], StringComparer.OrdinalIgnoreCase);
 

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -25,6 +25,7 @@ internal class Arguments
     public bool NoFetch;
     public bool NoCache;
     public bool NoNormalize;
+    public bool AllowShallow;
 
     public string? LogFilePath;
     public string? ShowVariable;
@@ -77,7 +78,8 @@ internal class Arguments
             {
                 NoFetch = NoFetch,
                 NoCache = NoCache,
-                NoNormalize = NoNormalize
+                NoNormalize = NoNormalize,
+                AllowShallow = AllowShallow,
             },
 
             WixInfo =

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -190,7 +190,14 @@ internal class GitPreparer(
 
         if (this.repository.IsShallow)
         {
-            throw new WarningException("Repository is a shallow clone. Git repositories must contain the full history. See https://gitversion.net/docs/reference/requirements#unshallow for more info.");
+            if (this.options.Value.Settings.AllowShallow)
+            {
+                this.log.Info("Repository is a shallow clone. GitVersion will continue, but it is recommended to use a full clone for accurate versioning.");
+            }
+            else
+            {
+                throw new WarningException("Repository is a shallow clone. Git repositories must contain the full history. See https://gitversion.net/docs/reference/requirements#unshallow for more info.");
+            }
         }
     }
 

--- a/src/GitVersion.Core/Options/Settings.cs
+++ b/src/GitVersion.Core/Options/Settings.cs
@@ -6,4 +6,5 @@ public record Settings
     public bool NoCache;
     public bool NoNormalize;
     public bool OnlyTrackedBranches = false;
+    public bool AllowShallow = false;
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -595,6 +595,7 @@ GitVersion.Settings.NoCache -> bool
 GitVersion.Settings.NoFetch -> bool
 GitVersion.Settings.NoNormalize -> bool
 GitVersion.Settings.OnlyTrackedBranches -> bool
+GitVersion.Settings.AllowShallow -> bool
 GitVersion.VersionCalculation.BaseVersion
 GitVersion.VersionCalculation.BaseVersion.BaseVersion() -> void
 GitVersion.VersionCalculation.BaseVersion.BaseVersion(GitVersion.VersionCalculation.BaseVersionOperand! Operand) -> void

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props
@@ -11,20 +11,22 @@
         <GitVersion_NoFetchEnabled Condition="$(GitVersion_NoFetchEnabled) == ''">false</GitVersion_NoFetchEnabled>
         <GitVersion_NoNormalizeEnabled Condition="$(GitVersion_NoNormalizeEnabled) == ''">false</GitVersion_NoNormalizeEnabled>
         <GitVersion_NoCacheEnabled Condition="$(GitVersion_NoCacheEnabled) == ''">false</GitVersion_NoCacheEnabled>
+        <GitVersion_AllowShallowEnabled Condition="$(GitVersion_AllowShallowEnabled) == ''">false</GitVersion_AllowShallowEnabled>
 
         <GitVersion_ToolArgments>$(GitVersion_CommandLineArguments) -output file -outputfile &quot;$(GitVersionOutputFile)&quot;</GitVersion_ToolArgments>
         <GitVersion_ToolArgments Condition=" '$(GitVersion_NoFetchEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nofetch</GitVersion_ToolArgments>
         <GitVersion_ToolArgments Condition=" '$(GitVersion_NoNormalizeEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nonormalize</GitVersion_ToolArgments>
         <GitVersion_ToolArgments Condition=" '$(GitVersion_NoCacheEnabled)' == 'true' ">$(GitVersion_ToolArgments) -nocache</GitVersion_ToolArgments>
+        <GitVersion_ToolArgments Condition=" '$(GitVersion_AllowShallowEnabled)' == 'true' ">$(GitVersion_ToolArgments) -allowshallow</GitVersion_ToolArgments>
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- The GitVersion task is explicitly disabled when running on the .NET Framework because it's no longer supported. 
-        If a project that uses GitVersion.MsBuild is opened in Visual Studio, 
-        the task will be turned off because Visual Studio operates on the .NET Framework's version of MSBuild. 
+        <!-- The GitVersion task is explicitly disabled when running on the .NET Framework because it's no longer supported.
+        If a project that uses GitVersion.MsBuild is opened in Visual Studio,
+        the task will be turned off because Visual Studio operates on the .NET Framework's version of MSBuild.
         However, you can still execute GitVersion.MsBuild as part of the `dotnet build` or `dotnet msbuild` commands. -->
         <DisableGitVersionTask Condition=" '$(MSBuildRuntimeType)' != 'Core' ">true</DisableGitVersionTask>
-        
+
         <DisableGitVersionTask Condition=" '$(DisableGitVersionTask)' == '' ">false</DisableGitVersionTask>
 
         <!-- Property that enables WriteVersionInfoToBuildLog -->


### PR DESCRIPTION
## Description

This PR adds support for shallow cloning of git repositories. While having the full git history available is the only way to truly be certain of the next version, this is not desirable on larger repositories with many thousands of commits as a full clone can take several minutes and is usually neither desirable nor needed as there is sufficient information (e.g. git tags) available on the N most recent commits to be able to reliably determine the next version without requiring a full clone.

Since this is a special scenario it put behind an explicit flag `allowshallow` to ensure both backwards compatibility and awareness of the user of the tool.

## Motivation and Context

Observation that the git checkout step on CI pipelines is taking 5-20 minutes on large internal repositories due to having to fetch the whole history as required by GitVersion. This step sometimes represents more time than the rest of the steps, leading to costs and undesirable long iteration cycles.

## How Has This Been Tested?

- Unit tests

## Checklist:

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
