### PR TITLE
feat: add support for environment variables in branch labels

### DIFF
--- a/docs/input/docs/learn/who.md
+++ b/docs/input/docs/learn/who.md
@@ -12,7 +12,6 @@ that we know about today.
 * [ChocolateyGUI](https://github.com/chocolatey/ChocolateyGUI)
 * [GitLink](https://github.com/GitTools/GitLink)
 * [OctopusDeploy](https://github.com/OctopusDeploy)
-* [NUKE](https://nuke.build)
 * [Orc.\* packages](https://github.com/wildgums?query=orc)
 * [Orchestra](https://github.com/wildgums/orchestra)
 * [Shouldly](https://github.com/shouldly/shouldly)

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -903,6 +903,8 @@ of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?
 
 Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
 
+You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax.
+
 **Note:** To clear a default use an empty string: `label: ''`
 
 ### increment

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -903,8 +903,6 @@ of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?
 
 Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
 
-You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax.
-
 **Note:** To clear a default use an empty string: `label: ''`
 
 ### increment

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -504,6 +504,8 @@ of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?
 
 Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
 
+You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax.
+
 **Note:** To clear a default use an empty string: `label: ''`
 
 ### increment

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -6,6 +6,8 @@ namespace GitVersion.Configuration.Tests;
 [TestFixture]
 public class ConfigurationExtensionsTests : TestBase
 {
+    private const string BranchName = "pull-request";
+
     [TestCase("release/2.0.0",
         "refs/heads/release/2.0.0", "release/2.0.0", "release/2.0.0",
         true, false, false, false, true)]
@@ -63,13 +65,13 @@ public class ConfigurationExtensionsTests : TestBase
 
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
-            .WithBranch("pull-request", builder => builder
+            .WithBranch(BranchName, builder => builder
                 .WithLabel("pr-{env:GITHUB_HEAD_REF}")
                 .WithRegularExpression(@"^pull[/-]"))
             .Build();
 
-        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment);
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
         actual.ShouldBe("pr-feature-branch");
     }
 
@@ -81,13 +83,13 @@ public class ConfigurationExtensionsTests : TestBase
 
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
-            .WithBranch("pull-request", builder => builder
+            .WithBranch(BranchName, builder => builder
                 .WithLabel("pr-{env:GITHUB_HEAD_REF ?? \"unknown\"}")
                 .WithRegularExpression(@"^pull[/-]"))
             .Build();
 
-        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment);
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
         actual.ShouldBe("pr-unknown");
     }
 
@@ -132,13 +134,13 @@ public class ConfigurationExtensionsTests : TestBase
 
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
-            .WithBranch("pull-request", builder => builder
+            .WithBranch(BranchName, builder => builder
                 .WithLabel("pr-{env:MISSING_VAR}")
                 .WithRegularExpression(@"^pull[/-]"))
             .Build();
 
-        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
         Should.Throw<ArgumentException>(() =>
-            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment));
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment));
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -141,25 +141,4 @@ public class ConfigurationExtensionsTests : TestBase
         Should.Throw<ArgumentException>(() =>
             effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment));
     }
-
-    [Test]
-    public void EnsureGetBranchSpecificLabelProcessesEnvironmentVariablesEvenWhenRegexDoesNotMatch()
-    {
-        var environment = new TestEnvironment();
-        environment.SetEnvironmentVariable("GITHUB_HEAD_REF", "feature-branch");
-
-        var configuration = GitFlowConfigurationBuilder.New
-            .WithoutBranches()
-            .WithBranch("pull-request", builder => builder
-                .WithLabel("pr-{env:GITHUB_HEAD_REF}")
-                .WithRegularExpression(@"^pull[/-]"))
-            .WithBranch("feature", builder => builder
-                .WithLabel("{BranchName}")
-                .WithRegularExpression(@"^features?[\/-](?<BranchName>.+)"))
-            .Build();
-
-        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/other-branch"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/other-branch"), null, environment);
-        actual.ShouldBe("other-branch");
-    }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -51,7 +51,115 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(branchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(branchName), null);
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(branchName), null, new TestEnvironment());
         actual.ShouldBe(expectedLabel);
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelProcessesEnvironmentVariables()
+    {
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable("GITHUB_HEAD_REF", "feature-branch");
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("pull-request", builder => builder
+                .WithLabel("pr-{env:GITHUB_HEAD_REF}")
+                .WithRegularExpression(@"^pull[/-]"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment);
+        actual.ShouldBe("pr-feature-branch");
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelProcessesEnvironmentVariablesWithFallback()
+    {
+        var environment = new TestEnvironment();
+        // Don't set GITHUB_HEAD_REF to test fallback
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("pull-request", builder => builder
+                .WithLabel("pr-{env:GITHUB_HEAD_REF ?? \"unknown\"}")
+                .WithRegularExpression(@"^pull[/-]"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment);
+        actual.ShouldBe("pr-unknown");
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelProcessesEnvironmentVariablesAndRegexPlaceholders()
+    {
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable("GITHUB_HEAD_REF", "feature-branch");
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("feature/test-branch", builder => builder
+                .WithLabel("{BranchName}-{env:GITHUB_HEAD_REF}")
+                .WithRegularExpression(@"^features?[\/-](?<BranchName>.+)"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test-branch"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-branch"), null, environment);
+        actual.ShouldBe("test-branch-feature-branch");
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelWorksWithoutEnvironmentWhenNoEnvPlaceholders()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("feature/test", builder => builder
+                .WithLabel("{BranchName}")
+                .WithRegularExpression(@"^features?[\/-](?<BranchName>.+)"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test"), null, new TestEnvironment());
+        actual.ShouldBe("test");
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelThrowsWhenThrowIfNotFoundAndEnvVarMissing()
+    {
+        var environment = new TestEnvironment();
+        // Do not set MISSING_VAR
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("pull-request", builder => builder
+                .WithLabel("pr-{env:MISSING_VAR}")
+                .WithRegularExpression(@"^pull[/-]"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
+        Should.Throw<ArgumentException>(() =>
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment, throwIfNotFound: true));
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelProcessesEnvironmentVariablesEvenWhenRegexDoesNotMatch()
+    {
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable("GITHUB_HEAD_REF", "feature-branch");
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("pull-request", builder => builder
+                .WithLabel("pr-{env:GITHUB_HEAD_REF}")
+                .WithRegularExpression(@"^pull[/-]"))
+            .WithBranch("feature", builder => builder
+                .WithLabel("{BranchName}")
+                .WithRegularExpression(@"^features?[\/-](?<BranchName>.+)"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/other-branch"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/other-branch"), null, environment);
+        actual.ShouldBe("other-branch");
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -139,7 +139,7 @@ public class ConfigurationExtensionsTests : TestBase
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("pull-request"));
         Should.Throw<ArgumentException>(() =>
-            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment, throwIfNotFound: true));
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("pull-request"), null, environment));
     }
 
     [Test]

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -1,5 +1,7 @@
+using System.Reflection.Emit;
 using GitVersion.Core;
 using GitVersion.Extensions;
+using GitVersion.Formatting;
 using GitVersion.Git;
 using GitVersion.VersionCalculation;
 
@@ -97,12 +99,13 @@ internal static class ConfigurationExtensions
 
     extension(EffectiveConfiguration configuration)
     {
-        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride)
-            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride);
+        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride, IEnvironment environment, bool throwIfNotFound = false)
+            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride, environment, throwIfNotFound);
 
-        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride)
+        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride, IEnvironment environment, bool throwIfNotFound = false)
         {
             configuration.NotNull();
+            environment.NotNull();
 
             var label = configuration.Label;
             if (label is null)
@@ -110,25 +113,36 @@ internal static class ConfigurationExtensions
                 return label;
             }
 
