### PR TITLE
Updates help writer to include all arguments

### DIFF
--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -19,21 +19,33 @@ public class HelpWriterTests : TestBase
     {
         var lookup = new Dictionary<string, string>
         {
-            { nameof(Arguments.TargetUrl), "/url" },
-            { nameof(Arguments.TargetBranch), "/b" },
-            { nameof(Arguments.LogFilePath) , "/l" },
-            { nameof(Arguments.OutputFile) , "/outputfile" },
-            { nameof(Arguments.ClonePath), "/dynamicRepoLocation" },
             { nameof(Arguments.IsHelp), "/?" },
             { nameof(Arguments.IsVersion), "/version" },
-            { nameof(Arguments.UpdateWixVersionFile), "/updatewixversionfile" },
-            { nameof(Arguments.ConfigurationFile), "/config" },
-            { nameof(Arguments.Verbosity), "/verbosity" },
+
+            { nameof(Arguments.TargetUrl), "/url" },
+            { nameof(Arguments.TargetBranch), "/b" },
+            { nameof(Arguments.ClonePath), "/dynamicRepoLocation" },
             { nameof(Arguments.CommitId), "/c" },
+
+            { nameof(Arguments.LogFilePath) , "/l" },
+            { nameof(Arguments.Verbosity), "/verbosity" },
+            { nameof(Arguments.Output) , "/output" },
+            { nameof(Arguments.OutputFile) , "/outputfile" },
+            { nameof(Arguments.ShowVariable), "/showvariable" },
+            { nameof(Arguments.Format), "/format" },
+
+            { nameof(Arguments.UpdateWixVersionFile), "/updatewixversionfile" },
+            { nameof(Arguments.UpdateProjectFiles), "/updateprojectfiles" },
+            { nameof(Arguments.UpdateAssemblyInfo), "/updateassemblyinfo" },
+            { nameof(Arguments.EnsureAssemblyInfo), "/ensureassemblyinfo" },
+
+            { nameof(Arguments.ConfigurationFile), "/config" },
             { nameof(Arguments.ShowConfiguration), "/showconfig" },
             { nameof(Arguments.OverrideConfiguration), "/overrideconfig" },
-            { nameof(Arguments.ShowVariable), "/showvariable" },
-            { nameof(Arguments.Format), "/format" }
+
+            { nameof(Arguments.NoCache), "/nocache" },
+            { nameof(Arguments.NoFetch), "/nofetch" },
+            { nameof(Arguments.NoNormalize), "/nonormalize" },
         };
         var helpText = string.Empty;
 
@@ -42,7 +54,7 @@ public class HelpWriterTests : TestBase
         var ignored = new[]
         {
             nameof(Arguments.Authentication),
-            nameof(Arguments.UpdateAssemblyInfoFileName)
+            nameof(Arguments.UpdateAssemblyInfoFileName),
         };
         typeof(Arguments).GetFields()
             .Select(p => p.Name)

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -13,8 +13,6 @@ internal class Arguments
 
     public string? TargetPath;
 
-    public bool UpdateWixVersionFile;
-
     public string? TargetUrl;
     public string? TargetBranch;
     public string? CommitId;
@@ -35,6 +33,7 @@ internal class Arguments
     public ISet<OutputType> Output = new HashSet<OutputType>();
     public Verbosity Verbosity = Verbosity.Normal;
 
+    public bool UpdateWixVersionFile;
     public bool UpdateProjectFiles;
     public bool UpdateAssemblyInfo;
     public bool EnsureAssemblyInfo;


### PR DESCRIPTION
Updates the help writer tests to verify that all arguments are present in the help output. This ensures that users have access to comprehensive information about available command-line options.