### PR TITLE
Configure code coverage generation and publishing

### DIFF
--- a/build/build/Tasks/Test/PublishCoverage.cs
+++ b/build/build/Tasks/Test/PublishCoverage.cs
@@ -20,7 +20,7 @@ public class PublishCoverage : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         var coverageFiles = context
-            .GetFiles($"{Paths.TestOutput}/*.coverage.*.xml")
+            .GetFiles($"{Paths.Src}/**/coverage.*.xml")
             .Select(file => context.MakeRelative(file).ToString()).ToArray();
 
         var token = context.Credentials?.CodeCov?.Token;

--- a/build/build/Tasks/Test/UnitTest.cs
+++ b/build/build/Tasks/Test/UnitTest.cs
@@ -82,6 +82,10 @@ public class UnitTest : FrostingTask<BuildContext>
         settings.WithArgumentCustomization(args => args
             .Append("--report-spekt-junit")
             .Append("--report-spekt-junit-filename").AppendQuoted(resultsPath.FullPath)
+            .Append("--coverlet")
+            .Append("--coverlet-output-format").AppendQuoted("cobertura")
+            .Append("--coverlet-exclude ").AppendQuoted("[GitVersion*.Tests]*")
+            .Append("--coverlet-exclude ").AppendQuoted("[GitTools.Testing]*")
         );
 
         context.DotNetTest(project.FullPath, settings);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -75,17 +75,17 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup Condition=" '$(IsUnitTestProject)' == 'true' ">
+        <PackageReference Include="coverlet.MTP" />
+        <PackageReference Include="JunitXml.TestLogger" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="JunitXml.TestLogger" />
-        <PackageReference Include="Shouldly" />
-
         <PackageReference Include="NUnit.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Shouldly" />
 
     </ItemGroup>
     <ItemGroup Condition=" '$(IsUnitTestProject)' == 'true' ">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- common packages -->
+    <PackageVersion Include="coverlet.MTP" Version="8.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />


### PR DESCRIPTION
## Description

Integrate Coverlet into the build process to generate code coverage reports during unit tests. This enables automatic coverage tracking by adding `coverlet.MTP` and specifying `dotnet test` arguments for Cobertura output, while also broadening the scope for coverage file discovery and publication.

## Related Issue

Resolves #4870

## Motivation and Context

Enable automated code coverage generation and publishing to improve insights into test coverage and overall code quality.

## How Has This Been Tested?

Tested by running the build pipeline locally to verify successful generation and collection of coverage reports.

## Screenshots (if appropriate):

## Checklist:

*   \[ ] My code follows the code style of this project.
*   \[ ] My change requires a change to the documentation.
*   \[ ] I have updated the documentation accordingly.
*   \[ ] I have added tests to cover my changes.
*   \[ ] All new and existing tests passed.