### PR TITLE
refactor(serializer): utilize source-generated JSON context for seria…

### DIFF
--- a/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using System.Text.Encodings.Web;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 
@@ -9,8 +8,7 @@ internal class VersionVariableSerializer(IFileSystem fileSystem) : IVersionVaria
 {
     public static GitVersionVariables FromJson(string json)
     {
-        var serializeOptions = JsonSerializerOptions();
-        var variablePairs = JsonSerializer.Deserialize<Dictionary<string, string>>(json, serializeOptions);
+        var variablePairs = JsonSerializer.Deserialize(json, VersionVariablesJsonContext.Custom.DictionaryStringString);
         return FromDictionary(variablePairs);
     }
 
@@ -25,9 +23,7 @@ internal class VersionVariableSerializer(IFileSystem fileSystem) : IVersionVaria
             propertyInfo?.SetValue(variables, ChangeType(value, propertyInfo.PropertyType));
         }
 
-        var serializeOptions = JsonSerializerOptions();
-
-        return JsonSerializer.Serialize(variables, serializeOptions);
+        return JsonSerializer.Serialize(variables, VersionVariablesJsonContext.Custom.VersionVariablesJsonModel);
     }
 
     public GitVersionVariables FromFile(string filePath)
@@ -93,8 +89,6 @@ internal class VersionVariableSerializer(IFileSystem fileSystem) : IVersionVaria
         var json = ToJson(gitVersionVariables);
         fileSystem.File.WriteAllText(filePath, json);
     }
-
-    private static JsonSerializerOptions JsonSerializerOptions() => new() { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Converters = { new VersionVariablesJsonStringConverter() } };
 
     private static object? ChangeType(object? value, Type type)
     {

--- a/src/GitVersion.Output/Serializer/VersionVariablesJsonContext.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariablesJsonContext.cs
@@ -1,0 +1,18 @@
+using System.Text.Encodings.Web;
+
+namespace GitVersion.OutputVariables;
+
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    Converters = [typeof(VersionVariablesJsonStringConverter)])]
+[JsonSerializable(typeof(VersionVariablesJsonModel))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class VersionVariablesJsonContext : JsonSerializerContext
+{
+    public static VersionVariablesJsonContext Custom => field ??= new VersionVariablesJsonContext(
+        new JsonSerializerOptions(Default.Options)
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        });
+}

--- a/src/GitVersion.Output/Serializer/VersionVariablesJsonStringConverter.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariablesJsonStringConverter.cs
@@ -31,5 +31,11 @@ internal class VersionVariablesJsonStringConverter : JsonConverter<string>
         writer.WriteStringValue(value);
     }
 
+    public override string ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.GetString() ?? "";
+
+    public override void WriteAsPropertyName(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        => writer.WritePropertyName(value);
+
     public override bool HandleNull => true;
 }


### PR DESCRIPTION
This pull request refactors the JSON serialization and deserialization logic for `GitVersionVariables` by moving from manual `JsonSerializerOptions` setup to using a source-generated context (`VersionVariablesJsonContext`). This change improves performance, maintainability, and type safety. Additionally, custom property name handling is added for JSON string conversion.

**Serialization improvements:**

* Replaced manual `JsonSerializerOptions` configuration with the source-generated `VersionVariablesJsonContext` for both serialization and deserialization in `VersionVariableSerializer`. [[1]](diffhunk://#diff-144a227c720f42a596f71df4b58e23c92f96d087061aedc9eb0a52d986307eafL12-R11) [[2]](diffhunk://#diff-144a227c720f42a596f71df4b58e23c92f96d087061aedc9eb0a52d986307eafL28-R26) [[3]](diffhunk://#diff-144a227c720f42a596f71df4b58e23c92f96d087061aedc9eb0a52d986307eafL97-L98)
* Introduced the new `VersionVariablesJsonContext` partial class, configuring it for indented output, custom converters, and relaxed JSON escaping.

**Custom converter enhancements:**

* Added `ReadAsPropertyName` and `WriteAsPropertyName` methods to `VersionVariablesJsonStringConverter` to support correct property name handling during JSON (de)serialization.

**Code cleanup:**

* Removed unused imports and the now-unnecessary `JsonSerializerOptions` method from `VersionVariableSerializer`. [[1]](diffhunk://#diff-144a227c720f42a596f71df4b58e23c92f96d087061aedc9eb0a52d986307eafL2) [[2]](diffhunk://#diff-144a227c720f42a596f71df4b58e23c92f96d087061aedc9eb0a52d986307eafL97-L98)