-            var effectiveBranchName = branchNameOverride ?? branchName;
-            if (configuration.RegularExpression.IsNullOrWhiteSpace() || effectiveBranchName.IsNullOrEmpty()) return label;
-            var regex = RegexPatterns.Cache.GetOrAdd(configuration.RegularExpression);
-            var match = regex.Match(effectiveBranchName);
-            if (!match.Success) return label;
-            foreach (var groupName in regex.GetGroupNames())
+            if (environment is not null)
             {
-                var groupValue = match.Groups[groupName].Value;
-                Lazy<string> escapedGroupValueLazy = new(() => groupValue.RegexReplace(RegexPatterns.SanitizeNameRegexPattern, "-"));
-                var placeholder = $"{{{groupName}}}";
-                int index, startIndex = 0;
-                while ((index = label.IndexOf(placeholder, startIndex, StringComparison.InvariantCulture)) >= 0)
+                try
                 {
-                    var escapedGroupValue = escapedGroupValueLazy.Value;
-                    label = label.Remove(index, placeholder.Length).Insert(index, escapedGroupValue);
-                    startIndex = index + escapedGroupValue.Length;
+                    label = label.FormatWith(new { }, environment);
+                }
+                catch (ArgumentException)
+                {
+                    // If environment variable is missing an dno fallback, return label as-is
+                    // This maintains backward compatibility
                 }
             }
