### PR TITLE
fix: resolve SonarCloud issues in build, new-cli, and CI workflows

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/actions/docker-manifests/action.yml
+++ b/.github/actions/docker-manifests/action.yml
@@ -31,10 +31,13 @@ runs:
 
     - name: '[Docker Publish Manifests] DockerHub'
       shell: pwsh
+      env:
+        DOTNET_VERSION: ${{ inputs.dotnet_version }}
+        DOCKER_DISTRO: ${{ inputs.docker_distro }}
       run: |
         dotnet run/docker.dll `
-              --target=DockerManifest --arch=amd64 --arch=arm64 --dotnet_version=${{ inputs.dotnet_version }} `
-              --docker_distro=${{ inputs.docker_distro }} --docker_registry dockerhub
+              --target=DockerManifest --arch=amd64 --arch=arm64 --dotnet_version=$env:DOTNET_VERSION `
+              --docker_distro=$env:DOCKER_DISTRO --docker_registry dockerhub
 
     - name: Login to GitHub
       uses: docker/login-action@v4
@@ -45,7 +48,10 @@ runs:
 
     - name: '[Docker Publish Manifests] GitHub'
       shell: pwsh
+      env:
+        DOTNET_VERSION: ${{ inputs.dotnet_version }}
+        DOCKER_DISTRO: ${{ inputs.docker_distro }}
       run: |
         dotnet run/docker.dll `
-              --target=DockerManifest --arch=amd64 --arch=arm64 --dotnet_version=${{ inputs.dotnet_version }} `
-              --docker_distro=${{ inputs.docker_distro }} --docker_registry github
+              --target=DockerManifest --arch=amd64 --arch=arm64 --dotnet_version=$env:DOTNET_VERSION `
+              --docker_distro=$env:DOCKER_DISTRO --docker_registry github

--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -34,10 +34,14 @@ runs:
 
     - name: '[Docker Publish] DockerHub'
       shell: pwsh
+      env:
+        ARCH: ${{ inputs.arch }}
+        DOTNET_VERSION: ${{ inputs.dotnet_version }}
+        DOCKER_DISTRO: ${{ inputs.docker_distro }}
       run: |
         dotnet run/docker.dll `
-              --target=DockerPublish --arch=${{ inputs.arch }} --dotnet_version=${{ inputs.dotnet_version }} `
-              --docker_distro=${{ inputs.docker_distro }} --docker_registry dockerhub --verbosity=diagnostic
+              --target=DockerPublish --arch=$env:ARCH --dotnet_version=$env:DOTNET_VERSION `
+              --docker_distro=$env:DOCKER_DISTRO --docker_registry dockerhub --verbosity=diagnostic
 
     - name: Login to GitHub
       uses: docker/login-action@v4
@@ -48,7 +52,11 @@ runs:
 
     - name: '[Docker Publish] GitHub'
       shell: pwsh
+      env:
+        ARCH: ${{ inputs.arch }}
+        DOTNET_VERSION: ${{ inputs.dotnet_version }}
+        DOCKER_DISTRO: ${{ inputs.docker_distro }}
       run: |
         dotnet run/docker.dll `
-              --target=DockerPublish --arch=${{ inputs.arch }} --dotnet_version=${{ inputs.dotnet_version }} `
-              --docker_distro=${{ inputs.docker_distro }} --docker_registry github --verbosity=diagnostic
+              --target=DockerPublish --arch=$env:ARCH --dotnet_version=$env:DOTNET_VERSION `
+              --docker_distro=$env:DOCKER_DISTRO --docker_registry github --verbosity=diagnostic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,7 @@ env:
   ENABLED_DIAGNOSTICS: ${{ vars.ENABLED_DIAGNOSTICS }}
 
 permissions:
-  id-token: write
   contents: read
-  packages: write
-  attestations: write
 
 jobs:
   prepare:
