### PR TITLE
Extend git flow complex example to post merge and rebase behaviour

### DIFF
--- a/CommitsSinceVersionSource.txt
+++ b/CommitsSinceVersionSource.txt
@@ -1,0 +1,207 @@
+
+
+@startuml
+skinparam participantMargin 10
+skinparam noteMargin 10
+skinparam shadowing false
+
+participant main
+participant develop
+participant feature_f1
+participant release_1_1_0
+participant feature_f2
+participant release_1_2_0
+participant hotfix_hf
+
+note right of main #LightBlue
+📝 Commit: A  
+Version Source: A (initial commit)  
+Commits beyond Version Source: none  
+Version: 1.0.0
+end note
+
+main --> develop: 🌿 branch develop from A
+
+note right of develop #LightSkyBlue
+📝 Commit: B  
+Version Source: A (already merged to develop)  
+Commits beyond Version Source: B  
+Version: 1.1.0-alpha.1
+end note
+
+develop --> feature_f1: 🌿 branch feature/f1 from B
+
+note right of feature_f1 #LightGreen
+📝 Commit: C  
+Version Source: B (already merged to develop)  
+Commits beyond Version Source: C  
+Version: 1.1.0-f1.1+2
+end note
+
+feature_f1 --> develop: 🔀 E (merge f1 → develop)
+
+note right of develop #Khaki
+📝 Commit: E  
+Version Source: E (develop tip)  
+Commits beyond Version Source: none  
+Version: 1.1.0-alpha.3
+end note
+
+develop --> release_1_1_0: 🌿 branch release/1.1.0 from E
+
+note right of release_1_1_0 #PaleGreen
+📝 Commit: F  
+Version Source: E (already merged to develop)  
+Commits beyond Version Source: F  
+Version: 1.1.0-beta.1+4
+end note
+
+release_1_1_0 --> main: 🔀 G (merge release/1.1.0 → main)
+
+note right of main #Gold
+📝 Commit: G  
+🏷 Tag: 1.1.0  
+Version Source: G (main tip)  
+Commits beyond Version Source: none  
+Version: 1.1.0-5
+end note
+
+main -> main: 🏷 tag 1.1.0
+
+note right of main #Gold
+Version: 1.1.0
+end note
+
+release_1_1_0 --> develop: 🔀 H (merge release/1.1.0 → develop)
+
+note right of develop #Khaki
+📝 Commit: H  
+Version Source: H (develop tip)  
+Commits beyond Version Source: none  
+Version: 1.2.0-alpha.1
+end note
+
+develop --> feature_f2: 🌿 branch feature/f2 from H
+
+note right of feature_f2 #LightGreen
+📝 Commit: I  
+Version Source: H (already merged to develop)  
+Commits beyond Version Source: I  
+Version: 1.2.0-f2.1+2
+end note
+
+feature_f2 -> feature_f2: Commit 'feature 2 additional commit (J)'
+
+note right of feature_f2 #LightGreen
+📝 Commit: J  
+Version Source: H (already merged to develop)  
+Commits beyond Version Source: J  
+Version: 1.3.0-f2.1+0
+end note
+
+feature_f2 --> develop: 🔀 K (merge f2 → develop)
+
+note right of develop #Khaki
+📝 Commit: K  
+Version Source: K (develop tip)  
+Commits beyond Version Source: none  
+Version: 1.2.0-alpha.3
+end note
+
+develop --> release_1_2_0: 🌿 branch release/1.2.0 from K
+
+note right of release_1_2_0 #PaleGreen
+📝 Commit: L  
+Version Source: K (already merged to develop)  
+Commits beyond Version Source: L  
+Beta parent: B.. E,F,G,H,I,J,K
+Version: 1.2.0-beta.1+8
+end note
+
+release_1_2_0 --> main: 🔀 M (merge release/1.2.0 → main)
+
+note right of main #Gold
+📝 Commit: M  
+🏷 Tag: 1.2.0  
+Version Source: M (main tip)  
+Commits beyond Version Source: none  
+Version: 1.2.0-5
+end note
+
+main -> main: 🏷 tag 1.2.0
+
+note right of main #Gold
+Version: 1.2.0
+end note
+
+release_1_2_0 --> develop: 🔀 N (merge release/1.2.0 → develop)
+
+note right of develop #Khaki
+📝 Commit: N  
+Version Source: N (develop tip)  
+Commits beyond Version Source: none  
+Version: 1.3.0-alpha.1
+end note
+
+main --> hotfix_hf: 🌿 branch hotfix/hf from M
+
+note right of hotfix_hf #LightCoral
+📝 Commit: O  
+Version Source: M (already merged to main)  
+Commits beyond Version Source: O  
+Version: 1.2.1-beta.1+1
+end note
+
+hotfix_hf --> main: 🔀 P (merge hotfix → main)
+
+note right of main #Gold
+📝 Commit: P  
+🏷 Tag: 1.2.1  
+Version Source: P (main tip)  
+Commits beyond Version Source: none  
+Version: 1.2.1-2
+end note
+
+main -> main: 🏷 tag 1.2.1
+
+note right of main #Gold
+Version: 1.2.1
+end note
+
+hotfix_hf --> develop: 🔀 Q (merge hotfix → develop)
+
+note right of develop #Khaki
+📝 Commit: Q  
+Version Source: Q (develop tip)  
+Commits beyond Version Source: none  
+Version: 1.3.0-alpha.2
+end note
+
+note right of feature_f2 #Orange
+⬅ Returned to feature/f2 at Commit J  
+Version Source: J (already merged to develop)  
+Commits beyond Version Source: none  
+Version recalculates to: 1.3.0-f2.1+0
+end note
+
+note right of feature_f2 #LightGreen
+Version: 1.3.0-f2.1+0
+end note
+
+note right of feature_f2 #LightGreen
+📝 Commit: R  
+Version Source: J (already merged to develop)  
+Commits beyond Version Source: R  
+Version: 1.3.0-f2.1+1
+end note
+
+feature_f2 --> develop: --> rebase R onto develop tip Q
+
+note right of feature_f2 #Thistle
+📝 Commit: R′  
+Version Source: Q (develop tip)  
+Commits beyond Version Source: R′  
+Version: 1.3.0-f2.1+1 (after rebase)
+end note
+
+@enduml

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -144,12 +144,12 @@ public static class GitRepositoryTestingExtensions
     }
 
     public static void AssertFullSemver(this RepositoryFixtureBase fixture, string fullSemver,
-        IGitVersionConfiguration? configuration = null, IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
+        IGitVersionConfiguration? configuration = null, IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null, string? customMessage = null)
     {
         repository ??= fixture.Repository;
 
         var variables = GetVersion(fixture, configuration, repository, commitId, onlyTrackedBranches, targetBranch);
-        variables.FullSemVer.ShouldBe(fullSemver);
+        variables.FullSemVer.ShouldBe(fullSemver, customMessage);
         if (commitId == null)
         {
             fixture.SequenceDiagram.NoteOver(fullSemver, repository.Head.FriendlyName, color: "#D3D3D3");

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -165,17 +165,31 @@ public static class GitRepositoryTestingExtensions
         variables.CommitsSinceVersionSource.ShouldBe(commitsSinceVersionSourceExpected.ToString(), customMessage);
         if (commitId == null)
         {
-            var message = new StringBuilder($"CommitsSinceVersionSource:{commitsSinceVersionSourceExpected}");
-            if (variables.CommitsSinceVersionSourceList != null)
+            var message = new StringBuilder();
+            var versionSourceLabel = fixture.SequenceDiagram.GetOrAddSourceLabel(variables.VersionSourceSha);
+            message.AppendLine($"                      Commit: {fixture.SequenceDiagram.GetOrAddLabel(variables.Sha)}");
+            message.Append($"              Version source: {versionSourceLabel}");
+            if (commitsSinceVersionSourceExpected != 0 && variables.CommitsSinceVersionSourceList != null)
             {
-                foreach (var sha in variables.CommitsSinceVersionSourceList)
+                bool isFirst = true;
+                foreach (var sha in variables.CommitsSinceVersionSourceList.Split(", ").Reverse())
                 {
-                    message.Append(System.Environment.NewLine);
-                    message.Append($"- {sha}");
+                    if (isFirst)
+                    {
+                        message.Append(System.Environment.NewLine);
+                        message.Append($"Commits since version source: {variables.CommitsSinceVersionSource} - ");
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        message.Append(", ");
+                    }
+
+                    message.Append($"{fixture.SequenceDiagram.GetOrAddLabel(sha)}");
                 }
             }
 
-            fixture.SequenceDiagram.NoteOver(message.ToString(), repository.Head.FriendlyName, color: "#D3D3D3");
+            fixture.SequenceDiagram.NoteOver(message.ToString(), repository.Head.FriendlyName, color: "#A9B7C6");
         }
     }
 

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -156,6 +156,29 @@ public static class GitRepositoryTestingExtensions
         }
     }
 