-            return label;
+
+            var effectiveBranchName = branchNameOverride ?? branchName;
+            var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
+
+            if (throwIfNotFound)
+            {
+                return label.FormatWith(labelPlaceholders, environment);
+            }
+
+            try
+            {
+                return label.FormatWith(labelPlaceholders, environment);
+            }
+            catch (ArgumentException)
+            {
+                // If environment variable is missing and no fallback, return label as-is (backward compatibility)
+                return label;
+            }
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()
@@ -152,6 +166,28 @@ internal static class ConfigurationExtensions
                 taggedSemanticVersion |= TaggedSemanticVersions.OfMainBranches;
             }
             return taggedSemanticVersion;
+        }
+
+        private static Dictionary<string, object> BuildLabelPlaceholders(string? regularExpression, string? effectiveBranchName)
+        {
+            var placeholders = new Dictionary<string, object>();
+
+            if (regularExpression.IsNullOrWhiteSpace() || effectiveBranchName.IsNullOrEmpty())
+                return placeholders;
+
+            var regex = RegexPatterns.Cache.GetOrAdd(regularExpression);
+            var match = regex.Match(effectiveBranchName);
+
+            if (!match.Success)
+                return placeholders;
+
+            foreach (var groupName in regex.GetGroupNames())
+            {
+                var groupValue = match.Groups[groupName].Value;
+                placeholders[groupName] = groupValue.RegexReplace(RegexPatterns.SanitizeNameRegexPattern, "-");
+            }
+
+            return placeholders;
         }
     }
 }

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -107,22 +107,20 @@ internal static class ConfigurationExtensions
             environment.NotNull();
 
             var label = configuration.Label;
+
             if (label is null)
             {
                 return label;
             }
 
-            if (environment is not null)
+            try
             {
-                try
-                {
-                    label = label.FormatWith(new { }, environment);
-                }
-                catch (ArgumentException)
-                {
-                    // If environment variable is missing an dno fallback, return label as-is
-                    // This maintains backward compatibility
-                }
+                label = label.FormatWith(new { }, environment);
+            }
+            catch (ArgumentException)
+            {
+                // If environment variable is missing an dno fallback, return label as-is
+                // This maintains backward compatibility
             }
 
             var effectiveBranchName = branchNameOverride ?? branchName;

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Emit;
 using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Formatting;

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -98,10 +98,10 @@ internal static class ConfigurationExtensions
 
     extension(EffectiveConfiguration configuration)
     {
-        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride, IEnvironment environment, bool throwIfNotFound = false)
-            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride, environment, throwIfNotFound);
+        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride, IEnvironment environment)
+            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride, environment);
 
-        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride, IEnvironment environment, bool throwIfNotFound = false)
+        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride, IEnvironment environment)
         {
             configuration.NotNull();
             environment.NotNull();
@@ -113,33 +113,10 @@ internal static class ConfigurationExtensions
                 return label;
             }
 
-            try
-            {
-                label = label.FormatWith(new { }, environment);
-            }
-            catch (ArgumentException)
-            {
-                // If environment variable is missing an dno fallback, return label as-is
-                // This maintains backward compatibility
-            }
-
             var effectiveBranchName = branchNameOverride ?? branchName;
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
 
-            if (throwIfNotFound)
-            {
-                return label.FormatWith(labelPlaceholders, environment);
-            }
-
-            try
-            {
-                return label.FormatWith(labelPlaceholders, environment);
-            }
-            catch (ArgumentException)
-            {
-                // If environment variable is missing and no fallback, return label as-is (backward compatibility)
-                return label;
-            }
+            return label.FormatWith(labelPlaceholders, environment);
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()