@@ -66,6 +63,9 @@ jobs:
   unit_test:
     name: Test
     needs: [ prepare, publish_flags ]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_unit_tests.yml
     with:
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
@@ -98,6 +98,9 @@ jobs:
   docker_linux_images:
     needs: [ prepare, build, publish_flags ]
     name: Docker Images (${{ matrix.arch }})
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -119,6 +122,9 @@ jobs:
   docker_linux_manifests:
     needs: [ prepare, docker_linux_images, publish_flags ]
     name: Docker Manifests
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/_docker_manifests.yml
     with:
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
@@ -129,6 +135,10 @@ jobs:
   publish:
     name: Publish
     needs: [ artifacts_windows_test, artifacts_linux_test, publish_flags ]
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: ./.github/workflows/_publish.yml
     with:
       publish_packages: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -51,4 +51,4 @@ jobs:
         run: dotnet format ./build/ --verify-no-changes
 
       - name: Run Format 'GitVersion' solution
-        run: dotnet format ./src/ --exclude **/AddFormats/ --verify-no-changes
+        run: dotnet format ./src/ --exclude "**/AddFormats/" --verify-no-changes

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,7 @@ The build stage to execute.
 The build script target to run.
 .PARAMETER Verbosity
 Specifies the amount of information to be displayed.
-.PARAMETER WhatIf
+.PARAMETER DryRun
 Performs a dry run of the build script.
 No tasks will be executed.
 .PARAMETER ScriptArgs
@@ -14,13 +14,13 @@ Remaining arguments are added here.
 #>
 
 [CmdletBinding()]
