### PR TITLE
Reduce memory usage by caching commits on their sha hash

### DIFF
--- a/src/GitVersion.LibGit2Sharp/Git/Branch.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Branch.cs
@@ -10,16 +10,18 @@ internal sealed class Branch : IBranch
 
     private readonly LibGit2Sharp.Branch innerBranch;
 
-    internal Branch(LibGit2Sharp.Branch branch, LibGit2Sharp.Diff diff)
+    internal Branch(LibGit2Sharp.Branch branch, LibGit2Sharp.Diff diff, GitRepository repo)
     {
+        diff.NotNull();
+        repo.NotNull();
         this.innerBranch = branch.NotNull();
         Name = new(branch.CanonicalName);
 
         var commit = this.innerBranch.Tip;
-        Tip = commit is null ? null : new Commit(commit, diff);
+        Tip = commit is null ? null : repo.GetOrCreate(commit, diff);
 
         var commits = this.innerBranch.Commits;
-        Commits = new CommitCollection(commits, diff);
+        Commits = new CommitCollection(commits, diff, repo);
     }
 
     public ReferenceName Name { get; }

--- a/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/BranchCollection.cs
@@ -8,12 +8,14 @@ internal sealed class BranchCollection : IBranchCollection
     private readonly LibGit2Sharp.BranchCollection innerCollection;
     private readonly Lazy<IReadOnlyCollection<IBranch>> branches;
     private readonly Diff diff;
+    private readonly GitRepository repo;
 
-    internal BranchCollection(LibGit2Sharp.BranchCollection collection, Diff diff)
+    internal BranchCollection(LibGit2Sharp.BranchCollection collection, Diff diff, GitRepository repo)
     {
         this.innerCollection = collection.NotNull();
-        this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => new Branch(branch, diff))]);
+        this.branches = new Lazy<IReadOnlyCollection<IBranch>>(() => [.. this.innerCollection.Select(branch => repo.GetOrCreate(branch, diff))]);
         this.diff = diff.NotNull();
+        this.repo = repo.NotNull();
     }
 
     public IEnumerator<IBranch> GetEnumerator()
@@ -27,7 +29,7 @@ internal sealed class BranchCollection : IBranchCollection
         {
             name = name.NotNull();
             var branch = this.innerCollection[name];
-            return branch is null ? null : new Branch(branch, this.diff);
+            return branch is null ? null : this.repo.GetOrCreate(branch, this.diff);
         }
     }
 

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -14,10 +14,12 @@ internal sealed class Commit : GitObject, ICommit
     private readonly LibGit2Sharp.Commit innerCommit;
     private readonly LibGit2Sharp.Diff repoDiff;
 
-    internal Commit(LibGit2Sharp.Commit innerCommit, LibGit2Sharp.Diff repoDiff) : base(innerCommit)
+    internal Commit(LibGit2Sharp.Commit innerCommit, LibGit2Sharp.Diff repoDiff, GitRepository repo) : base(innerCommit)
     {
+        repoDiff.NotNull();
+        repo.NotNull();
         this.innerCommit = innerCommit.NotNull();
-        this.parentsLazy = new(() => innerCommit.Parents.Select(parent => new Commit(parent, repoDiff)).ToList());
+        this.parentsLazy = new(() => innerCommit.Parents.Select(parent => repo.GetOrCreate(parent, repoDiff)).ToList());
         When = innerCommit.Committer.When;
         this.repoDiff = repoDiff;
     }

--- a/src/GitVersion.LibGit2Sharp/Git/Tag.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Tag.cs
@@ -11,12 +11,14 @@ internal sealed class Tag : ITag
     private readonly LibGit2Sharp.Tag innerTag;
     private readonly Diff diff;
     private readonly Lazy<ICommit?> commitLazy;
+    private readonly GitRepository repo;
 
-    internal Tag(LibGit2Sharp.Tag tag, Diff diff)
+    internal Tag(LibGit2Sharp.Tag tag, Diff diff, GitRepository repo)
     {
         this.innerTag = tag.NotNull();
         this.commitLazy = new(PeeledTargetCommit);
         this.diff = diff.NotNull();
+        this.repo = repo.NotNull();
         Name = new(this.innerTag.CanonicalName);
     }
 
@@ -35,7 +37,7 @@ internal sealed class Tag : ITag
             target = annotation.Target;
         }
 
-        return target is LibGit2Sharp.Commit commit ? new Commit(commit, this.diff) : null;
+        return target is LibGit2Sharp.Commit commit ? this.repo.GetOrCreate(commit, this.diff) : null;
     }
 
     public override bool Equals(object? obj) => Equals(obj as ITag);

--- a/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/TagCollection.cs
@@ -6,10 +6,12 @@ internal sealed class TagCollection : ITagCollection
 {
     private readonly Lazy<IReadOnlyCollection<ITag>> tags;
 
-    internal TagCollection(LibGit2Sharp.TagCollection collection, LibGit2Sharp.Diff diff)
+    internal TagCollection(LibGit2Sharp.TagCollection collection, LibGit2Sharp.Diff diff, GitRepository repo)
     {
-        collection = collection.NotNull();
-        this.tags = new Lazy<IReadOnlyCollection<ITag>>(() => [.. collection.Select(tag => new Tag(tag, diff))]);
+        collection.NotNull();
+        diff.NotNull();
+        repo.NotNull();
+        this.tags = new Lazy<IReadOnlyCollection<ITag>>(() => [.. collection.Select(tag => repo.GetOrCreate(tag, diff))]);
     }
 
     public IEnumerator<ITag> GetEnumerator()


### PR DESCRIPTION
## Description
Reduce the amount of allocations of `Commit` instances.

## Related Issue
Fix #4680, Fix #4409

## Motivation and Context

After some investigation it turned out that a lot of commits are being re-created during the process of calculating the version.
By implementing a cache for the commits the overall memory consumption went from ~10GB to ~400MB.

## How Has This Been Tested?

The solution was tested by running the project again with the changes against the same repository resulting in less memory consumption as shown below.

The problem of the memory usage was internally reported on Linux environments and reproduced on Windows.
My machine has 64GB & 22 logical processors.

## Screenshots (if appropriate):

The CPU and Memory consumption before the change, peaking at ~10GB.
<img width="238" height="141" alt="before" src="https://github.com/user-attachments/assets/a3d8a87b-2c9e-4838-abc3-7790f5dfbe50" />
The CPU and Memory consumption after the change, peaking at ~400MB.
<img width="242" height="140" alt="after" src="https://github.com/user-attachments/assets/8328699a-2651-4595-8af3-e7c82048e644" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* \[ ] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[ ] All new and existing tests passed.
