### PR TITLE
Various code cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -158,8 +158,19 @@ resharper_csharp_use_roslyn_logic_for_evident_types = true
 # Alignment
 resharper_csharp_align_multiline_parameter = true
 
-# Qualify fields with "this."
+# Qualify fields with `this.` in ReSharper
 resharper_csharp_instance_members_qualify_members = field
+
+# Qualify fields with `this.` in Roslyn
+dotnet_style_qualification_for_field = true:error
+
+# Do not qualify properties, methods, and events with `this.` in Roslyn
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
+
+# Make missing `this.` qualification an error
+dotnet_diagnostic.IDE0009.severity = error
 
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.ide0005.severity = warning

--- a/.github/skills/dotnet-dev/SKILL.md
+++ b/.github/skills/dotnet-dev/SKILL.md
@@ -151,7 +151,7 @@ public string RequiredProperty { get; set; } = string.Empty;
 Use file-scoped namespaces:
 
 ```csharp
-namespace GitVersion.Core;
+namespace GitVersion;
 
 public class MyClass
 {

--- a/new-cli/GitVersion.Calculation/CalculateCommand.cs
+++ b/new-cli/GitVersion.Calculation/CalculateCommand.cs
@@ -9,20 +9,20 @@ public record CalculateSettings : GitVersionSettings;
 [Command("calculate", "Calculates the version object from the git history.")]
 public class CalculateCommand(ILogger<CalculateCommand> logger, IService service, IGitRepository repository) : ICommand<CalculateSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
-    private readonly IGitRepository _repository = repository.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
+    private readonly IGitRepository repository = repository.NotNull();
 
     public Task<int> InvokeAsync(CalculateSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
+        var value = this.service.Call();
         if (settings.WorkDir != null)
         {
-            _repository.DiscoverRepository(settings.WorkDir.FullName);
-            var branches = _repository.Branches.ToList();
-            _logger.LogInformation("Command : 'calculate', LogFile : '{logFile}', WorkDir : '{workDir}' ",
+            this.repository.DiscoverRepository(settings.WorkDir.FullName);
+            var branches = this.repository.Branches.ToList();
+            this.logger.LogInformation("Command : 'calculate', LogFile : '{logFile}', WorkDir : '{workDir}' ",
                 settings.LogFile, settings.WorkDir);
-            _logger.LogInformation("Found {count} branches", branches.Count);
+            this.logger.LogInformation("Found {count} branches", branches.Count);
         }
 
         return Task.FromResult(value);

--- a/new-cli/GitVersion.Cli.Generator/TypeVisitor.cs
+++ b/new-cli/GitVersion.Cli.Generator/TypeVisitor.cs
@@ -3,9 +3,9 @@ namespace GitVersion;
 internal class TypeVisitor(Func<INamedTypeSymbol, bool> searchQuery, CancellationToken cancellation)
     : SymbolVisitor
 {
-    private readonly HashSet<INamedTypeSymbol> _exportedTypes = new(SymbolEqualityComparer.Default);
+    private readonly HashSet<INamedTypeSymbol> exportedTypes = new(SymbolEqualityComparer.Default);
 
-    public ImmutableArray<INamedTypeSymbol> GetResults() => [.. _exportedTypes];
+    public ImmutableArray<INamedTypeSymbol> GetResults() => [.. this.exportedTypes];
 
     public override void VisitAssembly(IAssemblySymbol symbol)
     {
@@ -28,7 +28,7 @@ internal class TypeVisitor(Func<INamedTypeSymbol, bool> searchQuery, Cancellatio
 
         if (searchQuery(type))
         {
-            _exportedTypes.Add(type);
+            this.exportedTypes.Add(type);
         }
     }
 }

--- a/new-cli/GitVersion.Configuration/ConfigCommand.cs
+++ b/new-cli/GitVersion.Configuration/ConfigCommand.cs
@@ -8,13 +8,13 @@ public record ConfigSettings : GitVersionSettings;
 [Command("config", "Manages the GitVersion configuration file.")]
 public class ConfigCommand(ILogger<ConfigCommand> logger, IService service) : ICommand<ConfigSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(ConfigSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'config', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'config', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Configuration/Init/ConfigInitCommand.cs
+++ b/new-cli/GitVersion.Configuration/Init/ConfigInitCommand.cs
@@ -8,13 +8,13 @@ public record ConfigInitSettings : ConfigSettings;
 [Command<ConfigCommand>("init", "Inits the configuration for current repository.")]
 public class ConfigInitCommand(ILogger<ConfigInitCommand> logger, IService service) : ICommand<ConfigInitSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(ConfigInitSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'config init', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'config init', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Configuration/Show/ConfigShowCommand.cs
+++ b/new-cli/GitVersion.Configuration/Show/ConfigShowCommand.cs
@@ -8,13 +8,13 @@ public record ConfigShowSettings : ConfigSettings;
 [Command<ConfigCommand>("show", "Shows the effective configuration.")]
 public class ConfigShowCommand(ILogger<ConfigShowCommand> logger, IService service) : ICommand<ConfigShowSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(ConfigShowSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'config show', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'config show', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
+++ b/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
@@ -6,11 +6,11 @@ namespace GitVersion.Infrastructure;
 public class LoggingEnricher : ILogEventEnricher
 {
     public static readonly LoggingLevelSwitch LogLevel = new();
-    private string? _cachedLogFilePath;
-    private LogEventProperty? _cachedLogFilePathProp;
+    private string? cachedLogFilePath;
+    private LogEventProperty? cachedLogFilePathProp;
 
     // this path and level will be set by the LogInterceptor.cs after parsing the settings
-    private static string _path = string.Empty;
+    private static string path = string.Empty;
 
     public const string LogFilePathPropertyName = "LogFilePath";
 
@@ -20,17 +20,17 @@ public class LoggingEnricher : ILogEventEnricher
         // we won't have the setting, so a default value for the log file will be required
         LogEventProperty logFilePathProp;
 
-        if (_cachedLogFilePathProp != null && _path.Equals(_cachedLogFilePath))
+        if (this.cachedLogFilePathProp != null && path.Equals(this.cachedLogFilePath))
         {
             // The Path hasn't changed, so let's use the cached property
-            logFilePathProp = _cachedLogFilePathProp;
+            logFilePathProp = this.cachedLogFilePathProp;
         }
         else
         {
             // We've got a new path for the log. Let's create a new property
             // and cache it for future log events to use
-            _cachedLogFilePath = _path;
-            _cachedLogFilePathProp = logFilePathProp = propFactory.CreateProperty(LogFilePathPropertyName, _path);
+            this.cachedLogFilePath = path;
+            this.cachedLogFilePathProp = logFilePathProp = propFactory.CreateProperty(LogFilePathPropertyName, path);
         }
 
         logEvent.AddPropertyIfAbsent(logFilePathProp);
@@ -38,7 +38,7 @@ public class LoggingEnricher : ILogEventEnricher
 
     public static void Configure(string? logFile, Verbosity verbosity)
     {
-        if (!string.IsNullOrWhiteSpace(logFile)) _path = logFile;
+        if (!string.IsNullOrWhiteSpace(logFile)) path = logFile;
         LogLevel.MinimumLevel = GetLevelForVerbosity(verbosity);
     }
 

--- a/new-cli/GitVersion.Normalization/NormalizeCommand.cs
+++ b/new-cli/GitVersion.Normalization/NormalizeCommand.cs
@@ -8,13 +8,13 @@ public record NormalizeSettings : GitVersionSettings;
 [Command("normalize", "Normalizes the git repository for GitVersion calculations.")]
 public class NormalizeCommand(ILogger<NormalizeCommand> logger, IService service) : ICommand<NormalizeSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(NormalizeSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'normalize', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'normalize', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/AssemblyInfo/OutputAssemblyInfoCommand.cs
+++ b/new-cli/GitVersion.Output/AssemblyInfo/OutputAssemblyInfoCommand.cs
@@ -6,15 +6,15 @@ namespace GitVersion.Commands;
 [Command<OutputCommand>("assemblyinfo", "Outputs version to assembly")]
 public class OutputAssemblyInfoCommand(ILogger<OutputAssemblyInfoCommand> logger, IService service) : ICommand<OutputAssemblyInfoSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(OutputAssemblyInfoSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
+        var value = this.service.Call();
         var versionInfo = settings.VersionInfo.Value;
-        _logger.LogInformation($"Command : 'output assemblyinfo', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', AssemblyInfo: '{settings.AssemblyinfoFile}' ");
-        _logger.LogInformation($"Version info: {versionInfo}");
+        this.logger.LogInformation($"Command : 'output assemblyinfo', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', AssemblyInfo: '{settings.AssemblyinfoFile}' ");
+        this.logger.LogInformation($"Version info: {versionInfo}");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/OutputCommand.cs
+++ b/new-cli/GitVersion.Output/OutputCommand.cs
@@ -6,13 +6,13 @@ namespace GitVersion.Commands;
 [Command("output", "Outputs the version object.")]
 public class OutputCommand(ILogger<OutputCommand> logger, IService service) : ICommand<OutputSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(OutputSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'output', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'output', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/Project/OutputProjectCommand.cs
+++ b/new-cli/GitVersion.Output/Project/OutputProjectCommand.cs
@@ -6,13 +6,13 @@ namespace GitVersion.Commands;
 [Command<OutputCommand>("project", "Outputs version to project")]
 public class OutputProjectCommand(ILogger<OutputProjectCommand> logger, IService service) : ICommand<OutputProjectSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(OutputProjectSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'output project', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', Project: '{settings.ProjectFile}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'output project', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', Project: '{settings.ProjectFile}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/Wix/OutputWixCommand.cs
+++ b/new-cli/GitVersion.Output/Wix/OutputWixCommand.cs
@@ -6,13 +6,13 @@ namespace GitVersion.Commands;
 [Command<OutputCommand>("wix", "Outputs version to wix file")]
 public class OutputWixCommand(ILogger<OutputWixCommand> logger, IService service) : ICommand<OutputWixSettings>
 {
-    private readonly ILogger _logger = logger.NotNull();
-    private readonly IService _service = service.NotNull();
+    private readonly ILogger logger = logger.NotNull();
+    private readonly IService service = service.NotNull();
 
     public Task<int> InvokeAsync(OutputWixSettings settings, CancellationToken cancellationToken = default)
     {
-        var value = _service.Call();
-        _logger.LogInformation($"Command : 'output wix', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', WixFile: '{settings.WixFile}' ");
+        var value = this.service.Call();
+        this.logger.LogInformation($"Command : 'output wix', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', WixFile: '{settings.WixFile}' ");
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.sln.DotSettings
+++ b/new-cli/GitVersion.sln.DotSettings
@@ -1,2 +1,729 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
+
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
+
+	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignToImplicitGlobalInFunctionScope/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BaseObjectEqualsIsObjectEquals/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassWithVirtualMembersNeverInherited_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareNonConstrainedGenericWithNull/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionalTernaryEqualBranch/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionIsAlwaysTrueOrFalse/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstantNullCoalescingCondition/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstructorInitializerLoop/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0108/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0109/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0162/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1570/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1571/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1573/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1574/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1580/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1584/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1587/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1589/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS1710/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=DoubleNegationOperator/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyConstructor/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyDestructor/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyForStatement/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyGeneralCatchClause/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyNamespace/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EmptyStatement/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EventNeverInvoked/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ExpressionIsAlwaysNull/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeuristicUnreachableCode/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=LocalizableElement/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MultipleOrderBy/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedField_002EGlobal/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedVariable_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleIntendedRethrow/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMistakenCallToGetType_002E1/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMistakenCallToGetType_002E2/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleNullReferenceException/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateFieldCanBeConvertedToLocalVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentName/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentNameForLiteralExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAssignment/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseConstructorCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBoolCompare/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast_002E0/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCatchClause/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCollectionInitializerElementBraces/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInArrayInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantDefaultFieldInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyDefaultSwitchBranch/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyFinallyBlock/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEmptyObjectOrCollectionInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantEnumerableCastCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExplicitArrayCreation/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExtendsListEntry/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantIfElseBlock/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLambdaParameterType/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLambdaSignatureParentheses/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringFormatCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringToCharArrayCall/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCall/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeArgumentsOfMethod/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FormatStringProblem/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=IteratorMethodResultIsIgnored/@EntryIndexedValue">WARNING</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NotAccessedField_002ELocal/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseQualifier/@EntryIndexedValue">ERROR</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ClassCanBeSealed_002EGlobal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ClassCanBeSealed_002ELocal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertIfStatementToReturnStatement_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertIfStatementToSwitchStatement_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022ConvertToAutoPropertyWithPrivateSetter_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022InvertIf_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022LoopCanBePartlyConvertedToQuery_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeInternal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeMadeStatic_002EGlobal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022MemberCanBeMadeStatic_002ELocal_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022RedundantArgumentNameForLiteralExpression_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022RedundantToStringCallForValueType_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SimilarAnonymousTypeNearby_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SuggestBaseTypeForParameter_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SuggestUseVarKeywordEverywhere_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022TryStatementsCanBeMerged_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022UnknownCssVendorExtension_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022Xaml_002EBindingWithoutContextReferenceNotResolvedHighlighting_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CStaticSeverity_0020Severity_003D_00222_0022_0020Title_003D_0022Structural_0020Search_0020Hints_0022_0020GroupId_003D_0022StructuralSearch_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SealedMemberInSealedClass/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticFieldInGenericType/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEverywhere/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ThreadStaticAtInstanceField/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TooWideLocalVariableScope/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ELocal/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnreachableCode/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedField_002ECompiler/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedLabel/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002ELocal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">WARNING</s:String>
+
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseObjectOrCollectionInitializer/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ValueParameterNotUsed/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E1/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E2/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=C_0023_0020Only/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="C# Only"&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;
+  &amp;lt;option name="myName" value="C# Only" /&amp;gt;
+  &amp;lt;inspection_tool class="ES6ShorthandObjectProperty" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="JSArrowFunctionBracesCanBeRemoved" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="JSRemoveUnnecessaryParentheses" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="JSUnnecessarySemicolon" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="TypeScriptExplicitMemberType" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="UnnecessaryContinueJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="UnnecessaryLabelJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="UnnecessaryReturnJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;
+  &amp;lt;inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="false" level="WEAK WARNING" enabled_by_default="false" /&amp;gt;
+&amp;lt;/profile&amp;gt;&lt;/IDEA_SETTINGS&gt;&lt;RIDER_SETTINGS&gt;&amp;lt;profile&amp;gt;
+  &amp;lt;Language id="CSS"&amp;gt;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="EditorConfig"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="HTML"&amp;gt;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="HTTP Request"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Handlebars"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Ini"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="JSON"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Jade"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="JavaScript"&amp;gt;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Markdown"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Properties"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="RELAX-NG"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="SQL"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="XML"&amp;gt;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="yaml"&amp;gt;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;CSCodeStyleAttributes ArrangeVarStyle="True" ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" /&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;/Profile&gt;</s:String>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=GitVersion/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="GitVersion"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;JsInsertSemicolon&gt;True&lt;/JsInsertSemicolon&gt;&lt;JsReformatCode&gt;True&lt;/JsReformatCode&gt;&lt;CssReformatCode&gt;True&lt;/CssReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;CSCodeStyleAttributes ArrangeVarStyle="True" ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" /&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;
+  &amp;lt;option name="myName" value="GitVersion" /&amp;gt;
+&amp;lt;/profile&amp;gt;&lt;/IDEA_SETTINGS&gt;&lt;RIDER_SETTINGS&gt;&amp;lt;profile&amp;gt;
+  &amp;lt;Language id=""&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="CMake"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="CSS"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="EditorConfig"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="HTML"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="HTTP Request"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Handlebars"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Ini"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="JSON"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Jade"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="JavaScript"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Markdown"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Properties"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="RELAX-NG"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Razor"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="SQL"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="VueExpr"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="XML"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="yaml"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;UpgradedBackendToFrontendHtml&gt;True&lt;/UpgradedBackendToFrontendHtml&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Default: Reformat Code</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">GitVersion</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOR_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOREACH_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
+
+
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_MULTIPLE_TYPE_PARAMEER_CONSTRAINTS_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/JavaScriptFormatOther/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
+&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+  &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;Or&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Interface" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.InterfaceTypeAttribute" /&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;And&gt;&#xD;
+        &lt;Kind Is="Class" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
+      &lt;/And&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+    &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Delegate" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Enum" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Constant" /&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="Field" /&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Kind Order="Constant Field" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Fields"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Field" /&gt;&#xD;
+          &lt;Not&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/Not&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Readonly /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Constructors"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Constructor" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Static /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Property" /&gt;&#xD;
+          &lt;Kind Is="Indexer" /&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Member" /&gt;&#xD;
+          &lt;ImplementsInterface /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="Nested Types"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Type" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+&lt;/Patterns&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
+&#xD;
+&lt;!--&#xD;
+I. Overall&#xD;
+&#xD;
+I.1 Each pattern can have &lt;Match&gt;....&lt;/Match&gt; element. For the given type declaration, the pattern with the match, evaluated to 'true' with the largest weight, will be used &#xD;
+I.2 Each pattern consists of the sequence of &lt;Entry&gt;...&lt;/Entry&gt; elements. Type member declarations are distributed between entries&#xD;
+I.3 If pattern has RemoveAllRegions="true" attribute, then all regions will be cleared prior to reordering. Otherwise, only auto-generated regions will be cleared&#xD;
+I.4 The contents of each entry is sorted by given keys (First key is primary,  next key is secondary, etc). Then the declarations are grouped and en-regioned by given property&#xD;
+&#xD;
+II. Available match operands&#xD;
+&#xD;
+Each operand may have Weight="..." attribute. This weight will be added to the match weight if the operand is evaluated to 'true'.&#xD;
+The default weight is 1&#xD;
+&#xD;
+II.1 Boolean functions:&#xD;
+II.1.1 &lt;And&gt;....&lt;/And&gt;&#xD;
+II.1.2 &lt;Or&gt;....&lt;/Or&gt;&#xD;
+II.1.3 &lt;Not&gt;....&lt;/Not&gt;&#xD;
+&#xD;
+II.2 Operands&#xD;
+II.2.1 &lt;Kind Is="..."/&gt;. Kinds are: class, struct, interface, enum, delegate, type, constructor, destructor, property, indexer, method, operator, field, constant, event, member&#xD;
+II.2.2 &lt;Name Is="..." [IgnoreCase="true/false"] /&gt;. The 'Is' attribute contains regular expression&#xD;
+II.2.3 &lt;HasAttribute CLRName="..." [Inherit="true/false"] /&gt;. The 'CLRName' attribute contains regular expression&#xD;
+II.2.4 &lt;Access Is="..."/&gt;. The 'Is' values are: public, protected, internal, protected internal, private&#xD;
+II.2.5 &lt;Static/&gt;&#xD;
+II.2.6 &lt;Abstract/&gt;&#xD;
+II.2.7 &lt;Virtual/&gt;&#xD;
+II.2.8 &lt;Override/&gt;&#xD;
+II.2.9 &lt;Sealed/&gt;&#xD;
+II.2.10 &lt;Readonly/&gt;&#xD;
+II.2.11 &lt;ImplementsInterface CLRName="..."/&gt;. The 'CLRName' attribute contains regular expression&#xD;
+II.2.12 &lt;HandlesEvent /&gt;&#xD;
+--&gt;&#xD;
+&#xD;
+&lt;Patterns xmlns="urn:shemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+&#xD;
+  &lt;!--Do not reorder COM interfaces and structs marked by StructLayout attribute--&gt;&#xD;
+  &lt;Pattern&gt;&#xD;
+    &lt;Match&gt;&#xD;
+      &lt;Or Weight="100"&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="interface"/&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute CLRName="System.Runtime.InteropServices.InterfaceTypeAttribute"/&gt;&#xD;
+            &lt;HasAttribute CLRName="System.Runtime.InteropServices.ComImport"/&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+        &lt;HasAttribute CLRName="System.Runtime.InteropServices.StructLayoutAttribute"/&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+    &lt;/Match&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+&#xD;
+  &lt;!--Special formatting of NUnit test fixture--&gt;&#xD;
+  &lt;Pattern RemoveAllRegions="true"&gt;&#xD;
+    &lt;Match&gt;&#xD;
+      &lt;And Weight="100"&gt;&#xD;
+        &lt;Kind Is="class"/&gt;&#xD;
+        &lt;HasAttribute CLRName="NUnit.Framework.TestFixtureAttribute" Inherit="true"/&gt;&#xD;
+      &lt;/And&gt;&#xD;
+    &lt;/Match&gt;&#xD;
+&#xD;
+    &lt;!--Setup/Teardow--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="method"/&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.SetUpAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.TearDownAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.FixtureSetUpAttribute" Inherit="true"/&gt;&#xD;
+            &lt;HasAttribute CLRName="NUnit.Framework.FixtureTearDownAttribute" Inherit="true"/&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--All other members--&gt;&#xD;
+    &lt;Entry/&gt;&#xD;
+    &#xD;
+    &lt;!--Test methods--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Kind Is="method"/&gt;&#xD;
+          &lt;HasAttribute CLRName="NUnit.Framework.TestAttribute" Inherit="false"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+&#xD;
+  &lt;!--Default pattern--&gt;&#xD;
+  &lt;Pattern&gt;&#xD;
+&#xD;
+    &lt;!--public delegate--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Access Is="public"/&gt;&#xD;
+          &lt;Kind Is="delegate"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--public enum--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Access Is="public"/&gt;&#xD;
+          &lt;Kind Is="enum"/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+&#xD;
+    &lt;!--Constructors. Place static one first--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Kind Is="constructor"/&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Static/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--properties, indexers--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="property"/&gt;&#xD;
+          &lt;Kind Is="indexer"/&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--interface implementations--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And Weight="100"&gt;&#xD;
+          &lt;Kind Is="member"/&gt;&#xD;
+          &lt;ImplementsInterface/&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;ImplementsInterface Immediate="true"/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--all other members--&gt;&#xD;
+    &lt;Entry/&gt;&#xD;
+    &#xD;
+&lt;!--static fields and constants--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="constant"/&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="field"/&gt;&#xD;
+            &lt;Static/&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Kind Order="constant field"/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &#xD;
+    &lt;!--instance fields--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="field"/&gt;&#xD;
+          &lt;Not&gt;&#xD;
+            &lt;Static/&gt;&#xD;
+          &lt;/Not&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Readonly/&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+&#xD;
+    &lt;!--nested types--&gt;&#xD;
+    &lt;Entry&gt;&#xD;
+      &lt;Match&gt;&#xD;
+        &lt;Kind Is="type"/&gt;&#xD;
+      &lt;/Match&gt;&#xD;
+      &lt;Sort&gt;&#xD;
+        &lt;Name/&gt;&#xD;
+      &lt;/Sort&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/Pattern&gt;&#xD;
+  &#xD;
+&lt;/Patterns&gt;&#xD;
+</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/LayoutType/@EntryValue">CustomLayout</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Constructor/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Constructor/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Equality/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=EqualityOperators/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=ImplementIEquatable/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Equality/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Global/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Global/Options/=PropertyBody/@EntryIndexedValue">Automatic property</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Implementations/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=WrapInRegion/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DTC/@EntryIndexedValue">DTC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NSB/@EntryIndexedValue">NSB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SLA/@EntryIndexedValue">SLA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Locals/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Other/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Parameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=15b5b1f1_002D457c_002D4ca6_002Db278_002D5615aedc07d3/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Private" Description="Static readonly fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=236f7aa5_002D7b06_002D43ca_002Dbf2a_002D9b31bfcff09a/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Private" Description="Constant fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="CONSTANT_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=2c62818f_002D621b_002D4425_002Dadc9_002D78611099bfcb/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Type parameters"&gt;&lt;ElementKinds&gt;&lt;Kind Name="TYPE_PARAMETER" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=4a98fdf6_002D7d98_002D4f5a_002Dafeb_002Dea44ad98c70c/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Private" Description="Instance fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=53eecf85_002Dd821_002D40e8_002Dac97_002Dfdb734542b84/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Protected, ProtectedInternal, Internal, Public, PrivateProtected" Description="Instance fields (not private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=61a991a4_002Dd0a3_002D4d19_002D90a5_002Df8f4d75c30c1/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Local variables"&gt;&lt;ElementKinds&gt;&lt;Kind Name="LOCAL_VARIABLE" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=669e5282_002Dfb4b_002D4e90_002D91e7_002D07d269d04b60/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Protected, ProtectedInternal, Internal, Public, PrivateProtected" Description="Constant fields (not private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="CONSTANT_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=70345118_002D4b40_002D4ece_002D937c_002Dbbeb7a0b2e70/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Protected, ProtectedInternal, Internal, Public, PrivateProtected" Description="Static fields (not private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=8a85b61a_002D1024_002D4f87_002Db9ef_002D1fdae19930a1/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Parameters"&gt;&lt;ElementKinds&gt;&lt;Kind Name="PARAMETER" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=8b8504e3_002Df0be_002D4c14_002D9103_002Dc732f2bddc15/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Enum members"&gt;&lt;ElementKinds&gt;&lt;Kind Name="ENUM_MEMBER" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=a0b4bc4d_002Dd13b_002D4a37_002Db37e_002Dc9c6864e4302/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Types and namespaces"&gt;&lt;ElementKinds&gt;&lt;Kind Name="NAMESPACE" /&gt;&lt;Kind Name="CLASS" /&gt;&lt;Kind Name="STRUCT" /&gt;&lt;Kind Name="ENUM" /&gt;&lt;Kind Name="DELEGATE" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=a4f433b8_002Dabcd_002D4e55_002Da08f_002D82e78cef0f0c/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Local constants"&gt;&lt;ElementKinds&gt;&lt;Kind Name="LOCAL_CONSTANT" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=a7a3339e_002D4e89_002D4319_002D9735_002Da9dc4cb74cc7/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Interfaces"&gt;&lt;ElementKinds&gt;&lt;Kind Name="INTERFACE" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=c873eafb_002Dd57f_002D481d_002D8c93_002D77f6863c2f88/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Protected, ProtectedInternal, Internal, Public, PrivateProtected" Description="Static readonly fields (not private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=f9fce829_002De6f4_002D4cb2_002D80f1_002D5497c44f51df/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Private" Description="Static fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FGLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLABEL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FOBJECT_005FPROPERTY_005FOF_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Locals/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Other/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=Parameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=5C63448180C9174C8C28A084F80E37DF/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=5C63448180C9174C8C28A084F80E37DF/AbsolutePath/@EntryValue">D:\Projects\OSS\GitTools\GitVersion\src\GitVersion.sln.DotSettings</s:String>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=5C63448180C9174C8C28A084F80E37DF/RelativePath/@EntryValue"></s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File5C63448180C9174C8C28A084F80E37DF/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File5C63448180C9174C8C28A084F80E37DF/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EUnitTestFramework_002EMigrations_002EEnableDisabledProvidersMigration/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/Environment/UnitTesting/SeparateAppDomainPerAssembly/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
+  <s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=asbjornu/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gitversion/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reacheable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=veyor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/GitVersion.App.Tests/ArgumentParserOnBuildServerTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserOnBuildServerTests.cs
@@ -1,7 +1,7 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.OutputVariables;
+using GitVersion.Tests;
 
 namespace GitVersion.App.Tests;
 

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -1,9 +1,9 @@
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Logging;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.App.Tests;

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -1,5 +1,5 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
+using GitVersion.Tests;
 
 namespace GitVersion.App.Tests;
 

--- a/src/GitVersion.App.Tests/Helpers/ArgumentBuilder.cs
+++ b/src/GitVersion.App.Tests/Helpers/ArgumentBuilder.cs
@@ -12,14 +12,14 @@ public class ArgumentBuilder(string? workingDirectory, string? additionalArgumen
     {
         var arguments = new StringBuilder();
 
-        if (!this.WorkingDirectory.IsNullOrWhiteSpace())
+        if (!WorkingDirectory.IsNullOrWhiteSpace())
         {
-            arguments.Append(" /targetpath \"").Append(this.WorkingDirectory).Append('\"');
+            arguments.Append(" /targetpath \"").Append(WorkingDirectory).Append('\"');
         }
 
-        if (!this.LogFile.IsNullOrWhiteSpace())
+        if (!LogFile.IsNullOrWhiteSpace())
         {
-            arguments.Append(" /l \"").Append(this.LogFile).Append('\"');
+            arguments.Append(" /l \"").Append(LogFile).Append('\"');
         }
 
         arguments.Append(additionalArguments);

--- a/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
+++ b/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
@@ -1,6 +1,6 @@
-using GitVersion.Core.Tests;
 using GitVersion.Extensions;
 using GitVersion.OutputVariables;
+using GitVersion.Tests;
 
 namespace GitVersion.App.Tests;
 

--- a/src/GitVersion.App.Tests/Helpers/ProgramFixture.cs
+++ b/src/GitVersion.App.Tests/Helpers/ProgramFixture.cs
@@ -1,6 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Logging;
+using GitVersion.Tests;
 
 namespace GitVersion.App.Tests;
 

--- a/src/GitVersion.App.Tests/JsonOutputOnBuildServerTest.cs
+++ b/src/GitVersion.App.Tests/JsonOutputOnBuildServerTest.cs
@@ -1,7 +1,7 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
+using GitVersion.Tests;
 
 namespace GitVersion.App.Tests;
 

--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -1,10 +1,10 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Helpers;
 using GitVersion.Output;
 using GitVersion.Testing.Extensions;
+using GitVersion.Tests;
 using LibGit2Sharp;
 
 namespace GitVersion.App.Tests;

--- a/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
+++ b/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
@@ -1,7 +1,7 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
+using GitVersion.Tests;
 using LibGit2Sharp;
 
 namespace GitVersion.App.Tests;

--- a/src/GitVersion.App.Tests/VersionWriterTests.cs
+++ b/src/GitVersion.App.Tests/VersionWriterTests.cs
@@ -1,5 +1,5 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
+using GitVersion.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -292,7 +292,7 @@ internal class ArgumentParser(IEnvironment environment,
 
         if (name.IsSwitch("verbosity"))
         {
-            ParseVerbosity(arguments, value);
+            arguments.Verbosity = ParseVerbosity(value);
             return true;
         }
 
@@ -437,13 +437,8 @@ internal class ArgumentParser(IEnvironment environment,
         }
     }
 
-    private static void ParseVerbosity(Arguments arguments, string? value)
-    {
-        if (!Enum.TryParse(value, true, out arguments.Verbosity))
-        {
-            throw new WarningException($"Could not parse Verbosity value '{value}'");
-        }
-    }
+    private static Verbosity ParseVerbosity(string? value) =>
+        Enum.TryParse(value, true, out Verbosity verbosity) ? verbosity : throw new WarningException($"Could not parse Verbosity value '{value}'");
 
     private static void ParseOverrideConfig(Arguments arguments, IReadOnlyCollection<string>? values)
     {

--- a/src/GitVersion.App/ArgumentParserExtensions.cs
+++ b/src/GitVersion.App/ArgumentParserExtensions.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.Helpers;
 
 namespace GitVersion;

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -5,40 +5,33 @@ namespace GitVersion;
 
 internal class Arguments
 {
-    public AuthenticationInfo Authentication = new();
-
-    public string? ConfigurationFile;
-    public IReadOnlyDictionary<object, object?> OverrideConfiguration = new Dictionary<object, object?>();
-    public bool ShowConfiguration;
-
-    public string? TargetPath;
-
-    public string? TargetUrl;
-    public string? TargetBranch;
-    public string? CommitId;
-    public string? ClonePath;
-
-    public bool Diag;
-    public bool IsVersion;
-    public bool IsHelp;
-
-    public bool NoFetch;
-    public bool NoCache;
-    public bool NoNormalize;
-    public bool AllowShallow;
-
-    public string? LogFilePath;
-    public string? ShowVariable;
-    public string? Format;
-    public string? OutputFile;
-    public ISet<OutputType> Output = new HashSet<OutputType>();
-    public Verbosity Verbosity = Verbosity.Normal;
-
-    public bool UpdateWixVersionFile;
-    public bool UpdateProjectFiles;
-    public bool UpdateAssemblyInfo;
-    public bool EnsureAssemblyInfo;
-    public ISet<string> UpdateAssemblyInfoFileName = new HashSet<string>();
+    public AuthenticationInfo Authentication { get; set; } = new();
+    public string? ConfigurationFile { get; set; }
+    public IReadOnlyDictionary<object, object?> OverrideConfiguration { get; set; } = new Dictionary<object, object?>();
+    public bool ShowConfiguration { get; set; }
+    public string? TargetPath { get; set; }
+    public string? TargetUrl { get; set; }
+    public string? TargetBranch { get; set; }
+    public string? CommitId { get; set; }
+    public string? ClonePath { get; set; }
+    public bool Diag { get; set; }
+    public bool IsVersion { get; set; }
+    public bool IsHelp { get; set; }
+    public bool NoFetch { get; set; }
+    public bool NoCache { get; set; }
+    public bool NoNormalize { get; set; }
+    public bool AllowShallow { get; set; }
+    public string? LogFilePath { get; set; }
+    public string? ShowVariable { get; set; }
+    public string? Format { get; set; }
+    public string? OutputFile { get; set; }
+    public ISet<OutputType> Output { get; set; } = new HashSet<OutputType>();
+    public Verbosity Verbosity { get; set; } = Verbosity.Normal;
+    public bool UpdateWixVersionFile { get; set; }
+    public bool UpdateProjectFiles { get; set; }
+    public bool UpdateAssemblyInfo { get; set; }
+    public bool EnsureAssemblyInfo { get; set; }
+    public ISet<string> UpdateAssemblyInfoFileName { get; set; } = new HashSet<string>();
 
     public GitVersionOptions ToOptions()
     {
@@ -54,9 +47,9 @@ internal class Arguments
 
             AuthenticationInfo =
             {
-                Username = this.Authentication.Username,
-                Password = this.Authentication.Password,
-                Token = this.Authentication.Token
+                Username = Authentication.Username,
+                Password = Authentication.Password,
+                Token = Authentication.Token
             },
 
             ConfigurationInfo =
@@ -99,7 +92,7 @@ internal class Arguments
             OutputFile = OutputFile
         };
 
-        var workingDirectory = this.TargetPath?.TrimEnd('/', '\\');
+        var workingDirectory = TargetPath?.TrimEnd('/', '\\');
         if (workingDirectory != null)
         {
             gitVersionOptions.WorkingDirectory = workingDirectory;

--- a/src/GitVersion.App/OverrideConfigurationOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigurationOptionParser.cs
@@ -50,7 +50,7 @@ internal class OverrideConfigurationOptionParser
                || unwrappedType == typeof(VersionStrategies[]);
     }
 
-    internal void SetValue(string key, string value) => overrideConfiguration[key] = QuotedStringHelpers.UnquoteText(value);
+    internal void SetValue(string key, string value) => this.overrideConfiguration[key] = QuotedStringHelpers.UnquoteText(value);
 
     internal IReadOnlyDictionary<object, object?> GetOverrideConfiguration() => this.overrideConfiguration;
 }

--- a/src/GitVersion.BuildAgents.Tests/Agents/AzurePipelinesTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/AzurePipelinesTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/BitBucketPipelinesTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/BitBucketPipelinesTests.cs
@@ -1,8 +1,8 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.BuildAgents.Tests;

--- a/src/GitVersion.BuildAgents.Tests/Agents/BuildKiteTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/BuildKiteTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
@@ -1,9 +1,9 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Logging;
 using GitVersion.OutputVariables;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.BuildAgents.Tests;

--- a/src/GitVersion.BuildAgents.Tests/Agents/CodeBuildTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/CodeBuildTests.cs
@@ -1,8 +1,8 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.BuildAgents.Tests;

--- a/src/GitVersion.BuildAgents.Tests/Agents/ContinuaCiTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/ContinuaCiTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/DroneTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/DroneTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/EnvRunTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/EnvRunTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
@@ -1,8 +1,8 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.BuildAgents.Tests;

--- a/src/GitVersion.BuildAgents.Tests/Agents/JenkinsTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/JenkinsTests.cs
@@ -1,8 +1,8 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.BuildAgents.Tests;

--- a/src/GitVersion.BuildAgents.Tests/Agents/MyGetTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/MyGetTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/SpaceAutomationTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/SpaceAutomationTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/TeamCityTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/TeamCityTests.cs
@@ -1,5 +1,5 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.BuildAgents.Tests;
 

--- a/src/GitVersion.BuildAgents/Agents/AppVeyor.cs
+++ b/src/GitVersion.BuildAgents/Agents/AppVeyor.cs
@@ -13,8 +13,8 @@ internal class AppVeyor(IEnvironment environment, ILog log, IFileSystem fileSyst
 
     public override string SetBuildNumber(GitVersionVariables variables)
     {
-        var buildNumber = Environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
-        var apiUrl = Environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
+        var buildNumber = this.environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
+        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
 
         using var httpClient = GetHttpClient(apiUrl);
 
@@ -40,7 +40,7 @@ internal class AppVeyor(IEnvironment environment, ILog log, IFileSystem fileSyst
 
     public override string[] SetOutputVariables(string name, string? value)
     {
-        var apiUrl = Environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
+        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
         var httpClient = GetHttpClient(apiUrl);
 
         var body = new
@@ -66,10 +66,10 @@ internal class AppVeyor(IEnvironment environment, ILog log, IFileSystem fileSyst
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        var pullRequestBranchName = Environment.GetEnvironmentVariable("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH");
+        var pullRequestBranchName = this.environment.GetEnvironmentVariable("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH");
         return !pullRequestBranchName.IsNullOrWhiteSpace()
             ? pullRequestBranchName
-            : this.Environment.GetEnvironmentVariable("APPVEYOR_REPO_BRANCH");
+            : this.environment.GetEnvironmentVariable("APPVEYOR_REPO_BRANCH");
     }
 
     public override bool PreventFetch() => false;

--- a/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
@@ -19,11 +19,11 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        var gitBranch = Environment.GetEnvironmentVariable("GIT_BRANCH");
+        var gitBranch = this.environment.GetEnvironmentVariable("GIT_BRANCH");
         if (gitBranch is not null)
             return gitBranch;
 
-        var sourceBranch = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+        var sourceBranch = this.environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
         // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
         // BUILD_SOURCEBRANCH must be used only for "real" branches, not for tags.
@@ -37,7 +37,7 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
     {
         // For AzurePipelines, we'll get the Build Number and insert GitVersion variables where
         // specified
-        var buildNumberEnv = Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER");
+        var buildNumberEnv = this.environment.GetEnvironmentVariable("BUILD_BUILDNUMBER");
         if (buildNumberEnv.IsNullOrWhiteSpace())
             return variables.FullSemVer;
 

--- a/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
@@ -55,13 +55,13 @@ internal class BitBucketPipelines : BuildAgentBase
             .Select(variable => $"export GITVERSION_{variable.Key.ToUpperInvariant()}={variable.Value}")
             .ToList();
 
-        this.FileSystem.File.WriteAllLines(this.propertyFile, exports);
+        this.fileSystem.File.WriteAllLines(this.propertyFile, exports);
 
         var psExports = variables
             .Select(variable => $"$GITVERSION_{variable.Key.ToUpperInvariant()} = \"{variable.Value}\"")
             .ToList();
 
-        this.FileSystem.File.WriteAllLines(this.ps1File, psExports);
+        this.fileSystem.File.WriteAllLines(this.ps1File, psExports);
     }
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
@@ -72,7 +72,7 @@ internal class BitBucketPipelines : BuildAgentBase
 
     private string? EvaluateEnvironmentVariable(string variableName)
     {
-        var branchName = Environment.GetEnvironmentVariable(variableName);
+        var branchName = this.environment.GetEnvironmentVariable(variableName);
         this.Log.Info("Evaluating environment variable {0} : {1}", variableName, branchName ?? "(null)");
         return branchName;
     }

--- a/src/GitVersion.BuildAgents/Agents/BuildKite.cs
+++ b/src/GitVersion.BuildAgents/Agents/BuildKite.cs
@@ -10,7 +10,7 @@ internal class BuildKite(IEnvironment environment, ILog log, IFileSystem fileSys
 
     protected override string EnvironmentVariable => EnvironmentVariableName;
 
-    public override bool CanApplyToCurrentContext() => "true".Equals(Environment.GetEnvironmentVariable(EnvironmentVariable), StringComparison.OrdinalIgnoreCase);
+    public override bool CanApplyToCurrentContext() => "true".Equals(this.environment.GetEnvironmentVariable(EnvironmentVariable), StringComparison.OrdinalIgnoreCase);
 
     public override string SetBuildNumber(GitVersionVariables variables) =>
         string.Empty; // There is no equivalent function in BuildKite.
@@ -20,10 +20,10 @@ internal class BuildKite(IEnvironment environment, ILog log, IFileSystem fileSys
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        var pullRequest = Environment.GetEnvironmentVariable("BUILDKITE_PULL_REQUEST");
+        var pullRequest = this.environment.GetEnvironmentVariable("BUILDKITE_PULL_REQUEST");
         if (string.IsNullOrEmpty(pullRequest) || pullRequest == "false")
         {
-            return Environment.GetEnvironmentVariable("BUILDKITE_BRANCH");
+            return this.environment.GetEnvironmentVariable("BUILDKITE_BRANCH");
         }
 
         // For pull requests BUILDKITE_BRANCH refers to the head, so adjust the

--- a/src/GitVersion.BuildAgents/Agents/CodeBuild.cs
+++ b/src/GitVersion.BuildAgents/Agents/CodeBuild.cs
@@ -26,9 +26,9 @@ internal sealed class CodeBuild : BuildAgentBase
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        var currentBranch = Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName);
+        var currentBranch = this.environment.GetEnvironmentVariable(WebHookEnvironmentVariableName);
 
-        return currentBranch.IsNullOrEmpty() ? Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName) : currentBranch;
+        return currentBranch.IsNullOrEmpty() ? this.environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName) : currentBranch;
     }
 
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
@@ -38,11 +38,11 @@ internal sealed class CodeBuild : BuildAgentBase
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");
-        this.FileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
+        this.fileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
     }
 
     public override bool PreventFetch() => true;
 
-    public override bool CanApplyToCurrentContext() => !Environment.GetEnvironmentVariable(WebHookEnvironmentVariableName).IsNullOrEmpty()
-                                                       || !Environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName).IsNullOrEmpty();
+    public override bool CanApplyToCurrentContext() => !this.environment.GetEnvironmentVariable(WebHookEnvironmentVariableName).IsNullOrEmpty()
+                                                       || !this.environment.GetEnvironmentVariable(SourceVersionEnvironmentVariableName).IsNullOrEmpty();
 }

--- a/src/GitVersion.BuildAgents/Agents/Drone.cs
+++ b/src/GitVersion.BuildAgents/Agents/Drone.cs
@@ -9,7 +9,7 @@ internal class Drone(IEnvironment environment, ILog log, IFileSystem fileSystem)
 {
     public const string EnvironmentVariableName = "DRONE";
     protected override string EnvironmentVariable => EnvironmentVariableName;
-    public override bool CanApplyToCurrentContext() => "true".Equals(Environment.GetEnvironmentVariable(EnvironmentVariable), StringComparison.OrdinalIgnoreCase);
+    public override bool CanApplyToCurrentContext() => "true".Equals(this.environment.GetEnvironmentVariable(EnvironmentVariable), StringComparison.OrdinalIgnoreCase);
 
     public override string SetBuildNumber(GitVersionVariables variables) => variables.FullSemVer;
 
@@ -23,20 +23,20 @@ internal class Drone(IEnvironment environment, ILog log, IFileSystem fileSystem)
         // In Drone DRONE_BRANCH variable is equal to destination branch in case of pull request
         // https://discourse.drone.io/t/getting-the-branch-a-pull-request-is-created-from/670
         // Unfortunately, DRONE_REFSPEC isn't populated, however CI_COMMIT_REFSPEC can be used instead of.
-        var pullRequestNumber = Environment.GetEnvironmentVariable("DRONE_PULL_REQUEST");
-        if (pullRequestNumber.IsNullOrWhiteSpace()) return this.Environment.GetEnvironmentVariable("DRONE_BRANCH");
+        var pullRequestNumber = this.environment.GetEnvironmentVariable("DRONE_PULL_REQUEST");
+        if (pullRequestNumber.IsNullOrWhiteSpace()) return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
         // DRONE_SOURCE_BRANCH is available in Drone 1.x.x version
-        var sourceBranch = this.Environment.GetEnvironmentVariable("DRONE_SOURCE_BRANCH");
+        var sourceBranch = this.environment.GetEnvironmentVariable("DRONE_SOURCE_BRANCH");
         if (!sourceBranch.IsNullOrWhiteSpace())
             return sourceBranch;
 
         // In drone lower than 1.x.x source branch can be parsed from CI_COMMIT_REFSPEC
         // CI_COMMIT_REFSPEC - {sourceBranch}:{destinationBranch}
         // https://github.com/drone/drone/issues/2222
-        var ciCommitRefSpec = this.Environment.GetEnvironmentVariable("CI_COMMIT_REFSPEC");
-        if (ciCommitRefSpec.IsNullOrWhiteSpace()) return this.Environment.GetEnvironmentVariable("DRONE_BRANCH");
+        var ciCommitRefSpec = this.environment.GetEnvironmentVariable("CI_COMMIT_REFSPEC");
+        if (ciCommitRefSpec.IsNullOrWhiteSpace()) return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
         var colonIndex = ciCommitRefSpec.IndexOf(':');
-        return colonIndex > 0 ? ciCommitRefSpec[..colonIndex] : this.Environment.GetEnvironmentVariable("DRONE_BRANCH");
+        return colonIndex > 0 ? ciCommitRefSpec[..colonIndex] : this.environment.GetEnvironmentVariable("DRONE_BRANCH");
     }
 
     public override bool PreventFetch() => false;

--- a/src/GitVersion.BuildAgents/Agents/EnvRun.cs
+++ b/src/GitVersion.BuildAgents/Agents/EnvRun.cs
@@ -11,9 +11,9 @@ internal class EnvRun(IEnvironment environment, ILog log, IFileSystem fileSystem
     protected override string EnvironmentVariable => EnvironmentVariableName;
     public override bool CanApplyToCurrentContext()
     {
-        var envRunDatabasePath = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+        var envRunDatabasePath = this.environment.GetEnvironmentVariable(EnvironmentVariableName);
         if (envRunDatabasePath.IsNullOrEmpty()) return false;
-        if (this.FileSystem.File.Exists(envRunDatabasePath)) return true;
+        if (this.fileSystem.File.Exists(envRunDatabasePath)) return true;
         this.Log.Error($"The database file of EnvRun.exe was not found at {envRunDatabasePath}.");
 
         return false;

--- a/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
@@ -27,12 +27,12 @@ internal class GitHubActions(IEnvironment environment, ILog log, IFileSystem fil
         // https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
         // The outgoing environment variables must be written to a temporary file (identified by the $GITHUB_ENV environment
         // variable, which changes for every step in a workflow) which is then parsed. That file must also be UTF-8, or it will fail.
-        var gitHubSetEnvFilePath = this.Environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
+        var gitHubSetEnvFilePath = this.environment.GetEnvironmentVariable(GitHubSetEnvTempFileEnvironmentVariableName);
 
         if (gitHubSetEnvFilePath != null)
         {
             writer($"Writing version variables to $GITHUB_ENV file for '{GetType().Name}'.");
-            using var streamWriter = this.FileSystem.File.AppendText(gitHubSetEnvFilePath);
+            using var streamWriter = this.fileSystem.File.AppendText(gitHubSetEnvFilePath);
             foreach (var (key, value) in variables)
             {
                 if (!value.IsNullOrEmpty())
@@ -53,8 +53,8 @@ internal class GitHubActions(IEnvironment environment, ILog log, IFileSystem fil
         // GITHUB_REF must be used only for "real" branches, not for tags.
         // Bug fix for https://github.com/GitTools/GitVersion/issues/2838
 
-        var refType = Environment.GetEnvironmentVariable("GITHUB_REF_TYPE") ?? "";
-        return refType.Equals("tag", StringComparison.OrdinalIgnoreCase) ? null : Environment.GetEnvironmentVariable("GITHUB_REF");
+        var refType = this.environment.GetEnvironmentVariable("GITHUB_REF_TYPE") ?? "";
+        return refType.Equals("tag", StringComparison.OrdinalIgnoreCase) ? null : this.environment.GetEnvironmentVariable("GITHUB_REF");
     }
 
     public override bool PreventFetch() => true;

--- a/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
@@ -27,8 +27,8 @@ internal class GitLabCi : BuildAgentBase
     // CI_COMMIT_TAG is only available in tag pipelines,
     // so we can exit if CI_COMMIT_REF_NAME would return the tag
     public override string? GetCurrentBranch(bool usingDynamicRepos) =>
-        string.IsNullOrEmpty(this.Environment.GetEnvironmentVariable("CI_COMMIT_TAG"))
-            ? this.Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME")
+        string.IsNullOrEmpty(this.environment.GetEnvironmentVariable("CI_COMMIT_TAG"))
+            ? this.environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME")
             : null;
 
     public override bool PreventFetch() => true;
@@ -41,6 +41,6 @@ internal class GitLabCi : BuildAgentBase
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");
 
-        this.FileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
+        this.fileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
     }
 }

--- a/src/GitVersion.BuildAgents/Agents/Jenkins.cs
+++ b/src/GitVersion.BuildAgents/Agents/Jenkins.cs
@@ -23,10 +23,10 @@ internal class Jenkins : BuildAgentBase
     ];
 
     public override string? GetCurrentBranch(bool usingDynamicRepos) => IsPipelineAsCode()
-        ? Environment.GetEnvironmentVariable("BRANCH_NAME")
-        : Environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH") ?? Environment.GetEnvironmentVariable("GIT_BRANCH");
+        ? this.environment.GetEnvironmentVariable("BRANCH_NAME")
+        : this.environment.GetEnvironmentVariable("GIT_LOCAL_BRANCH") ?? this.environment.GetEnvironmentVariable("GIT_BRANCH");
 
-    private bool IsPipelineAsCode() => !Environment.GetEnvironmentVariable("BRANCH_NAME").IsNullOrEmpty();
+    private bool IsPipelineAsCode() => !this.environment.GetEnvironmentVariable("BRANCH_NAME").IsNullOrEmpty();
 
     public override bool PreventFetch() => true;
 
@@ -44,6 +44,6 @@ internal class Jenkins : BuildAgentBase
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");
-        this.FileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
+        this.fileSystem.File.WriteAllLines(this.file, SetOutputVariables(variables));
     }
 }

--- a/src/GitVersion.BuildAgents/Agents/MyGet.cs
+++ b/src/GitVersion.BuildAgents/Agents/MyGet.cs
@@ -12,8 +12,7 @@ internal class MyGet(IEnvironment environment, ILog log, IFileSystem fileSystem)
     protected override string EnvironmentVariable => EnvironmentVariableName;
     public override bool CanApplyToCurrentContext()
     {
-        var buildRunner = Environment.GetEnvironmentVariable(EnvironmentVariable);
-
+        var buildRunner = this.environment.GetEnvironmentVariable(EnvironmentVariable);
         return !buildRunner.IsNullOrEmpty()
                && buildRunner.Equals("MyGet", StringComparison.InvariantCultureIgnoreCase);
     }

--- a/src/GitVersion.BuildAgents/Agents/SpaceAutomation.cs
+++ b/src/GitVersion.BuildAgents/Agents/SpaceAutomation.cs
@@ -10,7 +10,7 @@ internal class SpaceAutomation(IEnvironment environment, ILog log, IFileSystem f
 
     protected override string EnvironmentVariable => EnvironmentVariableName;
 
-    public override string? GetCurrentBranch(bool usingDynamicRepos) => Environment.GetEnvironmentVariable("JB_SPACE_GIT_BRANCH");
+    public override string? GetCurrentBranch(bool usingDynamicRepos) => this.environment.GetEnvironmentVariable("JB_SPACE_GIT_BRANCH");
 
     public override string[] SetOutputVariables(string name, string? value) => [];
 

--- a/src/GitVersion.BuildAgents/Agents/TeamCity.cs
+++ b/src/GitVersion.BuildAgents/Agents/TeamCity.cs
@@ -14,7 +14,7 @@ internal class TeamCity(IEnvironment environment, ILog log, IFileSystem fileSyst
 
     public override string? GetCurrentBranch(bool usingDynamicRepos)
     {
-        var branchName = Environment.GetEnvironmentVariable("Git_Branch");
+        var branchName = this.environment.GetEnvironmentVariable("Git_Branch");
 
         if (!branchName.IsNullOrEmpty()) return branchName;
         if (!usingDynamicRepos)
@@ -32,7 +32,7 @@ internal class TeamCity(IEnvironment environment, ILog log, IFileSystem fileSyst
                                                                      See https://gitversion.net/docs/reference/build-servers/teamcity for more info
                                                                      """);
 
-    public override bool PreventFetch() => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("Git_Branch"));
+    public override bool PreventFetch() => !string.IsNullOrEmpty(this.environment.GetEnvironmentVariable("Git_Branch"));
 
     public override string[] SetOutputVariables(string name, string? value) =>
     [

--- a/src/GitVersion.BuildAgents/Agents/TravisCI.cs
+++ b/src/GitVersion.BuildAgents/Agents/TravisCI.cs
@@ -9,7 +9,7 @@ internal class TravisCi(IEnvironment environment, ILog log, IFileSystem fileSyst
     public const string EnvironmentVariableName = "TRAVIS";
     protected override string EnvironmentVariable => EnvironmentVariableName;
 
-    public override bool CanApplyToCurrentContext() => "true".Equals(Environment.GetEnvironmentVariable(EnvironmentVariable)) && "true".Equals(Environment.GetEnvironmentVariable("CI"));
+    public override bool CanApplyToCurrentContext() => "true".Equals(this.environment.GetEnvironmentVariable(EnvironmentVariable)) && "true".Equals(this.environment.GetEnvironmentVariable("CI"));
 
     public override string SetBuildNumber(GitVersionVariables variables) => variables.FullSemVer;
 

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -1,5 +1,5 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Git;
+using GitVersion.Tests;
 
 namespace GitVersion.Configuration.Tests;
 

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -21,7 +21,7 @@ public static class ConfigurationFileLocatorTests
         {
             this.repoPath = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "MyGitRepo");
             this.workingPath = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "MyGitRepo", "Working");
-            var options = Options.Create(new GitVersionOptions { WorkingDirectory = repoPath });
+            var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
 
             var sp = ConfigureServices(services => services.AddSingleton(options));
 

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Abstractions;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Logging;
+using GitVersion.Tests;
 
 namespace GitVersion.Configuration.Tests;
 

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -1,9 +1,8 @@
 using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
-using GitVersion.Core;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Logging;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration.Tests;

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -18,7 +18,7 @@ public class ConfigurationProviderTests : TestBase
     public void Setup()
     {
         this.repoPath = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "MyGitRepo");
-        var options = Options.Create(new GitVersionOptions { WorkingDirectory = repoPath });
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services => services.AddSingleton(options));
         this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
@@ -282,7 +282,7 @@ public class ConfigurationProviderTests : TestBase
         var logAppender = new TestLogAppender(Action);
         var log = new Log(logAppender);
 
-        var options = Options.Create(new GitVersionOptions { WorkingDirectory = repoPath });
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services =>
         {
             services.AddSingleton(options);

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -20,7 +20,7 @@ public class IgnoreConfigurationTests : TestBase
                 commits-before: 2015-10-23T12:23:15
             """;
 
-        var configuration = serializer.ReadConfiguration(yaml);
+        var configuration = this.serializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -40,7 +40,7 @@ public class IgnoreConfigurationTests : TestBase
                     - 6c19c7c219ecf8dbc468042baefa73a1b213e8b1
             """;
 
-        var configuration = serializer.ReadConfiguration(yaml);
+        var configuration = this.serializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -53,7 +53,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "next-version: 1.0";
 
-        var configuration = serializer.ReadConfiguration(yaml);
+        var configuration = this.serializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -70,7 +70,7 @@ public class IgnoreConfigurationTests : TestBase
                 commits-before: bad format date
             """;
 
-        Should.Throw<YamlException>(() => serializer.ReadConfiguration(yaml));
+        Should.Throw<YamlException>(() => this.serializer.ReadConfiguration(yaml));
     }
 
     [Test]
@@ -78,7 +78,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "strategies: ConfiguredNextVersion, TaggedCommit";
 
-        var configuration = serializer.ReadConfiguration(yaml);
+        var configuration = this.serializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.VersionStrategy.ShouldBe(VersionStrategies.ConfiguredNextVersion | VersionStrategies.TaggedCommit);

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 using SharpYaml;
 

--- a/src/GitVersion.Configuration.Tests/Workflows/WorkflowsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Workflows/WorkflowsTests.cs
@@ -18,7 +18,7 @@ public class WorkflowsTests
     {
         var configuration = configurationBuilder.Build();
 
-        var serializedConfiguration = serializer.Serialize(configuration);
+        var serializedConfiguration = this.serializer.Serialize(configuration);
         var segments = workflow.Split("/");
         var folderName = segments[0];
         var fileName = segments[^1];

--- a/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
@@ -159,24 +159,24 @@ internal class BranchConfigurationBuilder
 
     public IBranchConfiguration Build() => new BranchConfiguration
     {
-        DeploymentMode = deploymentMode,
-        Label = label,
-        Increment = increment,
-        RegularExpression = regularExpression,
-        TracksReleaseBranches = tracksReleaseBranches,
-        TrackMergeTarget = trackMergeTarget,
-        TrackMergeMessage = trackMergeMessage,
-        CommitMessageIncrementing = commitMessageIncrementing,
-        IsMainBranch = isMainBranch,
-        IsReleaseBranch = isReleaseBranch,
+        DeploymentMode = this.deploymentMode,
+        Label = this.label,
+        Increment = this.increment,
+        RegularExpression = this.regularExpression,
+        TracksReleaseBranches = this.tracksReleaseBranches,
+        TrackMergeTarget = this.trackMergeTarget,
+        TrackMergeMessage = this.trackMergeMessage,
+        CommitMessageIncrementing = this.commitMessageIncrementing,
+        IsMainBranch = this.isMainBranch,
+        IsReleaseBranch = this.isReleaseBranch,
         PreventIncrement = new PreventIncrementConfiguration
         {
-            OfMergedBranch = preventIncrementOfMergedBranch,
-            WhenBranchMerged = preventIncrementWhenBranchMerged,
-            WhenCurrentCommitTagged = preventIncrementWhenCurrentCommitTagged
+            OfMergedBranch = this.preventIncrementOfMergedBranch,
+            WhenBranchMerged = this.preventIncrementWhenBranchMerged,
+            WhenCurrentCommitTagged = this.preventIncrementWhenCurrentCommitTagged
         },
-        PreReleaseWeight = preReleaseWeight,
-        SourceBranches = sourceBranches,
-        IsSourceBranchFor = isSourceBranchFor
+        PreReleaseWeight = this.preReleaseWeight,
+        SourceBranches = this.sourceBranches,
+        IsSourceBranchFor = this.isSourceBranchFor
     };
 }

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -399,7 +399,7 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
             CommitDateFormat = this.commitDateFormat,
             UpdateBuildNumber = this.updateBuildNumber,
             SemanticVersionFormat = this.semanticVersionFormat,
-            VersionStrategies = versionStrategies,
+            VersionStrategies = this.versionStrategies,
             Branches = branches,
             MergeMessageFormats = this.mergeMessageFormats,
             DeploymentMode = this.versioningMode,

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.VersionCalculation;

--- a/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;

--- a/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitFlowConfigurationBuilder.cs
@@ -41,11 +41,11 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             IsMainBranch = false
         });
 
-        WithBranch(DevelopBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.DevelopBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Minor,
             DeploymentMode = DeploymentMode.ContinuousDelivery,
-            RegularExpression = DevelopBranch.RegexPattern,
+            RegularExpression = this.DevelopBranch.RegexPattern,
             SourceBranches = [this.MainBranch.Name],
             Label = "alpha",
             PreventIncrement = new PreventIncrementConfiguration
@@ -60,10 +60,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 0
         });
 
-        WithBranch(MainBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.MainBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Patch,
-            RegularExpression = MainBranch.RegexPattern,
+            RegularExpression = this.MainBranch.RegexPattern,
             SourceBranches = [],
             Label = string.Empty,
             PreventIncrement = new PreventIncrementConfiguration
@@ -78,11 +78,11 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 55000
         });
 
-        WithBranch(ReleaseBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.ReleaseBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Minor,
             DeploymentMode = DeploymentMode.ManualDeployment,
-            RegularExpression = ReleaseBranch.RegexPattern,
+            RegularExpression = this.ReleaseBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name,
@@ -101,10 +101,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 30000
         });
 
-        WithBranch(FeatureBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.FeatureBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Inherit,
-            RegularExpression = FeatureBranch.RegexPattern,
+            RegularExpression = this.FeatureBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ManualDeployment,
             SourceBranches =
             [
@@ -124,10 +124,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 30000
         });
 
-        WithBranch(PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Inherit,
-            RegularExpression = PullRequestBranch.RegexPattern,
+            RegularExpression = this.PullRequestBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             SourceBranches =
             [
@@ -148,10 +148,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 30000
         });
 
-        WithBranch(HotfixBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.HotfixBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Inherit,
-            RegularExpression = HotfixBranch.RegexPattern,
+            RegularExpression = this.HotfixBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ManualDeployment,
             PreventIncrement = new PreventIncrementConfiguration
             {
@@ -168,10 +168,10 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 30000
         });
 
-        WithBranch(SupportBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.SupportBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Patch,
-            RegularExpression = SupportBranch.RegexPattern,
+            RegularExpression = this.SupportBranch.RegexPattern,
             SourceBranches = [this.MainBranch.Name],
             Label = string.Empty,
             PreventIncrement = new PreventIncrementConfiguration
@@ -185,9 +185,9 @@ internal sealed class GitFlowConfigurationBuilder : ConfigurationBuilderBase<Git
             PreReleaseWeight = 55000
         });
 
-        WithBranch(UnknownBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.UnknownBranch.Name).WithConfiguration(new BranchConfiguration
         {
-            RegularExpression = UnknownBranch.RegexPattern,
+            RegularExpression = this.UnknownBranch.RegexPattern,
             DeploymentMode = DeploymentMode.ManualDeployment,
             Increment = IncrementStrategy.Inherit,
             SourceBranches =

--- a/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;

--- a/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/GitHubFlowConfigurationBuilder.cs
@@ -41,7 +41,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             IsMainBranch = false
         });
 
-        WithBranch(MainBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.MainBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Label = string.Empty,
             Increment = IncrementStrategy.Patch,
@@ -51,7 +51,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             },
             TrackMergeTarget = false,
             TrackMergeMessage = true,
-            RegularExpression = MainBranch.RegexPattern,
+            RegularExpression = this.MainBranch.RegexPattern,
             SourceBranches = [],
             TracksReleaseBranches = false,
             IsReleaseBranch = false,
@@ -59,7 +59,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 55000
         });
 
-        WithBranch(ReleaseBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.ReleaseBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = "beta",
@@ -72,7 +72,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             },
             TrackMergeTarget = false,
             TrackMergeMessage = true,
-            RegularExpression = ReleaseBranch.RegexPattern,
+            RegularExpression = this.ReleaseBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name
@@ -83,7 +83,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(FeatureBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.FeatureBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = ConfigurationConstants.BranchNamePlaceholder,
@@ -92,7 +92,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             {
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = FeatureBranch.RegexPattern,
+            RegularExpression = this.FeatureBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name,
@@ -103,7 +103,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = $"PullRequest{ConfigurationConstants.PullRequestNumberPlaceholder}",
@@ -113,7 +113,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = PullRequestBranch.RegexPattern,
+            RegularExpression = this.PullRequestBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name,
@@ -124,7 +124,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(UnknownBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.UnknownBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ManualDeployment,
             Label = ConfigurationConstants.BranchNamePlaceholder,
@@ -133,7 +133,7 @@ internal sealed class GitHubFlowConfigurationBuilder : ConfigurationBuilderBase<
             {
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = UnknownBranch.RegexPattern,
+            RegularExpression = this.UnknownBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name,

--- a/src/GitVersion.Configuration/Builders/IgnoreConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/IgnoreConfigurationBuilder.cs
@@ -34,7 +34,7 @@ internal sealed class IgnoreConfigurationBuilder
 
     public IIgnoreConfiguration Build() => new IgnoreConfiguration
     {
-        Before = before,
-        Shas = shas
+        Before = this.before,
+        Shas = this.shas
     };
 }

--- a/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;

--- a/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/TrunkBasedConfigurationBuilder.cs
@@ -44,7 +44,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             IsMainBranch = false
         });
 
-        WithBranch(MainBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.MainBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDeployment,
             Label = string.Empty,
@@ -55,7 +55,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             },
             TrackMergeTarget = false,
             TrackMergeMessage = true,
-            RegularExpression = MainBranch.RegexPattern,
+            RegularExpression = this.MainBranch.RegexPattern,
             SourceBranches = [],
             TracksReleaseBranches = false,
             IsReleaseBranch = false,
@@ -63,7 +63,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 55000
         });
 
-        WithBranch(FeatureBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.FeatureBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = ConfigurationConstants.BranchNamePlaceholder,
@@ -72,7 +72,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             {
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = FeatureBranch.RegexPattern,
+            RegularExpression = this.FeatureBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name
@@ -82,7 +82,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(HotfixBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.HotfixBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = ConfigurationConstants.BranchNamePlaceholder,
@@ -91,7 +91,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             {
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = HotfixBranch.RegexPattern,
+            RegularExpression = this.HotfixBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name
@@ -101,7 +101,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.PullRequestBranch.Name).WithConfiguration(new BranchConfiguration
         {
             DeploymentMode = DeploymentMode.ContinuousDelivery,
             Label = $"PullRequest{ConfigurationConstants.PullRequestNumberPlaceholder}",
@@ -111,7 +111,7 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
                 OfMergedBranch = true,
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = PullRequestBranch.RegexPattern,
+            RegularExpression = this.PullRequestBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name,
@@ -122,14 +122,14 @@ internal sealed class TrunkBasedConfigurationBuilder : ConfigurationBuilderBase<
             PreReleaseWeight = 30000
         });
 
-        WithBranch(UnknownBranch.Name).WithConfiguration(new BranchConfiguration
+        WithBranch(this.UnknownBranch.Name).WithConfiguration(new BranchConfiguration
         {
             Increment = IncrementStrategy.Patch,
             PreventIncrement = new PreventIncrementConfiguration
             {
                 WhenCurrentCommitTagged = false
             },
-            RegularExpression = UnknownBranch.RegexPattern,
+            RegularExpression = this.UnknownBranch.RegexPattern,
             SourceBranches =
             [
                 this.MainBranch.Name

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -28,11 +28,11 @@ internal class ConfigurationFileLocator(
     private readonly ILog log = log.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
-    private string? ConfigurationFile => options.Value.ConfigurationInfo.ConfigurationFile;
+    private string? ConfigurationFile => this.options.Value.ConfigurationInfo.ConfigurationFile;
 
     public void Verify(string? workingDirectory, string? projectRootDirectory)
     {
-        if (FileSystemHelper.Path.IsPathRooted(this.ConfigurationFile)) return;
+        if (FileSystemHelper.Path.IsPathRooted(ConfigurationFile)) return;
         if (FileSystemHelper.Path.Equal(workingDirectory, projectRootDirectory)) return;
         WarnAboutAmbiguousConfigFileSelection(workingDirectory, projectRootDirectory);
     }
@@ -46,12 +46,12 @@ internal class ConfigurationFileLocator(
             return customConfigurationFile;
         }
 
-        if (string.IsNullOrWhiteSpace(directoryPath) || !fileSystem.Directory.Exists(directoryPath))
+        if (string.IsNullOrWhiteSpace(directoryPath) || !this.fileSystem.Directory.Exists(directoryPath))
         {
             return null;
         }
 
-        var files = fileSystem.Directory.GetFiles(directoryPath);
+        var files = this.fileSystem.Directory.GetFiles(directoryPath);
         foreach (var fileName in this.SupportedConfigFileNames)
         {
             this.log.Debug($"Trying to find configuration file {fileName} at '{directoryPath}'");
@@ -66,11 +66,11 @@ internal class ConfigurationFileLocator(
 
     private string? GetCustomConfigurationFilePathIfEligable(string? directoryPath)
     {
-        if (string.IsNullOrWhiteSpace(this.ConfigurationFile)) return null;
-        var configurationFilePath = this.ConfigurationFile;
+        if (string.IsNullOrWhiteSpace(ConfigurationFile)) return null;
+        var configurationFilePath = ConfigurationFile;
         if (!string.IsNullOrWhiteSpace(directoryPath))
         {
-            configurationFilePath = FileSystemHelper.Path.Combine(directoryPath, this.ConfigurationFile);
+            configurationFilePath = FileSystemHelper.Path.Combine(directoryPath, ConfigurationFile);
         }
 
         return this.fileSystem.File.Exists(configurationFilePath) ? configurationFilePath : null;
@@ -89,10 +89,10 @@ internal class ConfigurationFileLocator(
             throw new WarningException($"Ambiguous configuration file selection from '{workingConfigFile}' and '{projectRootConfigFile}'");
         }
 
-        if (hasConfigInProjectRootDirectory || hasConfigInWorkingDirectory || this.SupportedConfigFileNames.Any(entry => entry.Equals(this.ConfigurationFile, StringComparison.OrdinalIgnoreCase))) return;
+        if (hasConfigInProjectRootDirectory || hasConfigInWorkingDirectory || this.SupportedConfigFileNames.Any(entry => entry.Equals(ConfigurationFile, StringComparison.OrdinalIgnoreCase))) return;
 
-        workingConfigFile = FileSystemHelper.Path.Combine(workingDirectory, this.ConfigurationFile);
-        projectRootConfigFile = FileSystemHelper.Path.Combine(projectRootDirectory, this.ConfigurationFile);
+        workingConfigFile = FileSystemHelper.Path.Combine(workingDirectory, ConfigurationFile);
+        projectRootConfigFile = FileSystemHelper.Path.Combine(projectRootDirectory, ConfigurationFile);
         throw new WarningException($"The configuration file was not found at '{workingConfigFile}' or '{projectRootConfigFile}'");
     }
 }

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -87,8 +87,8 @@ internal class ConfigurationProvider(
         }
 
         this.log.Info($"Using configuration file '{configFilePath}'");
-        var content = fileSystem.File.ReadAllText(configFilePath);
-        return configurationSerializer.Deserialize<Dictionary<object, object?>>(content);
+        var content = this.fileSystem.File.ReadAllText(configFilePath);
+        return this.configurationSerializer.Deserialize<Dictionary<object, object?>>(content);
     }
 
     private static string? GetWorkflow(IReadOnlyDictionary<object, object?>? overrideConfiguration, IReadOnlyDictionary<object, object?>? overrideConfigurationFromFile)

--- a/src/GitVersion.Configuration/GitVersionConfiguration.cs
+++ b/src/GitVersion.Configuration/GitVersionConfiguration.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using GitVersion.Configuration.Attributes;
-using GitVersion.Core;
 using GitVersion.VersionCalculation;
 using static GitVersion.Configuration.ConfigurationConstants;
 

--- a/src/GitVersion.Configuration/GitVersionConfiguration.cs
+++ b/src/GitVersion.Configuration/GitVersionConfiguration.cs
@@ -50,9 +50,9 @@ internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersio
     [JsonPropertyDescription("Allows you to bump the next version explicitly. Useful for bumping main or a feature branch with breaking changes")]
     public string? NextVersion
     {
-        get => nextVersion;
+        get => this.nextVersion;
         set =>
-            nextVersion = int.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var major)
+            this.nextVersion = int.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var major)
                 ? $"{major}.0"
                 : value;
     }

--- a/src/GitVersion.Core.Tests/CommitDateTests.cs
+++ b/src/GitVersion.Core.Tests/CommitDateTests.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class CommitDateTests : TestBase

--- a/src/GitVersion.Core.Tests/Core/DynamicRepositoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/DynamicRepositoryTests.cs
@@ -1,8 +1,7 @@
 using System.IO.Abstractions;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class DynamicRepositoryTests : TestBase

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Helpers;
@@ -10,7 +9,7 @@ using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation.Caching;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 [Parallelizable(ParallelScope.None)]
@@ -69,7 +68,7 @@ public class GitVersionExecutorTests : TestBase
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
         var preparer = this.sp.GetRequiredService<IGitPreparer>();
         var repositoryInfo = this.sp.GetRequiredService<IGitRepositoryInfo>();
@@ -126,7 +125,7 @@ public class GitVersionExecutorTests : TestBase
 
             this.sp = GetServiceProvider(gitVersionOptions);
 
-            sp.DiscoverRepository();
+            this.sp.DiscoverRepository();
 
             var preparer = this.sp.GetRequiredService<IGitPreparer>();
             var repositoryInfo = this.sp.GetRequiredService<IGitRepositoryInfo>();
@@ -416,7 +415,7 @@ public class GitVersionExecutorTests : TestBase
         // Setup
         this.fileSystem = new FileSystem();
         using var fixture = new EmptyRepositoryFixture();
-        var repoDir = fileSystem.DirectoryInfo.New(fixture.RepositoryPath);
+        var repoDir = this.fileSystem.DirectoryInfo.New(fixture.RepositoryPath);
         var worktreePath = FileSystemHelper.Path.Combine(repoDir.Parent?.FullName, $"{repoDir.Name}-v1");
 
         fixture.Repository.MakeATaggedCommit("v1.0.0");
@@ -461,9 +460,9 @@ public class GitVersionExecutorTests : TestBase
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
-        var sut = sp.GetRequiredService<IGitVersionCalculateTool>();
+        var sut = this.sp.GetRequiredService<IGitVersionCalculateTool>();
 
         // Execute & Verify
         var exception = Assert.Throws<WarningException>(() => sut.CalculateVersionVariables());
@@ -491,9 +490,9 @@ public class GitVersionExecutorTests : TestBase
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
-        var sut = sp.GetRequiredService<IGitVersionCalculateTool>();
+        var sut = this.sp.GetRequiredService<IGitVersionCalculateTool>();
 
         // Execute
         var version = sut.CalculateVersionVariables();
@@ -520,9 +519,9 @@ public class GitVersionExecutorTests : TestBase
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
-        var sut = sp.GetRequiredService<IGitVersionCalculateTool>();
+        var sut = this.sp.GetRequiredService<IGitVersionCalculateTool>();
 
         // Execute & Verify
         var exception = Assert.Throws<WarningException>(() => sut.CalculateVersionVariables());
@@ -548,9 +547,9 @@ public class GitVersionExecutorTests : TestBase
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
-        var sut = sp.GetRequiredService<IGitVersionCalculateTool>();
+        var sut = this.sp.GetRequiredService<IGitVersionCalculateTool>();
 
         // Execute
         var version = sut.CalculateVersionVariables();
@@ -584,8 +583,8 @@ public class GitVersionExecutorTests : TestBase
         environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
 
         this.sp = GetServiceProvider(gitVersionOptions, environment: environment);
-        sp.DiscoverRepository();
-        var sut = sp.GetRequiredService<IGitVersionCalculateTool>();
+        this.sp.DiscoverRepository();
+        var sut = this.sp.GetRequiredService<IGitVersionCalculateTool>();
 
         // Execute
         var version = sut.CalculateVersionVariables();
@@ -625,7 +624,7 @@ public class GitVersionExecutorTests : TestBase
         this.log = this.sp.GetRequiredService<ILog>();
         this.gitVersionCacheProvider = (GitVersionCacheProvider)this.sp.GetRequiredService<IGitVersionCacheProvider>();
 
-        sp.DiscoverRepository();
+        this.sp.DiscoverRepository();
 
         return this.sp.GetRequiredService<IGitVersionCalculateTool>();
     }

--- a/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
@@ -29,7 +29,7 @@ public class GitVersionTaskDirectoryTests : TestBase
     {
         var exception = Assert.Catch(() =>
         {
-            var options = Options.Create(new GitVersionOptions { WorkingDirectory = workDirectory, Settings = { NoFetch = true } });
+            var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.workDirectory, Settings = { NoFetch = true } });
 
             var sp = ConfigureServices(services => services.AddSingleton(options));
 

--- a/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
@@ -1,9 +1,8 @@
 using System.IO.Abstractions;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class GitVersionTaskDirectoryTests : TestBase

--- a/src/GitVersion.Core.Tests/Core/RegexPatternTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RegexPatternTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.RegularExpressions;
-using static GitVersion.Core.RegexPatterns.AssemblyVersion;
+using static GitVersion.RegexPatterns.AssemblyVersion;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 public class RegexPatternsTests
 {

--- a/src/GitVersion.Core.Tests/Core/RepositoryExtensionsTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RepositoryExtensionsTests.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Git;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class RepositoryExtensionsTests : TestBase

--- a/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RepositoryStoreTests.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Git;
 using GitVersion.Logging;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class RepositoryStoreTests : TestBase

--- a/src/GitVersion.Core.Tests/DocumentationTests.cs
+++ b/src/GitVersion.Core.Tests/DocumentationTests.cs
@@ -1,10 +1,9 @@
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.OutputVariables;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class DocumentationTests : TestBase
@@ -62,7 +61,7 @@ public class DocumentationTests : TestBase
     {
         var documentationFilePath = FileSystemHelper.Path.Combine(this.docsDirectory.FullName, relativeDocumentationFilePath);
         // Normalize path separators and such.
-        documentationFilePath = fileSystem.FileInfo.New(documentationFilePath).FullName;
+        documentationFilePath = this.fileSystem.FileInfo.New(documentationFilePath).FullName;
 
         if (!this.fileSystem.File.Exists(documentationFilePath))
         {

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -1,6 +1,5 @@
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Helpers;
@@ -9,7 +8,7 @@ using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 public static class GitRepositoryTestingExtensions
 {

--- a/src/GitVersion.Core.Tests/Extensions/GitVersionVariablesExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitVersionVariablesExtensions.cs
@@ -1,7 +1,7 @@
 using System.IO.Abstractions;
 using GitVersion.OutputVariables;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 public static class GitVersionVariablesExtensions
 {

--- a/src/GitVersion.Core.Tests/Extensions/MockCollectionExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/MockCollectionExtensions.cs
@@ -1,4 +1,4 @@
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 public static class MockCollectionExtensions
 {

--- a/src/GitVersion.Core.Tests/Extensions/ShouldlyExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/ShouldlyExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersion.Core.Tests.Extensions;
+﻿namespace GitVersion.Tests.Extensions;
 
 public static class ShouldlyExtensions
 {

--- a/src/GitVersion.Core.Tests/Extensions/StringFormatWithExtensionTests.cs
+++ b/src/GitVersion.Core.Tests/Extensions/StringFormatWithExtensionTests.cs
@@ -1,8 +1,7 @@
 using System.Globalization;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class StringFormatWithExtensionTests

--- a/src/GitVersion.Core.Tests/Formatting/DateFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/DateFormatterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class DateFormatterTests

--- a/src/GitVersion.Core.Tests/Formatting/EdgeCaseTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/EdgeCaseTests.cs
@@ -1,7 +1,7 @@
-﻿using GitVersion.Core.Tests.Extensions;
-using GitVersion.Formatting;
+﻿using GitVersion.Formatting;
+using GitVersion.Tests.Extensions;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class EdgeCaseTests

--- a/src/GitVersion.Core.Tests/Formatting/FormattableFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/FormattableFormatterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class FormattableFormatterTests

--- a/src/GitVersion.Core.Tests/Formatting/NumericFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/NumericFormatterTests.cs
@@ -1,6 +1,6 @@
 ﻿using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class NumericFormatterTests

--- a/src/GitVersion.Core.Tests/Formatting/SanitizeEnvVarNameTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/SanitizeEnvVarNameTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using GitVersion.Core.Tests.Extensions;
 using GitVersion.Formatting;
+using GitVersion.Tests.Extensions;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value")]
 [SuppressMessage("Style", "IDE0060:Remove unused parameter")]

--- a/src/GitVersion.Core.Tests/Formatting/SanitizeFormatTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/SanitizeFormatTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using GitVersion.Core.Tests.Extensions;
 using GitVersion.Formatting;
+using GitVersion.Tests.Extensions;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value")]
 [SuppressMessage("Style", "IDE0060:Remove unused parameter")]

--- a/src/GitVersion.Core.Tests/Formatting/SanitizeMemberNameTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/SanitizeMemberNameTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using GitVersion.Core.Tests.Extensions;
 using GitVersion.Formatting;
+using GitVersion.Tests.Extensions;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value")]
 [SuppressMessage("Style", "IDE0060:Remove unused parameter")]

--- a/src/GitVersion.Core.Tests/Formatting/StringFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/StringFormatterTests.cs
@@ -1,6 +1,6 @@
 ﻿using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class StringFormatterTests

--- a/src/GitVersion.Core.Tests/Formatting/ValueFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/ValueFormatterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using GitVersion.Formatting;
 
-namespace GitVersion.Core.Tests.Formatting;
+namespace GitVersion.Tests.Formatting;
 
 [TestFixture]
 public class ValueFormatterTests

--- a/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
+++ b/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
@@ -4,6 +4,7 @@
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
         <DebugSymbols>true</DebugSymbols>
+        <RootNamespace>GitVersion.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj.DotSettings
+++ b/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj.DotSettings
+++ b/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=helpers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/GitVersion.Core.Tests/Helpers/GitVersionContextBuilder.cs
+++ b/src/GitVersion.Core.Tests/Helpers/GitVersionContextBuilder.cs
@@ -1,8 +1,7 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 public class GitVersionContextBuilder : IDisposable
 {
@@ -56,8 +55,8 @@ public class GitVersionContextBuilder : IDisposable
     {
         var repo = this.repository ?? CreateRepository();
 
-        emptyRepositoryFixture = new();
-        var options = Options.Create(new GitVersionOptions { WorkingDirectory = emptyRepositoryFixture.RepositoryPath, ConfigurationInfo = { OverrideConfiguration = this.overrideConfiguration } });
+        this.emptyRepositoryFixture = new();
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.emptyRepositoryFixture.RepositoryPath, ConfigurationInfo = { OverrideConfiguration = this.overrideConfiguration } });
 
         this.ServicesProvider = ConfigureServices(services =>
         {

--- a/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
+++ b/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
@@ -5,7 +5,7 @@ using GitVersion.Extensions;
 using GitVersion.Logging;
 using GitVersion.Output;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 public class GitVersionCoreTestModule : IGitVersionModule
 {

--- a/src/GitVersion.Core.Tests/Helpers/ParticipantSanitizerTests.cs
+++ b/src/GitVersion.Core.Tests/Helpers/ParticipantSanitizerTests.cs
@@ -1,6 +1,6 @@
 using GitVersion.Testing.Helpers;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class ParticipantSanitizerTests

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -1,7 +1,7 @@
 using GitVersion.Extensions;
 using GitVersion.Git;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 public class TestBase
 {

--- a/src/GitVersion.Core.Tests/Helpers/TestConsoleAdapter.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestConsoleAdapter.cs
@@ -1,7 +1,7 @@
 using GitVersion.Helpers;
 using GitVersion.Logging;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 public class TestConsoleAdapter(StringBuilder sb) : IConsole
 {

--- a/src/GitVersion.Core.Tests/Helpers/TestEnvironment.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestEnvironment.cs
@@ -1,4 +1,4 @@
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 public class TestEnvironment : IEnvironment
 {

--- a/src/GitVersion.Core.Tests/Helpers/TestLogAppender.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestLogAppender.cs
@@ -1,6 +1,6 @@
 using GitVersion.Logging;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 public class TestLogAppender(Action<string> logAction) : ILogAppender
 {

--- a/src/GitVersion.Core.Tests/Helpers/TestableGitVersionVariables.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestableGitVersionVariables.cs
@@ -1,6 +1,6 @@
 using GitVersion.OutputVariables;
 
-namespace GitVersion.Core.Tests.Helpers;
+namespace GitVersion.Tests;
 
 internal record TestableGitVersionVariables() : GitVersionVariables(
     AssemblySemFileVer: "",

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
@@ -2,7 +2,7 @@ using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 // ReSharper disable ConvertIfStatementToConditionalTernaryExpression
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
@@ -2,7 +2,7 @@ using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 // ReSharper disable ConvertIfStatementToConditionalTernaryExpression
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]

--- a/src/GitVersion.Core.Tests/IntegrationTests/BranchWithoutCommitScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/BranchWithoutCommitScenarios.cs
@@ -1,8 +1,7 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class BranchWithoutCommitScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]

--- a/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]

--- a/src/GitVersion.Core.Tests/IntegrationTests/ComparingTheBehaviorOfDifferentVersioningModes.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ComparingTheBehaviorOfDifferentVersioningModes.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 /// <summary>
 /// - For mode 1 the main-releases are especially not marked with dedicated tags.

--- a/src/GitVersion.Core.Tests/IntegrationTests/ContinuousDeliveryTestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ContinuousDeliveryTestScenarios.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class ContinuousDeliveryTestScenarios
@@ -115,7 +115,7 @@ public class ContinuousDeliveryTestScenarios
     public void ShouldCalculateTheCorrectVersionWhenMergingFromMainToFeatureBranch()
     {
         // *94f03f8 55 minutes ago(HEAD -> main)
-        // |\  
+        // |\
         // | *b1f41a4 56 minutes ago
         // |/
         // *ec77f9c 58 minutes ago
@@ -168,7 +168,7 @@ public class ContinuousDeliveryTestScenarios
     public void ShouldCalculateTheCorrectVersionWhenMergingFromDevelopToFeatureBranch()
     {
         // *2c475bf 55 minutes ago(HEAD -> develop)
-        // |\  
+        // |\
         // | *e05365d 56 minutes ago
         // |/
         // *67acc03 58 minutes ago(main)
@@ -220,7 +220,7 @@ public class ContinuousDeliveryTestScenarios
     {
         // *b1e5593 53 minutes ago(HEAD -> release/ 1.0.0)
         // *8752695 55 minutes ago
-        // |\  
+        // |\
         // | *0965b88 56 minutes ago
         // |/
         // *f63a536 58 minutes ago(main)
@@ -272,7 +272,7 @@ public class ContinuousDeliveryTestScenarios
     public void ShouldFallbackToTheVersionOnDevelopLikeTheReleaseWasNeverCreatedWhenReleaseHasBeenCanceled()
     {
         // *8f062c7 49 minutes ago(HEAD -> develop)
-        // |\  
+        // |\
         // | *bda6ba8 52 minutes ago
         // | *6f5cf19 54 minutes ago
         // * | 3b20f15 50 minutes ago
@@ -354,16 +354,16 @@ public class ContinuousDeliveryTestScenarios
     public void ShouldConsiderTheMergeCommitFromMainToDevelopWhenReleaseHasBeenMergedAndTaggedOnMain()
     {
         // *   5d13120 48 minutes ago  (HEAD -> develop)
-        // |\  
+        // |\
         // | *   8ddd9b0 49 minutes ago  (tag: 1.0.0, main)
-        // | |\  
-        // | | * 4b826b8 52 minutes ago 
-        // | | * d4b0047 54 minutes ago 
-        // * | | 0457671 50 minutes ago 
-        // | |/  
-        // |/|   
-        // * | 5f31f30 56 minutes ago 
-        // |/  
+        // | |\
+        // | | * 4b826b8 52 minutes ago
+        // | | * d4b0047 54 minutes ago
+        // * | | 0457671 50 minutes ago
+        // | |/
+        // |/|
+        // * | 5f31f30 56 minutes ago
+        // |/
         // * 252971e 58 minutes ago
 
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/CreatingAFeatureBranchFromAReleaseBranchScenario.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CreatingAFeatureBranchFromAReleaseBranchScenario.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 /// <summary>
 /// Version not generated correct when creating a feature branch from a release branch #3101
@@ -14,7 +14,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *f59b84f in the future(HEAD -> release/ 1.0.0)
         // *d0f4669 in the future
-        // |\  
+        // |\
         // | *471acec in the future
         // |/
         // | *266fa68 in the future(release/ 1.1.0, main)
@@ -90,7 +90,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *19ed1e8 in the future(HEAD -> release/ 1.0.0)
         // *1684169 in the future
-        // |\  
+        // |\
         // | *07bd75c in the future
         // |/
         // | *ff34213 in the future(release/ 1.1.0, develop)
@@ -172,7 +172,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *2b9c8bf 42 minutes ago(HEAD -> release/ 1.0.0)
         // *66cfc66 44 minutes ago
-        // |\  
+        // |\
         // | *e9978b9 45 minutes ago
         // |/
         // | *c2b96e5 47 minutes ago(release/ 1.1.0, main|develop)
@@ -240,7 +240,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *2b9c8bf 42 minutes ago(HEAD -> release/ 1.0.0)
         // *66cfc66 44 minutes ago
-        // |\  
+        // |\
         // | *e9978b9 45 minutes ago
         // |/
         // | *c2b96e5 47 minutes ago(release/ 1.1.0, main|develop)
@@ -309,14 +309,14 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     public void ShouldTreatTheFeatureBranchLikeTheFirstReleaseBranchWhenItHasBeenBranchedFromFirstButNotFromTheSecondReleaseBranchFromMain()
     {
         // * 3807c66 49 minutes ago  (HEAD -> release/1.0.0)
-        // *   da32145 51 minutes ago 
-        // |\  
-        // | * 6a89f35 52 minutes ago 
-        // |/  
-        // * 19f2980 56 minutes ago 
+        // *   da32145 51 minutes ago
+        // |\
+        // | * 6a89f35 52 minutes ago
+        // |/
+        // * 19f2980 56 minutes ago
         // | * 2282a59 54 minutes ago  (release/1.1.0, main)
-        // |/  
-        // * d7b7c5e 58 minutes ago 
+        // |/
+        // * d7b7c5e 58 minutes ago
 
         var configuration = GitFlowConfigurationBuilder.New.Build();
 
@@ -380,7 +380,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *1525ad0 38 minutes ago(HEAD -> release/ 1.0.0)
         // *476fc51 40 minutes ago
-        // |\  
+        // |\
         // | *c8c5030 41 minutes ago
         // |/
         // *d91061d 45 minutes ago
@@ -453,7 +453,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *1525ad0 38 minutes ago(HEAD -> release/ 1.0.0)
         // *476fc51 40 minutes ago
-        // |\  
+        // |\
         // | *c8c5030 41 minutes ago
         // |/
         // *d91061d 45 minutes ago
@@ -523,7 +523,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *1525ad0 38 minutes ago(HEAD -> release/ 1.0.0)
         // *476fc51 40 minutes ago
-        // |\  
+        // |\
         // | *c8c5030 41 minutes ago
         // |/
         // *d91061d 45 minutes ago
@@ -596,7 +596,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *588f0de in the future(HEAD -> release/ 1.0.0)
         // *56f660c in the future
-        // |\  
+        // |\
         // | *9450fb0 in the future
         // |/
         // *9e557cd in the future
@@ -659,7 +659,7 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     {
         // *809eaa7 in the future(HEAD -> develop)
         // *46e2cb8 in the future
-        // |\  
+        // |\
         // | *08bd8ff in the future
         // | *9b741de in the future
         // * | 13206fd in the future
@@ -733,9 +733,9 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     public void ShouldOnlyTrackTheCommitsOnDevelopBranchForNextReleaseWhenReleaseHasBeenShippedToProduction()
     {
         // *9afb0ca in the future(HEAD -> develop)
-        // |\  
+        // |\
         // | *90c96f2 in the future(tag: 1.0.0, main)
-        // | |\  
+        // | |\
         // | | *7de3d63 in the future
         // | | *2ccf33b in the future
         // * | | e050757 in the future
@@ -822,9 +822,9 @@ public class CreatingAFeatureBranchFromAReleaseBranchScenario
     public void ShouldNotConsiderTheMergeCommitFromReleaseToMainWhenCommitHasNotBeenTagged()
     {
         // *457e0cd in the future(HEAD -> develop)
-        // |\  
+        // |\
         // | *d9da657 in the future(tag: 1.0.0, main)
-        // | |\  
+        // | |\
         // | | *026a6cd in the future
         // | | *7f5de6e in the future
         // * | | 3db6e6f in the future

--- a/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class DevelopScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamples.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamples.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class DocumentationSamples : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
@@ -3,7 +3,7 @@ using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class DocumentationSamplesForGitFlow

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitHubFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitHubFlow.cs
@@ -3,7 +3,7 @@ using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class DocumentationSamplesForGitHubFlow

--- a/src/GitVersion.Core.Tests/IntegrationTests/FallbackVersionStrategyScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FallbackVersionStrategyScenarios.cs
@@ -1,8 +1,7 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class FallbackVersionStrategyScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class FeatureBranchScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/GitflowScenarios.cs
@@ -1,6 +1,4 @@
-using GitVersion.Core.Tests.Helpers;
-
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class GitflowScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/HotfixBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/HotfixBranchScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class HotfixBranchScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
@@ -1,8 +1,7 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class IgnoreCommitScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainScenarios.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class MainScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainlineDevelopmentScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 public class MainlineDevelopmentScenarios : TestBase
 {

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherBranchScenarios.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class OtherBranchScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
@@ -1,14 +1,13 @@
 using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class OtherScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/PerformanceScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PerformanceScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 public class PerformanceScenarios : TestBase
 {

--- a/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class PullRequestScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class ReleaseBranchScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class RemoteRepositoryScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/SemVerOfAFeatureBranchStartedFromAReleaseBranchGetsDecrementedScenario.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SemVerOfAFeatureBranchStartedFromAReleaseBranchGetsDecrementedScenario.cs
@@ -1,4 +1,4 @@
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 /// <summary>
 /// [Bug] SemVer of a feature branch started from a release branch gets decremented #3151

--- a/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class SupportBranchScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/SwitchingToGitFlowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SwitchingToGitFlowScenarios.cs
@@ -1,8 +1,7 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class SwitchingToGitFlowScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/TagCheckoutScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/TagCheckoutScenarios.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class TagCheckoutScenarios

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class VersionBumpingScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
@@ -1,8 +1,7 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class VersionInCurrentBranchNameScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
@@ -1,8 +1,7 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class VersionInMergedBranchNameScenarios : TestBase

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInTagScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInTagScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 internal class VersionInTagScenarios

--- a/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
@@ -1,10 +1,9 @@
 using System.IO.Abstractions;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.IntegrationTests;
+namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class WorktreeScenarios : TestBase

--- a/src/GitVersion.Core.Tests/Logging/LoggerTest.cs
+++ b/src/GitVersion.Core.Tests/Logging/LoggerTest.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Logging;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class LoggerTest : TestBase

--- a/src/GitVersion.Core.Tests/Logging/LoggingTests.cs
+++ b/src/GitVersion.Core.Tests/Logging/LoggingTests.cs
@@ -1,6 +1,6 @@
 using GitVersion.Logging;
 
-namespace GitVersion.Core.Tests.Logging;
+namespace GitVersion.Tests.Logging;
 
 [TestFixture]
 public class LoggingTests

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhen.cs
@@ -24,16 +24,16 @@ internal partial class MainlineScenariosWithAGitFlow
             // |/
             // * 58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("develop");
-            fixture.MakeACommit("B");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("develop");
+            this.fixture.MakeACommit("B");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-alpha.1+2")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, ExpectedResult = "0.0.1-alpha.1+2")]
@@ -61,7 +61,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("develop", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-2+2")]
@@ -90,7 +90,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("develop", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhenMergedCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhenMergedCommitTaggedAsStable.cs
@@ -24,18 +24,18 @@ internal partial class MainlineScenariosWithAGitFlow
             // |/
             // * 58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("develop");
-            fixture.MakeACommit("B");
-            fixture.MergeTo("main");
-            fixture.ApplyTag("1.0.0");
-            fixture.Checkout("develop");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("develop");
+            this.fixture.MakeACommit("B");
+            this.fixture.MergeTo("main");
+            this.fixture.ApplyTag("1.0.0");
+            this.fixture.Checkout("develop");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "1.0.0-alpha.1+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, ExpectedResult = "1.0.1-alpha.1+0")]
@@ -63,7 +63,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("develop", b => b.WithIncrement(increment).WithTrackMergeTarget(true))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-alpha.1+1")]
@@ -92,7 +92,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("develop", b => b.WithIncrement(increment).WithTrackMergeTarget(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhenMergedCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitFlow+GivenADevelopBranchWithOneCommitMergedToMainWhenMergedCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
@@ -31,20 +31,20 @@ internal partial class MainlineScenariosWithAGitFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.Checkout("main");
-            fixture.MakeACommit("C");
-            fixture.Checkout("main");
-            fixture.MergeTo("feature/foo");
-            fixture.MergeTo("main", removeBranchAfterMerging: true);
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.Checkout("main");
+            this.fixture.MakeACommit("C");
+            this.fixture.Checkout("main");
+            this.fixture.MergeTo("feature/foo");
+            this.fixture.MergeTo("main", removeBranchAfterMerging: true);
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.1+3")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-foo.1+3")]
@@ -136,7 +136,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("feature", b => b.WithIncrement(incrementOnFeature))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.1+3")]
@@ -230,7 +230,7 @@ internal partial class MainlineScenariosWithAGitFlow
                 .WithBranch("feature", b => b.WithIncrement(incrementOnFeature))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainMergedBackToMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainWhen.cs
@@ -27,18 +27,18 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.Checkout("main");
-            fixture.MakeACommit("C");
-            fixture.MergeTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.Checkout("main");
+            this.fixture.MakeACommit("C");
+            this.fixture.MergeTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-foo.1+2")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, ExpectedResult = "0.0.1-foo.1+2")]
@@ -70,7 +70,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-foo.1+2")]
@@ -103,7 +103,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-foo.3+2")]
@@ -136,7 +136,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, ExpectedResult = "0.0.0-foo.1+2")]
@@ -169,7 +169,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithAMergeCommitFromMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhen.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -482,7 +482,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMajor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: major");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: major");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-2+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "1.0.1-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -258,7 +258,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -373,7 +373,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-2+1")]
@@ -487,7 +487,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -602,7 +602,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -717,7 +717,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-foo.2+1")]
@@ -830,7 +830,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -945,7 +945,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1060,7 +1060,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-bar.2+1")]
@@ -1173,7 +1173,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1288,7 +1288,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1403,7 +1403,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMinor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: minor");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: minor");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-2+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.1.1-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -258,7 +258,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -373,7 +373,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-2+1")]
@@ -487,7 +487,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -602,7 +602,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -717,7 +717,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-foo.2+1")]
@@ -830,7 +830,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -945,7 +945,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1060,7 +1060,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-bar.2+1")]
@@ -1173,7 +1173,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1288,7 +1288,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1403,7 +1403,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitAHasBumpMessagePatch.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: patch");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: patch");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-2+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -258,7 +258,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -373,7 +373,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-2+1")]
@@ -486,7 +486,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -601,7 +601,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-foo.2+1")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -944,7 +944,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1059,7 +1059,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-bar.2+1")]
@@ -1172,7 +1172,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1287,7 +1287,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1402,7 +1402,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreRelease.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago (main) (tag 0.0.0-4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-4");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-4");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseBar.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago (main) (tag 0.0.0-bar)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-bar");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-bar");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-bar+1")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsPreReleaseFoo.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago (main) (tag 0.0.0-foo.4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-foo.4");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-foo.1+1")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsStable.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main) (tag 0.0.0)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -145,7 +145,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -259,7 +259,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -373,7 +373,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -487,7 +487,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitATaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMajor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B +semver: major");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B +semver: major");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-1+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "1.0.0-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -259,7 +259,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-1+1")]
@@ -488,7 +488,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -604,7 +604,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -720,7 +720,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-foo.1+1")]
@@ -833,7 +833,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -949,7 +949,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1065,7 +1065,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-bar.1+1")]
@@ -1178,7 +1178,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1294,7 +1294,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1410,7 +1410,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessageMinor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B +semver: minor");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B +semver: minor");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-1+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.1.0-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -259,7 +259,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-1+1")]
@@ -488,7 +488,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -604,7 +604,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -720,7 +720,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-foo.1+1")]
@@ -833,7 +833,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -949,7 +949,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1065,7 +1065,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-bar.1+1")]
@@ -1178,7 +1178,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1294,7 +1294,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1410,7 +1410,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBHasBumpMessagePatch.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B +semver: patch");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B +semver: patch");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-1+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -259,7 +259,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-1+1")]
@@ -488,7 +488,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -604,7 +604,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -720,7 +720,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-foo.1+1")]
@@ -833,7 +833,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -949,7 +949,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+1")]
@@ -1065,7 +1065,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-bar.1+1")]
@@ -1178,7 +1178,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1294,7 +1294,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+1")]
@@ -1410,7 +1410,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreRelease.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo) (tag 0.0.0-4)
             // A 51 minutes ago (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-4");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-4")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseBar.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo) (tag 0.0.0-bar)
             // A 51 minutes ago (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-bar");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-bar");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-bar")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseFoo.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo) (tag 0.0.0-foo.4)
             // A 51 minutes ago (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-foo.4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-foo.4")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsStable.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago  (HEAD -> feature/foo) (tag 0.0.0)
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0")]
@@ -145,7 +145,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -239,7 +239,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -353,7 +353,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -447,7 +447,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -561,7 +561,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -655,7 +655,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -769,7 +769,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -863,7 +863,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitBranchedFromMainWhenCommitBTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
@@ -26,16 +26,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+2")]
@@ -148,7 +148,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -263,7 +263,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -377,7 +377,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -492,7 +492,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -606,7 +606,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -721,7 +721,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -835,7 +835,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -950,7 +950,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
@@ -20,7 +20,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
             // *  54 minutes ago  (HEAD -> main)
             // |\
@@ -28,15 +28,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-4");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-4");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-5+1")]
@@ -148,7 +148,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
@@ -262,7 +262,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+1")]
@@ -490,7 +490,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -603,7 +603,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -717,7 +717,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -830,7 +830,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -944,7 +944,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
@@ -20,7 +20,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
             // *  55 minutes ago  (HEAD -> main)
             // |\
@@ -28,15 +28,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-bar");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-bar");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-bar+1")]
@@ -148,7 +148,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
@@ -262,7 +262,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -489,7 +489,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -602,7 +602,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+1")]
@@ -943,7 +943,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsPreReleaseFoo.cs
@@ -20,7 +20,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
             // *  55 minutes ago  (HEAD -> main)
             // |\
@@ -28,15 +28,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0-foo.4");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-foo.5+1")]
@@ -148,7 +148,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
@@ -262,7 +262,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -489,7 +489,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
@@ -602,7 +602,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+1")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+2")]
@@ -943,7 +943,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWhenCommitBTaggedAsStable.cs
@@ -20,7 +20,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
             // *  55 minutes ago  (HEAD -> main)
             // |\
@@ -28,15 +28,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.0.0");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.0.0");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -148,7 +148,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -262,7 +262,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -375,7 +375,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -489,7 +489,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.1+1")]
@@ -602,7 +602,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.1+1")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.1+1")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.1+1")]
@@ -943,7 +943,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
@@ -27,20 +27,20 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.Checkout("main");
-            fixture.MakeACommit("C");
-            fixture.Checkout("feature/foo");
-            fixture.MergeTo("main", removeBranchAfterMerging: true);
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.Checkout("main");
+            this.fixture.MakeACommit("C");
+            this.fixture.Checkout("feature/foo");
+            this.fixture.MergeTo("main", removeBranchAfterMerging: true);
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+0")]
@@ -153,7 +153,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4+0")]
@@ -268,7 +268,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4+0")]
@@ -382,7 +382,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4+0")]
@@ -497,7 +497,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4+0")]
@@ -611,7 +611,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4+0")]
@@ -726,7 +726,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.4+0")]
@@ -840,7 +840,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.4+0")]
@@ -955,7 +955,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitMergedToMainWithOneCommitBranchedToFeatureWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhen.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago (HEAD -> feature/foo)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
+            this.fixture.MakeACommit("A");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  59 minutes ago  (HEAD -> feature/foo)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A +semver: major");
+            this.fixture.MakeACommit("A +semver: major");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "1.0.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "1.0.0-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  59 minutes ago  (HEAD -> feature/foo)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A +semver: minor");
+            this.fixture.MakeACommit("A +semver: minor");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.1.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.1.0-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  59 minutes ago  (HEAD -> feature/foo)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A +semver: patch");
+            this.fixture.MakeACommit("A +semver: patch");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.1-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
@@ -21,14 +21,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago (HEAD -> feature/foo) (tag 0.0.0-4)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-4");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-4")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+0")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
@@ -21,14 +21,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago (HEAD -> feature/foo) (tag 0.0.0-bar)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-bar");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-bar");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-bar")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+0")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
@@ -21,14 +21,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago (HEAD -> feature/foo) (tag 0.0.0-foo.4)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-foo.4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-foo.4")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+0")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsStable.cs
@@ -21,14 +21,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago (HEAD -> feature/foo) (tag 0.0.0)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithOneCommitWhenCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsBranchedFromMainWhen.cs
@@ -25,17 +25,17 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
-            fixture.MakeACommit("D");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
+            this.fixture.MakeACommit("D");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+3")]
@@ -127,7 +127,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
@@ -220,7 +220,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+3")]
@@ -313,7 +313,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsBranchedFromMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
@@ -28,18 +28,18 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
-            fixture.MakeACommit("D");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
+            this.fixture.MakeACommit("D");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+4")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+4")]
@@ -152,7 +152,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+4")]
@@ -267,7 +267,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+4")]
@@ -381,7 +381,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+4")]
@@ -496,7 +496,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+4")]
@@ -610,7 +610,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+4")]
@@ -725,7 +725,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+4")]
@@ -839,7 +839,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+4")]
@@ -954,7 +954,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsMergedToMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsWhen.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+3")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+3")]
@@ -58,7 +58,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithThreeCommitsWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsBranchedFromMainWhen.cs
@@ -24,16 +24,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 47 minutes ago
             // A 51 minutes ago  (main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+2")]
@@ -125,7 +125,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+2")]
@@ -218,7 +218,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+2")]
@@ -311,7 +311,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsBranchedFromMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsBranchedFromMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
@@ -27,17 +27,17 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // |/
             // A  58 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
-            fixture.MergeTo("main");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
+            this.fixture.MergeTo("main");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+3")]
@@ -150,7 +150,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
@@ -265,7 +265,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
@@ -379,7 +379,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+3")]
@@ -494,7 +494,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+3")]
@@ -608,7 +608,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+3")]
@@ -723,7 +723,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+3")]
@@ -837,7 +837,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+3")]
@@ -952,7 +952,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsMergedToMainWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> feature/foo)
             // A 59 minutes ago (tag 0.0.3-4)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-4");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-4");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-5+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.3-5+1")]
@@ -57,7 +57,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> feature/foo)
             // A 59 minutes ago (tag 0.0.3-bar)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-bar");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-bar");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.3-bar+1")]
@@ -57,7 +57,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAFeatureBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> feature/foo)
             // A 59 minutes ago (tag 0.0.3-foo.4)
 
-            fixture = new EmptyRepositoryFixture("feature/foo");
+            this.fixture = new EmptyRepositoryFixture("feature/foo");
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-foo.4");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-foo.4");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.5+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.3-foo.5+1")]
@@ -57,7 +57,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhen.cs
@@ -22,14 +22,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+0")]
@@ -141,7 +141,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -255,7 +255,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -368,7 +368,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -481,7 +481,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMajor.cs
@@ -22,14 +22,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: major");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: major");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-2+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "1.0.1-1+0")]
@@ -141,7 +141,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-2+0")]
@@ -485,7 +485,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -600,7 +600,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -715,7 +715,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-foo.2+0")]
@@ -828,7 +828,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -943,7 +943,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -1058,7 +1058,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-bar.2+0")]
@@ -1171,7 +1171,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1286,7 +1286,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1401,7 +1401,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessageMinor.cs
@@ -22,14 +22,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: minor");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: minor");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-2+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.1.1-1+0")]
@@ -141,7 +141,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-2+0")]
@@ -485,7 +485,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -600,7 +600,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -715,7 +715,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-foo.2+0")]
@@ -828,7 +828,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -943,7 +943,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -1058,7 +1058,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-bar.2+0")]
@@ -1171,7 +1171,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1286,7 +1286,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1401,7 +1401,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitHasBumpMessagePatch.cs
@@ -22,14 +22,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: patch");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: patch");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-2+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+0")]
@@ -141,7 +141,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-2+0")]
@@ -484,7 +484,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -599,7 +599,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -714,7 +714,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-foo.2+0")]
@@ -827,7 +827,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -942,7 +942,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -1057,7 +1057,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-bar.2+0")]
@@ -1170,7 +1170,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1285,7 +1285,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -1400,7 +1400,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreRelease.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main) (tag 0.0.0-4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-4");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-4");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-4")]
@@ -142,7 +142,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-5+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -596,7 +596,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -710,7 +710,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
@@ -823,7 +823,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -937,7 +937,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseBar.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main) (tag 0.0.0-bar)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-bar");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-bar");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-bar")]
@@ -142,7 +142,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -596,7 +596,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.2+0")]
@@ -710,7 +710,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
@@ -823,7 +823,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar+0")]
@@ -937,7 +937,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsPreReleaseFoo.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main) (tag 0.0.0-foo.4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-foo.4");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-foo.4")]
@@ -142,7 +142,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -596,7 +596,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.5+0")]
@@ -710,7 +710,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
@@ -823,7 +823,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.2+0")]
@@ -937,7 +937,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitBranchedToFeatureWhenCommitTaggedAsStable.cs
@@ -22,15 +22,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A  58 minutes ago  (HEAD -> feature/foo, main) (tag 0.0.0)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.0")]
@@ -142,7 +142,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -596,7 +596,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.1+0")]
@@ -710,7 +710,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
@@ -823,7 +823,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.1+0")]
@@ -937,7 +937,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label).WithPreventIncrementWhenCurrentCommitTagged(false))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhen.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
+            this.fixture.MakeACommit("A");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMajor.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: major");
+            this.fixture.MakeACommit("A +semver: major");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "1.0.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "1.0.0-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessageMinor.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: minor");
+            this.fixture.MakeACommit("A +semver: minor");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.1.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.1.0-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitHasBumpMessagePatch.cs
@@ -19,13 +19,13 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: patch");
+            this.fixture.MakeACommit("A +semver: patch");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.1-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+1")]
@@ -52,7 +52,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -81,7 +81,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-1+1")]
@@ -110,7 +110,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
@@ -19,14 +19,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main) (tag 0.0.0-4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-4");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-4")]
@@ -53,7 +53,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
@@ -19,14 +19,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main) (tag 0.0.0-bar)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-bar");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-bar");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-bar")]
@@ -53,7 +53,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
@@ -19,14 +19,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main) (tag 0.0.0-foo.4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0-foo.4");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0-foo.4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0-foo.4")]
@@ -53,7 +53,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsStable.cs
@@ -19,14 +19,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
         {
             // A 59 minutes ago  (HEAD -> main) (tag 0.0.0)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.0");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.0");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.0")]
@@ -53,7 +53,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithOneCommitWhenCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithThreeCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithThreeCommitsWhen.cs
@@ -21,15 +21,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.MakeACommit("C");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.MakeACommit("C");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.3-1+1")]
@@ -56,7 +56,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithThreeCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithThreeCommitsWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhen.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.1-1+0")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -256,7 +256,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -369,7 +369,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -482,7 +482,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMajor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: major");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: major");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-3+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "1.0.1-1+0")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-3+0")]
@@ -484,7 +484,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -600,7 +600,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-foo.3+0")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -944,7 +944,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -1060,7 +1060,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "1.0.0-bar.3+0")]
@@ -1173,7 +1173,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1288,7 +1288,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1403,7 +1403,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMinor.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: minor");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: minor");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-3+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.1.1-1+0")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-3+0")]
@@ -484,7 +484,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -600,7 +600,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-foo.3+0")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -944,7 +944,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -1060,7 +1060,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.1.0-bar.3+0")]
@@ -1173,7 +1173,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1288,7 +1288,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1403,7 +1403,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitHasBumpMessagePatch.cs
@@ -23,15 +23,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: patch");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A +semver: patch");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-3+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+0")]
@@ -143,7 +143,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -371,7 +371,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-3+0")]
@@ -484,7 +484,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -600,7 +600,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-3+0")]
@@ -716,7 +716,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-foo.3+0")]
@@ -829,7 +829,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -944,7 +944,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-foo.3+0")]
@@ -1060,7 +1060,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.1-bar.3+0")]
@@ -1173,7 +1173,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1288,7 +1288,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.0-bar.3+0")]
@@ -1403,7 +1403,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 ).WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreRelease.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago  (0.0.3-4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-4");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-4");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-6+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-1+0")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-6+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.3+0")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar.3+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago  (0.0.3-bar)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-bar");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-bar");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-bar+0")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-3+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.3+0")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago  (0.0.3-foo.4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-foo.4");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-foo.4");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.6+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-foo.1+0")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-3+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.6+0")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar.3+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsStable.cs
@@ -23,16 +23,16 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B  54 minutes ago  (main) (HEAD -> feature/foo)
             // A  56 minutes ago  (0.0.3)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3");
-            fixture.MakeACommit("B");
-            fixture.BranchTo("feature/foo");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3");
+            this.fixture.MakeACommit("B");
+            this.fixture.BranchTo("feature/foo");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-2+0")]
         [TestCase(IncrementStrategy.None, IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-1+0")]
@@ -144,7 +144,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-2+0")]
@@ -257,7 +257,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.2+0")]
@@ -370,7 +370,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar.2+0")]
@@ -483,7 +483,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("feature", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsBranchedToFeatureWhenFirstCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhen.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhen.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhen.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMajor.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: major");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: major");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "1.0.0-2+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "1.0.1-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessageMinor.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: minor");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: minor");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.1.0-2+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.1.1-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessagePatch.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A +semver: patch");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A +semver: patch");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.1-2+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> main)
             // A 59 minutes ago (tag 0.0.3-4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-4");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-4");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-5+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-1+1")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> main)
             // A 59 minutes ago (tag 0.0.3-bar)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-bar");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-bar");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-bar+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-bar+1")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsPreReleaseFoo.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> main)
             // A 59 minutes ago (tag 0.0.3-foo.4)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3-foo.4");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3-foo.4");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-foo.5+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-foo.1+1")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsStable.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago (HEAD -> main)
             // A 59 minutes ago (tag 0.0.3)
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.ApplyTag("0.0.3");
-            fixture.MakeACommit("B");
+            this.fixture.MakeACommit("A");
+            this.fixture.ApplyTag("0.0.3");
+            this.fixture.MakeACommit("B");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.3-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.4-1+1")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenFirstCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMajor.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B +semver: major");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B +semver: major");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "1.0.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "1.0.0-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMajor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMajor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMinor.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMinor.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessageMinor.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B +semver: minor");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B +semver: minor");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.1.0-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.1.0-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessagePatch.cs
@@ -20,14 +20,14 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B +semver: patch");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B +semver: patch");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.1-1+1")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.0.2-1+1")]
@@ -54,7 +54,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -83,7 +83,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.Disabled)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.0.0-2+1")]
@@ -112,7 +112,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                     .WithCommitMessageIncrementing(CommitMessageIncrementMode.MergeMessageOnly)
                 ).Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessagePatch.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitHasBumpMessagePatch.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreRelease.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreRelease.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreRelease.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main) (tag 0.2.0-4)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.2.0-4");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.2.0-4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.2.0-4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.2.0-4")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseBar.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseBar.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseBar.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main) (tag 0.2.0-bar)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.2.0-bar");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.2.0-bar");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.2.0-bar")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.2.0-bar")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseFoo.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseFoo.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsPreReleaseFoo.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main) (tag 0.2.0-foo.4)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.2.0-foo.4");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.2.0-foo.4");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.2.0-foo.4")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.2.0-foo.4")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsStable.cs
@@ -20,15 +20,15 @@ internal partial class MainlineScenariosWithAGitHubFlow
             // B 58 minutes ago  (HEAD -> main) (tag 0.2.0)
             // A 59 minutes ago
 
-            fixture = new EmptyRepositoryFixture();
+            this.fixture = new EmptyRepositoryFixture();
 
-            fixture.MakeACommit("A");
-            fixture.MakeACommit("B");
-            fixture.ApplyTag("0.2.0");
+            this.fixture.MakeACommit("A");
+            this.fixture.MakeACommit("B");
+            this.fixture.ApplyTag("0.2.0");
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown() => fixture?.Dispose();
+        public void OneTimeTearDown() => this.fixture?.Dispose();
 
         [TestCase(IncrementStrategy.None, null, ExpectedResult = "0.2.0")]
         [TestCase(IncrementStrategy.Patch, null, ExpectedResult = "0.2.0")]
@@ -55,7 +55,7 @@ internal partial class MainlineScenariosWithAGitHubFlow
                 .WithBranch("main", b => b.WithIncrement(increment).WithLabel(label))
                 .Build();
 
-            return fixture!.GetVersion(mainline).FullSemVer;
+            return this.fixture!.GetVersion(mainline).FullSemVer;
         }
     }
 }

--- a/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsStable.cs
+++ b/src/GitVersion.Core.Tests/Mainline/MainlineScenariosWithAGitHubFlow+GivenAMainBranchWithTwoCommitsWhenSecondCommitTaggedAsStable.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.Mainline;
+namespace GitVersion.Tests.Mainline;
 
 internal partial class MainlineScenariosWithAGitHubFlow
 {

--- a/src/GitVersion.Core.Tests/MergeMessageTests.cs
+++ b/src/GitVersion.Core.Tests/MergeMessageTests.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class MergeMessageTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
@@ -1,10 +1,9 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Git;
 using GitVersion.Logging;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.VersionCalculation;
+namespace GitVersion.Tests.VersionCalculation;
 
 [TestFixture]
 public class EffectiveBranchConfigurationFinderTests

--- a/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/JsonVersionBuilderTests.cs
@@ -1,9 +1,8 @@
 using System.Globalization;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class JsonVersionBuilderTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/MainlineIterationTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MainlineIterationTests.cs
@@ -1,7 +1,7 @@
 ﻿using GitVersion.Configuration;
 using GitVersion.VersionCalculation.Mainline;
 
-namespace GitVersion.Core.Tests.VersionCalculation;
+namespace GitVersion.Tests.VersionCalculation;
 
 [TestFixture]
 public class MainlineIterationTests

--- a/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/MinDateVersionFilterTests.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class MinDateVersionFilterTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
-namespace GitVersion.Core.Tests.VersionCalculation;
+namespace GitVersion.Tests.VersionCalculation;
 
 public class NextVersionCalculatorTests : TestBase
 {

--- a/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/PathFilterTests.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class PathFilterTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/SemanticVersionTests.cs
@@ -1,6 +1,4 @@
-using GitVersion.Core.Tests.Helpers;
-
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class SemanticVersionTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/ShaVersionFilterTests.cs
@@ -1,7 +1,6 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class ShaVersionFilterTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/ConfiguredNextVersionVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/ConfiguredNextVersionVersionStrategyTests.cs
@@ -1,9 +1,8 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.VersionCalculation.Strategies;
+namespace GitVersion.Tests.VersionCalculation.Strategies;
 
 [TestFixture]
 public class ConfiguredNextVersionVersionStrategyTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.VersionCalculation.Strategies;
+namespace GitVersion.Tests.VersionCalculation.Strategies;
 
 [TestFixture]
 public class MergeMessageBaseVersionStrategyTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests.VersionCalculation.Strategies;
+namespace GitVersion.Tests.VersionCalculation.Strategies;
 
 [TestFixture]
 public class VersionInBranchNameBaseVersionStrategyTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
@@ -1,11 +1,10 @@
 using System.Globalization;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Git;
 using GitVersion.Logging;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class VariableProviderTests : TestBase

--- a/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VersionSourceTests.cs
@@ -1,8 +1,7 @@
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Git;
 using GitVersion.VersionCalculation;
 
-namespace GitVersion.Core.Tests;
+namespace GitVersion.Tests;
 
 [TestFixture]
 public class VersionSourceTests : TestBase

--- a/src/GitVersion.Core/Agents/BuildAgentBase.cs
+++ b/src/GitVersion.Core/Agents/BuildAgentBase.cs
@@ -8,15 +8,15 @@ namespace GitVersion.Agents;
 internal abstract class BuildAgentBase(IEnvironment environment, ILog log, IFileSystem fileSystem) : ICurrentBuildAgent
 {
     protected readonly ILog Log = log.NotNull();
-    protected readonly IEnvironment Environment = environment.NotNull();
-    protected readonly IFileSystem FileSystem = fileSystem.NotNull();
+    protected readonly IEnvironment environment = environment.NotNull();
+    protected readonly IFileSystem fileSystem = fileSystem.NotNull();
 
     protected abstract string EnvironmentVariable { get; }
 
     public abstract string? SetBuildNumber(GitVersionVariables variables);
     public abstract string[] SetOutputVariables(string name, string? value);
 
-    public virtual bool CanApplyToCurrentContext() => !Environment.GetEnvironmentVariable(EnvironmentVariable).IsNullOrEmpty();
+    public virtual bool CanApplyToCurrentContext() => !this.environment.GetEnvironmentVariable(EnvironmentVariable).IsNullOrEmpty();
 
     public virtual string? GetCurrentBranch(bool usingDynamicRepos) => null;
 

--- a/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using GitVersion.Core;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Configuration;

--- a/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
+++ b/src/GitVersion.Core/Core/Abstractions/IRepositoryStore.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Git;
 
-namespace GitVersion.Common;
+namespace GitVersion;
 
 /// <summary>Provides high-level read access to a Git repository, exposing the objects and queries needed for version calculation.</summary>
 public interface IRepositoryStore

--- a/src/GitVersion.Core/Core/BranchRepository.cs
+++ b/src/GitVersion.Core/Core/BranchRepository.cs
@@ -1,9 +1,8 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal sealed class BranchRepository(IRepositoryStore repositoryStore) : IBranchRepository
 {

--- a/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
+++ b/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
@@ -22,16 +22,16 @@ internal class BranchesContainingCommitFinder(IRepositoryStore repositoryStore, 
 
     private IEnumerable<IBranch> InnerGetBranchesContainingCommit(ICommit commit, IEnumerable<IBranch> branches, bool onlyTrackedBranches)
     {
-        using (log.IndentLog($"Getting branches containing the commit '{commit.Id}'."))
+        using (this.log.IndentLog($"Getting branches containing the commit '{commit.Id}'."))
         {
             var directBranchHasBeenFound = false;
-            log.Info("Trying to find direct branches.");
+            this.log.Info("Trying to find direct branches.");
             // TODO: It looks wasteful looping through the branches twice. Can't these loops be merged somehow? @asbjornu
             var branchList = branches.ToList();
             foreach (var branch in branchList.Where(branch => BranchTipIsNullOrCommit(branch, commit) && !IncludeTrackedBranches(branch, onlyTrackedBranches)))
             {
                 directBranchHasBeenFound = true;
-                log.Info($"Direct branch found: '{branch}'.");
+                this.log.Info($"Direct branch found: '{branch}'.");
                 yield return branch;
             }
 
@@ -40,20 +40,20 @@ internal class BranchesContainingCommitFinder(IRepositoryStore repositoryStore, 
                 yield break;
             }
 
-            log.Info($"No direct branches found, searching through {(onlyTrackedBranches ? "tracked" : "all")} branches.");
+            this.log.Info($"No direct branches found, searching through {(onlyTrackedBranches ? "tracked" : "all")} branches.");
             foreach (var branch in branchList.Where(b => IncludeTrackedBranches(b, onlyTrackedBranches)))
             {
-                log.Info($"Searching for commits reachable from '{branch}'.");
+                this.log.Info($"Searching for commits reachable from '{branch}'.");
 
                 var commits = this.repositoryStore.GetCommitsReacheableFrom(commit, branch);
 
                 if (!commits.Any())
                 {
-                    log.Info($"The branch '{branch}' has no matching commits.");
+                    this.log.Info($"The branch '{branch}' has no matching commits.");
                     continue;
                 }
 
-                log.Info($"The branch '{branch}' has a matching commit.");
+                this.log.Info($"The branch '{branch}' has a matching commit.");
                 yield return branch;
             }
         }

--- a/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
+++ b/src/GitVersion.Core/Core/BranchesContainingCommitFinder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Logging;

--- a/src/GitVersion.Core/Core/GitVersionContextFactory.cs
+++ b/src/GitVersion.Core/Core/GitVersionContextFactory.cs
@@ -1,6 +1,4 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion;

--- a/src/GitVersion.Core/Core/IBranchRepository.cs
+++ b/src/GitVersion.Core/Core/IBranchRepository.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Git;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal interface IBranchRepository
 {

--- a/src/GitVersion.Core/Core/ITaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/ITaggedSemanticVersionRepository.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Git;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal interface ITaggedSemanticVersionRepository
 {

--- a/src/GitVersion.Core/Core/ITaggedSemanticVersionService.cs
+++ b/src/GitVersion.Core/Core/ITaggedSemanticVersionService.cs
@@ -1,7 +1,7 @@
 using GitVersion.Configuration;
 using GitVersion.Git;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal interface ITaggedSemanticVersionService
 {

--- a/src/GitVersion.Core/Core/MergeBaseFinder.cs
+++ b/src/GitVersion.Core/Core/MergeBaseFinder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Logging;

--- a/src/GitVersion.Core/Core/MergeCommitFinder.cs
+++ b/src/GitVersion.Core/Core/MergeCommitFinder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;

--- a/src/GitVersion.Core/Core/RegexPatterns.cs
+++ b/src/GitVersion.Core/Core/RegexPatterns.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal static partial class RegexPatterns
 {

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -24,7 +24,7 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
     /// </summary>
     public ICommit? FindMergeBase(IBranch? branch, IBranch? otherBranch)
     {
-        var mergeBaseFinder = new MergeBaseFinder(this, log);
+        var mergeBaseFinder = new MergeBaseFinder(this, this.log);
         return mergeBaseFinder.FindMergeBaseOf(branch, otherBranch);
     }
 

--- a/src/GitVersion.Core/Core/SourceBranchFinder.cs
+++ b/src/GitVersion.Core/Core/SourceBranchFinder.cs
@@ -1,6 +1,5 @@
 using System.Text.RegularExpressions;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
@@ -25,7 +25,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
         tagPrefix ??= string.Empty;
 
         var isCached = true;
-        var result = taggedSemanticVersionsOfBranchCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
+        var result = this.taggedSemanticVersionsOfBranchCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
         {
             isCached = false;
             return [.. GetElements().Distinct().OrderByDescending(element => element.Tag.Commit.When)];
@@ -66,7 +66,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
         tagPrefix ??= string.Empty;
 
         var isCached = true;
-        var result = taggedSemanticVersionsOfMergeTargetCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
+        var result = this.taggedSemanticVersionsOfMergeTargetCache.GetOrAdd(new(branch, tagPrefix, format), _ =>
         {
             isCached = false;
             return [.. GetElements().Distinct().OrderByDescending(element => element.Key.When)];
@@ -106,7 +106,7 @@ internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore
         tagPrefix ??= string.Empty;
 
         var isCached = true;
-        var result = taggedSemanticVersionsCache.GetOrAdd(new(tagPrefix, format), _ =>
+        var result = this.taggedSemanticVersionsCache.GetOrAdd(new(tagPrefix, format), _ =>
         {
             isCached = false;
             return [.. GetElements().OrderByDescending(element => element.Tag.Commit.When)];

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionRepository.cs
@@ -1,11 +1,10 @@
 using System.Collections.Concurrent;
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Logging;
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal sealed class TaggedSemanticVersionRepository(ILog log, IRepositoryStore repositoryStore) : ITaggedSemanticVersionRepository
 {

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
@@ -1,10 +1,9 @@
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;
-
 using CommitSemanticVersion = (GitVersion.Git.ICommit Commit, GitVersion.SemanticVersionWithTag SemanticVersion);
 
-namespace GitVersion.Core;
+namespace GitVersion;
 
 internal sealed class TaggedSemanticVersionService(
     ITaggedSemanticVersionRepository repository, IBranchRepository branchRepository)

--- a/src/GitVersion.Core/Core/TaggedSemanticVersions.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersions.cs
@@ -1,4 +1,4 @@
-namespace GitVersion.Core;
+namespace GitVersion;
 
 [Flags]
 internal enum TaggedSemanticVersions

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Formatting;
 using GitVersion.Git;

--- a/src/GitVersion.Core/Extensions/ReferenceNameExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ReferenceNameExtensions.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using SemanticVersionResult = (GitVersion.SemanticVersion Value, string? Name);

--- a/src/GitVersion.Core/Extensions/StringExtensions.cs
+++ b/src/GitVersion.Core/Extensions/StringExtensions.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using GitVersion.Core;
 
 namespace GitVersion.Extensions;
 

--- a/src/GitVersion.Core/Formatting/InputSanitizer.cs
+++ b/src/GitVersion.Core/Formatting/InputSanitizer.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 
 namespace GitVersion.Formatting;
 

--- a/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
+++ b/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using GitVersion.Core;
 
 namespace GitVersion.Formatting;
 

--- a/src/GitVersion.Core/Formatting/ValueFormatter.cs
+++ b/src/GitVersion.Core/Formatting/ValueFormatter.cs
@@ -11,7 +11,7 @@ internal class ValueFormatter : InvariantFormatter, IValueFormatterCombiner
     public int Priority => 0;
 
     internal ValueFormatter()
-        => formatters =
+        => this.formatters =
         [
             new StringFormatter(),
             new FormattableFormatter(),
@@ -27,7 +27,7 @@ internal class ValueFormatter : InvariantFormatter, IValueFormatterCombiner
             return false;
         }
 
-        foreach (var formatter in formatters.OrderBy(f => f.Priority))
+        foreach (var formatter in this.formatters.OrderBy(f => f.Priority))
         {
             if (formatter.TryFormat(value, format, out result))
                 return true;
@@ -36,7 +36,7 @@ internal class ValueFormatter : InvariantFormatter, IValueFormatterCombiner
         return false;
     }
 
-    void IValueFormatterCombiner.RegisterFormatter(IValueFormatter formatter) => formatters.Add(formatter);
+    void IValueFormatterCombiner.RegisterFormatter(IValueFormatter formatter) => this.formatters.Add(formatter);
 
-    void IValueFormatterCombiner.RemoveFormatter<T>() => formatters.RemoveAll(f => f is T);
+    void IValueFormatterCombiner.RemoveFormatter<T>() => this.formatters.RemoveAll(f => f is T);
 }

--- a/src/GitVersion.Core/GitVersion.Core.csproj.DotSettings
+++ b/src/GitVersion.Core/GitVersion.Core.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core_005Cabstractions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=core_005Cexceptions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/GitVersion.Core/GitVersionCoreModule.cs
+++ b/src/GitVersion.Core/GitVersionCoreModule.cs
@@ -1,5 +1,3 @@
-using GitVersion.Common;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.VersionCalculation;
 using GitVersion.VersionCalculation.Caching;

--- a/src/GitVersion.Core/Logging/Log.cs
+++ b/src/GitVersion.Core/Logging/Log.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using GitVersion.Core;
 using GitVersion.Helpers;
 
 namespace GitVersion.Logging;

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -19,26 +19,26 @@ GitVersion.BugException
 GitVersion.BugException.BugException() -> void
 GitVersion.BugException.BugException(string! message) -> void
 GitVersion.BugException.BugException(string? message, System.Exception? innerException) -> void
-GitVersion.Common.IRepositoryStore
-GitVersion.Common.IRepositoryStore.Branches.get -> GitVersion.Git.IBranchCollection!
-GitVersion.Common.IRepositoryStore.ExcludingBranches(System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>! branchesToExclude) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
-GitVersion.Common.IRepositoryStore.FindBranch(GitVersion.Git.ReferenceName! branchName) -> GitVersion.Git.IBranch?
-GitVersion.Common.IRepositoryStore.FindCommitBranchesBranchedFrom(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, params GitVersion.Git.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.BranchCommit>!
-GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.Git.IBranch? branch, GitVersion.Git.IBranch? otherBranch) -> GitVersion.Git.ICommit?
-GitVersion.Common.IRepositoryStore.FindMergeBase(GitVersion.Git.ICommit! commit, GitVersion.Git.ICommit! mainlineTip) -> GitVersion.Git.ICommit?
-GitVersion.Common.IRepositoryStore.GetBranchesContainingCommit(GitVersion.Git.ICommit! commit, System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>? branches = null, bool onlyTrackedBranches = false) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
-GitVersion.Common.IRepositoryStore.GetCommitLog(GitVersion.Git.ICommit? baseVersionSource, GitVersion.Git.ICommit! currentCommit, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
-GitVersion.Common.IRepositoryStore.GetCommitsReacheableFrom(GitVersion.Git.ICommit! commit, GitVersion.Git.IBranch! branch) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
-GitVersion.Common.IRepositoryStore.GetCommitsReacheableFromHead(GitVersion.Git.ICommit? headCommit, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
-GitVersion.Common.IRepositoryStore.GetCurrentCommit(GitVersion.Git.IBranch! currentBranch, string? commitId, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> GitVersion.Git.ICommit?
-GitVersion.Common.IRepositoryStore.GetForwardMerge(GitVersion.Git.ICommit? commitToFindCommonBase, GitVersion.Git.ICommit? findMergeBase) -> GitVersion.Git.ICommit?
-GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, params GitVersion.Git.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
-GitVersion.Common.IRepositoryStore.GetSourceBranches(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
-GitVersion.Common.IRepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.Git.IBranch!
-GitVersion.Common.IRepositoryStore.Head.get -> GitVersion.Git.IBranch!
-GitVersion.Common.IRepositoryStore.IsCommitOnBranch(GitVersion.Git.ICommit? baseVersionSource, GitVersion.Git.IBranch! branch, GitVersion.Git.ICommit! firstMatchingCommit) -> bool
-GitVersion.Common.IRepositoryStore.Tags.get -> GitVersion.Git.ITagCollection!
-GitVersion.Common.IRepositoryStore.UncommittedChangesCount.get -> int
+GitVersion.IRepositoryStore
+GitVersion.IRepositoryStore.Branches.get -> GitVersion.Git.IBranchCollection!
+GitVersion.IRepositoryStore.ExcludingBranches(System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>! branchesToExclude) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
+GitVersion.IRepositoryStore.FindBranch(GitVersion.Git.ReferenceName! branchName) -> GitVersion.Git.IBranch?
+GitVersion.IRepositoryStore.FindCommitBranchesBranchedFrom(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, params GitVersion.Git.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.BranchCommit>!
+GitVersion.IRepositoryStore.FindMergeBase(GitVersion.Git.IBranch? branch, GitVersion.Git.IBranch? otherBranch) -> GitVersion.Git.ICommit?
+GitVersion.IRepositoryStore.FindMergeBase(GitVersion.Git.ICommit! commit, GitVersion.Git.ICommit! mainlineTip) -> GitVersion.Git.ICommit?
+GitVersion.IRepositoryStore.GetBranchesContainingCommit(GitVersion.Git.ICommit! commit, System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>? branches = null, bool onlyTrackedBranches = false) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
+GitVersion.IRepositoryStore.GetCommitLog(GitVersion.Git.ICommit? baseVersionSource, GitVersion.Git.ICommit! currentCommit, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
+GitVersion.IRepositoryStore.GetCommitsReacheableFrom(GitVersion.Git.ICommit! commit, GitVersion.Git.IBranch! branch) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
+GitVersion.IRepositoryStore.GetCommitsReacheableFromHead(GitVersion.Git.ICommit? headCommit, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> System.Collections.Generic.IReadOnlyList<GitVersion.Git.ICommit!>!
+GitVersion.IRepositoryStore.GetCurrentCommit(GitVersion.Git.IBranch! currentBranch, string? commitId, GitVersion.Configuration.IIgnoreConfiguration! ignore) -> GitVersion.Git.ICommit?
+GitVersion.IRepositoryStore.GetForwardMerge(GitVersion.Git.ICommit? commitToFindCommonBase, GitVersion.Git.ICommit? findMergeBase) -> GitVersion.Git.ICommit?
+GitVersion.IRepositoryStore.GetSourceBranches(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, params GitVersion.Git.IBranch![]! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
+GitVersion.IRepositoryStore.GetSourceBranches(GitVersion.Git.IBranch! branch, GitVersion.Configuration.IGitVersionConfiguration! configuration, System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>! excludedBranches) -> System.Collections.Generic.IEnumerable<GitVersion.Git.IBranch!>!
+GitVersion.IRepositoryStore.GetTargetBranch(string? targetBranchName) -> GitVersion.Git.IBranch!
+GitVersion.IRepositoryStore.Head.get -> GitVersion.Git.IBranch!
+GitVersion.IRepositoryStore.IsCommitOnBranch(GitVersion.Git.ICommit? baseVersionSource, GitVersion.Git.IBranch! branch, GitVersion.Git.ICommit! firstMatchingCommit) -> bool
+GitVersion.IRepositoryStore.Tags.get -> GitVersion.Git.ITagCollection!
+GitVersion.IRepositoryStore.UncommittedChangesCount.get -> int
 GitVersion.Configuration.AssemblyFileVersioningScheme
 GitVersion.Configuration.AssemblyFileVersioningScheme.Major = 3 -> GitVersion.Configuration.AssemblyFileVersioningScheme
 GitVersion.Configuration.AssemblyFileVersioningScheme.MajorMinor = 2 -> GitVersion.Configuration.AssemblyFileVersioningScheme

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion;

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -38,11 +38,11 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
     /// <summary>Initializes a new semantic version with the given major, minor, and patch values.</summary>
     public SemanticVersion(long major = 0, long minor = 0, long patch = 0)
     {
-        this.Major = major;
-        this.Minor = minor;
-        this.Patch = patch;
-        this.PreReleaseTag = SemanticVersionPreReleaseTag.Empty;
-        this.BuildMetaData = SemanticVersionBuildMetaData.Empty;
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreReleaseTag = SemanticVersionPreReleaseTag.Empty;
+        BuildMetaData = SemanticVersionBuildMetaData.Empty;
     }
 
     /// <summary>Initializes a new semantic version as a copy of <paramref name="semanticVersion"/>.</summary>
@@ -50,12 +50,12 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
     {
         semanticVersion.NotNull();
 
-        this.Major = semanticVersion.Major;
-        this.Minor = semanticVersion.Minor;
-        this.Patch = semanticVersion.Patch;
+        Major = semanticVersion.Major;
+        Minor = semanticVersion.Minor;
+        Patch = semanticVersion.Patch;
 
-        this.PreReleaseTag = semanticVersion.PreReleaseTag;
-        this.BuildMetaData = semanticVersion.BuildMetaData;
+        PreReleaseTag = semanticVersion.PreReleaseTag;
+        BuildMetaData = semanticVersion.BuildMetaData;
     }
 
     /// <summary>Returns <see langword="true"/> when this version is equal to <paramref name="obj"/>.</summary>
@@ -65,11 +65,11 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
         {
             return false;
         }
-        return this.Major == obj.Major
-            && this.Minor == obj.Minor
-            && this.Patch == obj.Patch
-            && this.PreReleaseTag == obj.PreReleaseTag
-            && this.BuildMetaData == obj.BuildMetaData;
+        return Major == obj.Major
+            && Minor == obj.Minor
+            && Patch == obj.Patch
+            && PreReleaseTag == obj.PreReleaseTag
+            && BuildMetaData == obj.BuildMetaData;
     }
 
     /// <summary>Returns <see langword="true"/> when this instance equals <see cref="Empty"/>.</summary>
@@ -254,33 +254,33 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
         {
             return 1;
         }
-        if (this.Major != value.Major)
+        if (Major != value.Major)
         {
-            if (this.Major > value.Major)
+            if (Major > value.Major)
             {
                 return 1;
             }
             return -1;
         }
-        if (this.Minor != value.Minor)
+        if (Minor != value.Minor)
         {
-            if (this.Minor > value.Minor)
+            if (Minor > value.Minor)
             {
                 return 1;
             }
             return -1;
         }
-        if (this.Patch != value.Patch)
+        if (Patch != value.Patch)
         {
-            if (this.Patch > value.Patch)
+            if (Patch > value.Patch)
             {
                 return 1;
             }
             return -1;
         }
 
-        if (!includePreRelease || this.PreReleaseTag == value.PreReleaseTag) return 0;
-        if (this.PreReleaseTag > value.PreReleaseTag)
+        if (!includePreRelease || PreReleaseTag == value.PreReleaseTag) return 0;
+        if (PreReleaseTag > value.PreReleaseTag)
         {
             return 1;
         }
@@ -313,20 +313,20 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
         switch (format)
         {
             case "j":
-                return $"{this.Major}.{this.Minor}.{this.Patch}";
+                return $"{Major}.{Minor}.{Patch}";
             case "s":
-                return this.PreReleaseTag.HasTag() ? $"{ToString("j")}-{this.PreReleaseTag}" : ToString("j");
+                return PreReleaseTag.HasTag() ? $"{ToString("j")}-{PreReleaseTag}" : ToString("j");
             case "t":
-                return this.PreReleaseTag.HasTag() ? $"{ToString("j")}-{this.PreReleaseTag:t}" : ToString("j");
+                return PreReleaseTag.HasTag() ? $"{ToString("j")}-{PreReleaseTag:t}" : ToString("j");
             case "f":
                 {
-                    var buildMetadata = this.BuildMetaData.ToString();
+                    var buildMetadata = BuildMetaData.ToString();
 
                     return !buildMetadata.IsNullOrEmpty() ? $"{ToString("s")}+{buildMetadata}" : ToString("s");
                 }
             case "i":
                 {
-                    var buildMetadata = this.BuildMetaData.ToString("f");
+                    var buildMetadata = BuildMetaData.ToString("f");
 
                     return !buildMetadata.IsNullOrEmpty() ? $"{ToString("s")}+{buildMetadata}" : ToString("s");
                 }

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -67,17 +67,17 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
         VersionField versionSourceIncrement,
         string? otherMetadata = null)
     {
-        this.Sha = commitSha;
-        this.ShortSha = commitShortSha;
-        this.CommitsSinceTag = commitsSinceTag;
-        this.Branch = branch;
-        this.CommitDate = commitDate;
-        this.OtherMetaData = otherMetadata;
-        this.VersionSourceIncrement = versionSourceIncrement;
-        this.VersionSourceSemVer = versionSourceSemVer;
-        this.VersionSourceSha = versionSourceSha;
-        this.VersionSourceDistance = commitsSinceTag ?? 0;
-        this.UncommittedChanges = numberOfUnCommittedChanges;
+        Sha = commitSha;
+        ShortSha = commitShortSha;
+        CommitsSinceTag = commitsSinceTag;
+        Branch = branch;
+        CommitDate = commitDate;
+        OtherMetaData = otherMetadata;
+        VersionSourceIncrement = versionSourceIncrement;
+        VersionSourceSemVer = versionSourceSemVer;
+        VersionSourceSha = versionSourceSha;
+        VersionSourceDistance = commitsSinceTag ?? 0;
+        UncommittedChanges = numberOfUnCommittedChanges;
     }
 
     /// <summary>Initializes a new build metadata instance as a copy of <paramref name="buildMetaData"/>.</summary>
@@ -85,17 +85,17 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
     {
         buildMetaData.NotNull();
 
-        this.Sha = buildMetaData.Sha;
-        this.ShortSha = buildMetaData.ShortSha;
-        this.CommitsSinceTag = buildMetaData.CommitsSinceTag;
-        this.Branch = buildMetaData.Branch;
-        this.CommitDate = buildMetaData.CommitDate;
-        this.OtherMetaData = buildMetaData.OtherMetaData;
-        this.VersionSourceSemVer = buildMetaData.VersionSourceSemVer;
-        this.VersionSourceSha = buildMetaData.VersionSourceSha;
-        this.VersionSourceDistance = buildMetaData.VersionSourceDistance;
-        this.UncommittedChanges = buildMetaData.UncommittedChanges;
-        this.VersionSourceIncrement = buildMetaData.VersionSourceIncrement;
+        Sha = buildMetaData.Sha;
+        ShortSha = buildMetaData.ShortSha;
+        CommitsSinceTag = buildMetaData.CommitsSinceTag;
+        Branch = buildMetaData.Branch;
+        CommitDate = buildMetaData.CommitDate;
+        OtherMetaData = buildMetaData.OtherMetaData;
+        VersionSourceSemVer = buildMetaData.VersionSourceSemVer;
+        VersionSourceSha = buildMetaData.VersionSourceSha;
+        VersionSourceDistance = buildMetaData.VersionSourceDistance;
+        UncommittedChanges = buildMetaData.UncommittedChanges;
+        VersionSourceIncrement = buildMetaData.VersionSourceIncrement;
     }
 
     /// <summary>Returns <see langword="true"/> when <paramref name="obj"/> is a <see cref="SemanticVersionBuildMetaData"/> equal to this instance.</summary>
@@ -129,9 +129,9 @@ public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVer
         format = format.ToLower();
         return format.ToLower() switch
         {
-            "b" => $"{this.CommitsSinceTag}",
-            "s" => $"{this.CommitsSinceTag}{(this.Sha.IsNullOrEmpty() ? null : ".Sha." + this.Sha)}".TrimStart('.'),
-            "f" => $"{this.CommitsSinceTag}{(this.Branch.IsNullOrEmpty() ? null : ".Branch." + FormatMetaDataPart(this.Branch))}{(this.Sha.IsNullOrEmpty() ? null : ".Sha." + this.Sha)}{(this.OtherMetaData.IsNullOrEmpty() ? null : "." + FormatMetaDataPart(this.OtherMetaData))}".TrimStart('.'),
+            "b" => $"{CommitsSinceTag}",
+            "s" => $"{CommitsSinceTag}{(Sha.IsNullOrEmpty() ? null : ".Sha." + Sha)}".TrimStart('.'),
+            "f" => $"{CommitsSinceTag}{(Branch.IsNullOrEmpty() ? null : ".Branch." + FormatMetaDataPart(Branch))}{(Sha.IsNullOrEmpty() ? null : ".Sha." + Sha)}{(OtherMetaData.IsNullOrEmpty() ? null : "." + FormatMetaDataPart(OtherMetaData))}".TrimStart('.'),
             _ => throw new FormatException($"Unknown format '{format}'.")
         };
     }

--- a/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -158,7 +158,7 @@ internal class GitVersionCacheKeyFactory(
 
         // Doesn't depend on command line representation and
         // includes possible changes in default values of Config per se.
-        var configContent = configurationSerializer.Serialize(overrideConfiguration);
+        var configContent = this.configurationSerializer.Serialize(overrideConfiguration);
 
         return GetHash(configContent);
     }

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using System.Security.Cryptography;
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheProvider.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheProvider.cs
@@ -31,7 +31,7 @@ internal class GitVersionCacheProvider(
         {
             try
             {
-                serializer.ToFile(versionVariables, cacheFileName);
+                this.serializer.ToFile(versionVariables, cacheFileName);
             }
             catch (Exception ex)
             {
@@ -54,7 +54,7 @@ internal class GitVersionCacheProvider(
 
             try
             {
-                var loadedVariables = serializer.FromFile(cacheFileName);
+                var loadedVariables = this.serializer.FromFile(cacheFileName);
                 return loadedVariables;
             }
             catch (Exception ex)
@@ -99,7 +99,7 @@ internal class GitVersionCacheProvider(
 
     private GitVersionCacheKey GetCacheKey()
     {
-        var cacheKey = this.cacheKeyFactory.Create(options.Value.ConfigurationInfo.OverrideConfiguration);
+        var cacheKey = this.cacheKeyFactory.Create(this.options.Value.ConfigurationInfo.OverrideConfiguration);
         return cacheKey;
     }
 

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Git;

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -1,7 +1,5 @@
 using System.Text.RegularExpressions;
-using GitVersion.Common;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -98,7 +98,7 @@ internal class IncrementStrategyFinder(
         ICommit? baseVersionSource, ICommit currentCommit, string? label, IIgnoreConfiguration ignore)
     {
         var targetShas = new Lazy<HashSet<string>>(() =>
-            [.. taggedSemanticVersionRepository
+            [.. this.taggedSemanticVersionRepository
                 .GetTaggedSemanticVersions(tagPrefix, semanticVersionFormat, ignore)
                 .SelectMany(versionWithTags => versionWithTags)
                 .Where(versionWithTag => versionWithTag.Value.IsMatchForBranchSpecificLabel(label))

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineCommit.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineCommit.cs
@@ -50,7 +50,7 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
     [MemberNotNullWhen(true, nameof(ParentIteration), nameof(ParentCommit))]
     private bool HasParentIteration => Iteration.ParentIteration is not null && Iteration.ParentCommit is not null;
 
-    public IReadOnlyCollection<SemanticVersion> SemanticVersions => semanticVersions;
+    public IReadOnlyCollection<SemanticVersion> SemanticVersions => this.semanticVersions;
 
     private readonly HashSet<SemanticVersion> semanticVersions = [];
 
@@ -58,7 +58,7 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
 
     public EffectiveConfiguration GetEffectiveConfiguration(IGitVersionConfiguration configuration)
     {
-        if (effectiveConfiguration is not null) return effectiveConfiguration;
+        if (this.effectiveConfiguration is not null) return this.effectiveConfiguration;
 
         var branchConfiguration = Configuration;
 
@@ -81,7 +81,7 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
         var parentConfiguration = ParentCommit.GetEffectiveConfiguration(configuration);
         branchConfiguration = branchConfiguration.Inherit(parentConfiguration);
 
-        return effectiveConfiguration = new EffectiveConfiguration(configuration, branchConfiguration);
+        return this.effectiveConfiguration = new EffectiveConfiguration(configuration, branchConfiguration);
     }
 
     public VersionField GetIncrementForcedByBranch(IGitVersionConfiguration configuration)
@@ -97,7 +97,7 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
     {
         foreach (var semanticVersion in values.NotNull())
         {
-            semanticVersions.Add(semanticVersion);
+            this.semanticVersions.Add(semanticVersion);
         }
     }
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
@@ -44,9 +44,9 @@ internal record MainlineIteration
 
     public int Depth { get; }
 
-    public int NumberOfCommits => commits.Count;
+    public int NumberOfCommits => this.commits.Count;
 
-    public IReadOnlyCollection<MainlineCommit> Commits => commits;
+    public IReadOnlyCollection<MainlineCommit> Commits => this.commits;
     private readonly Stack<MainlineCommit> commits = new();
 
     private readonly Dictionary<ICommit, MainlineCommit> commitLookup = [];
@@ -68,11 +68,11 @@ internal record MainlineIteration
         var commit = this.commits.Count != 0
             ? this.commits.Peek().Append(value, branchName, configuration)
             : new MainlineCommit(this, value, branchName, configuration);
-        commits.Push(commit);
+        this.commits.Push(commit);
 
         if (value is not null)
         {
-            commitLookup.Add(value, commit);
+            this.commitLookup.Add(value, commit);
         }
 
         return commit;
@@ -82,7 +82,7 @@ internal record MainlineIteration
     {
         commit.NotNull();
 
-        commitLookup.TryGetValue(commit, out var result);
+        this.commitLookup.TryGetValue(commit, out var result);
         return result;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -24,10 +24,10 @@ internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = Pat
 
     private bool IsMatch(string path)
     {
-        if (!pathMatchCache.TryGetValue(path, out var isMatch))
+        if (!this.pathMatchCache.TryGetValue(path, out var isMatch))
         {
             isMatch = this.pathsRegexes.Any(regex => regex.IsMatch(path));
-            pathMatchCache[path] = isMatch;
+            this.pathMatchCache[path] = isMatch;
         }
         return isMatch;
     }
@@ -44,7 +44,7 @@ internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = Pat
         {
             case PathFilterMode.Inclusive:
                 {
-                    if (commit.DiffPaths.All(this.IsMatch))
+                    if (commit.DiffPaths.All(IsMatch))
                     {
                         reason = "Source was ignored due to all commit paths matching ignore regex";
                         return true;

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion;

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionFormatValues.cs
@@ -20,13 +20,13 @@ public class SemanticVersionFormatValues(SemanticVersion semver, IGitVersionConf
     public string PreReleaseTag => semver.PreReleaseTag.ToString();
 
     /// <summary>Gets the pre-release tag prefixed with a dash (e.g. <c>-beta.1</c>), or empty string when there is no tag.</summary>
-    public string PreReleaseTagWithDash => this.PreReleaseTag.WithPrefixIfNotNullOrEmpty("-");
+    public string PreReleaseTagWithDash => PreReleaseTag.WithPrefixIfNotNullOrEmpty("-");
 
     /// <summary>Gets the pre-release label without the numeric identifier (e.g. <c>beta</c>).</summary>
     public string PreReleaseLabel => semver.PreReleaseTag.Name;
 
     /// <summary>Gets the pre-release label prefixed with a dash (e.g. <c>-beta</c>), or empty string when there is no label.</summary>
-    public string PreReleaseLabelWithDash => this.PreReleaseLabel.WithPrefixIfNotNullOrEmpty("-");
+    public string PreReleaseLabelWithDash => PreReleaseLabel.WithPrefixIfNotNullOrEmpty("-");
 
     /// <summary>Gets the numeric pre-release identifier as a string, or empty string when absent.</summary>
     public string PreReleaseNumber => semver.PreReleaseTag.Number?.ToString() ?? string.Empty;

--- a/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
+++ b/src/GitVersion.Core/VersionCalculation/VariableProvider.cs
@@ -1,5 +1,4 @@
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Formatting;
 using GitVersion.OutputVariables;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeliveryVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeliveryVersionCalculator.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Logging;
 
 namespace GitVersion.VersionCalculation;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeploymentVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/ContinuousDeploymentVersionCalculator.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Logging;
 
 namespace GitVersion.VersionCalculation;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/ManualDeploymentVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/ManualDeploymentVersionCalculator.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Logging;
 
 namespace GitVersion.VersionCalculation;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.Logging;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -156,7 +156,7 @@ internal class NextVersionCalculator(
     private NextVersion CalculateNextVersion(IBranch branch, IGitVersionConfiguration configuration)
     {
         var nextVersions = GetNextVersions(branch, configuration);
-        log.Separator();
+        this.log.Separator();
 
         var maxVersion = nextVersions.Max()
             ?? throw new GitVersionException("No base versions determined on the current branch.");
@@ -173,7 +173,7 @@ internal class NextVersionCalculator(
             var latestVersion = matchingVersionsOnceIncremented.Aggregate(CompareVersions);
             latestBaseVersionSource = latestVersion.BaseVersion.BaseVersionSource;
             maxVersion = latestVersion;
-            log.Info(
+            this.log.Info(
                 $"Found multiple base versions which will produce the same SemVer ({maxVersion.IncrementedVersion}), " +
                 $"taking latest source for commit counting ({latestVersion.BaseVersion.Source})");
         }
@@ -210,8 +210,8 @@ internal class NextVersionCalculator(
             }
         };
 
-        log.Info($"Base version used: {calculatedBase}");
-        log.Separator();
+        this.log.Info($"Base version used: {calculatedBase}");
+        this.log.Separator();
 
         return new(maxVersion.IncrementedVersion, calculatedBase, maxVersion.BranchConfiguration);
     }
@@ -231,7 +231,7 @@ internal class NextVersionCalculator(
 
     private List<NextVersion> GetNextVersions(IBranch branch, IGitVersionConfiguration configuration)
     {
-        using (log.IndentLog("Fetching the base versions for version calculation..."))
+        using (this.log.IndentLog("Fetching the base versions for version calculation..."))
         {
             if (branch.Tip == null)
                 throw new GitVersionException("No commits found on the current branch.");
@@ -263,7 +263,7 @@ internal class NextVersionCalculator(
                         {
                             foreach (var baseVersion in versionStrategy.GetBaseVersions(effectiveBranchConfiguration))
                             {
-                                log.Info(baseVersion.ToString());
+                                this.log.Info(baseVersion.ToString());
                                 if (!IncludeVersion(baseVersion, configuration.Ignore)) continue;
                                 atLeastOneBaseVersionReturned = true;
 

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/VersionCalculatorBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/VersionCalculatorBase.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Extensions;
 using GitVersion.Logging;
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -13,7 +13,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
     {
@@ -27,7 +27,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
         var semanticVersion = SemanticVersion.Parse(
             nextVersion, Context.Configuration.TagPrefixPattern, Context.Configuration.SemanticVersionFormat
         );
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, environment);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 
         if (!semanticVersion.IsMatchForBranchSpecificLabel(label)) yield break;
         BaseVersionOperator? operation = null;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
@@ -1,5 +1,4 @@
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 
 namespace GitVersion.VersionCalculation;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
@@ -20,7 +20,7 @@ internal sealed class FallbackVersionStrategy(
     private readonly ITaggedSemanticVersionService taggedSemanticVersionService = taggedSemanticVersionService.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
         => GetBaseVersionsInternal(configuration);
@@ -34,7 +34,7 @@ internal sealed class FallbackVersionStrategy(
 
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 
-        var baseVersionSource = taggedSemanticVersionService.GetTaggedSemanticVersions(
+        var baseVersionSource = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,
             configuration: Context.Configuration,
             label: label,
@@ -42,7 +42,7 @@ internal sealed class FallbackVersionStrategy(
             taggedSemanticVersion: configuration.Value.GetTaggedSemanticVersion()
         ).Select(element => element.Key).FirstOrDefault();
 
-        var increment = incrementStrategyFinder.DetermineIncrementedField(
+        var increment = this.incrementStrategyFinder.DetermineIncrementedField(
             currentCommit: Context.CurrentCommit,
             baseVersionSource: baseVersionSource,
             shouldIncrement: true,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -1,6 +1,4 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 using GitVersion.VersionCalculation.Mainline;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -23,7 +23,7 @@ internal sealed class MainlineVersionStrategy(
     private readonly IEnvironment environment = environment.NotNull();
     private readonly Dictionary<string, Dictionary<ICommit, List<(IBranch, IBranchConfiguration)>>> commitsWasBranchedFromCache = new();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     private static readonly IReadOnlyCollection<IContextPreEnricher> TrunkContextPreEnricherCollection =
     [
@@ -95,7 +95,7 @@ internal sealed class MainlineVersionStrategy(
         {
             taggedSemanticVersion |= TaggedSemanticVersions.OfMainBranches;
         }
-        var taggedSemanticVersions = taggedSemanticVersionService.GetTaggedSemanticVersions(
+        var taggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,
             configuration: Context.Configuration,
             label: null,
@@ -111,14 +111,14 @@ internal sealed class MainlineVersionStrategy(
             taggedSemanticVersions: taggedSemanticVersions
         );
 
-        yield return DetermineBaseVersion(iteration, targetLabel, incrementStrategyFinder, Context.Configuration, this.environment);
+        yield return DetermineBaseVersion(iteration, targetLabel, this.incrementStrategyFinder, Context.Configuration, this.environment);
     }
 
     private MainlineIteration CreateIteration(
         ReferenceName branchName, IBranchConfiguration configuration,
         MainlineIteration? parentIteration = null, MainlineCommit? parentCommit = null)
     {
-        var iterationCount = Interlocked.Increment(ref iterationCounter);
+        var iterationCount = Interlocked.Increment(ref this.iterationCounter);
         return new MainlineIteration(
             id: $"#{iterationCount}",
             branchName: branchName,
@@ -138,7 +138,7 @@ internal sealed class MainlineVersionStrategy(
 
         var configuration = iteration.Configuration;
         var branchName = iteration.BranchName;
-        var branch = repositoryStore.FindBranch(branchName);
+        var branch = this.repositoryStore.FindBranch(branchName);
 
         var currentBranch = branch;
         Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Value)>>> commitsWasBranchedFromLazy = new(
@@ -165,7 +165,7 @@ internal sealed class MainlineVersionStrategy(
                     configuration = effectiveConfigurationWasBranchedFrom.Value;
                     branchName = effectiveConfigurationWasBranchedFrom.Branch.Name;
 
-                    branch = repositoryStore.FindBranch(branchName);
+                    branch = this.repositoryStore.FindBranch(branchName);
 
                     var branchPointer = branch;
                     commitsWasBranchedFromLazy = new Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Configuration)>>>
@@ -186,7 +186,7 @@ internal sealed class MainlineVersionStrategy(
                     {
                         taggedSemanticVersion |= TaggedSemanticVersions.OfMainBranches;
                     }
-                    taggedSemanticVersions = taggedSemanticVersionService.GetTaggedSemanticVersions(
+                    taggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
                         branch: effectiveConfigurationWasBranchedFrom.Branch,
                         configuration: Context.Configuration,
                         label: null,
@@ -289,7 +289,7 @@ internal sealed class MainlineVersionStrategy(
 
         Dictionary<ICommit, List<(IBranch, IBranchConfiguration Configuration)>> result = [];
 
-        var branchCommits = repositoryStore.FindCommitBranchesBranchedFrom(
+        var branchCommits = this.repositoryStore.FindCommitBranchesBranchedFrom(
             branch, Context.Configuration, excludedBranches: excludedBranches
         ).ToList();
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -19,7 +19,7 @@ internal sealed class MergeMessageVersionStrategy(ILog log, Lazy<GitVersionConte
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
         => GetBaseVersionsInternal(configuration).Take(5);

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -1,4 +1,3 @@
-using GitVersion.Common;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.Logging;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -1,5 +1,4 @@
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Logging;
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -23,7 +23,7 @@ internal sealed class TaggedCommitVersionStrategy(
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
         => GetBaseVersionsInternal(configuration);
@@ -35,7 +35,7 @@ internal sealed class TaggedCommitVersionStrategy(
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.TaggedCommit))
             yield break;
 
-        var taggedSemanticVersions = taggedSemanticVersionService.GetTaggedSemanticVersions(
+        var taggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,
             configuration: Context.Configuration,
             label: null,
@@ -69,7 +69,7 @@ internal sealed class TaggedCommitVersionStrategy(
             }
 
             var baseVersionSource = semanticVersion.Tag.Commit;
-            var increment = incrementStrategyFinder.DetermineIncrementedField(
+            var increment = this.incrementStrategyFinder.DetermineIncrementedField(
                 currentCommit: Context.CurrentCommit,
                 baseVersionSource: baseVersionSource,
                 shouldIncrement: true,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -20,7 +20,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
     private readonly IEnvironment environment = environment.NotNull();
     private readonly VersionInBranchNameVersionStrategy releaseVersionStrategy = new(contextLazy, environment);
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
     {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using GitVersion.Common;
 using GitVersion.Configuration;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Git;
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -14,7 +14,7 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
 
-    private GitVersionContext Context => contextLazy.Value;
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
     {

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -39,10 +39,10 @@ internal sealed class Commit : ICommit
     {
         get
         {
-            if (!pathsCache.TryGetValue(this.Sha, out var paths))
+            if (!pathsCache.TryGetValue(Sha, out var paths))
             {
-                paths = this.CommitChanges.Paths;
-                pathsCache[this.Sha] = paths;
+                paths = CommitChanges.Paths;
+                pathsCache[Sha] = paths;
             }
             return paths;
         }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryCache.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryCache.cs
@@ -17,21 +17,21 @@ internal class GitRepositoryCache
         var cacheKey = innerBranch.Tip is null
             ? $"{innerBranch.RemoteName}/{innerBranch.CanonicalName}"
             : $"{innerBranch.RemoteName}/{innerBranch.CanonicalName}@{innerBranch.Tip.Sha}";
-        return cachedBranches.GetOrAdd(cacheKey, _ => new Branch(innerBranch, repoDiff, this));
+        return this.cachedBranches.GetOrAdd(cacheKey, _ => new Branch(innerBranch, repoDiff, this));
     }
 
     public Commit GetOrWrap(LibGit2Sharp.Commit innerCommit, Diff repoDiff)
-        => cachedCommits.GetOrAdd(innerCommit.Sha, _ => new Commit(innerCommit, repoDiff, this));
+        => this.cachedCommits.GetOrAdd(innerCommit.Sha, _ => new Commit(innerCommit, repoDiff, this));
 
     public Tag GetOrWrap(LibGit2Sharp.Tag innerTag, Diff repoDiff)
-        => cachedTags.GetOrAdd(innerTag.CanonicalName, _ => new Tag(innerTag, repoDiff, this));
+        => this.cachedTags.GetOrAdd(innerTag.CanonicalName, _ => new Tag(innerTag, repoDiff, this));
 
     public Remote GetOrWrap(LibGit2Sharp.Remote innerRemote)
-        => cachedRemotes.GetOrAdd(innerRemote.Name, _ => new Remote(innerRemote, this));
+        => this.cachedRemotes.GetOrAdd(innerRemote.Name, _ => new Remote(innerRemote, this));
 
     public Reference GetOrWrap(LibGit2Sharp.Reference innerReference)
-        => cachedReferences.GetOrAdd(innerReference.CanonicalName, _ => new Reference(innerReference));
+        => this.cachedReferences.GetOrAdd(innerReference.CanonicalName, _ => new Reference(innerReference));
 
     public RefSpec GetOrWrap(LibGit2Sharp.RefSpec innerRefSpec)
-        => cachedRefSpecs.GetOrAdd(innerRefSpec.Specification, _ => new RefSpec(innerRefSpec));
+        => this.cachedRefSpecs.GetOrAdd(innerRefSpec.Specification, _ => new RefSpec(innerRefSpec));
 }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -33,7 +33,7 @@ public class GitRepositoryInfo : IGitRepositoryInfo
 
     private string? GetDynamicGitRepositoryPath()
     {
-        var repositoryInfo = gitVersionOptions.RepositoryInfo;
+        var repositoryInfo = this.gitVersionOptions.RepositoryInfo;
         if (repositoryInfo.TargetUrl.IsNullOrWhiteSpace()) return null;
 
         var targetUrl = repositoryInfo.TargetUrl;
@@ -64,7 +64,7 @@ public class GitRepositoryInfo : IGitRepositoryInfo
     {
         var gitDirectory = !DynamicGitRepositoryPath.IsNullOrWhiteSpace()
             ? DynamicGitRepositoryPath
-            : Repository.Discover(gitVersionOptions.WorkingDirectory);
+            : Repository.Discover(this.gitVersionOptions.WorkingDirectory);
 
         gitDirectory = gitDirectory?.TrimEnd('/', '\\');
         if (gitDirectory.IsNullOrEmpty())
@@ -80,10 +80,10 @@ public class GitRepositoryInfo : IGitRepositoryInfo
     {
         if (!DynamicGitRepositoryPath.IsNullOrWhiteSpace())
         {
-            return gitVersionOptions.WorkingDirectory;
+            return this.gitVersionOptions.WorkingDirectory;
         }
 
-        var gitDirectory = Repository.Discover(gitVersionOptions.WorkingDirectory);
+        var gitDirectory = Repository.Discover(this.gitVersionOptions.WorkingDirectory);
 
         if (gitDirectory.IsNullOrEmpty())
             throw new DirectoryNotFoundException("Cannot find the .git directory");

--- a/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/ReferenceCollection.cs
@@ -50,5 +50,5 @@ internal sealed class ReferenceCollection : IReferenceCollection
         });
 
     private void InitializeReferencesLazy()
-        => this.references = new Lazy<IReadOnlyCollection<IReference>>(() => [.. this.innerCollection.Select(repositoryCache.GetOrWrap)]);
+        => this.references = new Lazy<IReadOnlyCollection<IReference>>(() => [.. this.innerCollection.Select(this.repositoryCache.GetOrWrap)]);
 }

--- a/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RemoteCollection.cs
@@ -43,5 +43,5 @@ internal sealed class RemoteCollection : IRemoteCollection
         });
 
     private void InitializeRemotesLazy()
-        => this.remotes = new Lazy<IReadOnlyCollection<IRemote>>(() => [.. this.innerCollection.Select(repositoryCache.GetOrWrap)]);
+        => this.remotes = new Lazy<IReadOnlyCollection<IRemote>>(() => [.. this.innerCollection.Select(this.repositoryCache.GetOrWrap)]);
 }

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
@@ -18,13 +18,13 @@ public class MsBuildExeFixture
     public const string OutputTarget = "GitVersionOutput";
 
     private readonly AnalyzerManager manager = new();
-    private readonly string ProjectPath;
+    private readonly string projectPath;
 
     public MsBuildExeFixture(RepositoryFixtureBase fixture, string workingDirectory = "", string language = "C#")
     {
         var projectExtension = AssemblyInfoFileHelper.GetProjectExtension(language);
         this.fixture = fixture;
-        this.ProjectPath = FileSystemHelper.Path.Combine(workingDirectory, $"app.{projectExtension}");
+        this.projectPath = FileSystemHelper.Path.Combine(workingDirectory, $"app.{projectExtension}");
 
         var versionFile = FileSystemHelper.Path.Combine(workingDirectory, "gitversion.json");
 
@@ -33,7 +33,7 @@ public class MsBuildExeFixture
 
     public MsBuildExeFixtureResult Execute()
     {
-        var analyzer = this.manager.GetProject(this.ProjectPath);
+        var analyzer = this.manager.GetProject(this.projectPath);
 
         var output = new StringWriter();
         analyzer.AddBuildLogger(new ConsoleLogger(LoggerVerbosity.Normal, output.Write, null, null));
@@ -54,7 +54,7 @@ public class MsBuildExeFixture
 
         return new MsBuildExeFixtureResult(this.fixture)
         {
-            ProjectPath = ProjectPath,
+            ProjectPath = this.projectPath,
             Output = output.ToString(),
             MsBuild = results
         };
@@ -62,7 +62,7 @@ public class MsBuildExeFixture
 
     public void CreateTestProject(Action<ProjectCreator> extendProject)
     {
-        var project = ProjectCreator.Templates.SdkCsproj(this.ProjectPath);
+        var project = ProjectCreator.Templates.SdkCsproj(this.projectPath);
         extendProject(project);
 
         project.Save();

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
@@ -1,7 +1,7 @@
 using Buildalyzer;
 using Buildalyzer.Environment;
-using GitVersion.Core.Tests;
 using GitVersion.Helpers;
+using GitVersion.Tests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Utilities.ProjectCreation;

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
@@ -1,8 +1,8 @@
 using GitVersion.Agents;
-using GitVersion.Core.Tests;
 using GitVersion.Helpers;
 using GitVersion.MsBuild.Tasks;
 using GitVersion.MsBuild.Tests.Mocks;
+using GitVersion.Tests;
 
 namespace GitVersion.MsBuild.Tests.Helpers;
 

--- a/src/GitVersion.MsBuild.Tests/InvalidFileCheckerTests.cs
+++ b/src/GitVersion.MsBuild.Tests/InvalidFileCheckerTests.cs
@@ -1,7 +1,7 @@
 using System.IO.Abstractions;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.MsBuild.Tests.Mocks;
+using GitVersion.Tests;
 
 namespace GitVersion.MsBuild.Tests;
 

--- a/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
@@ -1,12 +1,11 @@
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.MsBuild.Tasks;
 using GitVersion.MsBuild.Tests.Helpers;
 using GitVersion.Testing.Extensions;
+using GitVersion.Tests;
 using LibGit2Sharp;
 using Microsoft.Build.Utilities.ProjectCreation;
 

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -39,7 +39,7 @@ internal class GitVersionTaskExecutor(
         if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
         {
             // Ensure provided output path exists first. Fixes issue #2815.
-            fileSystem.Directory.CreateDirectory(task.IntermediateOutputPath);
+            this.fileSystem.Directory.CreateDirectory(task.IntermediateOutputPath);
         }
 
         var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "AssemblyInfo");
@@ -55,7 +55,7 @@ internal class GitVersionTaskExecutor(
         gitVersionOptions.AssemblySettingsInfo.EnsureAssemblyInfo = true;
         gitVersionOptions.AssemblySettingsInfo.Files.Add(fileWriteInfo.FileName);
 
-        gitVersionOutputTool.UpdateAssemblyInfo(versionVariables);
+        this.gitVersionOutputTool.UpdateAssemblyInfo(versionVariables);
     }
 
     public void GenerateGitVersionInformation(GenerateGitVersionInformation task)
@@ -65,7 +65,7 @@ internal class GitVersionTaskExecutor(
         if (!string.IsNullOrEmpty(task.IntermediateOutputPath))
         {
             // Ensure provided output path exists first. Fixes issue #2815.
-            fileSystem.Directory.CreateDirectory(task.IntermediateOutputPath);
+            this.fileSystem.Directory.CreateDirectory(task.IntermediateOutputPath);
         }
 
         var fileWriteInfo = task.IntermediateOutputPath.GetFileWriteInfo(task.Language, task.ProjectFile, "GitVersionInformation");
@@ -78,7 +78,7 @@ internal class GitVersionTaskExecutor(
         var gitVersionOptions = this.options.Value;
         gitVersionOptions.WorkingDirectory = fileWriteInfo.WorkingDirectory;
         var targetNamespace = GetTargetNamespace(task);
-        gitVersionOutputTool.GenerateGitVersionInformation(versionVariables, fileWriteInfo, targetNamespace);
+        this.gitVersionOutputTool.GenerateGitVersionInformation(versionVariables, fileWriteInfo, targetNamespace);
         return;
 
         static string? GetTargetNamespace(GenerateGitVersionInformation task)
@@ -102,8 +102,8 @@ internal class GitVersionTaskExecutor(
         var gitVersionOptions = this.options.Value;
         var configuration = this.configurationProvider.Provide(gitVersionOptions.ConfigurationInfo.OverrideConfiguration);
 
-        gitVersionOutputTool.OutputVariables(versionVariables, configuration.UpdateBuildNumber);
+        this.gitVersionOutputTool.OutputVariables(versionVariables, configuration.UpdateBuildNumber);
     }
 
-    private GitVersionVariables GitVersionVariables(GitVersionTaskBase task) => serializer.FromFile(task.VersionFile);
+    private GitVersionVariables GitVersionVariables(GitVersionTaskBase task) => this.serializer.FromFile(task.VersionFile);
 }

--- a/src/GitVersion.MsBuild/Helpers/AssemblyInfoFileHelper.cs
+++ b/src/GitVersion.MsBuild/Helpers/AssemblyInfoFileHelper.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 using GitVersion.Helpers;
 using Microsoft.Build.Framework;
 
-using static GitVersion.Core.RegexPatterns.AssemblyVersion;
+using static GitVersion.RegexPatterns.AssemblyVersion;
 
 namespace GitVersion.MsBuild;
 

--- a/src/GitVersion.Output.Tests/Output/AssemblyFileVersionTests.cs
+++ b/src/GitVersion.Output.Tests/Output/AssemblyFileVersionTests.cs
@@ -1,6 +1,6 @@
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Extensions;
+using GitVersion.Tests;
 
 namespace GitVersion.Output.Tests;
 

--- a/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
@@ -1,11 +1,10 @@
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Logging;
 using GitVersion.Output.AssemblyInfo;
 using GitVersion.OutputVariables;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Output.Tests;

--- a/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
@@ -19,10 +19,10 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     private string workingDir = null!;
 
     [OneTimeSetUp]
-    public void OneTimeSetUp() => workingDir = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), nameof(AssemblyInfoFileUpdaterTests));
+    public void OneTimeSetUp() => this.workingDir = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), nameof(AssemblyInfoFileUpdaterTests));
 
     [OneTimeTearDown]
-    public void OneTimeTearDown() => FileSystemHelper.Directory.DeleteDirectory(workingDir);
+    public void OneTimeTearDown() => FileSystemHelper.Directory.DeleteDirectory(this.workingDir);
 
     [SetUp]
     public void Setup()
@@ -42,13 +42,13 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldCreateAssemblyInfoFileWhenNotExistsAndEnsureAssemblyInfo(string fileExtension)
     {
         var assemblyInfoFile = "VersionAssemblyInfo." + fileExtension;
-        var fullPath = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fullPath = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         var variables = this.variableProvider.GetVariablesFor(
             SemanticVersion.Parse("1.0.0", RegexPatterns.Configuration.DefaultTagPrefixRegexPattern), EmptyConfigurationBuilder.New.Build(), 0);
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, true, assemblyInfoFile));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, true, assemblyInfoFile));
 
         this.fileSystem.File.ReadAllText(fullPath).ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
     }
@@ -59,13 +59,13 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldCreateAssemblyInfoFileAtPathWhenNotExistsAndEnsureAssemblyInfo(string fileExtension)
     {
         var assemblyInfoFile = FileSystemHelper.Path.Combine("src", "Project", "Properties", $"VersionAssemblyInfo.{fileExtension}");
-        var fullPath = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fullPath = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
         var variables = this.variableProvider.GetVariablesFor(
             SemanticVersion.Parse("1.0.0", RegexPatterns.Configuration.DefaultTagPrefixRegexPattern), EmptyConfigurationBuilder.New.Build(), 0
         );
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, true, assemblyInfoFile));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, true, assemblyInfoFile));
 
         this.fileSystem.File.ReadAllText(fullPath).ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
     }
@@ -79,11 +79,11 @@ public class AssemblyInfoFileUpdaterTests : TestBase
         var variables = this.variableProvider.GetVariablesFor(SemanticVersion.Parse("1.0.0", RegexPatterns.Configuration.DefaultTagPrefixRegexPattern), EmptyConfigurationBuilder.New.Build(), 0);
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, true, [.. assemblyInfoFiles]));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, true, [.. assemblyInfoFiles]));
 
         foreach (var item in assemblyInfoFiles)
         {
-            var fullPath = FileSystemHelper.Path.Combine(workingDir, item);
+            var fullPath = FileSystemHelper.Path.Combine(this.workingDir, item);
             this.fileSystem.File.ReadAllText(fullPath).ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
         }
     }
@@ -94,13 +94,13 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldNotCreateAssemblyInfoFileWhenNotExistsAndNotEnsureAssemblyInfo(string fileExtension)
     {
         var assemblyInfoFile = "NoVersionAssemblyInfo." + fileExtension;
-        var fullPath = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fullPath = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
         var variables = this.variableProvider.GetVariablesFor(
             SemanticVersion.Parse("1.0.0", RegexPatterns.Configuration.DefaultTagPrefixRegexPattern), EmptyConfigurationBuilder.New.Build(), 0
         );
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
         this.fileSystem.File.Exists(fullPath).ShouldBeFalse();
     }
@@ -111,13 +111,13 @@ public class AssemblyInfoFileUpdaterTests : TestBase
         this.fileSystem = Substitute.For<IFileSystem>();
 
         const string assemblyInfoFile = "VersionAssemblyInfo.js";
-        var fullPath = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fullPath = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
         var variables = this.variableProvider.GetVariablesFor(
             SemanticVersion.Parse("1.0.0", RegexPatterns.Configuration.DefaultTagPrefixRegexPattern), EmptyConfigurationBuilder.New.Build(), 0
         );
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, true, assemblyInfoFile));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, true, assemblyInfoFile));
 
         this.fileSystem.Received(1).File.WriteAllText(fullPath, Arg.Any<string>());
     }
@@ -133,9 +133,9 @@ public class AssemblyInfoFileUpdaterTests : TestBase
         );
 
         using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, this.fileSystem);
-        assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, [.. assemblyInfoFiles]));
+        assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, [.. assemblyInfoFiles]));
 
-        this.fileSystem.Received(1).Directory.EnumerateFiles(Arg.Is(workingDir), Arg.Any<string>(), Arg.Any<SearchOption>());
+        this.fileSystem.Received(1).Directory.EnumerateFiles(Arg.Is(this.workingDir), Arg.Any<string>(), Arg.Any<SearchOption>());
     }
 
     [TestCase("cs", "[assembly: AssemblyVersion(\"1.0.0.0\")]\r\n[assembly: AssemblyInformationalVersion(\"1.0.0.0\")]\r\n[assembly: AssemblyFileVersion(\"1.0.0.0\")]")]
@@ -144,12 +144,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersion(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -164,12 +164,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldNotReplaceAssemblyVersionWhenVersionSchemeIsNone(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.None, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             assemblyFileContent = fs.File.ReadAllText(fileName);
             assemblyFileContent.ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
@@ -182,12 +182,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionInRelativePath(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = FileSystemHelper.Path.Combine("Project", "src", "Properties", "AssemblyInfo." + fileExtension);
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -202,12 +202,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionInRelativePathWithWhiteSpace(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = FileSystemHelper.Path.Combine("Project", "src", "Properties", "AssemblyInfo." + fileExtension);
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -222,12 +222,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionWithStar(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -242,12 +242,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionWithAttributeSuffix(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, verify: (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 !s.Contains("""AssemblyVersionAttribute("1.0.0.0")""") &&
@@ -265,12 +265,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldAddAssemblyVersionIfMissingFromInfoFile(string fileExtension)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile("", fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -285,12 +285,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAlreadySubstitutedValues(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -305,12 +305,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionWhenCreatingAssemblyVersionFileAndEnsureAssemblyInfo(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, verify: (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.1.0")""") &&
@@ -325,12 +325,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionInRelativePathWithVariables(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = FileSystemHelper.Path.Combine("Project", "src", "Properties", "AssemblyInfo." + fileExtension);
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -345,12 +345,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldReplaceAssemblyVersionInRelativePathWithVariablesAndWhiteSpace(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = FileSystemHelper.Path.Combine("Project", "src", "Properties", "AssemblyInfo." + fileExtension);
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.MajorMinor, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
@@ -365,12 +365,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldAddAssemblyInformationalVersionWhenUpdatingAssemblyVersionFile(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, verify: (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             assemblyFileContent = fs.File.ReadAllText(fileName);
             assemblyFileContent.ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
@@ -383,12 +383,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void Issue1183ShouldAddFSharpAssemblyInformationalVersionBesideOtherAttributes(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, verify: (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             assemblyFileContent = fs.File.ReadAllText(fileName);
             assemblyFileContent.ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));
@@ -401,12 +401,12 @@ public class AssemblyInfoFileUpdaterTests : TestBase
     public void ShouldNotAddAssemblyInformationalVersionWhenVersionSchemeIsNone(string fileExtension, string assemblyFileContent)
     {
         var assemblyInfoFile = "AssemblyInfo." + fileExtension;
-        var fileName = FileSystemHelper.Path.Combine(workingDir, assemblyInfoFile);
+        var fileName = FileSystemHelper.Path.Combine(this.workingDir, assemblyInfoFile);
 
         VerifyAssemblyInfoFile(assemblyFileContent, fileName, AssemblyVersioningScheme.None, (fs, variables) =>
         {
             using var assemblyInfoFileUpdater = new AssemblyInfoFileUpdater(this.log, fs);
-            assemblyInfoFileUpdater.Execute(variables, new(workingDir, false, assemblyInfoFile));
+            assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             assemblyFileContent = fs.File.ReadAllText(fileName);
             assemblyFileContent.ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved", fileExtension)));

--- a/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
+++ b/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
@@ -1,8 +1,7 @@
-using GitVersion.Core.Tests;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Logging;
 using GitVersion.Output.OutputGenerator;
 using GitVersion.Testing.Extensions;
+using GitVersion.Tests;
 using LibGit2Sharp;
 
 namespace GitVersion.Output.Tests;

--- a/src/GitVersion.Output.Tests/Output/GitVersionInfoGeneratorTests.cs
+++ b/src/GitVersion.Output.Tests/Output/GitVersionInfoGeneratorTests.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Output.GitVersionInfo;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Output.Tests;

--- a/src/GitVersion.Output.Tests/Output/InformationalVersionBuilderTests.cs
+++ b/src/GitVersion.Output.Tests/Output/InformationalVersionBuilderTests.cs
@@ -1,4 +1,4 @@
-using GitVersion.Core.Tests.Helpers;
+using GitVersion.Tests;
 
 namespace GitVersion.Output.Tests;
 

--- a/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
@@ -1,12 +1,11 @@
 using System.IO.Abstractions;
 using System.Xml.Linq;
 using GitVersion.Configuration;
-using GitVersion.Core;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Logging;
 using GitVersion.Output.AssemblyInfo;
 using GitVersion.OutputVariables;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Output.Tests;

--- a/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
@@ -55,10 +55,10 @@ public class ProjectFileUpdaterTests : TestBase
                      </PropertyGroup>
                    </Project>
                    """;
-        var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+        var canUpdate = this.projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
 
         canUpdate.ShouldBe(true);
-        logMessages.ShouldBeEmpty();
+        this.logMessages.ShouldBeEmpty();
     }
 
     [TestCase($"""
@@ -71,13 +71,13 @@ public class ProjectFileUpdaterTests : TestBase
                """)]
     public void CannotUpdateProjectFileWithIncorrectProjectSdk(string xml)
     {
-        var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+        var canUpdate = this.projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
 
         canUpdate.ShouldBe(false);
 
-        logMessages.ShouldNotBeEmpty();
-        logMessages.Count.ShouldBe(1);
-        logMessages[0].ShouldContain("Specified project file Sdk (SomeOtherProject.Sdk) is not supported, please ensure the project sdk starts with 'Microsoft.NET.Sdk' or 'Microsoft.Build.Sql'");
+        this.logMessages.ShouldNotBeEmpty();
+        this.logMessages.Count.ShouldBe(1);
+        this.logMessages[0].ShouldContain("Specified project file Sdk (SomeOtherProject.Sdk) is not supported, please ensure the project sdk starts with 'Microsoft.NET.Sdk' or 'Microsoft.Build.Sql'");
     }
 
     [TestCase($"""
@@ -90,13 +90,13 @@ public class ProjectFileUpdaterTests : TestBase
                """)]
     public void CannotUpdateProjectFileWithMissingProjectSdk(string xml)
     {
-        var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+        var canUpdate = this.projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
 
         canUpdate.ShouldBe(false);
 
-        logMessages.ShouldNotBeEmpty();
-        logMessages.Count.ShouldBe(1);
-        logMessages[0].ShouldContain("Specified project file Sdk () is not supported, please ensure the project sdk starts with 'Microsoft.NET.Sdk' or 'Microsoft.Build.Sql'");
+        this.logMessages.ShouldNotBeEmpty();
+        this.logMessages.Count.ShouldBe(1);
+        this.logMessages[0].ShouldContain("Specified project file Sdk () is not supported, please ensure the project sdk starts with 'Microsoft.NET.Sdk' or 'Microsoft.Build.Sql'");
     }
 
     [TestCase($"""
@@ -110,13 +110,13 @@ public class ProjectFileUpdaterTests : TestBase
                """)]
     public void CannotUpdateProjectFileWithoutAssemblyInfoGeneration(string xml)
     {
-        var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+        var canUpdate = this.projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
 
         canUpdate.ShouldBe(false);
 
-        logMessages.ShouldNotBeEmpty();
-        logMessages.Count.ShouldBe(1);
-        logMessages[0].ShouldContain("Project file specifies <GenerateAssemblyInfo>false</GenerateAssemblyInfo>: versions set in this project file will not affect the output artifacts");
+        this.logMessages.ShouldNotBeEmpty();
+        this.logMessages.Count.ShouldBe(1);
+        this.logMessages[0].ShouldContain("Project file specifies <GenerateAssemblyInfo>false</GenerateAssemblyInfo>: versions set in this project file will not affect the output artifacts");
     }
 
     [TestCase("""
@@ -125,13 +125,13 @@ public class ProjectFileUpdaterTests : TestBase
               """)]
     public void CannotUpdateProjectFileWithoutAPropertyGroup(string xml)
     {
-        var canUpdate = projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
+        var canUpdate = this.projectFileUpdater.CanUpdateProjectFile(XElement.Parse(xml));
 
         canUpdate.ShouldBe(false);
 
-        logMessages.ShouldNotBeEmpty();
-        logMessages.Count.ShouldBe(1);
-        logMessages[0].ShouldContain("Unable to locate any <PropertyGroup> elements in specified project file. Are you sure it is in a correct format?");
+        this.logMessages.ShouldNotBeEmpty();
+        this.logMessages.Count.ShouldBe(1);
+        this.logMessages[0].ShouldContain("Unable to locate any <PropertyGroup> elements in specified project file. Are you sure it is in a correct format?");
     }
 
     [TestCase($"""

--- a/src/GitVersion.Output.Tests/Output/WixFileTests.cs
+++ b/src/GitVersion.Output.Tests/Output/WixFileTests.cs
@@ -15,10 +15,10 @@ internal class WixFileTests : TestBase
     private string workingDir = null!;
 
     [OneTimeSetUp]
-    public void OneTimeSetUp() => workingDir = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "WixFileTests");
+    public void OneTimeSetUp() => this.workingDir = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "WixFileTests");
 
     [OneTimeTearDown]
-    public void OneTimeTearDown() => FileSystemHelper.Directory.DeleteDirectory(workingDir);
+    public void OneTimeTearDown() => FileSystemHelper.Directory.DeleteDirectory(this.workingDir);
 
     [SetUp]
     public void Setup() => ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
@@ -53,9 +53,9 @@ internal class WixFileTests : TestBase
 
         using var wixVersionFileUpdater = sp.GetRequiredService<IWixVersionFileUpdater>();
 
-        wixVersionFileUpdater.Execute(versionVariables, new(workingDir));
+        wixVersionFileUpdater.Execute(versionVariables, new(this.workingDir));
 
-        var file = FileSystemHelper.Path.Combine(workingDir, WixVersionFileUpdater.WixVersionFileName);
+        var file = FileSystemHelper.Path.Combine(this.workingDir, WixVersionFileUpdater.WixVersionFileName);
         fileSystem
             .File.ReadAllText(file)
             .ShouldMatchApproved(c => c.SubFolder(FileSystemHelper.Path.Combine("Approved")));
@@ -95,14 +95,14 @@ internal class WixFileTests : TestBase
         using var wixVersionFileUpdater = sp.GetRequiredService<IWixVersionFileUpdater>();
 
         // fake an already existing file
-        var file = FileSystemHelper.Path.Combine(workingDir, WixVersionFileUpdater.WixVersionFileName);
-        if (!fileSystem.Directory.Exists(workingDir))
+        var file = FileSystemHelper.Path.Combine(this.workingDir, WixVersionFileUpdater.WixVersionFileName);
+        if (!fileSystem.Directory.Exists(this.workingDir))
         {
-            fileSystem.Directory.CreateDirectory(workingDir);
+            fileSystem.Directory.CreateDirectory(this.workingDir);
         }
         fileSystem.File.WriteAllText(file, new('x', 1024 * 1024));
 
-        wixVersionFileUpdater.Execute(versionVariables, new(workingDir));
+        wixVersionFileUpdater.Execute(versionVariables, new(this.workingDir));
 
         fileSystem
             .File.ReadAllText(file)

--- a/src/GitVersion.Output.Tests/Output/WixFileTests.cs
+++ b/src/GitVersion.Output.Tests/Output/WixFileTests.cs
@@ -1,9 +1,9 @@
 using System.IO.Abstractions;
 using GitVersion.Configuration;
-using GitVersion.Core.Tests.Helpers;
 using GitVersion.Helpers;
 using GitVersion.Logging;
 using GitVersion.Output.WixUpdater;
+using GitVersion.Tests;
 using GitVersion.VersionCalculation;
 
 namespace GitVersion.Output.Tests;

--- a/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
-using GitVersion.Core;
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Logging;

--- a/src/GitVersion.Output/GitVersionOutputTool.cs
+++ b/src/GitVersion.Output/GitVersionOutputTool.cs
@@ -27,22 +27,22 @@ internal class GitVersionOutputTool(
     {
         using (this.outputGenerator)
         {
-            this.outputGenerator.Execute(variables, new OutputContext(gitVersionOptions.OutputFile, updateBuildNumber));
+            this.outputGenerator.Execute(variables, new OutputContext(this.gitVersionOptions.OutputFile, updateBuildNumber));
         }
     }
 
     public void UpdateAssemblyInfo(GitVersionVariables variables)
     {
-        var assemblyInfoContext = new AssemblyInfoContext(gitVersionOptions.WorkingDirectory, gitVersionOptions.AssemblySettingsInfo.EnsureAssemblyInfo, [.. gitVersionOptions.AssemblySettingsInfo.Files]);
+        var assemblyInfoContext = new AssemblyInfoContext(this.gitVersionOptions.WorkingDirectory, this.gitVersionOptions.AssemblySettingsInfo.EnsureAssemblyInfo, [.. this.gitVersionOptions.AssemblySettingsInfo.Files]);
 
-        if (gitVersionOptions.AssemblySettingsInfo.UpdateProjectFiles)
+        if (this.gitVersionOptions.AssemblySettingsInfo.UpdateProjectFiles)
         {
             using (this.projectFileUpdater)
             {
                 this.projectFileUpdater.Execute(variables, assemblyInfoContext);
             }
         }
-        else if (gitVersionOptions.AssemblySettingsInfo.UpdateAssemblyInfo)
+        else if (this.gitVersionOptions.AssemblySettingsInfo.UpdateAssemblyInfo)
         {
             using (this.assemblyInfoFileUpdater)
             {
@@ -64,7 +64,7 @@ internal class GitVersionOutputTool(
     {
         using (this.gitVersionInfoGenerator)
         {
-            this.gitVersionInfoGenerator.Execute(variables, new GitVersionInfoContext(gitVersionOptions.WorkingDirectory, fileWriteInfo.FileName, targetNamespace));
+            this.gitVersionInfoGenerator.Execute(variables, new GitVersionInfoContext(this.gitVersionOptions.WorkingDirectory, fileWriteInfo.FileName, targetNamespace));
         }
     }
 }

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -61,10 +61,10 @@ public abstract class RepositoryFixtureBase : IDisposable
             // throw;
         }
 
-        this.SequenceDiagram.End();
+        SequenceDiagram.End();
         Console.WriteLine("**Visualisation of test:**");
         Console.WriteLine(string.Empty);
-        Console.WriteLine(this.SequenceDiagram.GetDiagram());
+        Console.WriteLine(SequenceDiagram.GetDiagram());
     }
 
     public void Checkout(string branch) => Commands.Checkout(Repository, branch);
@@ -86,26 +86,26 @@ public abstract class RepositoryFixtureBase : IDisposable
 
     public void ApplyTag(string tag)
     {
-        this.SequenceDiagram.ApplyTag(tag, Repository.Head.FriendlyName);
+        SequenceDiagram.ApplyTag(tag, Repository.Head.FriendlyName);
         Repository.ApplyTag(tag);
     }
 
     public void CreateBranch(string branchName, string? @as = null)
     {
-        this.SequenceDiagram.BranchTo(branchName, Repository.Head.FriendlyName, @as);
+        SequenceDiagram.BranchTo(branchName, Repository.Head.FriendlyName, @as);
         Repository.CreateBranch(branchName);
     }
 
     public void BranchTo(string branchName, string? @as = null)
     {
-        this.SequenceDiagram.BranchTo(branchName, Repository.Head.FriendlyName, @as);
+        SequenceDiagram.BranchTo(branchName, Repository.Head.FriendlyName, @as);
         var branch = Repository.CreateBranch(branchName);
         Commands.Checkout(Repository, branch);
     }
 
     public void BranchToFromTag(string branchName, string fromTag, string onBranch, string? @as = null)
     {
-        this.SequenceDiagram.BranchToFromTag(branchName, fromTag, onBranch, @as);
+        SequenceDiagram.BranchToFromTag(branchName, fromTag, onBranch, @as);
         var branch = Repository.CreateBranch(branchName);
         Commands.Checkout(Repository, branch);
     }
@@ -113,7 +113,7 @@ public abstract class RepositoryFixtureBase : IDisposable
     public string MakeACommit()
     {
         var to = Repository.Head.FriendlyName;
-        this.SequenceDiagram.MakeACommit(to);
+        SequenceDiagram.MakeACommit(to);
         var commit = Repository.MakeACommit();
         return commit.Sha;
     }
@@ -139,7 +139,7 @@ public abstract class RepositoryFixtureBase : IDisposable
     /// </summary>
     public void MergeNoFF(string mergeSource)
     {
-        this.SequenceDiagram.Merge(mergeSource, Repository.Head.FriendlyName);
+        SequenceDiagram.Merge(mergeSource, Repository.Head.FriendlyName);
         Repository.MergeNoFF(mergeSource, Generate.SignatureNow());
     }
 

--- a/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
+++ b/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
@@ -15,8 +15,8 @@ public class SequenceDiagram
     /// </summary>
     public SequenceDiagram()
     {
-        this.DiagramBuilder = new StringBuilder();
-        this.DiagramBuilder.AppendLine("@startuml");
+        DiagramBuilder = new StringBuilder();
+        DiagramBuilder.AppendLine("@startuml");
     }
 
     public StringBuilder DiagramBuilder { get; }
@@ -24,17 +24,17 @@ public class SequenceDiagram
     /// <summary>
     /// Activates a branch/participant in the sequence diagram
     /// </summary>
-    public void Activate(string branch) => this.DiagramBuilder.AppendLineFormat("activate {0}", GetParticipant(branch));
+    public void Activate(string branch) => DiagramBuilder.AppendLineFormat("activate {0}", GetParticipant(branch));
 
     /// <summary>
     /// Deactivates a branch/participant in the sequence diagram
     /// </summary>
-    public void Deactivate(string branch) => this.DiagramBuilder.AppendLineFormat("deactivate {0}", GetParticipant(branch));
+    public void Deactivate(string branch) => DiagramBuilder.AppendLineFormat("deactivate {0}", GetParticipant(branch));
 
     /// <summary>
     /// Destroys a branch/participant in the sequence diagram
     /// </summary>
-    public void Destroy(string branch) => this.DiagramBuilder.AppendLineFormat("destroy {0}", GetParticipant(branch));
+    public void Destroy(string branch) => DiagramBuilder.AppendLineFormat("destroy {0}", GetParticipant(branch));
 
     /// <summary>
     /// Creates a participant in the sequence diagram
@@ -44,21 +44,21 @@ public class SequenceDiagram
         var cleanParticipant = ParticipantSanitizer.SanitizeParticipant(@as ?? participant);
         this.participants.Add(participant, cleanParticipant);
         if (participant == cleanParticipant)
-            this.DiagramBuilder.AppendLineFormat("participant {0}", participant);
+            DiagramBuilder.AppendLineFormat("participant {0}", participant);
         else
-            this.DiagramBuilder.AppendLineFormat("participant \"{0}\" as {1}", participant, cleanParticipant);
+            DiagramBuilder.AppendLineFormat("participant \"{0}\" as {1}", participant, cleanParticipant);
     }
 
     /// <summary>
     /// Appends a divider with specified text to the sequence diagram
     /// </summary>
-    public void Divider(string text) => this.DiagramBuilder.AppendLineFormat("== {0} ==", text);
+    public void Divider(string text) => DiagramBuilder.AppendLineFormat("== {0} ==", text);
 
     /// <summary>
     /// Appends a note over one or many participants to the sequence diagram
     /// </summary>
     public void NoteOver(string noteText, string startParticipant, string? endParticipant = null, string? prefix = null, string? color = null) =>
-        this.DiagramBuilder.AppendLineFormat(
+        DiagramBuilder.AppendLineFormat(
             prefix + """
                      note over {0}{1}{2}
                        {3}
@@ -72,7 +72,7 @@ public class SequenceDiagram
     /// <summary>
     /// Appends applying a tag to the specified branch/participant to the sequence diagram
     /// </summary>
-    public void ApplyTag(string tag, string toBranch) => this.DiagramBuilder.AppendLineFormat("{0} -> {0}: tag {1}", GetParticipant(toBranch), tag);
+    public void ApplyTag(string tag, string toBranch) => DiagramBuilder.AppendLineFormat("{0} -> {0}: tag {1}", GetParticipant(toBranch), tag);
 
     /// <summary>
     /// Appends branching from a branch to another branch, @as can override the participant name
@@ -81,11 +81,11 @@ public class SequenceDiagram
     {
         if (!this.participants.ContainsKey(branchName))
         {
-            this.DiagramBuilder.Append("create ");
+            DiagramBuilder.Append("create ");
             Participant(branchName, @as);
         }
 
-        this.DiagramBuilder.AppendLineFormat(
+        DiagramBuilder.AppendLineFormat(
             "{0} -> {1}: branch from {2}",
             GetParticipant(currentName),
             GetParticipant(branchName), currentName);
@@ -98,32 +98,32 @@ public class SequenceDiagram
     {
         if (!this.participants.ContainsKey(branchName))
         {
-            this.DiagramBuilder.Append("create ");
+            DiagramBuilder.Append("create ");
             Participant(branchName, @as);
         }
 
-        this.DiagramBuilder.AppendLineFormat("{0} -> {1}: branch from tag ({2})", GetParticipant(onBranch), GetParticipant(branchName), fromTag);
+        DiagramBuilder.AppendLineFormat("{0} -> {1}: branch from tag ({2})", GetParticipant(onBranch), GetParticipant(branchName), fromTag);
     }
 
     /// <summary>
     /// Appends a commit on the target participant/branch to the sequence diagram
     /// </summary>
-    public void MakeACommit(string toParticipant) => this.DiagramBuilder.AppendLineFormat("{0} -> {0}: commit", GetParticipant(toParticipant));
+    public void MakeACommit(string toParticipant) => DiagramBuilder.AppendLineFormat("{0} -> {0}: commit", GetParticipant(toParticipant));
 
     /// <summary>
     /// Append a merge to the sequence diagram
     /// </summary>
-    public void Merge(string from, string to) => this.DiagramBuilder.AppendLineFormat("{0} -> {1}: merge", GetParticipant(from), GetParticipant(to));
+    public void Merge(string from, string to) => DiagramBuilder.AppendLineFormat("{0} -> {1}: merge", GetParticipant(from), GetParticipant(to));
 
     public string GetParticipant(string branch) => this.participants.GetValueOrDefault(branch, branch);
 
     /// <summary>
     /// Ends the sequence diagram
     /// </summary>
-    public void End() => this.DiagramBuilder.AppendLine("@enduml");
+    public void End() => DiagramBuilder.AppendLine("@enduml");
 
     /// <summary>
     /// returns the plantUML representation of the Sequence Diagram
     /// </summary>
-    public string GetDiagram() => this.DiagramBuilder.ToString();
+    public string GetDiagram() => DiagramBuilder.ToString();
 }

--- a/src/GitVersion.Testing/Helpers/ParticipantSanitizer.cs
+++ b/src/GitVersion.Testing/Helpers/ParticipantSanitizer.cs
@@ -1,4 +1,3 @@
-using GitVersion.Core;
 
 namespace GitVersion.Testing.Helpers;
 

--- a/src/GitVersion.sln.DotSettings
+++ b/src/GitVersion.sln.DotSettings
@@ -1,4 +1,4 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
 
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
@@ -196,17 +196,23 @@
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=GitVersion/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="GitVersion"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;JsInsertSemicolon&gt;True&lt;/JsInsertSemicolon&gt;&lt;JsReformatCode&gt;True&lt;/JsReformatCode&gt;&lt;CssReformatCode&gt;True&lt;/CssReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;CSCodeStyleAttributes ArrangeVarStyle="True" ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" /&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;
   &amp;lt;option name="myName" value="GitVersion" /&amp;gt;
 &amp;lt;/profile&amp;gt;&lt;/IDEA_SETTINGS&gt;&lt;RIDER_SETTINGS&gt;&amp;lt;profile&amp;gt;
-  &amp;lt;Language id="CSS"&amp;gt;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
+  &amp;lt;Language id=""&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="CMake"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="CSS"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="EditorConfig"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="HTML"&amp;gt;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="HTTP Request"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
@@ -224,9 +230,9 @@
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="JavaScript"&amp;gt;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="Markdown"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
@@ -237,18 +243,24 @@
   &amp;lt;Language id="RELAX-NG"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
   &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="Razor"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="SQL"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
   &amp;lt;/Language&amp;gt;
-  &amp;lt;Language id="XML"&amp;gt;
-    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
-    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+  &amp;lt;Language id="VueExpr"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+  &amp;lt;/Language&amp;gt;
+  &amp;lt;Language id="XML"&amp;gt;
+    &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
+    &amp;lt;OptimizeImports&amp;gt;true&amp;lt;/OptimizeImports&amp;gt;
+    &amp;lt;Rearrange&amp;gt;true&amp;lt;/Rearrange&amp;gt;
   &amp;lt;/Language&amp;gt;
   &amp;lt;Language id="yaml"&amp;gt;
     &amp;lt;Reformat&amp;gt;true&amp;lt;/Reformat&amp;gt;
   &amp;lt;/Language&amp;gt;
-&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;/Profile&gt;</s:String>
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;UpgradedBackendToFrontendHtml&gt;True&lt;/UpgradedBackendToFrontendHtml&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Default: Reformat Code</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">GitVersion</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>


### PR DESCRIPTION
- Unmark `Core` and other folders that shouldn't provide namespaces for ReSharper and Rider. Then adjust the namespace everywhere accordingly.
- Qualify `this.` prefix on private fields; unqualify it on all other class members.

## Description

`GitVersion.Core` is just an assembly name, similar to `System.Core.dll`. It indicates on a project level that it is the inner-most kernel of the entire solution, when viewed through the lens of [Clean Architecture](https://www.geeksforgeeks.org/system-design/complete-guide-to-clean-architecture/), [Onion Architecture](https://jeffreypalermo.com/2008/07/the-onion-architecture-part-1/), [Hexagonal Architecture (or Ports and Adapters)](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)), etc. This is not to say that GitVersion slavishly follows either of these architectures, but it does indicate that a dependency-free, [functional core](https://www.destroyallsoftware.com/screencasts/catalog/functional-core-imperative-shell) is an important design principle.

As such, the name `Core` should not be visible anywhere in the codebase other than as the name of the assembly containing the code that lives there. This PR therefore removes `Core` from all namespaces and tries to ensure that it stays like this by creating namespace provider configuration files for ReSharper and Rider such that this is respected in the future.

## Related Issue

Resolves #4987.

## Checklist:

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[ ] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
