### PR TITLE
(deps): Bump NUnit3TestAdapter from 6.1.0 to 6.2.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SharpYaml" Version="3.7.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.7" />


### PR DESCRIPTION
Updated [NUnit3TestAdapter](https://github.com/nunit/nunit3-vs-adapter) from 6.1.0 to 6.2.0.

<details>
<summary>Release notes</summary>

_Sourced from [NUnit3TestAdapter's releases](https://github.com/nunit/nunit3-vs-adapter/releases)._

## 6.2.0

This is primarily a bug-fix release, with one new feature added.

The enhancement introduces filtering for the `--list-tests` option in `dotnet test`, and works for both standard runs and MTP runs.

### Bug fixes

- Fixes unwanted `Microsoft.Extensions.DependencyModel.dll` copies to output in 6.1.0.
- Fixes the need to pin `Microsoft.Extensions.DependencyModel` when using `Microsoft.Testing.Extensions.CodeCoverage`.
- Fixes ReSharper test runner failures seen with recent adapter versions.
- Fixes cancellation for `dotnet test` when using MTP.

See [full release notes](https://docs.nunit.org/articles/vs-test-adapter/AdapterV4-Release-Notes.html).

Commits viewable in [compare view](https://github.com/nunit/nunit3-vs-adapter/compare/V6.1.0...v6.2.0).
</details>
