### PR TITLE
Refactor help and version command handling

### DIFF
--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -57,7 +57,7 @@ internal class ArgumentParser(IEnvironment environment,
 
         if (firstArgument.IsHelp())
         {
-            helpWriter.Write();
+            this.helpWriter.Write();
             return new Arguments
             {
                 IsHelp = true
@@ -67,7 +67,7 @@ internal class ArgumentParser(IEnvironment environment,
         if (firstArgument.IsSwitch("version"))
         {
             var assembly = Assembly.GetExecutingAssembly();
-            versionWriter.Write(assembly);
+            this.versionWriter.Write(assembly);
             return new Arguments
             {
                 IsVersion = true

--- a/src/GitVersion.App/GitVersionApp.cs
+++ b/src/GitVersion.App/GitVersionApp.cs
@@ -23,19 +23,23 @@ internal class GitVersionApp(
             if (gitVersionOptions.IsHelp || gitVersionOptions.IsVersion)
             {
                 SysEnv.ExitCode = 0;
-                return Task.CompletedTask;
             }
-            this.log.Verbosity = gitVersionOptions.Verbosity;
-
-            SysEnv.ExitCode = this.gitVersionExecutor.Execute(gitVersionOptions);
+            else
+            {
+                this.log.Verbosity = gitVersionOptions.Verbosity;
+                SysEnv.ExitCode = this.gitVersionExecutor.Execute(gitVersionOptions);
+            }
         }
         catch (Exception exception)
         {
             Console.Error.WriteLine(exception.Message);
             SysEnv.ExitCode = 1;
         }
+        finally
+        {
+            this.applicationLifetime.StopApplication();
+        }
 
-        this.applicationLifetime.StopApplication();
         return Task.CompletedTask;
     }
 }

--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -36,7 +36,10 @@ internal class GitVersionExecutor(
     public int Execute(GitVersionOptions gitVersionOptions)
     {
         Initialize(gitVersionOptions);
-        var exitCode = RunGitVersionTool(gitVersionOptions);
+
+        var exitCode = !VerifyAndDisplayConfiguration(gitVersionOptions)
+            ? RunGitVersionTool(gitVersionOptions)
+            : 0;
 
         if (exitCode != 0)
         {
@@ -104,7 +107,15 @@ internal class GitVersionExecutor(
             gitVersionOptions.Settings.NoCache = true;
         }
 
-        ConfigureLogging(gitVersionOptions, this.log, this.fileSystem);
+        if (gitVersionOptions.Output.Contains(OutputType.BuildServer) || gitVersionOptions.LogFilePath == "console")
+        {
+            this.log.AddLogAppender(new ConsoleAppender());
+        }
+
+        if (gitVersionOptions.LogFilePath != null && gitVersionOptions.LogFilePath != "console")
+        {
+            this.log.AddLogAppender(new FileAppender(this.fileSystem, gitVersionOptions.LogFilePath));
+        }
 
         var workingDirectory = gitVersionOptions.WorkingDirectory;
         if (gitVersionOptions.Diag)
@@ -120,28 +131,19 @@ internal class GitVersionExecutor(
         {
             this.log.Info("Working directory: " + workingDirectory);
         }
+    }
 
-        if (!gitVersionOptions.ConfigurationInfo.ShowConfiguration) return;
-
+    private bool VerifyAndDisplayConfiguration(GitVersionOptions gitVersionOptions)
+    {
+        if (!gitVersionOptions.ConfigurationInfo.ShowConfiguration) return false;
         if (gitVersionOptions.RepositoryInfo.TargetUrl.IsNullOrWhiteSpace())
         {
-            this.configurationFileLocator.Verify(workingDirectory, this.repositoryInfo.ProjectRootDirectory);
+            this.configurationFileLocator.Verify(gitVersionOptions.WorkingDirectory, this.repositoryInfo.ProjectRootDirectory);
         }
+
         var configuration = this.configurationProvider.Provide();
         var configurationString = this.configurationSerializer.Serialize(configuration);
         this.console.WriteLine(configurationString);
-    }
-
-    private static void ConfigureLogging(GitVersionOptions gitVersionOptions, ILog log, IFileSystem fileSystem)
-    {
-        if (gitVersionOptions.Output.Contains(OutputType.BuildServer) || gitVersionOptions.LogFilePath == "console")
-        {
-            log.AddLogAppender(new ConsoleAppender());
-        }
-
-        if (gitVersionOptions.LogFilePath != null && gitVersionOptions.LogFilePath != "console")
-        {
-            log.AddLogAppender(new FileAppender(fileSystem, gitVersionOptions.LogFilePath));
-        }
+        return true;
     }
 }


### PR DESCRIPTION
Move help and version output logic from `GitVersionApp` to `ArgumentParser`, centralizing command handling. This simplifies the application's main execution flow by delegating output responsibility.

Fixes #4839