+    public static void AssertCommitsSinceVersionSource(this RepositoryFixtureBase fixture, int commitsSinceVersionSourceExpected,
+        IGitVersionConfiguration? configuration = null, IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null, string? customMessage = null)
+    {
+        repository ??= fixture.Repository;
+
+        var variables = GetVersion(fixture, configuration, repository, commitId, onlyTrackedBranches, targetBranch);
+        variables.CommitsSinceVersionSource.ShouldBe(commitsSinceVersionSourceExpected.ToString(), customMessage);
+        if (commitId == null)
+        {
+            var message = new StringBuilder($"CommitsSinceVersionSource:{commitsSinceVersionSourceExpected}");
+            if (variables.CommitsSinceVersionSourceList != null)
+            {
+                foreach (var sha in variables.CommitsSinceVersionSourceList)
+                {
+                    message.Append(System.Environment.NewLine);
+                    message.Append($"- {sha}");
+                }
+            }
+
+            fixture.SequenceDiagram.NoteOver(message.ToString(), repository.Head.FriendlyName, color: "#D3D3D3");
+        }
+    }
+
     /// <summary>
     /// Simulates running on build server
     /// </summary>

--- a/src/GitVersion.Core.Tests/Helpers/CommitLabelGeneratorTests.cs
+++ b/src/GitVersion.Core.Tests/Helpers/CommitLabelGeneratorTests.cs
@@ -1,0 +1,94 @@
+namespace GitVersion.Testing.Helpers;
+
+[TestFixture]
+public class CommitLabelGeneratorTests
+{
+    [TestCase("")]
+    [TestCase("   ")]
+    public void GetOrAdd_ShouldThrow_WhenKeyIsEmptyOrWhitespace(string key)
+    {
+        var sut = new CommitLabelGenerator();
+        var ex = Should.Throw<ArgumentException>(() => sut.GetOrAdd(key));
+        ex.Message.ShouldContain("SHA cannot be empty or whitespace");
+        ex.ParamName.ShouldBe("key");
+    }
+
+    [Test]
+    public void GetOrAdd_ShouldReturnNA_WhenKeyIsNA()
+    {
+        var sut = new CommitLabelGenerator();
+        sut.GetOrAdd("N/A").ShouldBe("N/A");
+    }
+
+    [Test]
+    public void GetOrAdd_ShouldAssignLabels_Sequentially()
+    {
+        var sut = new CommitLabelGenerator();
+
+        sut.GetOrAdd("sha1").ShouldBe("A");
+        sut.GetOrAdd("sha2").ShouldBe("B");
+        sut.GetOrAdd("sha3").ShouldBe("C");
+    }
+
+    [Test]
+    public void GetOrAdd_ShouldReturnSameLabel_OnRepeatedCalls()
+    {
+        var sut = new CommitLabelGenerator();
+        sut.GetOrAdd("sha1").ShouldBe(sut.GetOrAdd("sha1"));
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public void GetOrAddRoot_ShouldThrow_WhenKeyIsEmptyOrWhitespace(string key)
+    {
+        var sut = new CommitLabelGenerator();
+        var ex = Should.Throw<ArgumentException>(() => sut.GetOrAddRoot(key));
+        ex.Message.ShouldContain("Version source SHA cannot be empty or whitespace");
+        ex.ParamName.ShouldBe("versionSourceSha");
+    }
+
+    [Test]
+    public void GetOrAddRoot_ShouldReturnNA_WhenKeyIsNA()
+    {
+        var sut = new CommitLabelGenerator();
+        sut.GetOrAddRoot("N/A").ShouldBe("N/A");
+    }
+
+    [Test]
+    public void GetOrAddRoot_ShouldAssignRootLabels_Sequentially()
+    {
+        var sut = new CommitLabelGenerator();
+
+        sut.GetOrAddRoot("rootsha1").ShouldBe("RootA");
+        sut.GetOrAddRoot("rootsha2").ShouldBe("RootB");
+        sut.GetOrAddRoot("rootsha3").ShouldBe("RootC");
+    }
+
+    [Test]
+    public void GetOrAddRoot_ShouldReturnSameLabel_OnRepeatedCalls()
+    {
+        var sut = new CommitLabelGenerator();
+        sut.GetOrAddRoot("rootsha1").ShouldBe(sut.GetOrAddRoot("rootsha1"));
+    }
+
+    [Test]
+    public void GetOrAddRoot_And_GetOrAdd_ShouldMaintainSequenceLabels()
+    {
+        var sut = new CommitLabelGenerator();
+
+        sut.GetOrAddRoot("sha1").ShouldBe("RootA");
+        sut.GetOrAdd("sha2").ShouldBe("B");
+        sut.GetOrAddRoot("sha3").ShouldBe("RootC");
+    }
+
+    [Test]
+    public void GetOrAddRoot_And_GetOrAdd_ShouldAlign()
+    {
+        var sut = new CommitLabelGenerator();
+
+        sut.GetOrAddRoot("sha1").ShouldBe("RootA");
+        sut.GetOrAdd("sha1").ShouldBe("RootA");
+        sut.GetOrAdd("sha2").ShouldBe("B");
+        sut.GetOrAddRoot("sha2").ShouldBe("B");
+    }
+}

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -7,7 +7,7 @@ namespace GitVersion.Core.Tests.Helpers;
 
 public class TestBase
 {
-    public const string MainBranch = RepositoryFixtureBase.MainBranch;
+    public const string MainBranch = "main";
 
     protected static IServiceProvider ConfigureServices(Action<IServiceCollection>? overrideServices = null)
     {

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -7,7 +7,7 @@ namespace GitVersion.Core.Tests.Helpers;
 
 public class TestBase
 {
-    public const string MainBranch = "main";
+    public const string MainBranch = RepositoryFixtureBase.MainBranch;
 
     protected static IServiceProvider ConfigureServices(Action<IServiceCollection>? overrideServices = null)
     {

--- a/src/GitVersion.Core.Tests/Helpers/TestableGitVersionVariables.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestableGitVersionVariables.cs
@@ -26,4 +26,5 @@ internal record TestableGitVersionVariables() : GitVersionVariables("",
     "",
     "",
     "",
+    "",
     "");

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -1,3 +1,4 @@
+using GitVersion.Configuration;
 using GitVersion.Core.Tests.Helpers;
 
 namespace GitVersion.Core.Tests.IntegrationTests;
@@ -14,69 +15,70 @@ public class GitflowScenarios : TestBase
         const string release1Branch = "release/1.1.0";
         const string release2Branch = "release/1.2.0";
         const string hotfixBranch = "hotfix/hf";
+        var configuration = GitFlowConfigurationBuilder.New.Build();
 
         using var fixture = new BaseGitFlowRepositoryFixture("1.0.0");
-        fixture.AssertFullSemver("1.1.0-alpha.1");
+        fixture.AssertFullSemver("1.1.0-alpha.1", configuration);
 
         // Feature 1
         fixture.BranchTo(feature1Branch);
         fixture.MakeACommit("added feature 1");
-        fixture.AssertFullSemver("1.1.0-f1.1+2");
+        fixture.AssertFullSemver("1.1.0-f1.1+2", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(feature1Branch);
         fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature1Branch]);
-        fixture.AssertFullSemver("1.1.0-alpha.3");
+        fixture.AssertFullSemver("1.1.0-alpha.3", configuration);
 
         // Release 1.1.0
         fixture.BranchTo(release1Branch);
         fixture.MakeACommit("release stabilization");
-        fixture.AssertFullSemver("1.1.0-beta.1+4");
+        fixture.AssertFullSemver("1.1.0-beta.1+4", configuration);
         fixture.Checkout(MainBranch);
         fixture.MergeNoFF(release1Branch);
-        fixture.AssertFullSemver("1.1.0-5");
+        fixture.AssertFullSemver("1.1.0-5", configuration);
         fixture.ApplyTag("1.1.0");
-        fixture.AssertFullSemver("1.1.0");
+        fixture.AssertFullSemver("1.1.0", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(release1Branch);
         fixture.Repository.Branches.Remove(fixture.Repository.Branches[release1Branch]);
-        fixture.AssertFullSemver("1.2.0-alpha.1");
+        fixture.AssertFullSemver("1.2.0-alpha.1", configuration);
 
         // Feature 2
         fixture.BranchTo(feature2Branch);
         fixture.MakeACommit("added feature 2");
-        fixture.AssertFullSemver("1.2.0-f2.1+2");
+        fixture.AssertFullSemver("1.2.0-f2.1+2", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(feature2Branch);
         fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature2Branch]);
-        fixture.AssertFullSemver("1.2.0-alpha.3");
+        fixture.AssertFullSemver("1.2.0-alpha.3", configuration);
 
         // Release 1.2.0
         fixture.BranchTo(release2Branch);
         fixture.MakeACommit("release stabilization");
-        fixture.AssertFullSemver("1.2.0-beta.1+8");
+        fixture.AssertFullSemver("1.2.0-beta.1+8", configuration);
         fixture.Checkout(MainBranch);
         fixture.MergeNoFF(release2Branch);
-        fixture.AssertFullSemver("1.2.0-5");
+        fixture.AssertFullSemver("1.2.0-5", configuration);
         fixture.ApplyTag("1.2.0");
-        fixture.AssertFullSemver("1.2.0");
+        fixture.AssertFullSemver("1.2.0", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(release2Branch);
         fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
-        fixture.AssertFullSemver("1.3.0-alpha.1");
+        fixture.AssertFullSemver("1.3.0-alpha.1", configuration);
 
         // Hotfix
         fixture.Checkout(MainBranch);
         fixture.BranchTo(hotfixBranch);
         fixture.MakeACommit("added hotfix");
-        fixture.AssertFullSemver("1.2.1-beta.1+1");
+        fixture.AssertFullSemver("1.2.1-beta.1+1", configuration);
         fixture.Checkout(MainBranch);
         fixture.MergeNoFF(hotfixBranch);
-        fixture.AssertFullSemver("1.2.1-2");
+        fixture.AssertFullSemver("1.2.1-2", configuration);
         fixture.ApplyTag("1.2.1");
-        fixture.AssertFullSemver("1.2.1");
+        fixture.AssertFullSemver("1.2.1", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(hotfixBranch);
         fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
-        fixture.AssertFullSemver("1.3.0-alpha.2");
+        fixture.AssertFullSemver("1.3.0-alpha.2", configuration);
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -89,6 +89,7 @@ public class GitflowScenarios : TestBase
         fixture.AssertFullSemver("1.2.1-2", configuration);
         fixture.ApplyTag("1.2.1");
         fixture.AssertFullSemver("1.2.1", configuration);
+        fixture.AssertCommitsSinceVersionSource(2, configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(hotfixBranch);
         if (!keepBranches)

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -1,5 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Core.Tests.Helpers;
+using GitVersion.Helpers;
+using LibGit2Sharp;
 
 namespace GitVersion.Core.Tests.IntegrationTests;
 
@@ -9,24 +11,29 @@ public class GitflowScenarios : TestBase
     [Test]
     public void GitflowComplexExample()
     {
+        var keepBranches = true;
         const string developBranch = "develop";
         const string feature1Branch = "feature/f1";
         const string feature2Branch = "feature/f2";
         const string release1Branch = "release/1.1.0";
         const string release2Branch = "release/1.2.0";
         const string hotfixBranch = "hotfix/hf";
+
         var configuration = GitFlowConfigurationBuilder.New.Build();
 
-        using var fixture = new BaseGitFlowRepositoryFixture("1.0.0");
-        fixture.AssertFullSemver("1.1.0-alpha.1", configuration);
+        using var fixture = new BaseGitFlowRepositoryFixture(initialMainAction, deleteOnDispose: false);
+        var fullSemver = "1.1.0-alpha.1";
+        fixture.AssertFullSemver(fullSemver, configuration);
 
         // Feature 1
         fixture.BranchTo(feature1Branch);
-        fixture.MakeACommit("added feature 1");
-        fixture.AssertFullSemver("1.1.0-f1.1+2", configuration);
+
+        fixture.MakeACommit($"added feature 1 >> {fullSemver}");
+        fullSemver = "1.1.0-f1.1+2";
+        fixture.AssertFullSemver(fullSemver, configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(feature1Branch);
-        fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature1Branch]);
+        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature1Branch]);
         fixture.AssertFullSemver("1.1.0-alpha.3", configuration);
 
         // Release 1.1.0
@@ -45,17 +52,19 @@ public class GitflowScenarios : TestBase
 
         // Feature 2
         fixture.BranchTo(feature2Branch);
-        fixture.MakeACommit("added feature 2");
-        fixture.AssertFullSemver("1.2.0-f2.1+2", configuration);
+        fullSemver = "1.2.0-f2.1+2";
+        fixture.MakeACommit($"added feature 2 >> {fullSemver}");
+        fixture.AssertFullSemver(fullSemver, configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(feature2Branch);
-        fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature2Branch]);
+        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[feature2Branch]);
         fixture.AssertFullSemver("1.2.0-alpha.3", configuration);
 
         // Release 1.2.0
         fixture.BranchTo(release2Branch);
-        fixture.MakeACommit("release stabilization");
-        fixture.AssertFullSemver("1.2.0-beta.1+8", configuration);
+        fullSemver = "1.2.0-beta.1+8";
+        fixture.MakeACommit($"release stabilization >> {fullSemver}");
+        fixture.AssertFullSemver(fullSemver, configuration);
         fixture.Checkout(MainBranch);
         fixture.MergeNoFF(release2Branch);
         fixture.AssertFullSemver("1.2.0-5", configuration);
@@ -63,14 +72,15 @@ public class GitflowScenarios : TestBase
         fixture.AssertFullSemver("1.2.0", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(release2Branch);
-        fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
+        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
         fixture.AssertFullSemver("1.3.0-alpha.1", configuration);
 
         // Hotfix
         fixture.Checkout(MainBranch);
         fixture.BranchTo(hotfixBranch);
-        fixture.MakeACommit("added hotfix");
-        fixture.AssertFullSemver("1.2.1-beta.1+1", configuration);
+        fullSemver = "1.2.1-beta.1+1";
+        fixture.MakeACommit($"added hotfix >> {fullSemver}");
+        fixture.AssertFullSemver(fullSemver, configuration);
         fixture.Checkout(MainBranch);
         fixture.MergeNoFF(hotfixBranch);
         fixture.AssertFullSemver("1.2.1-2", configuration);
@@ -78,7 +88,63 @@ public class GitflowScenarios : TestBase
         fixture.AssertFullSemver("1.2.1", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(hotfixBranch);
-        fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
+        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
         fixture.AssertFullSemver("1.3.0-alpha.2", configuration);
+
+        fixture.Checkout(feature2Branch);
+        fixture.AssertFullSemver(
+            "1.3.0-f2.1+0",
+            configuration,
+            customMessage:
+        "Feature branches use inherited versioning (increment: inherit), " + System.Environment.NewLine +
+        "and your config inherits from develop." + System.Environment.NewLine + System.Environment.NewLine +
+        "GitVersion uses the merge base between the feature and develop to determine the version." + System.Environment.NewLine + System.Environment.NewLine +
+        "As develop progresses (e.g., by releasing 1.2.0), rebuilding old feature branches can" + System.Environment.NewLine +
+        "produce different versions.");
+
+        fullSemver = "1.3.0-f2.1+1";
+        fixture.MakeACommit(
+            "feature 2 additional commit after original feature has been merged to develop " + System.Environment.NewLine +
+            $"and release/1.2.0 has already happened >> {fullSemver}" +
+            "Problem #1: 1.3.0-f2.1+0 is what I observe when I run dotnet-gitversion 6.3.0 but in the repo the assertion is 1.3.0-f2.1+1" +
+            "After rebase 1.3.0-f2.1+3 is both what the test asserts and what I observe when I run dotnet-gitversion 6.3.0." +
+            "Problem #2: I expected to get the same before and after the rebase." +
+            "" +
+            "Whether my expectations are correct or not could we at least build upon the documentation I have started to add " +
+            "as an explanation of observed behaviour. I'm happy to translate an explanation in to test " +
+            "documentation if you confirm it would be accepted on PR."
+        );
+
+        var identity = new Identity(
+                fixture.Repository.Head.Tip.Committer.Name,
+                fixture.Repository.Head.Tip.Committer.Email);
+        fixture.AssertFullSemver(fullSemver, configuration);
+        var rebaseResult = fixture.Repository.Rebase.Start(
+            fixture.Repository.Branches[feature2Branch],
+            fixture.Repository.Branches[developBranch],
+            fixture.Repository.Branches[developBranch],
+            identity,
+            new RebaseOptions());
+        while (rebaseResult != null && rebaseResult.Status != RebaseStatus.Complete)
+        {
+            rebaseResult = fixture.Repository.Rebase.Continue(identity, new RebaseOptions());
+        }
+
+        fixture.AssertFullSemver(fullSemver, configuration, customMessage: "I expected to get the same before and after the rebase.");
+
+        void initialMainAction(IRepository r)
+        {
+            if (configuration is GitVersionConfiguration concreteConfig)
+            {
+                var yaml = new ConfigurationSerializer().Serialize(concreteConfig);
+                const string fileName = "GitVersion.yml";
+                var filePath = FileSystemHelper.Path.Combine(r.Info.Path, "..", fileName);
+                File.WriteAllText(filePath, yaml);
+                r.Index.Add(fileName);
+                r.Index.Write();
+            }
+
+            r.MakeATaggedCommit("1.0.0", $"Initial commit on {MainBranch}");
+        }
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -72,7 +72,10 @@ public class GitflowScenarios : TestBase
         fixture.AssertFullSemver("1.2.0", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(release2Branch);
-        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
+        if (!keepBranches)
+        {
+            fixture.Repository.Branches.Remove(fixture.Repository.Branches[release2Branch]);
+        }
         fixture.AssertFullSemver("1.3.0-alpha.1", configuration);
 
         // Hotfix
@@ -88,7 +91,10 @@ public class GitflowScenarios : TestBase
         fixture.AssertFullSemver("1.2.1", configuration);
         fixture.Checkout(developBranch);
         fixture.MergeNoFF(hotfixBranch);
-        if (!keepBranches) fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
+        if (!keepBranches)
+        {
+            fixture.Repository.Branches.Remove(fixture.Repository.Branches[hotfixBranch]);
+        }
         fixture.AssertFullSemver("1.3.0-alpha.2", configuration);
 
         fixture.Checkout(feature2Branch);

--- a/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
@@ -24,6 +24,7 @@ public class VersionSourceTests : TestBase
         var semanticVersion = nextVersionCalculator.FindVersion();
 
         semanticVersion.BuildMetaData.VersionSourceSha.ShouldBeNull();
+        semanticVersion.BuildMetaData.CommitsSinceVersionSourceList.Length.ShouldBe((int)semanticVersion.BuildMetaData.CommitsSinceVersionSource);
         semanticVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(3);
     }
 
@@ -39,6 +40,7 @@ public class VersionSourceTests : TestBase
         var semanticVersion = nextVersionCalculator.FindVersion();
 
         semanticVersion.BuildMetaData.VersionSourceSha.ShouldBeNull();
+        semanticVersion.BuildMetaData.CommitsSinceVersionSourceList.Length.ShouldBe((int)semanticVersion.BuildMetaData.CommitsSinceVersionSource);
         semanticVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(1);
     }
 
@@ -58,6 +60,9 @@ public class VersionSourceTests : TestBase
         var semanticVersion = nextVersionCalculator.FindVersion();
 
         semanticVersion.BuildMetaData.VersionSourceSha.ShouldBe(secondCommitSha);
+#if DEBUG
+        semanticVersion.BuildMetaData.CommitsSinceVersionSourceList.Length.ShouldBe((int)semanticVersion.BuildMetaData.CommitsSinceVersionSource);
+#endif
         semanticVersion.BuildMetaData.CommitsSinceVersionSource.ShouldBe(1);
     }
 

--- a/src/GitVersion.Core/OutputVariables/GitVersionVariables.cs
+++ b/src/GitVersion.Core/OutputVariables/GitVersionVariables.cs
@@ -24,6 +24,7 @@ public record GitVersionVariables(string Major,
                                   string? CommitDate,
                                   string? VersionSourceSha,
                                   string? CommitsSinceVersionSource,
+                                  string? CommitsSinceVersionSourceList,
                                   string? UncommittedChanges) : IEnumerable<KeyValuePair<string, string?>>
 {
     internal static readonly List<string> AvailableVariables =
@@ -52,6 +53,7 @@ public record GitVersionVariables(string Major,
         nameof(CommitDate),
         nameof(VersionSourceSha),
         nameof(CommitsSinceVersionSource),
+        nameof(CommitsSinceVersionSourceList),
         nameof(UncommittedChanges)
     ];
 
@@ -81,6 +83,7 @@ public record GitVersionVariables(string Major,
         { nameof(CommitDate), CommitDate },
         { nameof(VersionSourceSha), VersionSourceSha },
         { nameof(CommitsSinceVersionSource), CommitsSinceVersionSource },
+        { nameof(CommitsSinceVersionSourceList), CommitsSinceVersionSourceList },
         { nameof(UncommittedChanges), UncommittedChanges }
     };
 

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -426,6 +426,8 @@ GitVersion.OutputVariables.GitVersionVariables.CommitDate.get -> string?
 GitVersion.OutputVariables.GitVersionVariables.CommitDate.init -> void
 GitVersion.OutputVariables.GitVersionVariables.CommitsSinceVersionSource.get -> string?
 GitVersion.OutputVariables.GitVersionVariables.CommitsSinceVersionSource.init -> void
+GitVersion.OutputVariables.GitVersionVariables.CommitsSinceVersionSourceList.get -> string?
+GitVersion.OutputVariables.GitVersionVariables.CommitsSinceVersionSourceList.init -> void
 GitVersion.OutputVariables.GitVersionVariables.EscapedBranchName.get -> string?
 GitVersion.OutputVariables.GitVersionVariables.EscapedBranchName.init -> void
 GitVersion.OutputVariables.GitVersionVariables.FullBuildMetaData.get -> string?
@@ -433,7 +435,7 @@ GitVersion.OutputVariables.GitVersionVariables.FullBuildMetaData.init -> void
 GitVersion.OutputVariables.GitVersionVariables.FullSemVer.get -> string!
 GitVersion.OutputVariables.GitVersionVariables.FullSemVer.init -> void
 GitVersion.OutputVariables.GitVersionVariables.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, string?>>!
-GitVersion.OutputVariables.GitVersionVariables.GitVersionVariables(string! Major, string! Minor, string! Patch, string? BuildMetaData, string? FullBuildMetaData, string? BranchName, string? EscapedBranchName, string? Sha, string? ShortSha, string! MajorMinorPatch, string! SemVer, string! FullSemVer, string? AssemblySemVer, string? AssemblySemFileVer, string? PreReleaseTag, string? PreReleaseTagWithDash, string? PreReleaseLabel, string? PreReleaseLabelWithDash, string? PreReleaseNumber, string! WeightedPreReleaseNumber, string? InformationalVersion, string? CommitDate, string? VersionSourceSha, string? CommitsSinceVersionSource, string? UncommittedChanges) -> void
+GitVersion.OutputVariables.GitVersionVariables.GitVersionVariables(string! Major, string! Minor, string! Patch, string? BuildMetaData, string? FullBuildMetaData, string? BranchName, string? EscapedBranchName, string? Sha, string? ShortSha, string! MajorMinorPatch, string! SemVer, string! FullSemVer, string? AssemblySemVer, string? AssemblySemFileVer, string? PreReleaseTag, string? PreReleaseTagWithDash, string? PreReleaseLabel, string? PreReleaseLabelWithDash, string? PreReleaseNumber, string! WeightedPreReleaseNumber, string? InformationalVersion, string? CommitDate, string? VersionSourceSha, string? CommitsSinceVersionSource, string? CommitsSinceVersionSourceList, string? UncommittedChanges) -> void
 GitVersion.OutputVariables.GitVersionVariables.InformationalVersion.get -> string?
 GitVersion.OutputVariables.GitVersionVariables.InformationalVersion.init -> void
 GitVersion.OutputVariables.GitVersionVariables.Major.get -> string!
@@ -520,6 +522,8 @@ GitVersion.SemanticVersionBuildMetaData.CommitsSinceTag.get -> long?
 GitVersion.SemanticVersionBuildMetaData.CommitsSinceTag.init -> void
 GitVersion.SemanticVersionBuildMetaData.CommitsSinceVersionSource.get -> long
 GitVersion.SemanticVersionBuildMetaData.CommitsSinceVersionSource.init -> void
+GitVersion.SemanticVersionBuildMetaData.CommitsSinceVersionSourceList.get -> string[]
+GitVersion.SemanticVersionBuildMetaData.CommitsSinceVersionSourceList.init -> void
 GitVersion.SemanticVersionBuildMetaData.Equals(GitVersion.SemanticVersionBuildMetaData? other) -> bool
 GitVersion.SemanticVersionBuildMetaData.OtherMetaData.get -> string?
 GitVersion.SemanticVersionBuildMetaData.OtherMetaData.init -> void

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -11,10 +11,12 @@ GitVersion.Git.AuthenticationInfo.AuthenticationInfo() -> void
 GitVersion.Git.AuthenticationInfo.AuthenticationInfo(GitVersion.Git.AuthenticationInfo! original) -> void
 GitVersion.Git.CommitFilter.CommitFilter() -> void
 GitVersion.Git.CommitFilter.CommitFilter(GitVersion.Git.CommitFilter! original) -> void
-GitVersion.OutputVariables.GitVersionVariables.Deconstruct(out string! Major, out string! Minor, out string! Patch, out string? BuildMetaData, out string? FullBuildMetaData, out string? BranchName, out string? EscapedBranchName, out string? Sha, out string? ShortSha, out string! MajorMinorPatch, out string! SemVer, out string! FullSemVer, out string? AssemblySemVer, out string? AssemblySemFileVer, out string? PreReleaseTag, out string? PreReleaseTagWithDash, out string? PreReleaseLabel, out string? PreReleaseLabelWithDash, out string? PreReleaseNumber, out string! WeightedPreReleaseNumber, out string? InformationalVersion, out string? CommitDate, out string? VersionSourceSha, out string? CommitsSinceVersionSource, out string? UncommittedChanges) -> void
+GitVersion.OutputVariables.GitVersionVariables.Deconstruct(out string! Major, out string! Minor, out string! Patch, out string? BuildMetaData, out string? FullBuildMetaData, out string? BranchName, out string? EscapedBranchName, out string? Sha, out string? ShortSha, out string! MajorMinorPatch, out string! SemVer, out string! FullSemVer, out string? AssemblySemVer, out string? AssemblySemFileVer, out string? PreReleaseTag, out string? PreReleaseTagWithDash, out string? PreReleaseLabel, out string? PreReleaseLabelWithDash, out string? PreReleaseNumber, out string! WeightedPreReleaseNumber, out string? InformationalVersion, out string? CommitDate, out string? VersionSourceSha, out string? CommitsSinceVersionSource, out string? CommitsSinceVersionSourceList, out string? UncommittedChanges) -> void
 GitVersion.OutputVariables.GitVersionVariables.GitVersionVariables(GitVersion.OutputVariables.GitVersionVariables! original) -> void
 GitVersion.RepositoryInfo.RepositoryInfo() -> void
 GitVersion.RepositoryInfo.RepositoryInfo(GitVersion.RepositoryInfo! original) -> void
+GitVersion.SemanticVersionBuildMetaData.CommitsSinceVersionSourceList.get -> string![]!
+GitVersion.SemanticVersionFormatValues.CommitsSinceVersionSourceList.get -> string?
 GitVersion.SemanticVersionWithTag.<Clone>$() -> GitVersion.SemanticVersionWithTag!
 GitVersion.SemanticVersionWithTag.Deconstruct(out GitVersion.SemanticVersion! Value, out GitVersion.Git.ITag! Tag) -> void
 GitVersion.SemanticVersionWithTag.Equals(GitVersion.SemanticVersionWithTag? other) -> bool

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -26,7 +26,17 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
 
     public string? VersionSourceSha { get; init; }
 
-    public long CommitsSinceVersionSource { get; init; }
+    public long CommitsSinceVersionSource
+    {
+        get;
+        init;
+    }
+
+    public string[] CommitsSinceVersionSourceList
+    {
+        get;
+        init;
+    }
 
     public long UncommittedChanges { get; init; }
 
@@ -34,8 +44,28 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
     {
     }
 
-    public SemanticVersionBuildMetaData(string? versionSourceSha, long? commitsSinceTag, string? branch, string? commitSha,
-        string? commitShortSha, DateTimeOffset? commitDate, long numberOfUnCommittedChanges, string? otherMetadata = null)
+    public SemanticVersionBuildMetaData(
+        string? versionSourceSha,
+        long? commitsSinceTag,
+        string? branch,
+        string? commitSha,
+        string? commitShortSha,
+        DateTimeOffset? commitDate,
+        long numberOfUnCommittedChanges,
+        string? otherMetadata = null)
+        : this(versionSourceSha, commitsSinceTag, branch, commitSha, commitShortSha, commitDate, numberOfUnCommittedChanges, otherMetadata, [])
+    { }
+
+    internal SemanticVersionBuildMetaData(
+        string? versionSourceSha,
+        long? commitsSinceTag,
+        string? branch,
+        string? commitSha,
+        string? commitShortSha,
+        DateTimeOffset? commitDate,
+        long numberOfUnCommittedChanges,
+        string? otherMetadata,
+        string[]? commitSinceTagList)
     {
         this.Sha = commitSha;
         this.ShortSha = commitShortSha;
@@ -45,6 +75,7 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
         this.OtherMetaData = otherMetadata;
         this.VersionSourceSha = versionSourceSha;
         this.CommitsSinceVersionSource = commitsSinceTag ?? 0;
+        this.CommitsSinceVersionSourceList = commitsSinceTag == null ? [] : commitSinceTagList ?? [];
         this.UncommittedChanges = numberOfUnCommittedChanges;
     }
 

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -55,5 +55,7 @@ public class SemanticVersionFormatValues(SemanticVersion semver, IGitVersionConf
 
     public string CommitsSinceVersionSource => semver.BuildMetaData.CommitsSinceVersionSource.ToString(CultureInfo.InvariantCulture);
 
+    public string? CommitsSinceVersionSourceList => string.Join(", ", semver.BuildMetaData.CommitsSinceVersionSourceList ?? []).ToString(CultureInfo.InvariantCulture);
+
     public string UncommittedChanges => semver.BuildMetaData.UncommittedChanges.ToString(CultureInfo.InvariantCulture);
 }

--- a/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
@@ -63,6 +63,7 @@ internal sealed class VariableProvider(IEnvironment environment) : IVariableProv
             semverFormatValues.CommitDate,
             semverFormatValues.VersionSourceSha,
             semverFormatValues.CommitsSinceVersionSource,
+            semverFormatValues.CommitsSinceVersionSourceList,
             semverFormatValues.UncommittedChanges
         );
     }

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeliveryVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeliveryVersionCalculator.cs
@@ -35,6 +35,7 @@ internal sealed class ContinuousDeliveryVersionCalculator(
             BuildMetaData = new SemanticVersionBuildMetaData(buildMetaData)
             {
                 CommitsSinceVersionSource = buildMetaData.CommitsSinceTag!.Value,
+                CommitsSinceVersionSourceList = buildMetaData.CommitsSinceVersionSourceList,
                 CommitsSinceTag = null
             }
         };

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/VersionCalculatorBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/VersionCalculatorBase.cs
@@ -33,7 +33,9 @@ internal abstract class VersionCalculatorBase(
             commitSha: Context.CurrentCommit.Sha,
             commitShortSha: shortSha,
             commitDate: Context.CurrentCommit.When,
-            numberOfUnCommittedChanges: Context.NumberOfUncommittedChanges
+            numberOfUnCommittedChanges: Context.NumberOfUncommittedChanges,
+            otherMetadata: null,
+            commitSinceTagList: [.. commitLogs.Select(c => c.Sha)]
         );
     }
 }