-Param(
+param(
     [ValidateSet("artifacts", "build", "docker", "docs", "publish", "release")]
     [string]$Stage = "build",
     [string]$Target = "Default",
     [string]$Verbosity = "Normal",
-    [Alias("DryRun","Noop")]
-    [switch]$WhatIf,
+    [Alias("WhatIf","Noop")]
+    [switch]$DryRun,
     [switch]$Exclusive,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
@@ -39,7 +39,7 @@ $env:DOTNET_NOLOGO=$true
 $Arguments = @{
     target=$Target;
     verbosity=$Verbosity;
-    dryrun=$WhatIf;
+    dryrun=$DryRun;
     exclusive=$Exclusive;
     nuget_useinprocessclient=$true;
 }.GetEnumerator() | ForEach-Object {

--- a/build/build/BuildContext.cs
+++ b/build/build/BuildContext.cs
@@ -7,7 +7,7 @@ public class BuildContext(ICakeContext context) : BuildContextBase(context)
 {
     public string MsBuildConfiguration { get; set; } = Constants.DefaultConfiguration;
 
-    public readonly Dictionary<PlatformFamily, string[]> NativeRuntimes = new()
+    public readonly IReadOnlyDictionary<PlatformFamily, string[]> NativeRuntimes = new Dictionary<PlatformFamily, string[]>()
     {
         [PlatformFamily.Windows] = ["win-x64", "win-arm64"],
         [PlatformFamily.Linux] = ["linux-x64", "linux-musl-x64", "linux-arm64", "linux-musl-arm64"],

--- a/build/build/Tasks/Test/UnitTest.cs
+++ b/build/build/Tasks/Test/UnitTest.cs
@@ -24,7 +24,7 @@ public class UnitTest : FrostingTask<BuildContext>
             }
             if (!frameworks.Contains(dotnetVersion, StringComparer.OrdinalIgnoreCase))
             {
-                throw new Exception($"Dotnet Target {dotnetVersion} is not supported at the moment");
+                throw new NotSupportedException($"Dotnet Target {dotnetVersion} is not supported at the moment");
             }
             frameworks = [dotnetVersion];
         }

--- a/build/common/Addins/GitVersion/GitVersionRunner.cs
+++ b/build/common/Addins/GitVersion/GitVersionRunner.cs
@@ -62,17 +62,7 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
     {
         var builder = new ProcessArgumentBuilder();
 
-        if (settings.OutputTypes.Contains(GitVersionOutput.Json))
-        {
-            builder.Append("-output");
-            builder.Append("json");
-        }
-
-        if (settings.OutputTypes.Contains(GitVersionOutput.BuildServer))
-        {
-            builder.Append("-output");
-            builder.Append("buildserver");
-        }
+        AppendOutputArguments(builder, settings);
 
         if (!string.IsNullOrWhiteSpace(settings.ShowVariable))
         {
@@ -80,58 +70,9 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
             builder.Append(settings.ShowVariable);
         }
 
-        if (!string.IsNullOrWhiteSpace(settings.UserName))
-        {
-            builder.Append("-u");
-            builder.AppendQuoted(settings.UserName);
-
-            builder.Append("-p");
-            builder.AppendQuotedSecret(settings.Password);
-        }
-
-        if (settings.UpdateAssemblyInfo)
-        {
-            builder.Append("-updateassemblyinfo");
-
-            if (settings.UpdateAssemblyInfoFilePath != null)
-            {
-                builder.AppendQuoted(settings.UpdateAssemblyInfoFilePath.FullPath);
-            }
-        }
-
-        if (settings.RepositoryPath != null)
-        {
-            builder.Append("-targetpath");
-            builder.AppendQuoted(settings.RepositoryPath.FullPath);
-        }
-        else if (!string.IsNullOrWhiteSpace(settings.Url))
-        {
-            builder.Append("-url");
-            builder.AppendQuoted(settings.Url);
-
-            if (!string.IsNullOrWhiteSpace(settings.Branch))
-            {
-                builder.Append("-b");
-                builder.Append(settings.Branch);
-            }
-            else
-            {
-                this._log.Warning(
-                    "If you leave the branch name for GitVersion unset, it will fallback to the default branch for the repository.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.Commit))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.Commit);
-            }
-
-            if (settings.DynamicRepositoryPath != null)
-            {
-                builder.Append("-dynamicRepoLocation");
-                builder.AppendQuoted(settings.DynamicRepositoryPath.FullPath);
-            }
-        }
+        AppendAuthenticationArguments(builder, settings);
+        AppendAssemblyInfoArguments(builder, settings);
+        AppendRepositoryArguments(builder, settings);
 
         if (settings.LogFilePath != null)
         {
@@ -144,6 +85,98 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
             builder.Append("-nofetch");
         }
 
+        AppendVerbosityArguments(builder, settings);
+
+        return builder;
+    }
+
+    private static void AppendOutputArguments(ProcessArgumentBuilder builder, GitVersionSettings settings)
+    {
+        if (settings.OutputTypes.Contains(GitVersionOutput.Json))
+        {
+            builder.Append("-output");
+            builder.Append("json");
+        }
+
+        if (settings.OutputTypes.Contains(GitVersionOutput.BuildServer))
+        {
+            builder.Append("-output");
+            builder.Append("buildserver");
+        }
+    }
+
+    private static void AppendAuthenticationArguments(ProcessArgumentBuilder builder, GitVersionSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.UserName))
+        {
+            return;
+        }
+
+        builder.Append("-u");
+        builder.AppendQuoted(settings.UserName);
+
+        builder.Append("-p");
+        builder.AppendQuotedSecret(settings.Password);
+    }
+
+    private static void AppendAssemblyInfoArguments(ProcessArgumentBuilder builder, GitVersionSettings settings)
+    {
+        if (!settings.UpdateAssemblyInfo)
+        {
+            return;
+        }
+
+        builder.Append("-updateassemblyinfo");
+
+        if (settings.UpdateAssemblyInfoFilePath != null)
+        {
+            builder.AppendQuoted(settings.UpdateAssemblyInfoFilePath.FullPath);
+        }
+    }
+
+    private void AppendRepositoryArguments(ProcessArgumentBuilder builder, GitVersionSettings settings)
+    {
+        if (settings.RepositoryPath != null)
+        {
+            builder.Append("-targetpath");
+            builder.AppendQuoted(settings.RepositoryPath.FullPath);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Url))
+        {
+            return;
+        }
+
+        builder.Append("-url");
+        builder.AppendQuoted(settings.Url);
+
+        if (!string.IsNullOrWhiteSpace(settings.Branch))
+        {
+            builder.Append("-b");
+            builder.Append(settings.Branch);
+        }
+        else
+        {
+            this._log.Warning(
+                "If you leave the branch name for GitVersion unset, it will fallback to the default branch for the repository.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Commit))
+        {
+            builder.Append("-c");
+            builder.AppendQuoted(settings.Commit);
+        }
+
+        if (settings.DynamicRepositoryPath != null)
+        {
+            builder.Append("-dynamicRepoLocation");
+            builder.AppendQuoted(settings.DynamicRepositoryPath.FullPath);
+        }
+    }
+
+    private void AppendVerbosityArguments(ProcessArgumentBuilder builder, GitVersionSettings settings)
+    {
         var verbosity = settings.Verbosity ?? this._log.Verbosity;
 
         if (verbosity != Verbosity.Normal)
@@ -151,8 +184,6 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
             builder.Append("-verbosity");
             builder.Append(verbosity.ToString());
         }
-
-        return builder;
     }
 
     /// <summary>

--- a/build/common/Lifetime/BuildLifetimeBase.cs
+++ b/build/common/Lifetime/BuildLifetimeBase.cs
@@ -74,7 +74,7 @@ public class BuildLifetimeBase<T> : FrostingLifetime<T> where T : BuildContextBa
         }
         context.EndGroup();
     }