--- a/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
+++ b/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
@@ -37,17 +37,51 @@ internal static class StringFormatWithExtension
         /// "{env:BUILD_NUMBER}".FormatWith(new { }, env);
         /// "{env:BUILD_NUMBER ?? \"0\"}".FormatWith(new { }, env);
         /// </example>
-        public string FormatWith<T>(T? source, IEnvironment environment)
+        public string FormatWith(object source, IEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return template.FormatWith((member, format, fallback) => EvaluateMemberFromObject(source, member, format, fallback), environment);
+        }
+
+        /// <summary>
+        /// Formats the <paramref name="template"/>, replacing each expression wrapped in curly braces
+        /// with the corresponding property from the <paramref name="source"/> or <paramref name="environment"/>.
+        /// </summary>
+        /// <param name="source">The source object to apply to the <paramref name="template"/></param>
+        /// <param name="environment"></param>
+        /// <exception cref="ArgumentNullException">The <paramref name="template"/> is null.</exception>
+        /// <exception cref="ArgumentException">An environment variable was null and no fallback was provided.</exception>
+        /// <remarks>
+        /// An expression containing "." is treated as a property or field access on the <paramref name="source"/>.
+        /// An expression starting with "env:" is replaced with the value of the corresponding variable from the <paramref name="environment"/>.
+        /// Each expression may specify a single hardcoded fallback value using the {Prop ?? "fallback"} syntax, which applies if the expression evaluates to null.
+        /// </remarks>
+        /// <example>
+        /// // replace an expression with a property value
+        /// "Hello {Name}".FormatWith(new { Name = "Fred" }, env);
+        /// "Hello {Name ?? \"Fred\"}".FormatWith(new { Name = GetNameOrNull() }, env);
+        /// // replace an expression with an environment variable
+        /// "{env:BUILD_NUMBER}".FormatWith(new { }, env);
+        /// "{env:BUILD_NUMBER ?? \"0\"}".FormatWith(new { }, env);
+        /// </example>
+        public string FormatWith(IDictionary<string, object> source, IEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return template.FormatWith((member, format, fallback) => EvaluateMemberFromDictionary(source, member, format, fallback), environment);
+        }
+
+        private string FormatWith(EvaluateMemberDelegate memberEvaluator, IEnvironment environment)
         {
             ArgumentNullException.ThrowIfNull(template);
-            ArgumentNullException.ThrowIfNull(source);
 
             var result = new StringBuilder();
             var lastIndex = 0;
 
             foreach (var match in RegexPatterns.ExpandTokensRegex.Matches(template).Cast<Match>())
             {
-                var replacement = EvaluateMatch(match, source, environment);
+                var replacement = EvaluateMatch(match, memberEvaluator, environment);
                 result.Append(template, lastIndex, match.Index - lastIndex);
                 result.Append(replacement);
                 lastIndex = match.Index + match.Length;
@@ -58,7 +92,7 @@ internal static class StringFormatWithExtension
         }
     }
 
-    private static string EvaluateMatch<T>(Match match, T source, IEnvironment environment)
+    private static string EvaluateMatch(Match match, EvaluateMemberDelegate memberEvaluator, IEnvironment environment)
     {
         var fallback = match.Groups["fallback"].Success ? match.Groups["fallback"].Value : null;
 
@@ -68,7 +102,7 @@ internal static class StringFormatWithExtension
         if (match.Groups["member"].Success)
         {
             var format = match.Groups["format"].Success ? match.Groups["format"].Value : null;
-            return EvaluateMember(source, match.Groups["member"].Value, format, fallback);
+            return memberEvaluator(match.Groups["member"].Value, format, fallback);
         }
 
         throw new ArgumentException($"Invalid token format: '{match.Value}'");
@@ -82,15 +116,7 @@ internal static class StringFormatWithExtension
             ?? throw new ArgumentException($"Environment variable {safeName} not found and no fallback provided");
     }
 
-    private static string EvaluateMember<T>(T source, string member, string? format, string? fallback)
-    {
-        if (source is IDictionary<string, object> dictionary)
-            return EvaluateMemberFromDictionary(dictionary, member, format, fallback);
-        else
-            return EvaluateMemberFromObject(source, member, format, fallback);
-    }
-
-    private static string EvaluateMemberFromObject<T>(T source, string member, string? format, string? fallback)
+    private static string EvaluateMemberFromObject(object source, string member, string? format, string? fallback)
     {
         var safeMember = InputSanitizer.SanitizeMemberName(member);
         var memberPath = MemberResolver.ResolveMemberPath(source!.GetType(), safeMember);
@@ -126,4 +152,6 @@ internal static class StringFormatWithExtension
 
         return value.ToString() ?? fallback ?? string.Empty;
     }