--- a/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
@@ -12,7 +12,7 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
     /// <para>Creates a repo with a develop branch off main which is a single commit ahead of main branch</para>
     /// <para>Main will be tagged with the initial version before branching develop</para>
     /// </summary>
-    public BaseGitFlowRepositoryFixture(string initialVersion, string branchName = "main") :
+    public BaseGitFlowRepositoryFixture(string initialVersion, string branchName = MainBranch) :
         this(r => r.MakeATaggedCommit(initialVersion), branchName)
     {
     }
@@ -21,7 +21,7 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
     /// <para>Creates a repo with a develop branch off main which is a single commit ahead of main</para>
     /// <para>The initial setup actions will be performed before branching develop</para>
     /// </summary>
-    public BaseGitFlowRepositoryFixture(Action<IRepository> initialMainAction, string branchName = "main") :
+    public BaseGitFlowRepositoryFixture(Action<IRepository> initialMainAction, string branchName = MainBranch) :
         base(branchName) => SetupRepo(initialMainAction);
 
     private void SetupRepo(Action<IRepository> initialMainAction)

--- a/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
@@ -12,8 +12,8 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
     /// <para>Creates a repo with a develop branch off main which is a single commit ahead of main branch</para>
     /// <para>Main will be tagged with the initial version before branching develop</para>
     /// </summary>