-    protected void LogBuildInformation(T context)
+    protected static void LogBuildInformation(T context)
     {
         if (context.HasArgument(Arguments.Target))
         {

--- a/build/common/Tasks/Default.cs
+++ b/build/common/Tasks/Default.cs
@@ -26,7 +26,7 @@ public class Default : FrostingTask
 
             var taskName = task.GetTaskName();
             var target = taskName != nameof(Default) ? $"-Target {taskName}" : string.Empty;
-            context.Information($"  ./build.ps1 -Stage {entryAssembly?.GetName().Name} {target} {arguments}\n");
+            context.Information($"  ./build.ps1 -Stage {entryAssembly!.GetName().Name} {target} {arguments}\n");
         }
     }
 }

--- a/build/common/Utilities/Arguments.cs
+++ b/build/common/Utilities/Arguments.cs
@@ -1,6 +1,6 @@
 namespace Common.Utilities;
 
-public class Arguments
+public static class Arguments
 {
     public const string Target = "target";
     public const string Configuration = "configuration";

--- a/build/common/Utilities/EnvVars.cs
+++ b/build/common/Utilities/EnvVars.cs
@@ -2,6 +2,8 @@ namespace Common.Utilities;
 
 public class EnvVars
 {
+    protected EnvVars() { }
+
     public const string EnabledDiagnostics = "ENABLED_DIAGNOSTICS";
     public const string ActionsRunnerDebug = "ACTIONS_RUNNER_DEBUG";
     public const string ActionsStepDebug = "ACTIONS_STEP_DEBUG";

--- a/build/common/Utilities/Paths.cs
+++ b/build/common/Utilities/Paths.cs
@@ -1,6 +1,6 @@
 namespace Common.Utilities;
 
-public class Paths
+public static class Paths
 {
     public static readonly DirectoryPath Root = "./";
 

--- a/build/common/Utilities/Tools.cs
+++ b/build/common/Utilities/Tools.cs
@@ -1,6 +1,6 @@
 namespace Common.Utilities;
 
-public class Tools
+public static class Tools
 {
     public const string CodecovUploaderCmd = "CodecovUploader";
 

--- a/build/common/Utilities/Tools.cs
+++ b/build/common/Utilities/Tools.cs
@@ -4,7 +4,7 @@ public static class Tools
 {
     public const string CodecovUploaderCmd = "CodecovUploader";
 
-    public static readonly Dictionary<string, string> Versions = new()
+    public static readonly IReadOnlyDictionary<string, string> Versions = new Dictionary<string, string>()
     {
         { CodecovUploaderCmd, "0.8.0" }
     };

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION
 
 WORKDIR /nuget
 COPY $nugetFolder/ ./
-RUN dotnet tool install GitVersion.Tool --version $VERSION --tool-path /tools --add-source .
+RUN dotnet tool install GitVersion.Tool --version "$VERSION" --tool-path /tools --add-source .
 
 FROM $REGISTRY/gittools/build-images:$DISTRO-runtime-$DOTNET_VERSION
 

--- a/build/docs/Tasks/PublishDocs.cs
+++ b/build/docs/Tasks/PublishDocs.cs
@@ -35,7 +35,7 @@ public sealed class PublishDocsInternal : FrostingTask<BuildContext>
 
     public override void Run(BuildContext context)
     {
-        if (context.ForcePublish is false)
+        if (!context.ForcePublish)
         {
             if (AnyDocsChanged(context))
             {

--- a/build/publish/Tasks/PublishNuget.cs
+++ b/build/publish/Tasks/PublishNuget.cs
@@ -133,7 +133,7 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
         var tokenBody = await responseMessage.Content.ReadAsStringAsync();
 
         if (!responseMessage.IsSuccessStatusCode)
-            throw new Exception("Failed to retrieve OIDC token from GitHub.");
+            throw new InvalidOperationException("Failed to retrieve OIDC token from GitHub.");
 
         using var tokenDoc = JsonDocument.Parse(tokenBody);
         return ParseJsonProperty(tokenDoc, "value", "Failed to retrieve OIDC token from GitHub.");
@@ -157,7 +157,7 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
         if (!responseMessage.IsSuccessStatusCode)
         {
             var errorMessage = BuildErrorMessage((int)responseMessage.StatusCode, exchangeBody);
-            throw new Exception(errorMessage);
+            throw new InvalidOperationException(errorMessage);
         }
 
         using var respDoc = JsonDocument.Parse(exchangeBody);
@@ -168,9 +168,9 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
     {
         if (!document.RootElement.TryGetProperty(propertyName, out var property) ||
             property.ValueKind != JsonValueKind.String)
-            throw new Exception(errorMessage);
+            throw new InvalidOperationException(errorMessage);
 
-        return property.GetString() ?? throw new Exception(errorMessage);
+        return property.GetString() ?? throw new InvalidOperationException(errorMessage);
     }
 
     private static string BuildErrorMessage(int statusCode, string responseBody)

--- a/new-cli/GitVersion.Calculation/CalculateCommand.cs
+++ b/new-cli/GitVersion.Calculation/CalculateCommand.cs
@@ -20,7 +20,7 @@ public class CalculateCommand(ILogger<CalculateCommand> logger, IService service
         {
             this.repository.DiscoverRepository(settings.WorkDir.FullName);
             var branches = this.repository.Branches.ToList();
-            this.logger.LogInformation("Command : 'calculate', LogFile : '{logFile}', WorkDir : '{workDir}' ",
+            this.logger.LogInformation("Command : 'calculate', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ",
                 settings.LogFile, settings.WorkDir);
             this.logger.LogInformation("Found {count} branches", branches.Count);
         }

--- a/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
+++ b/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
@@ -51,7 +51,7 @@ public abstract class CommandBaseGenerator : IIncrementalGenerator
         description.NotNull();
 
         ITypeSymbol? parentCommandType = null;
-        if (commandAttribute.AttributeClass?.TypeArguments.Any() == true)
+        if (commandAttribute.AttributeClass?.TypeArguments.Any() is true)
         {
             parentCommandType = commandAttribute.AttributeClass.TypeArguments.Single();
         }

--- a/new-cli/GitVersion.Cli.Generator/TypeVisitor.cs
+++ b/new-cli/GitVersion.Cli.Generator/TypeVisitor.cs
@@ -22,13 +22,13 @@ internal class TypeVisitor(Func<INamedTypeSymbol, bool> searchQuery, Cancellatio
         }
     }
 
-    public override void VisitNamedType(INamedTypeSymbol type)
+    public override void VisitNamedType(INamedTypeSymbol symbol)
     {
         cancellation.ThrowIfCancellationRequested();
 
-        if (searchQuery(type))
+        if (searchQuery(symbol))
         {
-            this.exportedTypes.Add(type);
+            this.exportedTypes.Add(symbol);
         }
     }
 }

--- a/new-cli/GitVersion.Cli/TestCommandSettings.cs
+++ b/new-cli/GitVersion.Cli/TestCommandSettings.cs
@@ -2,6 +2,6 @@ namespace GitVersion.Commands.Test.Settings;
 
 public record TestCommandSettings : GitVersionSettings
 {
-    [Option("--input-file", description: "The input version file", aliases: ["-i"])]
+    [Option("--input-file", description: "The input version file", aliases: "-i")]
     public required string InputFile { get; init; }
 }

--- a/new-cli/GitVersion.Configuration/ConfigCommand.cs
+++ b/new-cli/GitVersion.Configuration/ConfigCommand.cs
@@ -14,7 +14,7 @@ public class ConfigCommand(ILogger<ConfigCommand> logger, IService service) : IC
     public Task<int> InvokeAsync(ConfigSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'config', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        this.logger.LogInformation("Command : 'config', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ", settings.LogFile, settings.WorkDir);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Configuration/Init/ConfigInitCommand.cs
+++ b/new-cli/GitVersion.Configuration/Init/ConfigInitCommand.cs
@@ -14,7 +14,7 @@ public class ConfigInitCommand(ILogger<ConfigInitCommand> logger, IService servi
     public Task<int> InvokeAsync(ConfigInitSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'config init', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        this.logger.LogInformation("Command : 'config init', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ", settings.LogFile, settings.WorkDir);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Configuration/Show/ConfigShowCommand.cs
+++ b/new-cli/GitVersion.Configuration/Show/ConfigShowCommand.cs
@@ -14,7 +14,7 @@ public class ConfigShowCommand(ILogger<ConfigShowCommand> logger, IService servi
     public Task<int> InvokeAsync(ConfigShowSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'config show', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        this.logger.LogInformation("Command : 'config show', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ", settings.LogFile, settings.WorkDir);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
+++ b/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
@@ -14,7 +14,7 @@ public class LoggingEnricher : ILogEventEnricher
 
     public const string LogFilePathPropertyName = "LogFilePath";
 
-    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propFactory)
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
         // the settings might not have a path, or we might not be within a command, in which case
         // we won't have the setting, so a default value for the log file will be required
@@ -30,7 +30,7 @@ public class LoggingEnricher : ILogEventEnricher
             // We've got a new path for the log. Let's create a new property
             // and cache it for future log events to use
             this.cachedLogFilePath = path;
-            this.cachedLogFilePathProp = logFilePathProp = propFactory.CreateProperty(LogFilePathPropertyName, path);
+            this.cachedLogFilePathProp = logFilePathProp = propertyFactory.CreateProperty(LogFilePathPropertyName, path);
         }
 
         logEvent.AddPropertyIfAbsent(logFilePathProp);

--- a/new-cli/GitVersion.Normalization/NormalizeCommand.cs
+++ b/new-cli/GitVersion.Normalization/NormalizeCommand.cs
@@ -14,7 +14,7 @@ public class NormalizeCommand(ILogger<NormalizeCommand> logger, IService service
     public Task<int> InvokeAsync(NormalizeSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'normalize', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        this.logger.LogInformation("Command : 'normalize', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ", settings.LogFile, settings.WorkDir);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/AssemblyInfo/OutputAssemblyInfoCommand.cs
+++ b/new-cli/GitVersion.Output/AssemblyInfo/OutputAssemblyInfoCommand.cs
@@ -13,8 +13,8 @@ public class OutputAssemblyInfoCommand(ILogger<OutputAssemblyInfoCommand> logger
     {
         var value = this.service.Call();
         var versionInfo = settings.VersionInfo.Value;
-        this.logger.LogInformation($"Command : 'output assemblyinfo', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', AssemblyInfo: '{settings.AssemblyinfoFile}' ");
-        this.logger.LogInformation($"Version info: {versionInfo}");
+        this.logger.LogInformation("Command : 'output assemblyinfo', LogFile : '{LogFile}', WorkDir : '{OutputDir}', InputFile: '{InputFile}', AssemblyInfo: '{AssemblyInfo}' ", settings.LogFile, settings.OutputDir, settings.InputFile, settings.AssemblyinfoFile);
+        this.logger.LogInformation("Version info: {VersionInfo}", versionInfo);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/OutputCommand.cs
+++ b/new-cli/GitVersion.Output/OutputCommand.cs
@@ -12,7 +12,7 @@ public class OutputCommand(ILogger<OutputCommand> logger, IService service) : IC
     public Task<int> InvokeAsync(OutputSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'output', LogFile : '{settings.LogFile}', WorkDir : '{settings.WorkDir}' ");
+        this.logger.LogInformation("Command : 'output', LogFile : '{LogFile}', WorkDir : '{WorkDir}' ", settings.LogFile, settings.WorkDir);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/Project/OutputProjectCommand.cs
+++ b/new-cli/GitVersion.Output/Project/OutputProjectCommand.cs
@@ -12,7 +12,7 @@ public class OutputProjectCommand(ILogger<OutputProjectCommand> logger, IService
     public Task<int> InvokeAsync(OutputProjectSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'output project', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', Project: '{settings.ProjectFile}' ");
+        this.logger.LogInformation("Command : 'output project', LogFile : '{LogFile}', WorkDir : '{OutputDir}', InputFile: '{InputFile}', Project: '{ProjectFile}' ", settings.LogFile, settings.OutputDir, settings.InputFile, settings.ProjectFile);
         return Task.FromResult(value);
     }
 }

--- a/new-cli/GitVersion.Output/Wix/OutputWixCommand.cs
+++ b/new-cli/GitVersion.Output/Wix/OutputWixCommand.cs
@@ -12,7 +12,7 @@ public class OutputWixCommand(ILogger<OutputWixCommand> logger, IService service
     public Task<int> InvokeAsync(OutputWixSettings settings, CancellationToken cancellationToken = default)
     {
         var value = this.service.Call();
-        this.logger.LogInformation($"Command : 'output wix', LogFile : '{settings.LogFile}', WorkDir : '{settings.OutputDir}', InputFile: '{settings.InputFile}', WixFile: '{settings.WixFile}' ");
+        this.logger.LogInformation("Command : 'output wix', LogFile : '{LogFile}', WorkDir : '{OutputDir}', InputFile: '{InputFile}', WixFile: '{WixFile}' ", settings.LogFile, settings.OutputDir, settings.InputFile, settings.WixFile);
         return Task.FromResult(value);
     }
 }


### PR DESCRIPTION
Resolves a batch of SonarCloud findings across the **build**, **new-cli**, and **CI (.github)** areas. Code fixes here; false-positives / won't-fix dispositions were applied on SonarCloud directly.

## Code fixes

### `.github` (CI security)
- **S7630 (×10, BLOCKER)** – prevent script injection in the `docker-publish` / `docker-manifests` composite actions by passing `inputs.*` (`dotnet_version`, `docker_distro`, `arch`) via `env:` and referencing `$env:VAR` in the pwsh `run:` steps instead of interpolating `${{ inputs.* }}` into the shell.
- **S8233 (×3)** – scope `GITHUB_TOKEN` to least privilege: workflow-level dropped to `contents: read`; write scopes granted only on the jobs that need them (`unit_test` → `id-token`; `docker_*` → `packages`; `publish` → `id-token`+`packages`), matching each reusable workflow's own declarations. `release` already declared its own.
- **S6573 (×1)** – quote the `**/AddFormats/` glob in `format.yml`.

### build
- **S1118 ×4** – `static` utility classes (`Arguments`/`Paths`/`Tools`); protected ctor for the subclassed `EnvVars`.
- **S2325** – `LogBuildInformation` made static.
- **S112 ×5** – `InvalidOperationException` instead of bare `Exception` (`UnitTest`, NuGet publish flow).
- **S6570** – quote `$VERSION` in the Dockerfile.
- **S1125 / S2589 / S3887 ×2 / S2386** – misc maintainability (redundant boolean, redundant null-conditional, `IReadOnlyDictionary` for public collections).
- **S3776** – reduced `GitVersionRunner.GetArguments` cognitive complexity via extracted helpers.
- **S8642 / S8637** – `build.ps1`: lowercase `param`; renamed reserved `$WhatIf` → `$DryRun` (kept `WhatIf`/`Noop` aliases, so the CLI is unchanged).

### new-cli
- **S927 ×2** – param names matched to base/interface (`propertyFactory`, `symbol`).
- **S2629 ×9** – interpolated log messages → structured message templates.
- **S6678** – PascalCase log placeholders.
- **S1125** – `== true` → `is true`.
- **S3878** – pass single alias directly instead of an array literal.

## Verification
- `dotnet build` of `src`/`new-cli`/`build` solutions: 0 errors / 0 warnings.
- `dotnet format --verify-no-changes` clean.
- All changed GitHub Actions YAML validated as parseable.

> ⚠️ **S8233** (reusable-workflow permission scoping) can only be fully verified by an actual publish/release CI run — if any publish step hits a permissions error, add the missing scope to that specific job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