+
+    private delegate string EvaluateMemberDelegate(string member, string? format, string? fallback);
 }

--- a/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
+++ b/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
@@ -84,6 +84,14 @@ internal static class StringFormatWithExtension
 
     private static string EvaluateMember<T>(T source, string member, string? format, string? fallback)
     {
+        if (source is IDictionary<string, object> dictionary)
+            return EvaluateMemberFromDictionary(dictionary, member, format, fallback);
+        else
+            return EvaluateMemberFromObject(source, member, format, fallback);
+    }
+
+    private static string EvaluateMemberFromObject<T>(T source, string member, string? format, string? fallback)
+    {
         var safeMember = InputSanitizer.SanitizeMemberName(member);
         var memberPath = MemberResolver.ResolveMemberPath(source!.GetType(), safeMember);
         var getter = ExpressionCompiler.CompileGetter(source.GetType(), memberPath);
@@ -93,12 +101,28 @@ internal static class StringFormatWithExtension
             return fallback ?? string.Empty;
 
         if (format is not null && ValueFormatter.Default.TryFormat(
-            value,
-            InputSanitizer.SanitizeFormat(format),
-            out var formatted))
+                value,
+                InputSanitizer.SanitizeFormat(format),
+                out var formatted))
         {
             return formatted;
         }
+
+        return value.ToString() ?? fallback ?? string.Empty;
+    }
+
+    private static string EvaluateMemberFromDictionary(IDictionary<string, object> source, string member, string? format, string? fallback)
+    {
+        var safeMember = InputSanitizer.SanitizeMemberName(member);
+
+        if (!source.TryGetValue(safeMember, out var value))
+            return fallback ?? string.Empty;
+
+        if (value is null)
+            return fallback ?? string.Empty;
+
+        if (format is not null && ValueFormatter.Default.TryFormat(value, InputSanitizer.SanitizeFormat(format), out var formatted))
+            return formatted;
 
         return value.ToString() ?? fallback ?? string.Empty;
     }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
@@ -19,7 +19,7 @@ internal sealed class EnrichIncrement : IContextPreEnricher
 
         if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
             context.Label = null;
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
 
         if (effectiveConfiguration.IsMainBranch)
             context.BaseVersionSource = commit.Predecessor?.Value;

