### PR TITLE
(deps): Bump coverlet.MTP from 8.0.1 to 10.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- common packages -->
-    <PackageVersion Include="coverlet.MTP" Version="8.0.1" />
+    <PackageVersion Include="coverlet.MTP" Version="10.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />


### PR DESCRIPTION
Updated [coverlet.MTP](https://github.com/coverlet-coverage/coverlet) from 8.0.1 to 10.0.0.

<details>
<summary>Release notes</summary>

_Sourced from [coverlet's releases](https://github.com/coverlet-coverage/coverlet/releases)._

## 10.0.0

### Improvements

- Unique report filenames for coverlet.MTP and Azure DevOps.
- Added `--coverlet-file-prefix` for unique report files.
- Introduced .NET 10 support.

### Fixed

- Wrong branch rate on `IAsyncEnumerable` for generic types.
- Missing coverage after moving to MTP.
- No coverage reported when targeting .NET Framework with 8.0.1.
- Behavior differences between MTP and legacy msbuild mode.
- Failure to load `coverlet.mtp.appsettings.json`.
- Empty coverage report and instrumentation issues fixed in related scenarios.

See [full release notes](https://github.com/coverlet-coverage/coverlet/releases/tag/v10.0.0).

Commits viewable in [compare view](https://github.com/coverlet-coverage/coverlet/compare/v8.0.1...v10.0.0).
</details>
