### PR TITLE
[WIP] Provide version dropdown in docs

### DIFF
--- a/docs/input/_Navbar.cshtml
+++ b/docs/input/_Navbar.cshtml
@@ -3,11 +3,65 @@
     {
         Tuple.Create("Documentation", Context.GetLink("docs")),
         Tuple.Create("API", Context.GetLink("api")),
-        Tuple.Create("<i></i> 5.12.0", "/5.12.0/docs"),
     };
+
+    // Define a list of versions with their respective links and status (e.g., latest, EOL).
+    var VersionList = new List<(string Name, string Link, string Status, bool IsReleased)>
+    {
+        ("5.12", "/5.12.0/docs", "(EOL)", true),
+        ("6.0", "/6.0.0/docs", "", true),
+        ("6.1-6.3", "/", "(latest)", true),
+        ("main branch", "/dev/docs", "(unstable)", false),
+    };
+
+    // determine currently viewed version
+    var CurrentlyViewedVersion = VersionList.Last().Name;
+    @foreach (var version in VersionList)
+    {
+        if (Context.GetLink(Document).StartsWith(version.Link))
+        {
+            CurrentlyViewedVersion = version.Name;
+            break;
+        }
+    }
+
     foreach(Tuple<string, string> p in pages)
     {
         string active = Context.GetLink(Document).StartsWith(p.Item2) ? "active" : null;
         <li class="@active"><a href="@p.Item2">@Html.Raw(p.Item1)</a></li>
     }
+
+    <li class="dropdown">
+        <a href="javascript:void(0)" class="dropbtn">
+            Other Versions - v: @Html.Raw(@CurrentlyViewedVersion)
+            <span class="fa fa-caret-down"></span>
+        </a>
+        <div class="dropdown-content">
+            <dl>
+                <dt>Releases</dt>
+                @foreach (var version in VersionList)
+                {
+                    if (version.IsReleased)
+                    {
+                        <dd>
+                        <a href="@version.Link">@version.Name @version.Status</a>
+                        </dd>
+                    }
+                }
+            </dl>
+            <dl>
+                <dt>In Development</dt>
+                @foreach (var version in VersionList)
+                {
+                    if (!version.IsReleased)
+                    {
+                        <dd>
+                        <a href="@version.Link">@version.Name @version.Status</a>
+                        </dd>
+                    }
+                }
+            </dl>
+
+        </div>
+    </li>
 }

--- a/docs/input/assets/css/override.less
+++ b/docs/input/assets/css/override.less
@@ -259,3 +259,44 @@ main .col-sm-6 {
         flex-direction: column;
     }
 }
+
+.dropdown {
+  display: inline-block;
+  left: 550px;
+}
+
+/* Dropdown Button */
+.dropbtn {
+  padding: 16px;
+  border: none;
+  cursor: pointer;
+}
+
+/* Dropdown content (hidden by default) */
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 150px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+
+/* Links inside dropdown content */
+.dropdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {
+   background-color: #f1f1f1
+}
+
+/* Show the dropdown content on hover */
+.dropdown:hover .dropdown-content {
+  display: block;
+  padding: 12px 16px;
+}


### PR DESCRIPTION
## Description
This provides a dropdown in the docs on the right side to select the desired docs for a specific version.

## Related Issue
Resolves #4537

## Motivation and Context
A dropdown in the docs will improve the user experience and ease the understanding which version of the docs are currently viewed (see #4537).  
It also allows to switch between multiple versions but this needs more changes since the docs for all versions need to be published. Dropdown selection for versions is used very often in documentation (e.g. https://docs.python.org/3.14/) and the design is inspired by [ROS 2](https://docs.ros.org/en/kilted/index.html)

## How Has This Been Tested?
By running the commands in a devcontainer that are provided in the [docs subfolder](https://github.com/GitTools/GitVersion/tree/main/docs). Browsing the docs was tested with Firefox under Linux.

## Screenshots (if appropriate):
<img width="1168" height="273" alt="Header" src="https://github.com/user-attachments/assets/c1e8b3b0-952c-4c10-ae2c-5e68bca7cc75" />

<img width="669" height="454" alt="Header_dropdown" src="https://github.com/user-attachments/assets/b22a4fae-dcce-4a16-bab6-1d13ece93f16" />

<img width="1462" height="387" alt="header_documentation" src="https://github.com/user-attachments/assets/aaf45f11-ff2f-4f38-ad2f-8e8c30c49c35" />

<img width="1532" height="678" alt="header_api" src="https://github.com/user-attachments/assets/ec06688d-674e-4345-a51a-6a44f627f811" />

## Checklist:
* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