--- a/src/GitVersion.Core/VersionCalculation/Mainline/EnrichSemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/EnrichSemanticVersion.cs
@@ -9,9 +9,9 @@ internal sealed class EnrichSemanticVersion : IContextPreEnricher
     {
         var branchSpecificLabel = context.TargetLabel;
         branchSpecificLabel ??= iteration.GetEffectiveConfiguration(context.Configuration)
-            .GetBranchSpecificLabel(commit.BranchName, null);
+            .GetBranchSpecificLabel(commit.BranchName, null, context.Environemnt);
         branchSpecificLabel ??= commit.GetEffectiveConfiguration(context.Configuration)
-            .GetBranchSpecificLabel(commit.BranchName, null);
+            .GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
 
         var semanticVersions = commit.SemanticVersions.Where(
             element => element.IsMatchForBranchSpecificLabel(branchSpecificLabel)

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineContext.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineContext.cs
@@ -4,11 +4,13 @@ using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation.Mainline;
 
-internal record MainlineContext(IIncrementStrategyFinder IncrementStrategyFinder, IGitVersionConfiguration Configuration)
+internal record MainlineContext(IIncrementStrategyFinder IncrementStrategyFinder, IGitVersionConfiguration Configuration, IEnvironment Environment)
 {
     public IIncrementStrategyFinder IncrementStrategyFinder { get; } = IncrementStrategyFinder.NotNull();
 
     public IGitVersionConfiguration Configuration { get; } = Configuration.NotNull();
+
+    public IEnvironment Environemnt { get; } = Environment.NotNull();
 
     public string? TargetLabel { get; init; }
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
@@ -22,7 +22,7 @@ internal sealed class CommitOnNonTrunk : IIncrementer
             context.Label = null;
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
 
         if (commit.Successor is not null) yield break;
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
@@ -21,7 +21,7 @@ internal abstract class CommitOnNonTrunkBranchedBase : IIncrementer
         context.Increment = context.Increment.Consolidate(incrementForcedByBranch);
 
         var iterationEffectiveConfiguration = iteration.GetEffectiveConfiguration(context.Configuration);
-        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
+        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment) ?? context.Label;
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
@@ -24,7 +24,7 @@ internal abstract class CommitOnNonTrunkWithPreReleaseTagBase : IIncrementer
 
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
         context.ForceIncrement = false;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
@@ -24,6 +24,6 @@ internal abstract class CommitOnNonTrunkWithStableTagBase : IIncrementer
 
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -22,7 +22,8 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
                    iteration: commit.ChildIteration,
                    targetLabel: context.TargetLabel,
                    incrementStrategyFinder: context.IncrementStrategyFinder,
-                   configuration: context.Configuration
+                   configuration: context.Configuration,
+                   environment: context.Environment
                );
 
             context.Label ??= baseVersion.Operator?.Label;

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
@@ -21,7 +21,7 @@ internal sealed class CommitOnTrunk : IIncrementer
             context.Label = null;
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
@@ -28,7 +28,7 @@ internal abstract class CommitOnTrunkBranchedBase : IIncrementer
         context.Increment = incrementForcedByBranch;
 
         var iterationEffectiveConfiguration = iteration.GetEffectiveConfiguration(context.Configuration);
-        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null) ?? context.Label;
+        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment) ?? context.Label;
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
@@ -22,6 +22,6 @@ internal abstract class CommitOnTrunkWithStableTagBase : IIncrementer
         };
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
@@ -22,7 +22,7 @@ internal sealed class LastCommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreR
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
         context.ForceIncrement = false;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -20,7 +20,8 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
                    iteration: commit.ChildIteration!,
                    targetLabel: context.TargetLabel,
                    incrementStrategyFinder: context.IncrementStrategyFinder,
