### PR TITLE
GIT_BRANCH override supported on azure pipelines with gitversion 5.x

### DIFF
--- a/src/GitVersion.Core.Tests/BuildAgents/AzurePipelinesTests.cs
+++ b/src/GitVersion.Core.Tests/BuildAgents/AzurePipelinesTests.cs
@@ -80,4 +80,43 @@ public class AzurePipelinesTests : TestBase
         var logMessage = this.buildServer.GenerateSetVersionMessage(vars);
         logMessage.ShouldBe(logPrefix + expectedBuildNumber);
     }
+
+    [Test]
+    public void GetCurrentBranchShouldHandleBranches()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", $"refs/heads/{MainBranch}");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBe($"refs/heads/{MainBranch}");
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldHandleTags()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/tags/1.0.0");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldHandlePullRequests()
+    {
+        // Arrange
+        this.environment.SetEnvironmentVariable("BUILD_SOURCEBRANCH", "refs/pull/1/merge");
+
+        // Act
+        var result = this.buildServer.GetCurrentBranch(false);
+
+        // Assert
+        result.ShouldBe("refs/pull/1/merge");
+    }
 }

--- a/src/GitVersion.Core/BuildAgents/AzurePipelines.cs
+++ b/src/GitVersion.Core/BuildAgents/AzurePipelines.cs
@@ -21,7 +21,24 @@ public class AzurePipelines : BuildAgentBase
         $"##vso[task.setvariable variable=GitVersion.{name};isOutput=true]{value}"
     };
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {
+        var gitBranch = Environment.GetEnvironmentVariable("GIT_BRANCH");
+        if (gitBranch is not null)
+            return gitBranch;
+
+        var sourceBranch = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+
+        // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+        // BUILD_SOURCEBRANCH must be used only for "real" branches, not for tags.
+        // Azure Pipelines sets BUILD_SOURCEBRANCH to refs/tags/<tag> when the pipeline is triggered for a tag.
+        if (sourceBranch?.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return null;
+        }
+
+        return sourceBranch;
+    }
 
     public override bool PreventFetch() => true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added support for `GIT_BRANCH` environment variable in Azure pipeline builds with gitversion 5.x

## Related Issue

#4662 

## Motivation and Context

Solves multi-repo build situations on azure pipelines without being forced to upgrade to gitversion 6.x,
Upgrading to gitversion 6.x breaks the versionning locally on Visual Studio (Windows).

## How Has This Been Tested?

Tested on azure by adding the env variable `GIT_BRANCH` as follows:

```
- task: DotNetCoreCLI@2
  displayName: 'Build project 1'
  env:
     GIT_BRANCH: '${{parameters.SpotBranch}}'
  ...
```

## Screenshots (if appropriate):


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[ x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[x ] I have added tests to cover my changes.
* \[x ] All new and existing tests passed.