-    public BaseGitFlowRepositoryFixture(string initialVersion, string branchName = MainBranch) :
-        this(r => r.MakeATaggedCommit(initialVersion), branchName)
+    public BaseGitFlowRepositoryFixture(string initialVersion, string branchName = MainBranch, bool deleteOnDispose = true) :
+        this(r => r.MakeATaggedCommit(initialVersion), branchName, deleteOnDispose)
     {
     }
 
@@ -21,8 +21,8 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
     /// <para>Creates a repo with a develop branch off main which is a single commit ahead of main</para>
     /// <para>The initial setup actions will be performed before branching develop</para>
     /// </summary>
-    public BaseGitFlowRepositoryFixture(Action<IRepository> initialMainAction, string branchName = MainBranch) :
-        base(branchName) => SetupRepo(initialMainAction);
+    public BaseGitFlowRepositoryFixture(Action<IRepository> initialMainAction, string branchName = MainBranch, bool deleteOnDispose = true) :
+        base(branchName, deleteOnDispose) => SetupRepo(initialMainAction);
 
     private void SetupRepo(Action<IRepository> initialMainAction)
     {
@@ -33,6 +33,6 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
         initialMainAction(Repository);
 
         Commands.Checkout(Repository, Repository.CreateBranch("develop"));
-        Repository.MakeACommit();
+        Repository.MakeACommit("First commit on new branch 'develop'");
     }
 }