-                   configuration: context.Configuration
+                   configuration: context.Configuration,
+                   environment: context.Environment
                );
 
             context.Label ??= baseVersion.Operator?.Label;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -14,13 +14,15 @@ internal class NextVersionCalculator(
     IEnumerable<IDeploymentModeCalculator> deploymentModeCalculators,
     IEnumerable<IVersionStrategy> versionStrategies,
     IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder,
-    ITaggedSemanticVersionService taggedSemanticVersionService)
+    ITaggedSemanticVersionService taggedSemanticVersionService,
+    IEnvironment environment)
     : INextVersionCalculator
 {
     private readonly ILog log = log.NotNull();
     private readonly Lazy<GitVersionContext> versionContext = versionContext.NotNull();
     private readonly IVersionStrategy[] versionStrategies = [.. versionStrategies.NotNull()];
     private readonly IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder = effectiveBranchConfigurationFinder.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => this.versionContext.Value;
 
@@ -108,7 +110,7 @@ internal class NextVersionCalculator(
     {
         result = null;
 
-        var label = effectiveConfiguration.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var label = effectiveConfiguration.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
         var currentCommitTaggedVersion = taggedSemanticVersionsOfCurrentCommit
             .Where(element => element.Value.IsMatchForBranchSpecificLabel(label)).Max();
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -8,9 +8,10 @@ namespace GitVersion.VersionCalculation;
 /// BaseVersionSource is null.
 /// Does not increment.
 /// </summary>
-internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContext> contextLazy) : IVersionStrategy
+internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContext> contextLazy, IEnvironment environment) : IVersionStrategy
 {
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -26,7 +27,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
         var semanticVersion = SemanticVersion.Parse(
             nextVersion, Context.Configuration.TagPrefixPattern, Context.Configuration.SemanticVersionFormat
         );
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, environment);
 
         if (!semanticVersion.IsMatchForBranchSpecificLabel(label)) yield break;
         BaseVersionOperator? operation = null;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
@@ -12,12 +12,14 @@ namespace GitVersion.VersionCalculation;
 internal sealed class FallbackVersionStrategy(
     Lazy<GitVersionContext> contextLazy,
     IIncrementStrategyFinder incrementStrategyFinder,
-    ITaggedSemanticVersionService taggedSemanticVersionService)
+    ITaggedSemanticVersionService taggedSemanticVersionService,
+    IEnvironment environment)
     : IVersionStrategy
 {
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
     private readonly ITaggedSemanticVersionService taggedSemanticVersionService = taggedSemanticVersionService.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -31,7 +33,7 @@ internal sealed class FallbackVersionStrategy(
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.Fallback))
             yield break;
 
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 
         var baseVersionSource = taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -13,7 +13,8 @@ internal sealed class MainlineVersionStrategy(
     Lazy<GitVersionContext> contextLazy,
     IRepositoryStore repositoryStore,
     ITaggedSemanticVersionService taggedSemanticVersionService,
-    IIncrementStrategyFinder incrementStrategyFinder)
+    IIncrementStrategyFinder incrementStrategyFinder,
+    IEnvironment environment)
     : IVersionStrategy
 {
     private volatile int iterationCounter;
@@ -21,6 +22,7 @@ internal sealed class MainlineVersionStrategy(
     private readonly ITaggedSemanticVersionService taggedSemanticVersionService = taggedSemanticVersionService.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
     private readonly Dictionary<string, Dictionary<ICommit, List<(IBranch, IBranchConfiguration)>>> commitsWasBranchedFromCache = new();
 
     private GitVersionContext Context => contextLazy.Value;
@@ -102,7 +104,7 @@ internal sealed class MainlineVersionStrategy(
             notOlderThan: Context.CurrentCommit.When,
             taggedSemanticVersion: taggedSemanticVersion
         );
-        var targetLabel = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var targetLabel = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
         IterateOverCommitsRecursive(
             commitsInReverseOrder: commitsInReverseOrder,
             iteration: iteration,
@@ -111,7 +113,7 @@ internal sealed class MainlineVersionStrategy(
             taggedSemanticVersions: taggedSemanticVersions
         );
 
-        yield return DetermineBaseVersion(iteration, targetLabel, incrementStrategyFinder, Context.Configuration);
+        yield return DetermineBaseVersion(iteration, targetLabel, incrementStrategyFinder, Context.Configuration, this.environment);
     }
 
     private MainlineIteration CreateIteration(
@@ -204,7 +206,7 @@ internal sealed class MainlineVersionStrategy(
             var label = targetLabel ?? new EffectiveConfiguration(
                 configuration: Context.Configuration,
                 branchConfiguration: configuration
-            ).GetBranchSpecificLabel(branchName, null);
+            ).GetBranchSpecificLabel(branchName, null, this.environment);
 
             foreach (var semanticVersion in semanticVersions)
             {
@@ -334,15 +336,15 @@ internal sealed class MainlineVersionStrategy(
     }
 
     private static BaseVersion DetermineBaseVersion(MainlineIteration iteration, string? targetLabel,
-            IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration)
-        => DetermineBaseVersionRecursive(iteration, targetLabel, incrementStrategyFinder, configuration);
+            IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
+        => DetermineBaseVersionRecursive(iteration, targetLabel, incrementStrategyFinder, configuration, environment);
 
     internal static BaseVersion DetermineBaseVersionRecursive(MainlineIteration iteration, string? targetLabel,
-        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration)
+        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
     {
         iteration.NotNull();
 
-        var incrementSteps = GetIncrements(iteration, targetLabel, incrementStrategyFinder, configuration).ToArray();
+        var incrementSteps = GetIncrements(iteration, targetLabel, incrementStrategyFinder, configuration, environment).ToArray();
 
         BaseVersion? result = null;
         foreach (var baseVersionIncrement in incrementSteps)
@@ -365,9 +367,9 @@ internal sealed class MainlineVersionStrategy(
     }
 
     private static IEnumerable<IBaseVersionIncrement> GetIncrements(MainlineIteration iteration, string? targetLabel,
-        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration)
+        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
     {
-        MainlineContext context = new(incrementStrategyFinder, configuration)
+        MainlineContext context = new(incrementStrategyFinder, configuration, environment)
         {
             TargetLabel = targetLabel
         };

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -11,13 +11,14 @@ namespace GitVersion.VersionCalculation;
 /// Increments if PreventIncrementOfMergedBranchVersion (from the branch configuration) is false.
 /// </summary>
 internal sealed class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionContext> contextLazy,
-    IRepositoryStore repositoryStore, IIncrementStrategyFinder incrementStrategyFinder)
+    IRepositoryStore repositoryStore, IIncrementStrategyFinder incrementStrategyFinder, IEnvironment environment)
     : IVersionStrategy
 {
     private readonly ILog log = log.NotNull();
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -51,7 +52,7 @@ internal sealed class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionConte
                 baseVersionSource = this.repositoryStore.FindMergeBase(commit.Parents[0], commit.Parents[1]);
             }
 
-            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
             var increment = configuration.Value.PreventIncrementOfMergedBranch
                 ? VersionField.None : this.incrementStrategyFinder.DetermineIncrementedField(
                     currentCommit: Context.CurrentCommit,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -14,13 +14,15 @@ internal sealed class TaggedCommitVersionStrategy(
     ILog log,
     Lazy<GitVersionContext> contextLazy,
     ITaggedSemanticVersionService taggedSemanticVersionService,
-    IIncrementStrategyFinder incrementStrategyFinder)
+    IIncrementStrategyFinder incrementStrategyFinder,
+    IEnvironment environment)
     : IVersionStrategy
 {
     private readonly ILog log = log.NotNull();
     private readonly ITaggedSemanticVersionService taggedSemanticVersionService = taggedSemanticVersionService.NotNull();
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -42,7 +44,7 @@ internal sealed class TaggedCommitVersionStrategy(
             taggedSemanticVersion: configuration.Value.GetTaggedSemanticVersion()
         ).SelectMany(elements => elements).Distinct().ToArray();
 
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 
         var semanticVersionTreshold = SemanticVersion.Empty;
         List<SemanticVersionWithTag> alternativeSemanticVersionsWithTag = [];

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -11,14 +11,16 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
     Lazy<GitVersionContext> contextLazy,
     IRepositoryStore repositoryStore,
     IBranchRepository branchRepository,
-    IIncrementStrategyFinder incrementStrategyFinder)
+    IIncrementStrategyFinder incrementStrategyFinder,
+    IEnvironment environment)
     : IVersionStrategy
 {
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly IBranchRepository branchRepository = branchRepository.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
-    private readonly VersionInBranchNameVersionStrategy releaseVersionStrategy = new(contextLazy);
+    private readonly IEnvironment environment = environment.NotNull();
+    private readonly VersionInBranchNameVersionStrategy releaseVersionStrategy = new(contextLazy, environment);
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -48,7 +50,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
         if (!this.releaseVersionStrategy.TryGetBaseVersion(releaseBranchConfiguration, out var baseVersion)) return result is not null;
         // Find the commit where the child branch was created.
         var baseVersionSource = this.repositoryStore.FindMergeBase(releaseBranch, Context.CurrentBranch);
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
         var increment = this.incrementStrategyFinder.DetermineIncrementedField(
             currentCommit: Context.CurrentCommit,
             baseVersionSource: baseVersionSource,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -9,9 +9,10 @@ namespace GitVersion.VersionCalculation;
 /// BaseVersionSource is the commit where the branch was branched from its parent.
 /// Does not increment.
 /// </summary>
-internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext> contextLazy) : IVersionStrategy
+internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext> contextLazy, IEnvironment environment) : IVersionStrategy
 {
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
 
     private GitVersionContext Context => contextLazy.Value;
 
@@ -43,7 +44,7 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
                 branchNameOverride = result.Name;
             }
 
-            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, branchNameOverride);
+            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, branchNameOverride, this.environment);
 
             baseVersion = new BaseVersion("Version in branch name", result.Value)
             {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Supports environment variable substitution in the label configuration for a branch using the established format used elsewhere. Fallbacks are also supported if the environment variable is not found. The changes are backwards compatible and should not fail for existing configuration.

Documentation detailing the changes has been added to `configuration.md`.

## Related Issue
<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

Resolves #4745 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Allow labels to include environment variables as well as regex-captured variables. This is useful for CICD environments like GitHub where the pull request head_ref can be provided instead of the merge commit target.

## How Has This Been Tested?

<!-- 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Please describe in detail how you tested your changes.

-->
Unit tests covering the new functionality have been added.

## Screenshots (if appropriate):

<!-- Drag and drop screenshots here -->

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
