### PR TITLE
Format the commitMsg so it doesn't break PlantUml

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/RepositoryFixtureExtensions.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RepositoryFixtureExtensions.cs
@@ -13,8 +13,9 @@ internal static class RepositoryFixtureExtensions
 
         var participant = GetParticipant(fixture.Repository.Head.FriendlyName);
         if (participant != null)
-            diagramBuilder?.AppendLineFormat("{0} -> {0}: Commit '{1}'", participant, commitMsg);
-        return;
+        {
+            AddTheCommitMessage(fixture, commitMsg, diagramBuilder, participant);
+        }
 
         string? GetParticipant(string participantName) =>
             (string?)typeof(SequenceDiagram).GetMethod("GetParticipant", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -22,5 +23,18 @@ internal static class RepositoryFixtureExtensions
                 [
                     participantName
                 ]);
+    }
+
+    private static void AddTheCommitMessage(RepositoryFixtureBase fixture, string commitMsg, StringBuilder? diagramBuilder, string participant)
+    {
+        if (commitMsg.Length < 40)
+        {
+            diagramBuilder?.AppendLineFormat("{0} -> {0}: Commit '{1}'", participant, commitMsg);
+        }
+        else
+        {
+            var formattedCommitMsg = string.Join(System.Environment.NewLine, $"Commit '{commitMsg}'".SplitIntoLines(60));
+            fixture.SequenceDiagram.NoteOver(formattedCommitMsg, participant);
+        }
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/StringExtensions.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/StringExtensions.cs
@@ -1,0 +1,50 @@
+namespace GitVersion.Core.Tests.IntegrationTests;
+
+public static class StringExtensions
+{
+    public static IEnumerable<string> SplitIntoLines(this string str, int maxLineLength)
+    {
+        if (string.IsNullOrEmpty(str)) yield break;
+
+        foreach (var line in SplitByNewlines(str))
+        {
+            foreach (var wrapped in WrapWithWordBoundaries(line, maxLineLength))
+            {
+                yield return wrapped;
+            }
+        }
+    }
+
+    private static IEnumerable<string> SplitByNewlines(string str)
+        => str.Split(["\r\n", "\n"], StringSplitOptions.None);
+
+    private static IEnumerable<string> WrapWithWordBoundaries(string line, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            yield return string.Empty;
+            yield break;
+        }
+
+        var index = 0;
+        while (index < line.Length)
+        {
+            var wrapAt = GetWrapIndex(line, index, maxLength);
+            yield return line.Substring(index, wrapAt - index).TrimEnd();
+            index = wrapAt;
+        }
+    }
+
+    private static int GetWrapIndex(string line, int start, int maxLength)
+    {
+        var remaining = line.Length - start;
+        if (remaining <= maxLength)
+        {
+            return line.Length;
+        }
+
+        var end = start + maxLength;
+        var lastBreak = line.LastIndexOfAny([' ', '-'], end - 1, maxLength);
+        return lastBreak > start ? lastBreak + 1 : end;
+    }
+}


### PR DESCRIPTION
## Description

Test scenarios that generate UML output break PlantUml when the commit msg doesn't play nice.

## Related Issue

#4585

## Motivation and Context

I want to be able to copy paste from the scenario output without having to tidy upthe output.

## How Has This Been Tested?

Refer to screenshot following. If you're interested I'll add test coverage of added code.

## Screenshots (if appropriate):

Instead of this 

![image](https://github.com/user-attachments/assets/3a398426-ad76-4652-bd20-5acf19a32df2)

Get this

![image](https://github.com/user-attachments/assets/25521e5e-3147-431b-98e6-60a13932daad)

## Checklist:

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
