### PR TITLE
More Regexes for cache

### DIFF
--- a/src/GitVersion.Core/Core/RegexPatterns.cs
+++ b/src/GitVersion.Core/Core/RegexPatterns.cs
@@ -29,6 +29,7 @@ internal static partial class RegexPatterns
                 [Common.SwitchArgumentRegexPattern] = Common.SwitchArgumentRegex,
                 [Common.ObscurePasswordRegexPattern] = Common.ObscurePasswordRegex,
                 [Common.ExpandTokensRegexPattern] = Common.ExpandTokensRegex,
+                [Common.SanitizeNameRegexPattern] = Common.SanitizeNameRegex,
                 [Configuration.DefaultTagPrefixRegexPattern] = Configuration.DefaultTagPrefixRegex,
                 [Configuration.DefaultVersionInBranchRegexPattern] = Configuration.DefaultVersionInBranchRegex,
                 [Configuration.MainBranchRegexPattern] = Configuration.MainBranchRegex,
@@ -50,6 +51,7 @@ internal static partial class RegexPatterns
                 [Output.AssemblyVersionRegexPattern] = Output.AssemblyVersionRegex,
                 [Output.AssemblyInfoVersionRegexPattern] = Output.AssemblyInfoVersionRegex,
                 [Output.AssemblyFileVersionRegexPattern] = Output.AssemblyFileVersionRegex,
+                [Output.SanitizeAssemblyInfoRegexPattern] = Output.SanitizeAssemblyInfoRegex,
                 [Output.CsharpAssemblyAttributeRegexPattern] = Output.CsharpAssemblyAttributeRegex,
                 [Output.FsharpAssemblyAttributeRegexPattern] = Output.FsharpAssemblyAttributeRegex,
                 [Output.VisualBasicAssemblyAttributeRegexPattern] = Output.VisualBasicAssemblyAttributeRegex,
@@ -84,6 +86,9 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string ExpandTokensRegexPattern = """{((env:(?<envvar>\w+))|(?<member>\w+))(\s+(\?\?)??\s+((?<fallback>\w+)|"(?<fallback>.*)"))??}""";
 
+        [StringSyntax(StringSyntaxAttribute.Regex, Options)]
+        internal const string SanitizeNameRegexPattern = "[^a-zA-Z0-9-]";
+
         [GeneratedRegex(SwitchArgumentRegexPattern, Options)]
         public static partial Regex SwitchArgumentRegex();
 
@@ -92,6 +97,9 @@ internal static partial class RegexPatterns
 
         [GeneratedRegex(ExpandTokensRegexPattern, Options)]
         public static partial Regex ExpandTokensRegex();
+
+        [GeneratedRegex(SanitizeNameRegexPattern, Options)]
+        public static partial Regex SanitizeNameRegex();
     }
 
     internal static partial class Configuration
@@ -231,6 +239,9 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string SanitizeParticipantRegexPattern = "[^a-zA-Z0-9]";
 
+        [StringSyntax(StringSyntaxAttribute.Regex)]
+        internal const string SanitizeAssemblyInfoRegexPattern = "[^0-9A-Za-z-.+]";
+
         [GeneratedRegex(AssemblyVersionRegexPattern, Options)]
         public static partial Regex AssemblyVersionRegex();
 
@@ -251,6 +262,9 @@ internal static partial class RegexPatterns
 
         [GeneratedRegex(SanitizeParticipantRegexPattern, Options)]
         public static partial Regex SanitizeParticipantRegex();
+
+        [GeneratedRegex(SanitizeAssemblyInfoRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
+        public static partial Regex SanitizeAssemblyInfoRegex();
     }
 
     internal static partial class VersionCalculation

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -110,7 +110,7 @@ internal static class ConfigurationExtensions
         return label;
     }
 
-    private static string EscapeInvalidCharacters(string groupValue) => groupValue.RegexReplace("[^a-zA-Z0-9-]", "-");
+    private static string EscapeInvalidCharacters(string groupValue) => groupValue.RegexReplace(RegexPatterns.Common.SanitizeNameRegexPattern, "-");
 
     public static (string GitDirectory, string WorkingTreeDirectory)? FindGitDir(this IFileSystem fileSystem, string? path)
     {

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using GitVersion.Configuration;
+using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion;
@@ -41,7 +42,7 @@ public class SemanticVersionFormatValues(SemanticVersion semver, IGitVersionConf
 
     public string? BranchName => semver.BuildMetaData.Branch;
 
-    public string? EscapedBranchName => semver.BuildMetaData.Branch?.RegexReplace("[^a-zA-Z0-9-]", "-");
+    public string? EscapedBranchName => semver.BuildMetaData.Branch?.RegexReplace(RegexPatterns.Common.SanitizeNameRegexPattern, "-");
 
     public string? Sha => semver.BuildMetaData.Sha;
 

--- a/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
@@ -1,4 +1,5 @@
 using GitVersion.Configuration;
+using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.OutputVariables;
@@ -79,7 +80,8 @@ internal sealed class VariableProvider(IEnvironment environment) : IVariableProv
         {
             try
             {
-                formattedString = formatString.FormatWith(source, this.environment).RegexReplace("[^0-9A-Za-z-.+]", "-");
+                formattedString = formatString.FormatWith(source, this.environment)
+                                              .RegexReplace(RegexPatterns.Output.SanitizeAssemblyInfoRegexPattern, "-");
             }
             catch (ArgumentException exception)
             {


### PR DESCRIPTION
## Description

Happened across a few more regexes for cache.

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Checklist:

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