--- a/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
@@ -1,3 +1,3 @@
 namespace GitVersion.Testing;
 
-public class EmptyRepositoryFixture(string branchName = RepositoryFixtureBase.MainBranch) : RepositoryFixtureBase(path => CreateNewRepository(path, branchName));
+public class EmptyRepositoryFixture(string branchName = RepositoryFixtureBase.MainBranch, bool deleteOnDispose = true) : RepositoryFixtureBase(path => CreateNewRepository(path, branchName), deleteOnDispose);

--- a/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/EmptyRepositoryFixture.cs
@@ -1,3 +1,3 @@
 namespace GitVersion.Testing;
 
-public class EmptyRepositoryFixture(string branchName = "main") : RepositoryFixtureBase(path => CreateNewRepository(path, branchName));
+public class EmptyRepositoryFixture(string branchName = RepositoryFixtureBase.MainBranch) : RepositoryFixtureBase(path => CreateNewRepository(path, branchName));

--- a/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
@@ -12,7 +12,7 @@ public class RemoteRepositoryFixture : RepositoryFixtureBase
     public RemoteRepositoryFixture(Func<string, Repository> builder)
         : base(builder) => LocalRepositoryFixture = CloneRepository();
 
-    public RemoteRepositoryFixture(string branchName = "main")
+    public RemoteRepositoryFixture(string branchName = MainBranch)
         : this(path => CreateNewRepository(path, branchName, 5))
     {
     }

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -9,6 +9,9 @@ namespace GitVersion.Testing;
 /// </summary>
 public abstract class RepositoryFixtureBase : IDisposable
 {
+    public const string MainBranch = "master";
+    public const bool DeleteOnDispose = true;
+
     protected RepositoryFixtureBase(Func<string, Repository> repositoryBuilder)
         : this(repositoryBuilder(FileSystemHelper.Path.GetRepositoryTempPath()))
     {
@@ -47,16 +50,23 @@ public abstract class RepositoryFixtureBase : IDisposable
         Repository.Dispose();
         var directoryPath = FileSystemHelper.Path.GetFileName(RepositoryPath);
 
-        try
+        if (DeleteOnDispose)
         {
-            Console.WriteLine("Cleaning up repository path at {0}", directoryPath);
-            FileSystemHelper.Directory.DeleteDirectory(RepositoryPath);
-            Console.WriteLine("Cleaned up repository path at {0}", directoryPath);
+            try
+            {
+                Console.WriteLine("Cleaning up repository path at {0}", directoryPath);
+                FileSystemHelper.Directory.DeleteDirectory(RepositoryPath);
+                Console.WriteLine("Cleaned up repository path at {0}", directoryPath);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed to clean up repository path at {0}. Received exception: {1}", directoryPath, e.Message);
+                // throw;
+            }
         }
-        catch (Exception e)
+        else
         {
-            Console.WriteLine("Failed to clean up repository path at {0}. Received exception: {1}", directoryPath, e.Message);
-            // throw;
+            Console.WriteLine("Leaving repository path at {0} intact", directoryPath);
         }
 
         this.SequenceDiagram.End();
@@ -73,7 +83,7 @@ public abstract class RepositoryFixtureBase : IDisposable
         SequenceDiagram.Destroy(branch);
     }
 
-    public static void Init(string path, string branchName = "main") => GitTestExtensions.ExecuteGitCmd($"init {path} -b {branchName}", ".");
+    public static void Init(string path, string branchName = MainBranch) => GitTestExtensions.ExecuteGitCmd($"init {path} -b {branchName}", ".");
 
     public string MakeATaggedCommit(string tag)
     {

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -10,19 +10,20 @@ namespace GitVersion.Testing;
 public abstract class RepositoryFixtureBase : IDisposable
 {
     public const string MainBranch = "master";
-    public const bool DeleteOnDispose = true;
+    private readonly bool deleteOnDispose;
 
-    protected RepositoryFixtureBase(Func<string, Repository> repositoryBuilder)
-        : this(repositoryBuilder(FileSystemHelper.Path.GetRepositoryTempPath()))
+    protected RepositoryFixtureBase(Func<string, Repository> repositoryBuilder, bool deleteOnDispose = true)
+        : this(repositoryBuilder(FileSystemHelper.Path.GetRepositoryTempPath()), deleteOnDispose)
     {
     }
 
-    protected RepositoryFixtureBase(Repository repository)
+    protected RepositoryFixtureBase(Repository repository, bool deleteOnDispose = true)
     {
         SequenceDiagram = new();
         Repository = repository.ShouldNotBeNull();
         Repository.Config.Set("user.name", "Test");
         Repository.Config.Set("user.email", "test@email.com");
+        this.deleteOnDispose = deleteOnDispose;
     }
 
     public Repository Repository { get; }
@@ -50,7 +51,7 @@ public abstract class RepositoryFixtureBase : IDisposable
         Repository.Dispose();
         var directoryPath = FileSystemHelper.Path.GetFileName(RepositoryPath);
 
-        if (DeleteOnDispose)
+        if (deleteOnDispose)
         {
             try
             {

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -9,7 +9,7 @@ namespace GitVersion.Testing;
 /// </summary>
 public abstract class RepositoryFixtureBase : IDisposable
 {
-    public const string MainBranch = "master";
+    public const string MainBranch = "main";
     private readonly bool deleteOnDispose;
 
     protected RepositoryFixtureBase(Func<string, Repository> repositoryBuilder, bool deleteOnDispose = true)

--- a/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
+++ b/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
@@ -10,6 +10,7 @@ public class SequenceDiagram
 {
     private readonly Dictionary<string, string> participants = [];
     private readonly StringBuilder diagramBuilder;
+    private readonly CommitLabelGenerator commitLabelGenerator = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="T:SequenceDiagram"/> class.
@@ -125,4 +126,8 @@ public class SequenceDiagram
     /// returns the plantUML representation of the Sequence Diagram
     /// </summary>
     public string GetDiagram() => this.diagramBuilder.ToString();
+
+    public string GetOrAddLabel(string? key) => commitLabelGenerator.GetOrAdd(key ?? "N/A");
+
+    public string GetOrAddSourceLabel(string? key) => commitLabelGenerator.GetOrAddRoot(key ?? "N/A");
 }

--- a/src/GitVersion.Testing/GitTestExtensions.cs
+++ b/src/GitVersion.Testing/GitTestExtensions.cs
@@ -38,9 +38,9 @@ public static class GitTestExtensions
             Generate.SignatureNow(), Generate.SignatureNow());
     }
 
-    public static Tag MakeATaggedCommit(this IRepository repository, string tag)
+    public static Tag MakeATaggedCommit(this IRepository repository, string tag, string? commitMessage = null)
     {
-        var commit = repository.MakeACommit();
+        var commit = repository.MakeACommit(commitMessage);
         var existingTag = repository.Tags.SingleOrDefault(t => t.FriendlyName == tag);
         return existingTag ?? repository.Tags.Add(tag, commit);
     }

--- a/src/GitVersion.Testing/Helpers/CommitLabelGenerator.cs
+++ b/src/GitVersion.Testing/Helpers/CommitLabelGenerator.cs
@@ -1,0 +1,87 @@
+namespace GitVersion.Testing.Helpers;
+
+/// <summary>
+/// Generates unique uppercase letter labels (A, B, ..., Z, AA, AB, etc.) for unique keys.
+/// </summary>
+public class CommitLabelGenerator
+{
+    private readonly Dictionary<string, string> lookup = new();
+
+    /// <summary>
+    /// Gets the label assigned to the specified key, creating a new one if not already assigned.
+    /// </summary>
+    public string GetOrAdd(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("SHA cannot be empty or whitespace.", nameof(key));
+        }
+
+        if (key == "N/A")
+        {
+            return "N/A";
+        }
+
+        if (lookup.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        var label = GetNextLabel();
+        lookup[key] = label;
+        return label;
+    }
+
+    public string GetOrAddRoot(string? versionSourceSha)
+    {
+        if (string.IsNullOrWhiteSpace(versionSourceSha))
+        {
+            throw new ArgumentException("Version source SHA cannot be empty or whitespace.", nameof(versionSourceSha));
+        }
+
+        if (versionSourceSha == "N/A")
+        {
+            return "N/A";
+        }
+
+        return GetOrAddRootPrivate(versionSourceSha);
+    }
+
+    private string GetOrAddRootPrivate(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("SHA cannot be empty or whitespace.", nameof(key));
+        }
+
+        if (key == "N/A")
+        {
+            return "N/A";
+        }
+
+        if (lookup.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        var label = GetNextRootLabel();
+        lookup[key] = label;
+        return label;
+    }
+
+    private string GetNextRootLabel() => "Root" + GetNextLabel();
+
+    private string GetNextLabel()
+    {
+        var index = lookup.Count;
+        var label = string.Empty;
+
+        do
+        {
+            label = (char)('A' + (index % 26)) + label;
+            index = (index / 26) - 1;
+        } while (index >= 0);
+
+        return label;
+    }
+}


### PR DESCRIPTION
## Description

Extend the GitFlowComplexExample to document unexpected post merge and rebase behaviour.
Fix the integration test fixtures so they can accept a "master" main branch instead of hardcoding "main".

## Related Issue

## Motivation and Context

I have been really struggling to get GitVersion to work post the v6 changes so I checked out the repo to run through sample scenarios to try and adapt but I either need more documentation to understand what the new behaviour is or the new behaviour is possibly unintended.

Rather than just rely on the Integration tests with injected configuration, I wanted to be able to revisit the repository that is created by the integration test and I observe 
1. Inconsistent behaviour between the TestFixture and when running dotnet-gitversion against GitVersion.yml output by the test fixture (problem number 1 documented in the penultimate commit in the amended GitFlowComplexExample - I set this assertion to pass but behaviour in the test does not match behaviour observed with dotnet-gitversion 6.3.0 and a persisted GitVersion.yml)
2. Consistent but unanticipated behaviour on a rebase (problem number 2 which is the current failure in the amended GitFlowComplexExample)

## How Has This Been Tested?

GitFlowComplexExample 

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/005e31bf-02a5-4b9a-9d39-be66de6b4b66)


## Checklist:

This is a WIP proposal to document a problem & ask for help; if I get direction I'm happy to update the PR as offered/advised.

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
