### PR TITLE
Adding Merge Commit Version Strategy

### DIFF
--- a/src/GitVersion.Core/Configuration/ConfigurationConstants.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationConstants.cs
@@ -19,7 +19,8 @@ internal static class ConfigurationConstants
         VersionStrategies.MergeMessage,
         VersionStrategies.TaggedCommit,
         VersionStrategies.TrackReleaseBranches,
-        VersionStrategies.VersionInBranchName
+        VersionStrategies.VersionInBranchName,
+        VersionStrategies.MergeCommit
     ];
     public const string DefaultAssemblyInformationalFormat = "{InformationalVersion}";
     public const string DefaultCommitDateFormat = "yyyy-MM-dd";

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -680,6 +680,7 @@ GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.ConfiguredNextVersion = 2 -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.Fallback = 1 -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.Mainline = 64 -> GitVersion.VersionCalculation.VersionStrategies
+GitVersion.VersionCalculation.VersionStrategies.MergeCommit = 128 -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.MergeMessage = 4 -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.None = 0 -> GitVersion.VersionCalculation.VersionStrategies
 GitVersion.VersionCalculation.VersionStrategies.TaggedCommit = 8 -> GitVersion.VersionCalculation.VersionStrategies

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeCommitVersionStrategy.cs
@@ -1,0 +1,97 @@
+using GitVersion.Common;
+using GitVersion.Configuration;
+using GitVersion.Core;
+using GitVersion.Extensions;
+using GitVersion.Git;
+using GitVersion.Logging;
+
+namespace GitVersion.VersionCalculation;
+
+/// <summary>
+/// Version is extracted from older merge commits.
+/// BaseVersionSource is the commit where the message was found.
+/// </summary>
+internal sealed class MergeCommitVersionStrategy(ILog log, Lazy<GitVersionContext> contextLazy,
+    IRepositoryStore repositoryStore, IIncrementStrategyFinder incrementStrategyFinder,     IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder,
+    ITaggedSemanticVersionRepository taggedSemanticVersionRepository
+    )
+    : IVersionStrategy
+{
+    private readonly ILog log = log.NotNull();
+    private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
+    private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
+    private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
+    private readonly IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder = effectiveBranchConfigurationFinder.NotNull();
+    private readonly ITaggedSemanticVersionRepository taggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
+
+    private GitVersionContext Context => contextLazy.Value;
+
+    public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
+    {
+        configuration.NotNull();
+
+        if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.MergeCommit))
+        {
+            yield break;
+        }
+
+        var taggedCommits = this.taggedSemanticVersionRepository.GetTaggedSemanticVersions(
+            tagPrefix: Context.Configuration.TagPrefixPattern,
+            format: Context.Configuration.SemanticVersionFormat,
+            ignore: Context.Configuration.Ignore
+        );
+        var previousVersion = new SemanticVersion(0, 0, 0);
+
+        // Must Loop In Reverse To Ensure Correct Version Calculation
+        foreach (var commit in configuration.Value.Ignore.Filter(Context.CurrentBranchCommits.ToArray()).Reverse())
+        {
+            if (taggedCommits.Contains(commit))
+            {
+                this.log.Debug($"Found tagged commit {commit}, adjusting previous version.");
+                previousVersion = taggedCommits[commit].First().Value;
+            }
+            if (!commit.IsMergeCommit())
+            {
+                continue;
+            }
+
+            // Using Merge Message Since The Formats Are Identical
+            if (!MergeMessage.TryParse(commit, Context.Configuration, out var mergeMessage))
+            {
+                continue;
+            }
+
+            this.log.Info($"Found commit [{commit}] matching merge message format: {mergeMessage.FormatName}");
+
+            var currentBranch = this.repositoryStore.GetTargetBranch(mergeMessage.MergedBranch!.Friendly);
+            var branchConfiguration = this.effectiveBranchConfigurationFinder.GetConfigurations(currentBranch, Context.Configuration).First();
+            var baseVersionSource = this.repositoryStore.FindMergeBase(commit.Parents[0], commit.Parents[1]);
+
+            var label = branchConfiguration.Value.GetBranchSpecificLabel(mergeMessage.MergedBranch!.Friendly, "");
+            var increment = this.incrementStrategyFinder.DetermineIncrementedField(
+                    currentCommit: commit,
+                    baseVersionSource: baseVersionSource,
+                    shouldIncrement: true,
+                    configuration: branchConfiguration.Value,
+                    label: label
+                );
+
+            yield return new BaseVersion($"Merge Commit From '{mergeMessage.MergedBranch?.Friendly}'", previousVersion
+            )
+            {
+                Operator = new()
+                {
+                    Increment = increment,
+                    ForceIncrement = false,
+                    Label = label
+                }
+            };
+
+            previousVersion = previousVersion.Increment(
+                increment,
+                label,
+                true
+            );
+        }
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/VersionStrategies.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionStrategies.cs
@@ -10,5 +10,6 @@ public enum VersionStrategies
     TaggedCommit = 8,
     TrackReleaseBranches = 16,
     VersionInBranchName = 32,
-    Mainline = 64
+    Mainline = 64,
+    MergeCommit = 128
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I'm posting this as a draft to get eyes on it and see if it's something to continue working on or not. Fair Warning: It's been a long time since I've worked with C#, so likely something I'm missing here. There may be someone else that wants/needs to pick it up from here.

This is my attempt at introducing an alternative strategy for identifying the version based on version names after the merger. The strategy works by looping through all the commits, looking for merges and/or tags. If it finds a merge branch, it then uses the source branch name in collaboration with the branch configuration to determine the version that the branch should have generated.

If it finds a tag, it uses it for a reset to the current version. By doing this, it allows for situations where a tag is resetting the version and/or a branch was merged in that normally should have incremented the version, but it was unintentional or incorrect.

Given the merged commit history of:
- hotfix/a
- hotfix/b
- tag 1.0.0
- feature/c
- feature/d
- unstable/e
- tag 1.1.0

And the config of:
- hotfix: Patch
- feature: Minor
- unstable: Major

The version would be detected as:
- 0.1.1
- 0.1.2
- 1.0.0
- 1.1.0
- 1.2.0
- 2.0.0
- 1.1.0

Leaving you with a final version of 1.1.0.

## Related Issue

#4624
#4433

## Motivation and Context

I am working in an environment where there are over 90 team members all wanting to mark a feature or release as their own. This is creating a scenario where, many times, people are scratching their heads about what version a feature should go into or what version a release should be flagged. To circumvent this, I am trying to push to get Semantic Versioning adopted, but I need to be able to get the version post-merge, without any involvement from any of the developers requiring them to tag releases or similar. Once a branch is merged, the source branch name should dictate the new version name. By doing this, the developers need only be concerned with the basic rules of whether it's a feature or not, and of if it's backward compatible or not. 

## How Has This Been Tested?

I ran the changes against another project that has the same "post-merge" setup as discussed above. No automated testing has been done yet.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!--- Drag and drop screenshots here -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[ ] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
