### PR TITLE
updates Alpine to 3.21 and Fedora to 41 in Docker image constants and…

### DIFF
--- a/build/.run/Artifacts DotnetTool Test.run.xml
+++ b/build/.run/Artifacts DotnetTool Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts DotnetTool Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsDotnetToolTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.20" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsDotnetToolTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.21" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts MsBuildCore Test.run.xml
+++ b/build/.run/Artifacts MsBuildCore Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts MsBuildCore Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsMsBuildCoreTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.20" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsMsBuildCoreTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.21" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Native Test.run.xml
+++ b/build/.run/Artifacts Native Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Native Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsNativeTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.20" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsNativeTest --arch=amd64 --dotnet_version=8.0 --docker_distro=alpine.3.21" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Prepare.run.xml
+++ b/build/.run/Artifacts Prepare.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Prepare" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsPrepare --dotnet_version=8.0 --docker_distro=alpine.3.20" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsPrepare --dotnet_version=8.0 --docker_distro=alpine.3.21" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/.run/Artifacts Test.run.xml
+++ b/build/.run/Artifacts Test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artifacts Test" type="DotNetProject" factoryName=".NET Project" folderName="Artifacts">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../run/artifacts" />
-    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsTest --dotnet_version=8.0 --docker_distro=alpine.3.20" />
+    <option name="PROGRAM_PARAMETERS" value="--target=ArtifactsTest --dotnet_version=8.0 --docker_distro=alpine.3.21" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -24,11 +24,10 @@ public static class Constants
     public const string GitHubContainerRegistry = "ghcr.io";
     public static readonly string[] DockerRegistries = [DockerHub, GitHub];
 
-    public const string AlpineLatest = "alpine.3.20";
+    public const string AlpineLatest = "alpine.3.21";
     public const string CentosStreamLatest = "centos.stream.9";
     public const string DebianLatest = "debian.12";
-    public const string FedoraLatest = "fedora.40";
-    public const string Ubuntu2004 = "ubuntu.20.04";
+    public const string FedoraLatest = "fedora.41";
     public const string Ubuntu2204 = "ubuntu.22.04";
     public const string Ubuntu2404 = "ubuntu.24.04";
 
@@ -40,7 +39,6 @@ public static class Constants
         CentosStreamLatest,
         DebianLatest,
         FedoraLatest,
-        Ubuntu2004,
         Ubuntu2204,
         Ubuntu2404
     ];


### PR DESCRIPTION
This pull request updates the Docker distribution versions used across multiple project configurations and constants, ensuring compatibility with newer versions. The primary focus is on upgrading Alpine and Fedora versions, and removing an outdated Ubuntu version.

### Updates to Docker Distribution Versions:

* Updated the Alpine version from `alpine.3.20` to `alpine.3.21` in multiple `.run.xml` configuration files to align with the latest release:
  - `build/.run/Artifacts DotnetTool Test.run.xml`
  - `build/.run/Artifacts MsBuildCore Test.run.xml`
  - `build/.run/Artifacts Native Test.run.xml`
  - `build/.run/Artifacts Prepare.run.xml`
  - `build/.run/Artifacts Test.run.xml`

* Updated the `AlpineLatest` constant in `build/common/Utilities/Constants.cs` to `alpine.3.21` for consistency across the codebase.

### Removal of Deprecated Versions:

* Removed the `Ubuntu2004` constant from `build/common/Utilities/Constants.cs` as it is no longer required.

* Updated the `FedoraLatest` constant to `fedora.41` in `build/common/Utilities/Constants.cs`.… run configs, remove deprecated ubuntu.20.04