### PR TITLE
test(build): verify mkdocs workflow fix

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,13 +1,6 @@
 name: Markdown Update
 on:
   push:
-    branches:
-      - main
-      - 'fix/*'
-      - 'feature/*'
-      - 'poc/*'
-      - 'support/*'
-      - 'next/*'
     paths:
       - 'docs/**'
 
@@ -29,11 +22,10 @@ defaults:
   run:
     shell: pwsh
 
-permissions:
-  contents: write
-
 jobs:
   docs:
+    permissions:
+      contents: write
     name: Update Markdown (embedded snippets)
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -9,11 +9,8 @@ defaults:
   run:
     shell: pwsh
 
-permissions:
-  contents: write
-
 jobs:
-  homebrew:
+  public-api:
     permissions:
       contents: write
     name: Mark public API as shipped


### PR DESCRIPTION
Tests that the mkdocs push step is correctly skipped when targeting main (branch protection prevents direct pushes).

Closes n/a — cleanup PR, to be closed after CI passes.