### PR TITLE
Set System.Collections.Immutable as a private asset

### DIFF
--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -17,9 +17,9 @@
         <PackageReference Include="Microsoft.Build.Utilities.Core" />
         <PackageReference Include="Microsoft.Win32.Registry" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="System.Collections.Immutable" />
         <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All"/>
-        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the order in which `System.Collections.Immutable` is referenced to ensure that it is set as a private asset

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/GitTools/GitVersion/issues/4593

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!--- Drag and drop screenshots here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
