### PR TITLE
Fix Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,9 +31,8 @@
         <AnalysisLevel>latest</AnalysisLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-        <IsUnitTestProject>false</IsUnitTestProject>
         <DisableApiAnalyzers>false</DisableApiAnalyzers>
-        <IsUnitTestProject Condition="$(MSBuildProjectName.EndsWith('.Tests')) or $(MSBuildProjectName.EndsWith('.Testing'))">true</IsUnitTestProject>
+        <IsUnitTestProject Condition="'$(MSBuildProjectName)' != '' and ($([System.String]::Copy($(MSBuildProjectName)).EndsWith('.Tests')) Or  $([System.String]::Copy($(MSBuildProjectName)).EndsWith('.Testing')))">true</IsUnitTestProject>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -50,7 +49,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
-    <ItemGroup Condition=" '$(IsUnitTestProject)' == 'false' and $(MSBuildProjectName.EndsWith('.Schema')) == 'false' and '$(DisableApiAnalyzers)' == 'false'">
+    <ItemGroup Condition=" '$(IsUnitTestProject)' == 'false' and '$(MSBuildProjectName)' != '' and $([System.String]::Copy($(MSBuildProjectName)).EndsWith('.Schema')) == 'false' and '$(DisableApiAnalyzers)' == 'false'">
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -76,7 +75,7 @@
         </PackageReference>
 
     </ItemGroup>
-    <ItemGroup Condition=" '$(IsUnitTestProject)' == 'true' and $(MSBuildProjectName.EndsWith('.Tests'))">
+    <ItemGroup Condition=" '$(IsUnitTestProject)' == 'true' and $([System.String]::Copy($(MSBuildProjectName)).EndsWith('.Tests'))">
         <ProjectReference Include="..\GitVersion.Testing\GitVersion.Testing.csproj"/>
 
         <Using Include="GitVersion.Testing"/>


### PR DESCRIPTION
## Description

Fix IsUnitTestProject (cannot be specified twice) and MSBuildProjectName.EndsWith (was invalid syntax so NCrunch was broken and VS was padlock unhappy if tolerant)

## Related Issue

## Motivation and Context

VS2022 wasn't happy and nCrunch wasn't building at all.

## How Has This Been Tested?

With the fix VisualStudio is happy again, but unfortunately NCrunch still isn't and that was really what I was aiming for. I'll propose the VisualStudio fix at least for now. If you know how to fix NCrunch please do let me know. I could see quite a few years ago there were some Issues raised to get NCrunch running again so hopefully someone's in the know?

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9430f65e-6121-4548-b45d-b0f9f6e3eebb)

## Checklist:

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
