### PR TITLE
Fix computing next `Depth` from `parentIteration`

### DIFF
--- a/src/GitVersion.Core.Tests/VersionCalculation/MainlineIterationTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MainlineIterationTests.cs
@@ -1,0 +1,19 @@
+﻿using GitVersion.Configuration;
+using GitVersion.VersionCalculation.Mainline;
+
+namespace GitVersion.Core.Tests.VersionCalculation;
+
+[TestFixture]
+public class MainlineIterationTests
+{
+    [Test]
+    public void ChildIsDeeperThanParent()
+    {
+        var configuration = new BranchConfiguration();
+        var parent = new MainlineIteration("id0", new("canonical0"), configuration, null, null);
+        var child = new MainlineIteration("id1", new("canonical1"), configuration, parent, null);
+
+        parent.Depth.ShouldBe(1);
+        child.Depth.ShouldBe(2);
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
@@ -55,7 +55,7 @@ internal record MainlineIteration
         MainlineIteration? parentIteration, MainlineCommit? parentCommit)
     {
         Id = id.NotNullOrEmpty();
-        Depth = parentIteration?.Depth ?? 0 + 1;
+        Depth = (parentIteration?.Depth ?? 0) + 1;
         BranchName = branchName.NotNull();
         Configuration = configuration.NotNull();
         ParentIteration = parentIteration;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Parenthesize `??` as `+` binds stronger.

<!-- Describe your changes in detail -->

## Related Issue

<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!-- 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Please describe in detail how you tested your changes.

-->

## Screenshots (if appropriate):

<!-- Drag and drop screenshots here -->

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
