### PR TITLE
(deps): Bump SharpYaml from 3.4.0 to 3.7.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageVersion Include="SharpYaml" Version="3.4.0" />
+    <PackageVersion Include="SharpYaml" Version="3.7.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.6" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.5" />


### PR DESCRIPTION
Updated [SharpYaml](https://github.com/xoofx/SharpYaml) from 3.4.0 to 3.7.0.

<details>
<summary>Release notes</summary>

_Sourced from [SharpYaml's releases](https://github.com/xoofx/SharpYaml/releases)._

## 3.7.0

### 🐛 Bug Fixes

- Apply `UnknownDerivedTypeHandling.Fail` to tag-based polymorphism.
- Suppress `SHARPYAML002` when a converter handles the type.

### 🚀 Enhancements

- Clarify that tag-only `YamlDerivedType` does not set a default derived type.
- Add `YamlSerializerContext.CreateOptions` for per-call option overrides.

### 📚 Documentation

- Expand converter documentation with registration methods and priority details.

### 🧰 Misc

- Support the C# `required` keyword in source generation and reflection.

See the [full release notes](https://github.com/xoofx/SharpYaml/releases/tag/3.7.0).

Commits viewable in [compare view](https://github.com/xoofx/SharpYaml/compare/3.4.0...3.7.0).
</details>
