### PR TITLE
fix: resolve SonarCloud findings across the codebase and enforce style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,7 +82,7 @@ csharp_prefer_static_local_function = true:warning
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
 
 # Code-block preferences
-csharp_prefer_braces = when_multiline:none
+csharp_prefer_braces = true:error
 csharp_prefer_simple_using_statement = true:warning
 
 # Expression-level preferences

--- a/.editorconfig
+++ b/.editorconfig
@@ -184,3 +184,9 @@ resharper_arrange_object_creation_when_type_not_evident_highlighting = none
 resharper_unused_auto_property_accessor_global_highlighting = none
 
 resharper_unused_method_return_value_global_highlighting = none
+
+# Test projects
+# Repeated string literals in tests (branch names, versions, config keys) are
+# intentionally inline for readability, so don't flag duplicate literals there.
+[**/*.Tests/**.cs]
+dotnet_diagnostic.S1192.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -161,13 +161,16 @@ dotnet_style_qualification_for_event = false:error
 dotnet_diagnostic.IDE0009.severity = error
 
 # IDE0005: Using directive is unnecessary.
-dotnet_diagnostic.ide0005.severity = warning
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0305: Use collection expression for fluent 
+dotnet_diagnostic.IDE0305.severity = error
 
 # RCS1037: Remove trailing white-space.
-dotnet_diagnostic.rcs1037.severity = error
+dotnet_diagnostic.RCS1037.severity = error
 
 # RCS1036: Remove redundant empty line.
-dotnet_diagnostic.rcs1036.severity = error
+dotnet_diagnostic.RCS1036.severity = error
 
 dotnet_diagnostic.S2325.severity = none
 dotnet_diagnostic.S4136.severity = none

--- a/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
+++ b/build/artifacts/Tasks/ArtifactsDotnetToolTest.cs
@@ -21,13 +21,19 @@ public class ArtifactsDotnetToolTest : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         if (context.Version == null)
+        {
             return;
+        }
+
         var rootPrefix = string.Empty;
         var version = context.Version.NugetVersion;
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageTesting(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage))
+            {
+                continue;
+            }
 
             var cmd = $"{rootPrefix}/scripts/test-global-tool.sh --version {version} --nugetPath {rootPrefix}/nuget --repoPath {rootPrefix}/repo";
 

--- a/build/artifacts/Tasks/ArtifactsExecutableTest.cs
+++ b/build/artifacts/Tasks/ArtifactsExecutableTest.cs
@@ -30,7 +30,9 @@ public class ArtifactsExecutableTest : FrostingTask<BuildContext>
     private static void PackageTest(BuildContextBase context, string packageToTest)
     {
         if (context.Version == null)
+        {
             return;
+        }
 
         var outputDirectory = Paths.Packages.Combine("test");
 

--- a/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildCoreTest.cs
@@ -20,13 +20,19 @@ public class ArtifactsMsBuildCoreTest : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         if (context.Version == null)
+        {
             return;
+        }
+
         var rootPrefix = string.Empty;
         var version = context.Version.NugetVersion;
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageTesting(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage))
+            {
+                continue;
+            }
 
             var cmd = $"{rootPrefix}/scripts/test-msbuild-task.sh --version {version} --nugetPath {rootPrefix}/nuget --repoPath {rootPrefix}/repo/tests/integration --targetframework net{dockerImage.TargetFramework}";
 

--- a/build/artifacts/Tasks/ArtifactsMsBuildFullTest.cs
+++ b/build/artifacts/Tasks/ArtifactsMsBuildFullTest.cs
@@ -17,7 +17,10 @@ public class ArtifactsMsBuildFullTest : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         if (context.Version == null)
+        {
             return;
+        }
+
         var version = context.Version.NugetVersion;
         var fullSemVer = context.Version.GitVersion.FullSemVer;
 

--- a/build/artifacts/Tasks/ArtifactsNativeTest.cs
+++ b/build/artifacts/Tasks/ArtifactsNativeTest.cs
@@ -21,13 +21,19 @@ public class ArtifactsNativeTest : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         if (context.Version?.SemVersion == null)
+        {
             return;
+        }
+
         var version = context.Version.SemVersion.ToLower();
         var rootPrefix = string.Empty;
 
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageTesting(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage))
+            {
+                continue;
+            }
 
             var runtime = "linux";
             if (dockerImage.Distro.StartsWith("alpine"))

--- a/build/artifacts/Tasks/ArtifactsPrepare.cs
+++ b/build/artifacts/Tasks/ArtifactsPrepare.cs
@@ -21,7 +21,11 @@ public class ArtifactsPrepare : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageTesting(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage))
+            {
+                continue;
+            }
+
             context.DockerPullImage(dockerImage);
         }
     }

--- a/build/build/Tasks/Package/PackageChocolatey.cs
+++ b/build/build/Tasks/Package/PackageChocolatey.cs
@@ -24,16 +24,12 @@ public class PackageChocolatey : FrostingTask<BuildContext>
         var artifactPath = context.MakeAbsolute(Paths.ArtifactsBinPortable).FullPath;
 
         var portableSettings = GetChocolateyPackSettings(context, "GitVersion.Portable");
-        portableSettings.Files = context.GetFiles(artifactPath + "/**/*.*")
-            .Select(file => new ChocolateyNuSpecContent { Source = file.FullPath, Target = file.FullPath.Replace(artifactPath, "") })
-            .ToArray();
+        portableSettings.Files = [.. context.GetFiles(artifactPath + "/**/*.*").Select(file => new ChocolateyNuSpecContent { Source = file.FullPath, Target = file.FullPath.Replace(artifactPath, "") })];
 
         context.ChocolateyPack(portableSettings);
 
         var metaPackageSettings = GetChocolateyPackSettings(context, "GitVersion");
-        metaPackageSettings.Files = context.GetFiles(artifactPath + "/**/*.txt")
-            .Select(file => new ChocolateyNuSpecContent { Source = file.FullPath, Target = file.FullPath.Replace(artifactPath, "") })
-            .ToArray();
+        metaPackageSettings.Files = [.. context.GetFiles(artifactPath + "/**/*.txt").Select(file => new ChocolateyNuSpecContent { Source = file.FullPath, Target = file.FullPath.Replace(artifactPath, "") })];
 
         metaPackageSettings.Dependencies =
         [

--- a/build/build/Tasks/Package/PackagePrepare.cs
+++ b/build/build/Tasks/Package/PackagePrepare.cs
@@ -33,7 +33,10 @@ public class PackagePrepare : FrostingTask<BuildContext>
             var outputPath = PackPrepareNative(context, runtime);
 
             // testing windows and macos artifacts, the linux is tested with docker
-            if (platform == PlatformFamily.Linux) continue;
+            if (platform == PlatformFamily.Linux)
+            {
+                continue;
+            }
 
             if (context.IsRunningOnAmd64() && runtime.EndsWith("x64") || context.IsRunningOnArm64() && runtime.EndsWith("arm64"))
             {

--- a/build/common/Addins/GitVersion/GitVersionRunner.cs
+++ b/build/common/Addins/GitVersion/GitVersionRunner.cs
@@ -38,7 +38,11 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
         Run(settings, GetArguments(settings), new ProcessSettings { RedirectStandardOutput = true }, process =>
         {
             output = string.Join("\n", process.GetStandardOutput());
-            if (this._log.Verbosity >= Verbosity.Diagnostic) return;
+            if (this._log.Verbosity >= Verbosity.Diagnostic)
+            {
+                return;
+            }
+
             var regex = ParseErrorRegex();
             var errors = regex.Matches(output)
                 .SelectMany(match => new[] { match.Groups[1].Value, match.Groups[2].Value });
@@ -49,7 +53,9 @@ public sealed partial class GitVersionRunner : Tool<GitVersionSettings>
         });
 
         if (!settings.OutputTypes.Contains(GitVersionOutput.Json))
+        {
             return new GitVersion();
+        }
 
         var jsonStartIndex = output.IndexOf('{');
         var jsonEndIndex = output.IndexOf('}');

--- a/build/common/Tasks/Default.cs
+++ b/build/common/Tasks/Default.cs
@@ -10,7 +10,10 @@ public class Default : FrostingTask
     {
         var entryAssembly = Assembly.GetEntryAssembly();
         var tasks = entryAssembly?.FindAllDerivedTypes(typeof(IFrostingTask)).Where(x => !x.Name.Contains("Internal")).ToList();
-        if (tasks == null) return;
+        if (tasks == null)
+        {
+            return;
+        }
 
         var defaultTask = tasks.Find(x => x.Name.Contains(nameof(Default)));
         if (defaultTask != null && tasks.Remove(defaultTask))

--- a/build/common/Utilities/ContextExtensions.cs
+++ b/build/common/Utilities/ContextExtensions.cs
@@ -19,7 +19,7 @@ public static class ContextExtensions
             }
 
             context.StartProcess(exe, processSettings, out var redirectedOutput);
-            return redirectedOutput.ToList();
+            return [.. redirectedOutput];
         }
 
         private IEnumerable<string> ExecGitCmd(string? cmd, DirectoryPath? workDir = null)

--- a/build/common/Utilities/ContextExtensions.cs
+++ b/build/common/Utilities/ContextExtensions.cs
@@ -84,9 +84,20 @@ public static class ContextExtensions
 
         public string GetOS()
         {
-            if (context.IsRunningOnWindows()) return "Windows";
-            if (context.IsRunningOnLinux()) return "Linux";
-            if (context.IsRunningOnMacOs()) return "macOs";
+            if (context.IsRunningOnWindows())
+            {
+                return "Windows";
+            }
+
+            if (context.IsRunningOnLinux())
+            {
+                return "Linux";
+            }
+
+            if (context.IsRunningOnMacOs())
+            {
+                return "macOs";
+            }
 
             return string.Empty;
         }
@@ -138,7 +149,10 @@ public static class ContextExtensions
 
         public bool ShouldRun(bool criteria, string skipMessage)
         {
-            if (criteria) return true;
+            if (criteria)
+            {
+                return true;
+            }
 
             context.Information(skipMessage);
             return false;

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -42,7 +42,10 @@ public static class DockerContextExtensions
 
         public void DockerBuildImage(DockerImage dockerImage)
         {
-            if (context.Version == null) return;
+            if (context.Version == null)
+            {
+                return;
+            }
 
             var (distro, targetFramework, arch, registry, _) = dockerImage;
 
@@ -185,7 +188,11 @@ public static class DockerContextExtensions
             var distro = dockerImage.Distro;
             var targetFramework = dockerImage.TargetFramework;
 
-            if (context.Version == null) return [];
+            if (context.Version == null)
+            {
+                return [];
+            }
+
             var tags = new List<string>
             {
                 $"{name}:{context.Version.Version}-{distro}-{targetFramework}",
@@ -209,7 +216,10 @@ public static class DockerContextExtensions
                 }
             }
 
-            if (!arch.HasValue) return tags.Distinct();
+            if (!arch.HasValue)
+            {
+                return tags.Distinct();
+            }
 
             var suffix = arch.Value.ToSuffix();
             return tags.Select(x => $"{x}-{suffix}").Distinct();

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -65,7 +65,7 @@ public static class DockerContextExtensions
                 Rm = true,
                 Pull = true,
                 // NoCache = true,
-                Tag = tags.ToArray(),
+                Tag = [.. tags],
                 Platform = [$"linux/{suffix}"],
                 Output = ["type=docker,oci-mediatypes=true"],
                 File = workDir.CombineWithFilePath("Dockerfile").FullPath,

--- a/build/common/Utilities/Extensions.cs
+++ b/build/common/Utilities/Extensions.cs
@@ -80,12 +80,22 @@ public static class Extensions
     /// </summary>
     public static string EscapeProcessArgument(this string literalValue, bool alwaysQuote = false)
     {
-        if (string.IsNullOrEmpty(literalValue)) return "\"\"";
+        if (string.IsNullOrEmpty(literalValue))
+        {
+            return "\"\"";
+        }
 
         if (literalValue.AsSpan().IndexOfAny(CharsRequiringQuoting) == -1) // Happy path
         {
-            if (!alwaysQuote) return literalValue;
-            if (literalValue[^1] != '\\') return $"\"{literalValue}\"";
+            if (!alwaysQuote)
+            {
+                return literalValue;
+            }
+
+            if (literalValue[^1] != '\\')
+            {
+                return $"\"{literalValue}\"";
+            }
         }
 
         return BuildEscapedArgument(literalValue);
@@ -99,16 +109,23 @@ public static class Extensions
         while (true)
         {
             var relativeIndex = s.AsSpan(nextPosition).IndexOfAny(CharsRequiringEscaping);
-            if (relativeIndex == -1) break;
+            if (relativeIndex == -1)
+            {
+                break;
+            }
 
             var nextEscapeChar = nextPosition + relativeIndex;
             sb.Append(s, nextPosition, relativeIndex);
             nextPosition = nextEscapeChar + 1;
 
             if (s[nextEscapeChar] == '"')
+            {
                 sb.Append("\\\"");
+            }
             else
+            {
                 nextPosition = AppendEscapedBackslashes(sb, s, nextPosition);
+            }
         }
 
         return sb.Append(s, nextPosition, s.Length - nextPosition).Append('"').ToString();
@@ -123,7 +140,9 @@ public static class Extensions
             nextPosition++;
         }
         if (nextPosition == s.Length || s[nextPosition] == '"')
+        {
             numBackslashes <<= 1;
+        }
 
         sb.Append('\\', numBackslashes);
         return nextPosition;

--- a/build/docker/Tasks/DockerTest.cs
+++ b/build/docker/Tasks/DockerTest.cs
@@ -23,7 +23,11 @@ public class DockerTest : FrostingTask<BuildContext>
     {
         foreach (var dockerImage in context.Images)
         {
-            if (context.SkipImageTesting(dockerImage)) continue;
+            if (context.SkipImageTesting(dockerImage))
+            {
+                continue;
+            }
+
             context.DockerTestImage(dockerImage);
         }
     }

--- a/build/docs/Tasks/PublishDocs.cs
+++ b/build/docs/Tasks/PublishDocs.cs
@@ -88,12 +88,18 @@ public sealed class PublishDocsInternal : FrostingTask<BuildContext>
         context.EnsureDirectoryExists(schemaTargetDir);
         context.CopyDirectory(Paths.Schemas, schemaTargetDir);
 
-        if (!context.GitHasUncommitedChanges(publishFolder)) return;
+        if (!context.GitHasUncommitedChanges(publishFolder))
+        {
+            return;
+        }
 
         context.Information("Stage all changes...");
         context.GitAddAll(publishFolder);
 
-        if (!context.GitHasStagedChanges(publishFolder)) return;
+        if (!context.GitHasStagedChanges(publishFolder))
+        {
+            return;
+        }
 
         context.Information("Commit all changes...");
         context.GitCommit(

--- a/build/publish/Tasks/PublishChocolatey.cs
+++ b/build/publish/Tasks/PublishChocolatey.cs
@@ -38,7 +38,11 @@ public class PublishChocolateyInternal : AsyncFrostingTask<BuildContext>
             .OrderByDescending(x => x.PackageName);
         foreach (var (packageName, filePath, _) in packages)
         {
-            if (IsPackagePublished(context, packageName, nugetVersion)) continue;
+            if (IsPackagePublished(context, packageName, nugetVersion))
+            {
+                continue;
+            }
+
             try
             {
                 context.Information($"Package {packageName}, version {nugetVersion} is being published.");

--- a/build/publish/Tasks/PublishNuget.cs
+++ b/build/publish/Tasks/PublishNuget.cs
@@ -121,7 +121,9 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
         var oidcRequestUrl = context.Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL");
 
         if (string.IsNullOrEmpty(oidcRequestToken) || string.IsNullOrEmpty(oidcRequestUrl))
+        {
             throw new InvalidOperationException("Missing GitHub OIDC request environment variables.");
+        }
 
         var tokenUrl = $"{oidcRequestUrl}&audience={Uri.EscapeDataString(nugetAudience)}";
         context.Information($"Requesting GitHub OIDC token from: {tokenUrl}");
@@ -133,7 +135,9 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
         var tokenBody = await responseMessage.Content.ReadAsStringAsync();
 
         if (!responseMessage.IsSuccessStatusCode)
+        {
             throw new InvalidOperationException("Failed to retrieve OIDC token from GitHub.");
+        }
 
         using var tokenDoc = JsonDocument.Parse(tokenBody);
         return ParseJsonProperty(tokenDoc, "value", "Failed to retrieve OIDC token from GitHub.");
@@ -168,7 +172,9 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
     {
         if (!document.RootElement.TryGetProperty(propertyName, out var property) ||
             property.ValueKind != JsonValueKind.String)
+        {
             throw new InvalidOperationException(errorMessage);
+        }
 
         return property.GetString() ?? throw new InvalidOperationException(errorMessage);
     }

--- a/build/release/Tasks/PublishRelease.cs
+++ b/build/release/Tasks/PublishRelease.cs
@@ -38,7 +38,10 @@ public class PublishReleaseInternal : FrostingTask<BuildContext>
 
         var milestone = context.Version?.Milestone;
 
-        if (milestone is null) return;
+        if (milestone is null)
+        {
+            return;
+        }
 
         context.GitReleaseManagerCreate(token, Constants.RepoOwner, Constants.Repository, new GitReleaseManagerCreateSettings
         {

--- a/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
+++ b/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
@@ -51,7 +51,7 @@ public abstract class CommandBaseGenerator : IIncrementalGenerator
         description.NotNull();
 
         ITypeSymbol? parentCommandType = null;
-        if (commandAttribute.AttributeClass?.TypeArguments.Any() is true)
+        if (commandAttribute.AttributeClass?.TypeArguments is { Length: > 0 })
         {
             parentCommandType = commandAttribute.AttributeClass.TypeArguments.Single();
         }

--- a/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
+++ b/new-cli/GitVersion.Cli.Generator/CommandBaseGenerator.cs
@@ -40,7 +40,10 @@ public abstract class CommandBaseGenerator : IIncrementalGenerator
         ct.ThrowIfCancellationRequested();
 
         var commandAttribute = classSymbol.GetAttributeData(CommandAttributeFullName) ?? classSymbol.GetAttributeData(CommandAttributeGenericFullName);
-        if (commandAttribute is null) return null;
+        if (commandAttribute is null)
+        {
+            return null;
+        }
 
         var ctorArguments = commandAttribute.ConstructorArguments;
 
@@ -57,7 +60,10 @@ public abstract class CommandBaseGenerator : IIncrementalGenerator
         }
 
         var commandBase = classSymbol.AllInterfaces.SingleOrDefault(x => x.OriginalDefinition.ToDisplayString() == CommandInterfaceFullName);
-        if (commandBase is null) return null;
+        if (commandBase is null)
+        {
+            return null;
+        }
 
         var settingsType = commandBase.TypeArguments.Single();
 

--- a/new-cli/GitVersion.Cli.Generator/SystemCommandlineGenerator.cs
+++ b/new-cli/GitVersion.Cli.Generator/SystemCommandlineGenerator.cs
@@ -8,7 +8,9 @@ public class SystemCommandlineGenerator : CommandBaseGenerator
         foreach (var commandInfo in commandInfos)
         {
             if (commandInfo == null)
+            {
                 continue;
+            }
 
             var commandHandlerTemplate = Template.Parse(SystemCommandlineContent.CommandImplContent);
 

--- a/new-cli/GitVersion.Cli/Program.cs
+++ b/new-cli/GitVersion.Cli/Program.cs
@@ -22,7 +22,10 @@ await using var serviceProvider = RegisterModules(modules);
 var app = serviceProvider.GetRequiredService<ICliApp>();
 
 var result = await app.RunAsync(args, cts.Token).ConfigureAwait(false);
-if (!Console.IsInputRedirected) Console.ReadKey();
+if (!Console.IsInputRedirected)
+{
+    Console.ReadKey();
+}
 
 return result;
 

--- a/new-cli/GitVersion.Core.Tester/Program.cs
+++ b/new-cli/GitVersion.Core.Tester/Program.cs
@@ -21,7 +21,10 @@ await using var serviceProvider = RegisterModules(modules);
 var app = serviceProvider.GetRequiredService<ICliApp>();
 
 var result = await app.RunAsync(args, cts.Token).ConfigureAwait(false);
-if (!Console.IsInputRedirected) Console.ReadKey();
+if (!Console.IsInputRedirected)
+{
+    Console.ReadKey();
+}
 
 return result;
 

--- a/new-cli/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/new-cli/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,10 @@ public static class ServiceCollectionExtensions
             .WriteTo.Console()
             .WriteTo.Map(LoggingEnricher.LogFilePathPropertyName, (logFilePath, sinkConfiguration) =>
             {
-                if (!string.IsNullOrEmpty(logFilePath)) sinkConfiguration.File(logFilePath);
+                if (!string.IsNullOrEmpty(logFilePath))
+                {
+                    sinkConfiguration.File(logFilePath);
+                }
             }, 1)
             .CreateLogger();
         return logger;

--- a/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
+++ b/new-cli/GitVersion.Core/Infrastructure/LoggingEnricher.cs
@@ -38,7 +38,11 @@ public class LoggingEnricher : ILogEventEnricher
 
     public static void Configure(string? logFile, Verbosity verbosity)
     {
-        if (!string.IsNullOrWhiteSpace(logFile)) path = logFile;
+        if (!string.IsNullOrWhiteSpace(logFile))
+        {
+            path = logFile;
+        }
+
         LogLevel.MinimumLevel = GetLevelForVerbosity(verbosity);
     }
 

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -67,7 +67,9 @@ public class HelpWriterTests : TestBase
     private static bool IsNotInHelp(Dictionary<string, string> lookup, string propertyName, string helpText)
     {
         if (lookup.TryGetValue(propertyName, out var value))
+        {
             return !helpText.Contains(value);
+        }
 
         return !helpText.Contains("/" + propertyName.ToLower());
     }

--- a/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
+++ b/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
@@ -14,7 +14,10 @@ public class ExecutionResults(int exitCode, string? output, string? logContents 
     {
         get
         {
-            if (Output.IsNullOrWhiteSpace()) return null;
+            if (Output.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
 
             var jsonStartIndex = Output.IndexOf('{');
             var jsonEndIndex = Output.IndexOf('}');

--- a/src/GitVersion.App.Tests/UpdateWixVersionFileTests.cs
+++ b/src/GitVersion.App.Tests/UpdateWixVersionFileTests.cs
@@ -78,7 +78,9 @@ internal class UpdateWixVersionFileTests
         while (reader.Read())
         {
             if (reader.Name != "define")
+            {
                 continue;
+            }
 
             var component = reader.Value.Split('=');
             gitVersionVarsInWix[component[0]] = component[1].TrimStart('"').TrimEnd('"');

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -103,7 +103,11 @@ internal class ArgumentParser(IEnvironment environment,
 
         arguments.TargetPath = arguments.TargetPath.TrimEnd('/', '\\');
 
-        if (!arguments.EnsureAssemblyInfo) arguments.UpdateAssemblyInfoFileName = ResolveFiles(arguments.TargetPath, arguments.UpdateAssemblyInfoFileName).ToHashSet();
+        if (!arguments.EnsureAssemblyInfo)
+        {
+            arguments.UpdateAssemblyInfoFileName = ResolveFiles(arguments.TargetPath, arguments.UpdateAssemblyInfoFileName).ToHashSet();
+        }
+
         arguments.NoFetch = arguments.NoFetch || this.buildAgent.PreventFetch();
 
         ValidateConfigurationFile(arguments);
@@ -113,17 +117,28 @@ internal class ArgumentParser(IEnvironment environment,
 
     private void ValidateConfigurationFile(Arguments arguments)
     {
-        if (arguments.ConfigurationFile.IsNullOrWhiteSpace()) return;
+        if (arguments.ConfigurationFile.IsNullOrWhiteSpace())
+        {
+            return;
+        }
 
         if (FileSystemHelper.Path.IsPathRooted(arguments.ConfigurationFile))
         {
-            if (!this.fileSystem.File.Exists(arguments.ConfigurationFile)) throw new WarningException($"Could not find config file at '{arguments.ConfigurationFile}'");
+            if (!this.fileSystem.File.Exists(arguments.ConfigurationFile))
+            {
+                throw new WarningException($"Could not find config file at '{arguments.ConfigurationFile}'");
+            }
+
             arguments.ConfigurationFile = FileSystemHelper.Path.GetFullPath(arguments.ConfigurationFile);
         }
         else
         {
             var configFilePath = FileSystemHelper.Path.GetFullPath(FileSystemHelper.Path.Combine(arguments.TargetPath, arguments.ConfigurationFile));
-            if (!this.fileSystem.File.Exists(configFilePath)) throw new WarningException($"Could not find config file at '{configFilePath}'");
+            if (!this.fileSystem.File.Exists(configFilePath))
+            {
+                throw new WarningException($"Could not find config file at '{configFilePath}'");
+            }
+
             arguments.ConfigurationFile = configFilePath;
         }
     }
@@ -134,7 +149,10 @@ internal class ArgumentParser(IEnvironment environment,
         var values = switchesAndValues.GetValues(name);
         var value = values?.FirstOrDefault();
 
-        if (ParseSwitches(arguments, name, values, value)) return;
+        if (ParseSwitches(arguments, name, values, value))
+        {
+            return;
+        }
 
         ParseTargetPath(arguments, name, values, value, i == 0);
     }
@@ -156,7 +174,10 @@ internal class ArgumentParser(IEnvironment environment,
 
     private IEnumerable<string> ResolveFiles(string workingDirectory, ISet<string>? assemblyInfoFiles)
     {
-        if (assemblyInfoFiles == null) yield break;
+        if (assemblyInfoFiles == null)
+        {
+            yield break;
+        }
 
         foreach (var file in assemblyInfoFiles)
         {
@@ -184,7 +205,11 @@ internal class ArgumentParser(IEnvironment environment,
         var couldNotParseMessage = $"Could not parse command line parameter '{name}'.";
 
         // If we've reached through all argument switches without a match, we can relatively safely assume that the first argument isn't a switch, but the target path.
-        if (!parseEnded) throw new WarningException(couldNotParseMessage);
+        if (!parseEnded)
+        {
+            throw new WarningException(couldNotParseMessage);
+        }
+
         if (name?.StartsWith('/') == true)
         {
             if (FileSystemHelper.Path.DirectorySeparatorChar == '/' && name.IsValidPath())
@@ -213,9 +238,15 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
-        if (ParseConfigArguments(arguments, name, values, value)) return true;
+        if (ParseConfigArguments(arguments, name, values, value))
+        {
+            return true;
+        }
 
-        if (ParseRemoteArguments(arguments, name, values, value)) return true;
+        if (ParseRemoteArguments(arguments, name, values, value))
+        {
+            return true;
+        }
 
         if (name.IsSwitch("diag"))
         {
@@ -296,7 +327,11 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
-        if (!name.IsSwitch("updatewixversionfile")) return false;
+        if (!name.IsSwitch("updatewixversionfile"))
+        {
+            return false;
+        }
+
         arguments.UpdateWixVersionFile = true;
         return true;
     }
@@ -317,7 +352,9 @@ internal class ArgumentParser(IEnvironment environment,
         }
 
         if (!name.IsSwitch("showConfig"))
+        {
             return false;
+        }
 
         arguments.ShowConfiguration = value.IsTrue() || !value.IsFalse();
         return true;
@@ -360,7 +397,11 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
-        if (!name.IsSwitch("b")) return false;
+        if (!name.IsSwitch("b"))
+        {
+            return false;
+        }
+
         EnsureArgumentValueCount(values);
         arguments.TargetBranch = value;
         return true;
@@ -424,7 +465,9 @@ internal class ArgumentParser(IEnvironment environment,
     private static void ParseOutput(Arguments arguments, IEnumerable<string>? values)
     {
         if (values == null)
+        {
             return;
+        }
 
         foreach (var v in values)
         {
@@ -443,7 +486,9 @@ internal class ArgumentParser(IEnvironment environment,
     private static void ParseOverrideConfig(Arguments arguments, IReadOnlyCollection<string>? values)
     {
         if (values == null || values.Count == 0)
+        {
             return;
+        }
 
         var parser = new OverrideConfigurationOptionParser();
 

--- a/src/GitVersion.App/ArgumentParserExtensions.cs
+++ b/src/GitVersion.App/ArgumentParserExtensions.cs
@@ -15,7 +15,9 @@ internal static class ArgumentParserExtensions
         public bool IsValidPath()
         {
             if (value == null)
+            {
                 return false;
+            }
 
             try
             {
@@ -50,7 +52,9 @@ internal static class ArgumentParserExtensions
         public bool IsSwitch(string switchName)
         {
             if (value == null)
+            {
                 return false;
+            }
 
             if (value.StartsWith('-'))
             {
@@ -78,7 +82,9 @@ internal static class ArgumentParserExtensions
 
             // If this is the first argument that might be a target path, the argument starts with slash, and we're on an OS that supports paths with slashes, the argument does not require a value.
             if (argumentMightRequireValue && argumentIndex == 0 && singleArgument.StartsWith('/') && FileSystemHelper.Path.DirectorySeparatorChar == '/' && singleArgument.IsValidPath())
+            {
                 return false;
+            }
 
             return argumentMightRequireValue;
         }

--- a/src/GitVersion.App/FileAppender.cs
+++ b/src/GitVersion.App/FileAppender.cs
@@ -20,7 +20,7 @@ internal class FileAppender : ILogAppender
         logFile.Directory?.Create();
         if (logFile.Exists) return;
 
-        using (logFile.CreateText()) { }
+        logFile.CreateText().Dispose();
     }
 
     public void WriteTo(LogLevel level, string message)
@@ -31,7 +31,7 @@ internal class FileAppender : ILogAppender
         }
         catch
         {
-            //
+            // Logging failures must not interrupt the main GitVersion command.
         }
     }
 

--- a/src/GitVersion.App/FileAppender.cs
+++ b/src/GitVersion.App/FileAppender.cs
@@ -18,7 +18,10 @@ internal class FileAppender : ILogAppender
         var logFile = this.fileSystem.FileInfo.New(FileSystemHelper.Path.GetFullPath(filePath));
 
         logFile.Directory?.Create();
-        if (logFile.Exists) return;
+        if (logFile.Exists)
+        {
+            return;
+        }
 
         logFile.CreateText().Dispose();
     }

--- a/src/GitVersion.App/FileSystemGlobbing/DirectoryInfoGlobbingWrapper.cs
+++ b/src/GitVersion.App/FileSystemGlobbing/DirectoryInfoGlobbingWrapper.cs
@@ -36,7 +36,11 @@ internal sealed class DirectoryInfoGlobbingWrapper
 
     public override IEnumerable<Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase> EnumerateFileSystemInfos()
     {
-        if (!this.directoryInfo.Exists) yield break;
+        if (!this.directoryInfo.Exists)
+        {
+            yield break;
+        }
+
         IEnumerable<IFileSystemInfo> fileSystemInfos;
         try
         {

--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -135,7 +135,11 @@ internal class GitVersionExecutor(
 
     private bool VerifyAndDisplayConfiguration(GitVersionOptions gitVersionOptions)
     {
-        if (!gitVersionOptions.ConfigurationInfo.ShowConfiguration) return false;
+        if (!gitVersionOptions.ConfigurationInfo.ShowConfiguration)
+        {
+            return false;
+        }
+
         if (gitVersionOptions.RepositoryInfo.TargetUrl.IsNullOrWhiteSpace())
         {
             this.configurationFileLocator.Verify(gitVersionOptions.WorkingDirectory, this.repositoryInfo.ProjectRootDirectory);

--- a/src/GitVersion.App/QuotedStringHelpers.cs
+++ b/src/GitVersion.App/QuotedStringHelpers.cs
@@ -23,7 +23,9 @@ internal static class QuotedStringHelpers
     public static string[] SplitUnquoted(string? input, char splitChar)
     {
         if (input == null)
+        {
             return [];
+        }
 
         var split = new List<string>();
         var isPreviousCharBackslash = false;
@@ -37,7 +39,10 @@ internal static class QuotedStringHelpers
             {
                 case '"':
                     if (!isPreviousCharBackslash)
+                    {
                         isInsideQuotes = !isInsideQuotes;
+                    }
+
                     break;
                 default:
                     if (current == splitChar && !isInsideQuotes)
@@ -69,10 +74,14 @@ internal static class QuotedStringHelpers
         var sb = new StringBuilder(input);
 
         if (sb[0] == '"')
+        {
             sb.Remove(0, 1);
+        }
 
         if (sb[^1] == '"' && sb[^2] != '\\')
+        {
             sb.Remove(sb.Length - 1, 1);
+        }
 
         sb.Replace("\\\"", "\""); // unescape quotes.
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitHubActionsTests.cs
@@ -33,7 +33,9 @@ public class GitHubActionsTests : TestBase
         this.environment.SetEnvironmentVariable(GitHubActions.EnvironmentVariableName, null);
         this.environment.SetEnvironmentVariable(GitHubActions.GitHubSetEnvTempFileEnvironmentVariableName, null);
         if (this.githubSetEnvironmentTempFilePath == null || !this.fileSystem.File.Exists(this.githubSetEnvironmentTempFilePath))
+        {
             return;
+        }
 
         this.fileSystem.File.Delete(this.githubSetEnvironmentTempFilePath);
         this.githubSetEnvironmentTempFilePath = null;

--- a/src/GitVersion.BuildAgents/Agents/AppVeyor.cs
+++ b/src/GitVersion.BuildAgents/Agents/AppVeyor.cs
@@ -14,7 +14,7 @@ internal class AppVeyor(IEnvironment environment, ILog log, IFileSystem fileSyst
     public override string SetBuildNumber(GitVersionVariables variables)
     {
         var buildNumber = this.environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
-        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
+        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new InvalidOperationException("APPVEYOR_API_URL environment variable not set");
 
         using var httpClient = GetHttpClient(apiUrl);
 
@@ -40,7 +40,7 @@ internal class AppVeyor(IEnvironment environment, ILog log, IFileSystem fileSyst
 
     public override string[] SetOutputVariables(string name, string? value)
     {
-        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new Exception("APPVEYOR_API_URL environment variable not set");
+        var apiUrl = this.environment.GetEnvironmentVariable("APPVEYOR_API_URL") ?? throw new InvalidOperationException("APPVEYOR_API_URL environment variable not set");
         var httpClient = GetHttpClient(apiUrl);
 
         var body = new

--- a/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
@@ -21,7 +21,9 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
     {
         var gitBranch = this.environment.GetEnvironmentVariable("GIT_BRANCH");
         if (gitBranch is not null)
+        {
             return gitBranch;
+        }
 
         var sourceBranch = this.environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
@@ -39,12 +41,18 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
         // specified
         var buildNumberEnv = this.environment.GetEnvironmentVariable("BUILD_BUILDNUMBER");
         if (buildNumberEnv.IsNullOrWhiteSpace())
+        {
             return variables.FullSemVer;
+        }
 
         var newBuildNumber = variables.OrderBy(x => x.Key).Aggregate(buildNumberEnv, ReplaceVariables);
 
         // If no variable substitution has happened, use FullSemVer
-        if (buildNumberEnv != newBuildNumber) return $"##vso[build.updatebuildnumber]{newBuildNumber}";
+        if (buildNumberEnv != newBuildNumber)
+        {
+            return $"##vso[build.updatebuildnumber]{newBuildNumber}";
+        }
+
         var buildNumber = variables.FullSemVer.EndsWith("+0")
             ? variables.FullSemVer[..^2]
             : variables.FullSemVer;

--- a/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
@@ -30,7 +30,7 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
         // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
         // BUILD_SOURCEBRANCH must be used only for "real" branches, not for tags.
         // Azure Pipelines sets BUILD_SOURCEBRANCH to refs/tags/<tag> when the pipeline is triggered for a tag.
-        return sourceBranch?.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) is true ? null : sourceBranch;
+        return sourceBranch is not null && sourceBranch.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) ? null : sourceBranch;
     }
 
     public override bool PreventFetch() => true;

--- a/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/AzurePipelines.cs
@@ -28,7 +28,7 @@ internal class AzurePipelines(IEnvironment environment, ILog log, IFileSystem fi
         // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
         // BUILD_SOURCEBRANCH must be used only for "real" branches, not for tags.
         // Azure Pipelines sets BUILD_SOURCEBRANCH to refs/tags/<tag> when the pipeline is triggered for a tag.
-        return sourceBranch?.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) == true ? null : sourceBranch;
+        return sourceBranch?.StartsWith("refs/tags", StringComparison.OrdinalIgnoreCase) is true ? null : sourceBranch;
     }
 
     public override bool PreventFetch() => true;

--- a/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
+++ b/src/GitVersion.BuildAgents/Agents/BitBucketPipelines.cs
@@ -32,7 +32,9 @@ internal class BitBucketPipelines : BuildAgentBase
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
     {
         if (this.propertyFile is null || this.ps1File is null)
+        {
             return;
+        }
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.propertyFile}' for Bash,");

--- a/src/GitVersion.BuildAgents/Agents/CodeBuild.cs
+++ b/src/GitVersion.BuildAgents/Agents/CodeBuild.cs
@@ -34,7 +34,9 @@ internal sealed class CodeBuild : BuildAgentBase
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
     {
         if (this.file is null)
+        {
             return;
+        }
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");

--- a/src/GitVersion.BuildAgents/Agents/Drone.cs
+++ b/src/GitVersion.BuildAgents/Agents/Drone.cs
@@ -24,17 +24,26 @@ internal class Drone(IEnvironment environment, ILog log, IFileSystem fileSystem)
         // https://discourse.drone.io/t/getting-the-branch-a-pull-request-is-created-from/670
         // Unfortunately, DRONE_REFSPEC isn't populated, however CI_COMMIT_REFSPEC can be used instead of.
         var pullRequestNumber = this.environment.GetEnvironmentVariable("DRONE_PULL_REQUEST");
-        if (pullRequestNumber.IsNullOrWhiteSpace()) return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
+        if (pullRequestNumber.IsNullOrWhiteSpace())
+        {
+            return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
+        }
         // DRONE_SOURCE_BRANCH is available in Drone 1.x.x version
         var sourceBranch = this.environment.GetEnvironmentVariable("DRONE_SOURCE_BRANCH");
         if (!sourceBranch.IsNullOrWhiteSpace())
+        {
             return sourceBranch;
+        }
 
         // In drone lower than 1.x.x source branch can be parsed from CI_COMMIT_REFSPEC
         // CI_COMMIT_REFSPEC - {sourceBranch}:{destinationBranch}
         // https://github.com/drone/drone/issues/2222
         var ciCommitRefSpec = this.environment.GetEnvironmentVariable("CI_COMMIT_REFSPEC");
-        if (ciCommitRefSpec.IsNullOrWhiteSpace()) return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
+        if (ciCommitRefSpec.IsNullOrWhiteSpace())
+        {
+            return this.environment.GetEnvironmentVariable("DRONE_BRANCH");
+        }
+
         var colonIndex = ciCommitRefSpec.IndexOf(':');
         return colonIndex > 0 ? ciCommitRefSpec[..colonIndex] : this.environment.GetEnvironmentVariable("DRONE_BRANCH");
     }

--- a/src/GitVersion.BuildAgents/Agents/EnvRun.cs
+++ b/src/GitVersion.BuildAgents/Agents/EnvRun.cs
@@ -12,8 +12,16 @@ internal class EnvRun(IEnvironment environment, ILog log, IFileSystem fileSystem
     public override bool CanApplyToCurrentContext()
     {
         var envRunDatabasePath = this.environment.GetEnvironmentVariable(EnvironmentVariableName);
-        if (envRunDatabasePath.IsNullOrEmpty()) return false;
-        if (this.fileSystem.File.Exists(envRunDatabasePath)) return true;
+        if (envRunDatabasePath.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        if (this.fileSystem.File.Exists(envRunDatabasePath))
+        {
+            return true;
+        }
+
         this.Log.Error($"The database file of EnvRun.exe was not found at {envRunDatabasePath}.");
 
         return false;

--- a/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
@@ -36,7 +36,9 @@ internal class GitLabCi : BuildAgentBase
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
     {
         if (this.file is null)
+        {
             return;
+        }
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");

--- a/src/GitVersion.BuildAgents/Agents/Jenkins.cs
+++ b/src/GitVersion.BuildAgents/Agents/Jenkins.cs
@@ -40,7 +40,9 @@ internal class Jenkins : BuildAgentBase
     public override void WriteIntegration(Action<string?> writer, GitVersionVariables variables, bool updateBuildNumber = true)
     {
         if (this.file is null)
+        {
             return;
+        }
 
         base.WriteIntegration(writer, variables, updateBuildNumber);
         writer($"Outputting variables to '{this.file}' ... ");

--- a/src/GitVersion.BuildAgents/Agents/TeamCity.cs
+++ b/src/GitVersion.BuildAgents/Agents/TeamCity.cs
@@ -16,7 +16,11 @@ internal class TeamCity(IEnvironment environment, ILog log, IFileSystem fileSyst
     {
         var branchName = this.environment.GetEnvironmentVariable("Git_Branch");
 
-        if (!branchName.IsNullOrEmpty()) return branchName;
+        if (!branchName.IsNullOrEmpty())
+        {
+            return branchName;
+        }
+
         if (!usingDynamicRepos)
         {
             WriteBranchEnvVariableWarning();

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -265,7 +265,11 @@ public static class ConfigurationFileLocatorTests
         private static IServiceProvider GetServiceProvider(GitVersionOptions gitVersionOptions, ILog? log = null) =>
             ConfigureServices(services =>
             {
-                if (log != null) services.AddSingleton(log);
+                if (log != null)
+                {
+                    services.AddSingleton(log);
+                }
+
                 services.AddSingleton(Options.Create(gitVersionOptions));
             });
     }

--- a/src/GitVersion.Configuration/Attributes/JsonPropertyDefaultAttribute.cs
+++ b/src/GitVersion.Configuration/Attributes/JsonPropertyDefaultAttribute.cs
@@ -30,7 +30,9 @@ public sealed class JsonPropertyDefaultAttribute : JsonAttribute
             var typedObj = Convert.ChangeType(boxedValue, type);
             Value = typedObj.ToString() ?? string.Empty;
             if (Value == type.ToString())
+            {
                 Value = JsonSerializer.Serialize(typedObj, type);
+            }
         }
         else
         {

--- a/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/BranchConfigurationBuilder.cs
@@ -90,7 +90,7 @@ internal class BranchConfigurationBuilder
 
     public virtual BranchConfigurationBuilder WithSourceBranches(IEnumerable<string> values)
     {
-        WithSourceBranches([.. values]);
+        this.sourceBranches = [.. values];
         return this;
     }
 
@@ -102,7 +102,7 @@ internal class BranchConfigurationBuilder
 
     public virtual BranchConfigurationBuilder WithIsSourceBranchFor(IEnumerable<string> values)
     {
-        WithIsSourceBranchFor([.. values]);
+        this.isSourceBranchFor = [.. values];
         return this;
     }
 

--- a/src/GitVersion.Configuration/ConfigurationException.cs
+++ b/src/GitVersion.Configuration/ConfigurationException.cs
@@ -1,6 +1,5 @@
 namespace GitVersion.Configuration;
 
-[Serializable]
 public class ConfigurationException : GitVersionException
 {
     public ConfigurationException(string msg)

--- a/src/GitVersion.Configuration/ConfigurationFileLocator.cs
+++ b/src/GitVersion.Configuration/ConfigurationFileLocator.cs
@@ -32,8 +32,16 @@ internal class ConfigurationFileLocator(
 
     public void Verify(string? workingDirectory, string? projectRootDirectory)
     {
-        if (FileSystemHelper.Path.IsPathRooted(ConfigurationFile)) return;
-        if (FileSystemHelper.Path.Equal(workingDirectory, projectRootDirectory)) return;
+        if (FileSystemHelper.Path.IsPathRooted(ConfigurationFile))
+        {
+            return;
+        }
+
+        if (FileSystemHelper.Path.Equal(workingDirectory, projectRootDirectory))
+        {
+            return;
+        }
+
         WarnAboutAmbiguousConfigFileSelection(workingDirectory, projectRootDirectory);
     }
 
@@ -56,7 +64,11 @@ internal class ConfigurationFileLocator(
         {
             this.log.Debug($"Trying to find configuration file {fileName} at '{directoryPath}'");
             var matchingFile = files.FirstOrDefault(file => string.Equals(FileSystemHelper.Path.GetFileName(file), fileName, StringComparison.OrdinalIgnoreCase));
-            if (matchingFile == null) continue;
+            if (matchingFile == null)
+            {
+                continue;
+            }
+
             this.log.Info($"Found configuration file at '{matchingFile}'");
             return matchingFile;
         }
@@ -66,7 +78,11 @@ internal class ConfigurationFileLocator(
 
     private string? GetCustomConfigurationFilePathIfEligable(string? directoryPath)
     {
-        if (string.IsNullOrWhiteSpace(ConfigurationFile)) return null;
+        if (string.IsNullOrWhiteSpace(ConfigurationFile))
+        {
+            return null;
+        }
+
         var configurationFilePath = ConfigurationFile;
         if (!string.IsNullOrWhiteSpace(directoryPath))
         {
@@ -89,7 +105,10 @@ internal class ConfigurationFileLocator(
             throw new WarningException($"Ambiguous configuration file selection from '{workingConfigFile}' and '{projectRootConfigFile}'");
         }
 
-        if (hasConfigInProjectRootDirectory || hasConfigInWorkingDirectory || this.SupportedConfigFileNames.Any(entry => entry.Equals(ConfigurationFile, StringComparison.OrdinalIgnoreCase))) return;
+        if (hasConfigInProjectRootDirectory || hasConfigInWorkingDirectory || this.SupportedConfigFileNames.Any(entry => entry.Equals(ConfigurationFile, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
 
         workingConfigFile = FileSystemHelper.Path.Combine(workingDirectory, ConfigurationFile);
         projectRootConfigFile = FileSystemHelper.Path.Combine(projectRootDirectory, ConfigurationFile);

--- a/src/GitVersion.Configuration/ConfigurationHelper.cs
+++ b/src/GitVersion.Configuration/ConfigurationHelper.cs
@@ -14,7 +14,11 @@ internal class ConfigurationHelper
     {
         get
         {
-            if (this.dictionary != null) return this.dictionary;
+            if (this.dictionary != null)
+            {
+                return this.dictionary;
+            }
+
             this.yaml ??= Serializer.Serialize(this.configuration!);
             this.dictionary = Serializer.Deserialize<Dictionary<object, object?>>(this.yaml);
             return this.dictionary;
@@ -35,7 +39,11 @@ internal class ConfigurationHelper
     {
         value.NotNull();
 
-        if (!value.Any()) return;
+        if (!value.Any())
+        {
+            return;
+        }
+
         var map = Dictionary.ToDictionary(element => element.Key, element => element.Value);
         Merge(map, value);
         this.dictionary = map;

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -20,7 +20,7 @@ internal class ConfigurationProvider(
     private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
-    public IGitVersionConfiguration Provide(IReadOnlyDictionary<object, object?>? overrideConfiguration)
+    public IGitVersionConfiguration Provide(IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
         var gitVersionOptions = this.options.Value;
         var workingDirectory = gitVersionOptions.WorkingDirectory;
@@ -53,9 +53,10 @@ internal class ConfigurationProvider(
             : ConfigurationBuilder.New;
 
         var overrideConfigurationFromWorkflow = WorkflowManager.GetOverrideConfiguration(workflow);
-        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, overrideConfiguration })
+        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, overrideConfiguration }
+                     .OfType<IReadOnlyDictionary<object, object?>>())
         {
-            if (item is not null) configurationBuilder.AddOverride(item);
+            configurationBuilder.AddOverride(item);
         }
 
         try

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -43,7 +43,10 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
     private static Dictionary<object, object?> ConvertToObjectDictionary(IReadOnlyDictionary<string, object?>? source)
     {
-        if (source is null) return [];
+        if (source is null)
+        {
+            return [];
+        }
 
         Dictionary<object, object?> result = [];
         foreach (var item in source)
@@ -79,7 +82,10 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
         public override string ConvertName(string name)
         {
-            if (string.IsNullOrEmpty(name)) return name;
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
 
             var builder = new StringBuilder(name.Length + 8);
             for (var index = 0; index < name.Length; index++)

--- a/src/GitVersion.Configuration/VersionStrategiesConverter.cs
+++ b/src/GitVersion.Configuration/VersionStrategiesConverter.cs
@@ -99,5 +99,5 @@ internal sealed class VersionStrategiesConverter : YamlConverter<VersionStrategi
     }
 
     private static string Normalize(string value)
-        => new(value.Where(char.IsLetterOrDigit).Select(char.ToUpperInvariant).ToArray());
+        => new([.. value.Where(char.IsLetterOrDigit).Select(char.ToUpperInvariant)]);
 }

--- a/src/GitVersion.Configuration/VersionStrategiesConverter.cs
+++ b/src/GitVersion.Configuration/VersionStrategiesConverter.cs
@@ -69,7 +69,10 @@ internal sealed class VersionStrategiesConverter : YamlConverter<VersionStrategi
     private static IEnumerable<string> SplitScalarList(string scalar)
     {
         var trimmed = scalar.Trim();
-        if (trimmed.Length == 0) yield break;
+        if (trimmed.Length == 0)
+        {
+            yield break;
+        }
 
         if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
         {

--- a/src/GitVersion.Configuration/Workflows/WorkflowManager.cs
+++ b/src/GitVersion.Configuration/Workflows/WorkflowManager.cs
@@ -16,7 +16,10 @@ internal static class WorkflowManager
 
     public static IReadOnlyDictionary<object, object?>? GetOverrideConfiguration(string? workflow)
     {
-        if (string.IsNullOrEmpty(workflow)) return null;
+        if (string.IsNullOrEmpty(workflow))
+        {
+            return null;
+        }
 
         var resourceName = GetResourceName(workflow);
         var embeddedResource = resourceName.ReadAsStringFromEmbeddedResource(typeof(WorkflowManager).Assembly);

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -638,10 +638,26 @@ public class GitVersionExecutorTests : TestBase
                 var contextFactory = sp.GetRequiredService<IGitVersionContextFactory>();
                 return new Lazy<GitVersionContext>(() => contextFactory.Create());
             });
-            if (log != null) services.AddSingleton(log);
-            if (fileSystem != null) services.AddSingleton(fileSystem);
-            if (repository != null) services.AddSingleton(repository);
-            if (environment != null) services.AddSingleton(environment);
+            if (log != null)
+            {
+                services.AddSingleton(log);
+            }
+
+            if (fileSystem != null)
+            {
+                services.AddSingleton(fileSystem);
+            }
+
+            if (repository != null)
+            {
+                services.AddSingleton(repository);
+            }
+
+            if (environment != null)
+            {
+                services.AddSingleton(environment);
+            }
+
             var options = Options.Create(gitVersionOptions);
             services.AddSingleton(options);
             services.AddSingleton<IGitRepositoryInfo>(sp =>

--- a/src/GitVersion.Core.Tests/Core/RegexPatternTests.cs
+++ b/src/GitVersion.Core.Tests/Core/RegexPatternTests.cs
@@ -13,7 +13,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.SwitchArgumentRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("https://user:pass@host", true, "https://user:pass@")]
@@ -24,7 +26,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.ObscurePasswordRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("{env:FOO}", true, "{env:FOO}")]
@@ -37,7 +41,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.ExpandTokensRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("v", true, "v")]
@@ -52,7 +58,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.DefaultTagPrefixRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("v1.2.3", true, "v1.2.3")]
@@ -63,7 +71,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.DefaultVersionInBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("main", true, "main")]
@@ -74,7 +84,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.MainBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("develop", true, "develop")]
@@ -86,7 +98,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.DevelopBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("release/1.0", true, "release/1.0")]
@@ -97,7 +111,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.ReleaseBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("feature/foo", true, "feature/foo")]
@@ -108,7 +124,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.FeatureBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("pull-requests/123", true, "pull-requests/123")]
@@ -120,7 +138,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.PullRequestBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("hotfix/1.0", true, "hotfix/1.0")]
@@ -131,7 +151,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.HotfixBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("support/1.0", true, "support/1.0")]
@@ -142,7 +164,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.SupportBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("any-branch", true, "any-branch")]
@@ -152,7 +176,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Configuration.UnknownBranchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Merge branch 'feature/foo' into develop", true, "Merge branch 'feature/foo' into develop")]
@@ -163,7 +189,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.DefaultMergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Finish feature/foo into develop", true, "Finish feature/foo into develop")]
@@ -174,7 +202,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.SmartGitMergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Merge pull request #123 from repo from feature/foo to develop", true, "Merge pull request #123 from repo from feature/foo to develop")]
@@ -185,7 +215,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.BitBucketPullMergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Pull request #123\n\nMerge in repo from feature/foo to develop", true, "Pull request #123\n\nMerge in repo from feature/foo to develop")]
@@ -196,7 +228,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.BitBucketPullv7MergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Merged in feature/foo (pull request #123)", true, "Merged in feature/foo (pull request #123)")]
@@ -207,7 +241,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.BitBucketCloudPullMergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("Merge pull request #123 from repo/feature/foo", false, null)]
@@ -217,7 +253,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.MergeMessage.AzureDevOpsPullMergeMessageRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("[assembly: AssemblyVersion(\"1.0.0.0\")]", true, "[assembly: AssemblyVersion(\"1.0.0.0\")]")]
@@ -229,7 +267,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Output.CsharpAssemblyAttributeRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("[<assembly: AssemblyVersion(\"1.0.0.0\")>]", true, "[<assembly: AssemblyVersion(\"1.0.0.0\")>]")]
@@ -241,7 +281,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Output.FsharpAssemblyAttributeRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("<Assembly: AssemblyVersion(\"1.0.0.0\")>", true, "<Assembly: AssemblyVersion(\"1.0.0.0\")>")]
@@ -253,7 +295,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.Output.VisualBasicAssemblyAttributeRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("+semver: major", true, "+semver: major")]
@@ -264,7 +308,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.VersionCalculation.DefaultMajorRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("+semver: minor", true, "+semver: minor")]
@@ -275,7 +321,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.VersionCalculation.DefaultMinorRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("+semver: patch", true, "+semver: patch")]
@@ -286,7 +334,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.VersionCalculation.DefaultPatchRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("+semver: none", true, "+semver: none")]
@@ -297,7 +347,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.VersionCalculation.DefaultNoBumpRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("1.2.3", true, "1.2.3")]
@@ -308,7 +360,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.SemanticVersion.ParseStrictRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("1.2.3", true, "1.2.3")]
@@ -320,7 +374,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.SemanticVersion.ParseLooseRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("123.BranchName.foo.Sha.abc", true, "123.BranchName.foo.Sha.abc")]
@@ -331,7 +387,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.SemanticVersion.ParseBuildMetaDataRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("meta-data", false, new string[0])]
@@ -348,7 +406,9 @@ public class RegexPatternsTests
 
         var captured = new List<string>();
         foreach (Match m in matches)
+        {
             captured.Add(m.Value);
+        }
 
         captured.ShouldBe(expectedCaptures);
     }
@@ -361,7 +421,9 @@ public class RegexPatternsTests
         var match = RegexPatterns.SemanticVersion.ParsePreReleaseTagRegex.Match(input);
         match.Success.ShouldBe(expected);
         if (expected)
+        {
             match.Value.ShouldBe(expectedCapture);
+        }
     }
 
     [TestCase("/* block comment */", true, "block", " block comment ")]

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -82,7 +82,11 @@ public static class GitRepositoryTestingExtensions
     {
         public void RenameRemote(string oldName, string newName)
         {
-            if (oldName.IsEquivalentTo(newName)) return;
+            if (oldName.IsEquivalentTo(newName))
+            {
+                return;
+            }
+
             if (remotes.Any(remote => remote.Name == newName))
             {
                 throw new InvalidOperationException($"A remote with the name '{newName}' already exists.");

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
@@ -36,13 +36,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -100,13 +108,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -172,13 +188,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -244,13 +268,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -316,13 +348,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -380,7 +420,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -446,7 +490,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -512,7 +560,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -570,7 +622,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -628,7 +684,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -686,13 +746,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -750,13 +818,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -822,13 +898,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -886,13 +970,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -950,13 +1042,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1014,13 +1114,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1078,13 +1186,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1150,13 +1266,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1222,13 +1346,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1286,13 +1418,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1350,13 +1490,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1414,13 +1562,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1486,13 +1642,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1558,13 +1722,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1630,13 +1802,21 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1694,7 +1874,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1711,7 +1895,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1769,7 +1957,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1786,7 +1978,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1852,7 +2048,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1869,7 +2069,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1935,7 +2139,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1952,7 +2160,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2018,7 +2230,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2035,7 +2251,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2093,7 +2313,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2188,7 +2412,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2283,7 +2511,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2308,7 +2540,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         if (useMainline)
@@ -2382,7 +2618,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2407,7 +2647,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2465,7 +2709,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2490,7 +2738,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2548,7 +2800,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2565,7 +2821,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2623,7 +2883,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2640,7 +2904,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2706,7 +2974,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2723,7 +2995,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2781,7 +3057,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2798,7 +3078,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2856,7 +3140,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2873,7 +3161,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2931,7 +3223,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2948,7 +3244,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3006,7 +3306,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3023,7 +3327,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3089,7 +3397,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3106,7 +3418,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3172,7 +3488,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3189,7 +3509,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3247,7 +3571,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3264,7 +3592,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3322,7 +3654,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3339,7 +3675,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3397,7 +3737,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3414,7 +3758,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3480,7 +3828,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3497,7 +3849,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3563,7 +3919,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3580,7 +3940,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3646,7 +4010,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3663,7 +4031,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3721,7 +4093,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3773,7 +4149,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3841,7 +4221,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3909,7 +4293,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3977,7 +4365,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4029,7 +4421,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4089,7 +4485,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4149,7 +4549,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4209,7 +4613,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4269,7 +4677,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4329,7 +4741,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4381,7 +4797,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4449,7 +4869,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4501,7 +4925,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4561,7 +4989,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4621,7 +5053,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4673,7 +5109,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4741,7 +5181,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4809,7 +5253,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4861,7 +5309,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4921,7 +5373,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4973,7 +5429,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5041,7 +5501,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5109,7 +5573,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5177,7 +5645,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5238,7 +5710,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -5255,7 +5731,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -5286,7 +5766,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5332,7 +5816,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5349,7 +5837,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5380,7 +5872,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5422,7 +5918,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5439,7 +5939,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5526,7 +6030,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5543,7 +6051,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5582,7 +6094,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5628,7 +6144,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5645,7 +6165,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5684,7 +6208,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5730,7 +6258,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5747,7 +6279,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5778,7 +6314,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5820,7 +6360,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -5880,7 +6424,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -5924,7 +6472,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6040,7 +6592,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6156,7 +6712,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6216,7 +6776,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6260,7 +6824,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6320,7 +6888,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6364,7 +6936,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6424,7 +7000,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6474,7 +7054,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -6491,7 +7075,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -6522,7 +7110,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6562,7 +7154,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6579,7 +7175,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6610,7 +7210,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.3-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.3");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.3");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6648,7 +7252,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6665,7 +7273,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6748,7 +7360,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6765,7 +7381,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6796,7 +7416,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.3-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.3");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.3");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6834,7 +7458,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6851,7 +7479,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6882,7 +7514,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6920,7 +7556,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6937,7 +7577,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6968,7 +7612,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7010,7 +7658,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -7027,7 +7679,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -7058,7 +7714,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7098,7 +7758,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7115,7 +7779,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7146,7 +7814,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.3.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.3.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.3.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7186,7 +7858,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7203,7 +7879,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7286,7 +7966,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7303,7 +7987,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7342,7 +8030,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.3.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.2.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7382,7 +8074,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7399,7 +8095,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7430,7 +8130,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.3.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.3.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.3.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7472,7 +8176,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7489,7 +8197,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7520,7 +8232,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7562,7 +8278,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -7579,7 +8299,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -7610,7 +8334,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7656,7 +8384,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7673,7 +8405,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7704,7 +8440,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7744,7 +8484,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7761,7 +8505,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7846,7 +8594,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7863,7 +8615,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7902,7 +8658,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7946,7 +8706,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7963,7 +8727,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8002,7 +8770,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -8052,7 +8824,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8069,7 +8845,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8100,7 +8880,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -8142,7 +8926,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -8196,7 +8984,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8247,7 +9039,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8301,7 +9097,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8350,7 +9150,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8467,7 +9271,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8529,7 +9337,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8584,7 +9396,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8646,7 +9462,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8705,7 +9525,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8759,7 +9583,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8801,7 +9629,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -8855,7 +9687,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -8900,7 +9736,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9011,7 +9851,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9123,7 +9967,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9177,7 +10025,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9225,7 +10077,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9279,7 +10135,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9330,7 +10190,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9384,7 +10248,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9434,7 +10302,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -9488,7 +10360,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9529,7 +10405,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9583,7 +10463,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9622,7 +10506,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9729,7 +10617,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9783,7 +10675,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9823,7 +10719,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9877,7 +10777,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9921,7 +10825,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9975,7 +10883,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10017,7 +10929,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -10071,7 +10987,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10118,7 +11038,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10172,7 +11096,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10215,7 +11143,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10326,7 +11258,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10388,7 +11324,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.1.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10435,7 +11375,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10489,7 +11433,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10536,7 +11484,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10590,7 +11542,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10632,7 +11588,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -10686,7 +11646,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10737,7 +11701,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10791,7 +11759,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10840,7 +11812,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10957,7 +11933,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11019,7 +11999,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -11074,7 +12058,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11136,7 +12124,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -11195,7 +12187,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11249,7 +12245,11 @@ public class AlignGitFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
@@ -36,13 +36,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -100,13 +108,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -172,13 +188,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -244,13 +268,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -316,13 +348,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -380,7 +420,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -446,7 +490,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -512,7 +560,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -570,7 +622,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -628,7 +684,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -686,13 +746,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -750,13 +818,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -822,13 +898,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -886,13 +970,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -950,13 +1042,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1014,13 +1114,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1078,13 +1186,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1150,13 +1266,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1222,13 +1346,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1286,13 +1418,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1350,13 +1490,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1414,13 +1562,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1486,13 +1642,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1558,13 +1722,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1630,13 +1802,21 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1694,7 +1874,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1711,7 +1895,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1769,7 +1957,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1786,7 +1978,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1852,7 +2048,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1869,7 +2069,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1935,7 +2139,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -1952,7 +2160,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2018,7 +2230,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2035,7 +2251,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2093,7 +2313,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2188,7 +2412,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2283,7 +2511,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2308,7 +2540,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         if (useMainline)
@@ -2382,7 +2618,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2407,7 +2647,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2465,7 +2709,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2490,7 +2738,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.0.0-1+1", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2548,7 +2800,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2565,7 +2821,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2623,7 +2883,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2640,7 +2904,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2706,7 +2974,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2723,7 +2995,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2781,7 +3057,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2798,7 +3078,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2856,7 +3140,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2873,7 +3161,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2931,7 +3223,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -2948,7 +3244,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3006,7 +3306,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3023,7 +3327,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3089,7 +3397,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3106,7 +3418,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3172,7 +3488,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3189,7 +3509,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3247,7 +3571,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3264,7 +3592,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3322,7 +3654,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3339,7 +3675,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3397,7 +3737,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3414,7 +3758,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3480,7 +3828,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3497,7 +3849,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3563,7 +3919,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3580,7 +3940,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3646,7 +4010,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3663,7 +4031,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3721,7 +4093,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3773,7 +4149,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3841,7 +4221,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3909,7 +4293,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -3977,7 +4365,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4029,7 +4421,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4089,7 +4485,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4149,7 +4549,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4209,7 +4613,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4269,7 +4677,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4329,7 +4741,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4381,7 +4797,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4449,7 +4869,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4501,7 +4925,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4561,7 +4989,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4621,7 +5053,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4673,7 +5109,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4741,7 +5181,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4809,7 +5253,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4861,7 +5309,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4921,7 +5373,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -4973,7 +5429,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5041,7 +5501,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5109,7 +5573,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5177,7 +5645,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -5238,7 +5710,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -5255,7 +5731,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -5286,7 +5766,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5332,7 +5816,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5349,7 +5837,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5380,7 +5872,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5422,7 +5918,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5439,7 +5939,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5526,7 +6030,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5543,7 +6051,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5582,7 +6094,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5628,7 +6144,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5645,7 +6165,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5684,7 +6208,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5730,7 +6258,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5747,7 +6279,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -5778,7 +6314,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -5820,7 +6360,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -5880,7 +6424,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -5924,7 +6472,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6040,7 +6592,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6156,7 +6712,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6216,7 +6776,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6260,7 +6824,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6320,7 +6888,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6364,7 +6936,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6424,7 +7000,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         if (useMainline)
@@ -6474,7 +7054,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -6491,7 +7075,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -6522,7 +7110,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6562,7 +7154,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6579,7 +7175,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6610,7 +7210,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.3-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.3");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.3");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6648,7 +7252,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6665,7 +7273,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6748,7 +7360,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6765,7 +7381,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6796,7 +7416,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.3-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.3");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.3");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6834,7 +7458,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6851,7 +7479,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6882,7 +7514,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -6920,7 +7556,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6937,7 +7577,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -6968,7 +7612,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7010,7 +7658,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -7027,7 +7679,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -7058,7 +7714,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7098,7 +7758,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7115,7 +7779,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7146,7 +7814,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.3.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.3.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.3.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7186,7 +7858,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7203,7 +7879,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7286,7 +7966,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7303,7 +7987,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7342,7 +8030,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.3.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.2.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7382,7 +8074,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7399,7 +8095,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7430,7 +8130,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.3.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.3.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.3.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7472,7 +8176,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7489,7 +8197,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7520,7 +8232,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7562,7 +8278,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -7579,7 +8299,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo("release/3.0.0");
 
         // ✅ succeeds as expected
@@ -7610,7 +8334,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7656,7 +8384,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7673,7 +8405,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7704,7 +8440,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7744,7 +8484,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7761,7 +8505,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7846,7 +8594,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7863,7 +8615,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7902,7 +8658,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.1");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -7946,7 +8706,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -7963,7 +8727,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8002,7 +8770,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("3.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("2.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -8052,7 +8824,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8069,7 +8845,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8100,7 +8880,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("3.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("3.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("3.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -8142,7 +8926,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -8196,7 +8984,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8247,7 +9039,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8301,7 +9097,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8350,7 +9150,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8467,7 +9271,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8529,7 +9337,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8584,7 +9396,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8646,7 +9462,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8705,7 +9525,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -8759,7 +9583,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -8801,7 +9629,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -8855,7 +9687,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -8900,7 +9736,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9011,7 +9851,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9123,7 +9967,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9177,7 +10025,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9225,7 +10077,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9279,7 +10135,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9330,7 +10190,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9384,7 +10248,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         if (useMainline)
@@ -9434,7 +10302,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -9488,7 +10360,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9529,7 +10405,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9583,7 +10463,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9622,7 +10506,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9729,7 +10617,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9783,7 +10675,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9823,7 +10719,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9877,7 +10777,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -9921,7 +10825,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -9975,7 +10883,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10017,7 +10929,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -10071,7 +10987,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10118,7 +11038,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10172,7 +11096,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10215,7 +11143,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10326,7 +11258,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10388,7 +11324,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("0.1.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10435,7 +11375,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10489,7 +11433,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.2.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.2.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.2.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10536,7 +11484,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10590,7 +11542,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10632,7 +11588,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -10686,7 +11646,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10737,7 +11701,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10791,7 +11759,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -10840,7 +11812,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -10957,7 +11933,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11019,7 +11999,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.1");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -11074,7 +12058,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11136,7 +12124,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
             fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
-        if (!useMainline) fixture.ApplyTag("1.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -11195,7 +12187,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-1+1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -11249,7 +12245,11 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-1+6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected

--- a/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
@@ -28,13 +28,21 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -85,7 +93,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -102,7 +114,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -153,7 +169,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -195,7 +215,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -249,7 +273,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -279,7 +307,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -333,7 +365,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -359,7 +395,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -376,7 +416,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -407,7 +451,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -440,7 +488,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -457,7 +509,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -488,7 +544,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -511,7 +571,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -585,7 +649,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-7", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -608,7 +676,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -667,7 +739,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-5", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("E");
 
         // ✅ succeeds as expected
@@ -690,7 +766,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -730,7 +810,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-4", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -753,7 +837,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("hotfix/bar");
 
         // ✅ succeeds as expected
@@ -793,7 +881,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-4", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -816,7 +908,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -872,7 +968,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-5", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -895,7 +995,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -946,7 +1050,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-4", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("E");
 
         // ✅ succeeds as expected
@@ -969,7 +1077,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -1055,7 +1167,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-8", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -1078,7 +1194,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -1159,7 +1279,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.1.0-7", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.1.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.1.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -1182,7 +1306,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("develop");
 
         // ✅ succeeds as expected
@@ -1268,7 +1396,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("1.0.0-8", configuration);
 
-        if (!useMainline) fixture.ApplyTag("1.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("1.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected

--- a/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow.cs
@@ -28,13 +28,21 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.MakeACommit("B");
 
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -85,7 +93,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -102,7 +114,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -153,7 +169,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("feature/foo");
 
         // ✅ succeeds as expected
@@ -195,7 +215,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -249,7 +273,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -277,7 +305,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -331,7 +363,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MakeACommit("F");
 
         // ✅ succeeds as expected
@@ -357,7 +393,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -374,7 +414,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo("release/2.0.0");
 
         // ✅ succeeds as expected
@@ -405,7 +449,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("2.0.0-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("2.0.0");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected
@@ -437,7 +485,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.1-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.1");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.1");
+        }
+
         fixture.BranchTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -454,7 +506,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.2-1", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.2");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.2");
+        }
+
         fixture.MergeTo(releaseBranch);
 
         // ✅ succeeds as expected
@@ -485,7 +541,11 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitHubFlow
         // ✅ succeeds as expected
         fixture.AssertFullSemver("0.0.3-6", configuration);
 
-        if (!useMainline) fixture.ApplyTag("0.0.3");
+        if (!useMainline)
+        {
+            fixture.ApplyTag("0.0.3");
+        }
+
         fixture.MakeACommit("G");
 
         // ✅ succeeds as expected

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
@@ -115,7 +115,9 @@ public class OtherScenarios : TestBase
             fileSystem.File.WriteAllText(repoFile, $"Hello world / testfile {i}");
 
             if (stageFile)
+            {
                 Commands.Stage(fixture.Repository, repoFile);
+            }
         }
 
         var version = fixture.GetVersion();
@@ -1077,7 +1079,11 @@ public class OtherScenarios : TestBase
 
         using var fixture = new EmptyRepositoryFixture();
         fixture.MakeACommit("A");
-        if (!tag.IsNullOrEmpty()) fixture.ApplyTag(tag);
+        if (!tag.IsNullOrEmpty())
+        {
+            fixture.ApplyTag(tag);
+        }
+
         fixture.BranchTo("develop");
 
         fixture.AssertFullSemver(version, configuration);
@@ -1106,7 +1112,11 @@ public class OtherScenarios : TestBase
 
         using var fixture = new EmptyRepositoryFixture();
         fixture.MakeACommit("A");
-        if (!tag.IsNullOrEmpty()) fixture.ApplyTag(tag);
+        if (!tag.IsNullOrEmpty())
+        {
+            fixture.ApplyTag(tag);
+        }
+
         fixture.BranchTo("develop");
 
         fixture.AssertFullSemver(version, configuration);
@@ -1135,7 +1145,11 @@ public class OtherScenarios : TestBase
 
         using var fixture = new EmptyRepositoryFixture();
         fixture.MakeACommit("A");
-        if (!tag.IsNullOrEmpty()) fixture.ApplyTag(tag);
+        if (!tag.IsNullOrEmpty())
+        {
+            fixture.ApplyTag(tag);
+        }
+
         fixture.BranchTo("develop");
 
         fixture.AssertFullSemver(version, configuration);
@@ -1276,7 +1290,11 @@ public class OtherScenarios : TestBase
 
         fixture.Checkout("main");
         fixture.MakeACommit("C");
-        if (applyTag) fixture.ApplyTag("1.0.1");
+        if (applyTag)
+        {
+            fixture.ApplyTag("1.0.1");
+        }
+
         fixture.Checkout("develop");
         fixture.MergeNoFF("main");
 
@@ -1302,7 +1320,11 @@ public class OtherScenarios : TestBase
 
         fixture.Checkout("main");
         fixture.MakeACommit("C");
-        if (applyTag) fixture.ApplyTag("2.0.0");
+        if (applyTag)
+        {
+            fixture.ApplyTag("2.0.0");
+        }
+
         fixture.Checkout("develop");
         fixture.MergeNoFF("main");
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -125,7 +125,11 @@ public class RemoteRepositoryScenarios : TestBase
     {
         foreach (var branch in repository.Branches)
         {
-            if (!branch.IsRemote) continue;
+            if (!branch.IsRemote)
+            {
+                continue;
+            }
+
             var localName = branch.FriendlyName.Replace($"{branch.RemoteName}/", "");
             if (repository.Branches[localName] == null)
             {
@@ -145,7 +149,11 @@ public class RemoteRepositoryScenarios : TestBase
         fixture.CreateBranch(branchName);
         fixture.MakeACommit();
 
-        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
+        if (origin != "origin")
+        {
+            fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
+        }
+
         fixture.LocalRepositoryFixture.Fetch(origin);
         fixture.LocalRepositoryFixture.Checkout("develop");
 

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/VersionInBranchNameBaseVersionStrategyTests.cs
@@ -100,7 +100,11 @@ public class VersionInBranchNameBaseVersionStrategyTests : TestBase
         using var fixture = new RemoteRepositoryFixture();
 
         fixture.CreateBranch(branchName);
-        if (origin != "origin") fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
+        if (origin != "origin")
+        {
+            fixture.LocalRepositoryFixture.Repository.Network.Remotes.RenameRemote("origin", origin);
+        }
+
         fixture.LocalRepositoryFixture.Fetch(origin);
 
         var localRepository = fixture.LocalRepositoryFixture.Repository.ToGitRepository();

--- a/src/GitVersion.Core/Agents/BuildAgentResolver.cs
+++ b/src/GitVersion.Core/Agents/BuildAgentResolver.cs
@@ -17,7 +17,11 @@ internal class BuildAgentResolver(IEnumerable<IBuildAgent> buildAgents, ILog log
         {
             try
             {
-                if (!buildAgent.CanApplyToCurrentContext()) continue;
+                if (!buildAgent.CanApplyToCurrentContext())
+                {
+                    continue;
+                }
+
                 instance = (ICurrentBuildAgent)buildAgent;
             }
             catch (Exception ex)

--- a/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
@@ -30,22 +30,34 @@ public record EffectiveConfiguration
         }
 
         if (!branchConfiguration.DeploymentMode.HasValue)
+        {
             throw new InvalidOperationException("Configuration value for 'Deployment mode' has no value. (this should not happen, please report an issue)");
+        }
 
         if (!configuration.AssemblyVersioningScheme.HasValue)
+        {
             throw new InvalidOperationException("Configuration value for 'AssemblyVersioningScheme' has no value. (this should not happen, please report an issue)");
+        }
 
         if (!configuration.AssemblyFileVersioningScheme.HasValue)
+        {
             throw new InvalidOperationException("Configuration value for 'AssemblyFileVersioningScheme' has no value. (this should not happen, please report an issue)");
+        }
 
         if (!branchConfiguration.CommitMessageIncrementing.HasValue)
+        {
             throw new InvalidOperationException("Configuration value for 'CommitMessageIncrementing' has no value. (this should not happen, please report an issue)");
+        }
 
         if (!configuration.TagPreReleaseWeight.HasValue)
+        {
             throw new InvalidOperationException("Configuration value for 'TagPreReleaseWeight' has no value. (this should not happen, please report an issue)");
+        }
 
         if (configuration.CommitDateFormat.IsNullOrEmpty())
+        {
             throw new InvalidOperationException("Configuration value for 'CommitDateFormat' has no value. (this should not happen, please report an issue)");
+        }
 
         AssemblyVersioningScheme = configuration.AssemblyVersioningScheme.Value;
         AssemblyFileVersioningScheme = configuration.AssemblyFileVersioningScheme.Value;

--- a/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/EffectiveConfiguration.cs
@@ -30,22 +30,22 @@ public record EffectiveConfiguration
         }
 
         if (!branchConfiguration.DeploymentMode.HasValue)
-            throw new("Configuration value for 'Deployment mode' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'Deployment mode' has no value. (this should not happen, please report an issue)");
 
         if (!configuration.AssemblyVersioningScheme.HasValue)
-            throw new("Configuration value for 'AssemblyVersioningScheme' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'AssemblyVersioningScheme' has no value. (this should not happen, please report an issue)");
 
         if (!configuration.AssemblyFileVersioningScheme.HasValue)
-            throw new("Configuration value for 'AssemblyFileVersioningScheme' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'AssemblyFileVersioningScheme' has no value. (this should not happen, please report an issue)");
 
         if (!branchConfiguration.CommitMessageIncrementing.HasValue)
-            throw new("Configuration value for 'CommitMessageIncrementing' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'CommitMessageIncrementing' has no value. (this should not happen, please report an issue)");
 
         if (!configuration.TagPreReleaseWeight.HasValue)
-            throw new("Configuration value for 'TagPreReleaseWeight' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'TagPreReleaseWeight' has no value. (this should not happen, please report an issue)");
 
         if (configuration.CommitDateFormat.IsNullOrEmpty())
-            throw new("Configuration value for 'CommitDateFormat' has no value. (this should not happen, please report an issue)");
+            throw new InvalidOperationException("Configuration value for 'CommitDateFormat' has no value. (this should not happen, please report an issue)");
 
         AssemblyVersioningScheme = configuration.AssemblyVersioningScheme.Value;
         AssemblyFileVersioningScheme = configuration.AssemblyFileVersioningScheme.Value;

--- a/src/GitVersion.Core/Core/BranchRepository.cs
+++ b/src/GitVersion.Core/Core/BranchRepository.cs
@@ -21,7 +21,11 @@ internal sealed class BranchRepository(IRepositoryStore repositoryStore) : IBran
 
         foreach (var branch in this.repositoryStore.Branches)
         {
-            if (excludeBranches.Contains(branch)) continue;
+            if (excludeBranches.Contains(branch))
+            {
+                continue;
+            }
+
             var branchConfiguration = configuration.GetBranchConfiguration(branch.Name);
             if (predicate(branchConfiguration))
             {

--- a/src/GitVersion.Core/Core/Exceptions/GitVersionException.cs
+++ b/src/GitVersion.Core/Core/Exceptions/GitVersionException.cs
@@ -1,7 +1,6 @@
 namespace GitVersion;
 
 /// <summary>Base exception type for errors raised by GitVersion during normal operation.</summary>
-[Serializable]
 public class GitVersionException : Exception
 {
     /// <summary>Initializes a new instance with no message.</summary>

--- a/src/GitVersion.Core/Core/Exceptions/WarningException.cs
+++ b/src/GitVersion.Core/Core/Exceptions/WarningException.cs
@@ -1,7 +1,6 @@
 namespace GitVersion;
 
 /// <summary>Raised to report a recoverable warning condition that should be presented to the user rather than treated as a hard error.</summary>
-[Serializable]
 public class WarningException : Exception
 {
     /// <summary>Initializes a new instance with the given warning message.</summary>

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -59,7 +59,11 @@ internal class GitPreparer(
         else
         {
             // Normalize if we are running on build server
-            if (gitVersionOptions.Settings.NoNormalize || this.buildAgent is LocalBuild) return;
+            if (gitVersionOptions.Settings.NoNormalize || this.buildAgent is LocalBuild)
+            {
+                return;
+            }
+
             if (this.buildAgent.ShouldCleanUpRemotes())
             {
                 CleanupDuplicateOrigin();
@@ -185,7 +189,11 @@ internal class GitPreparer(
         EnsureHeadIsAttachedToBranch(currentBranchName, authentication);
         EnsureRepositoryHeadDuringNormalisation(nameof(EnsureHeadIsAttachedToBranch), expectedSha);
 
-        if (!this.repository.IsShallow) return;
+        if (!this.repository.IsShallow)
+        {
+            return;
+        }
+
         if (this.options.Value.Settings.AllowShallow)
         {
             this.log.Info("Repository is a shallow clone. GitVersion will continue, but it is recommended to use a full clone for accurate versioning.");
@@ -200,10 +208,14 @@ internal class GitPreparer(
     {
         expectedSha.NotNull();
         if (this.repository.Head.Tip?.Sha == expectedSha)
+        {
             return;
+        }
 
         if (this.environment.GetEnvironmentVariable("IGNORE_NORMALISATION_GIT_HEAD_MOVE") == "1")
+        {
             return;
+        }
 
         // Whoa, HEAD has moved, it shouldn't have. We need to blow up because there is a bug in normalisation
         throw new BugException($"""
@@ -311,7 +323,9 @@ internal class GitPreparer(
             var remote = remotes.Single();
             this.log.Info($"One remote found ({remote.Name} -> '{remote.Url}').");
             if (remote.FetchRefSpecs.Any(r => r.Source == "refs/heads/*"))
+            {
                 return remote;
+            }
 
             var allBranchesFetchRefSpec = $"+refs/heads/*:refs/remotes/{remote.Name}/*";
             this.log.Info($"Adding refspec: {allBranchesFetchRefSpec}");
@@ -339,7 +353,10 @@ internal class GitPreparer(
             var localReferenceName = ReferenceName.FromBranchName(branchName);
 
             // We do not want to touch our current branch
-            if (this.repository.Head.Name.EquivalentTo(branchName)) continue;
+            if (this.repository.Head.Name.EquivalentTo(branchName))
+            {
+                continue;
+            }
 
             var localRef = this.repository.References[localReferenceName];
             if (localRef != null)
@@ -373,17 +390,26 @@ internal class GitPreparer(
     {
         remote.NotNull();
 
-        if (currentBranch.IsNullOrEmpty()) return;
+        if (currentBranch.IsNullOrEmpty())
+        {
+            return;
+        }
 
         const string referencePrefix = "refs/";
         var isLocalBranch = currentBranch.StartsWith(ReferenceName.LocalBranchPrefix);
         string localCanonicalName;
         if (!currentBranch.StartsWith(referencePrefix))
+        {
             localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch;
+        }
         else if (isLocalBranch)
+        {
             localCanonicalName = currentBranch;
+        }
         else
+        {
             localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch[referencePrefix.Length..];
+        }
 
         var repoTip = this.repository.Head.Tip;
 

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -171,17 +171,15 @@ internal class GitPreparer(
         var currentBranch = this.repository.Branches.FirstOrDefault(x => x.Name.EquivalentTo(currentBranchName));
         // Bug fix for https://github.com/GitTools/GitVersion/issues/1754, head maybe have been changed
         // if this is a dynamic repository. But only allow this in case the branches are different (branch switch)
-        if (expectedSha != this.repository.Head.Tip?.Sha)
+        if (expectedSha != this.repository.Head.Tip?.Sha
+            && (isDynamicRepository || currentBranch is null || !this.repository.Head.Equals(currentBranch)))
         {
-            if (isDynamicRepository || currentBranch is null || !this.repository.Head.Equals(currentBranch))
-            {
-                var newExpectedSha = this.repository.Head.Tip?.Sha;
-                var newExpectedBranchName = this.repository.Head.Name.Canonical;
+            var newExpectedSha = this.repository.Head.Tip?.Sha;
+            var newExpectedBranchName = this.repository.Head.Name.Canonical;
 
-                this.log.Info($"Head has moved from '{expectedBranchName} | {expectedSha}' => '{newExpectedBranchName} | {newExpectedSha}', allowed since this is a dynamic repository");
+            this.log.Info($"Head has moved from '{expectedBranchName} | {expectedSha}' => '{newExpectedBranchName} | {newExpectedSha}', allowed since this is a dynamic repository");
 
-                expectedSha = newExpectedSha;
-            }
+            expectedSha = newExpectedSha;
         }
 
         EnsureHeadIsAttachedToBranch(currentBranchName, authentication);
@@ -379,11 +377,13 @@ internal class GitPreparer(
 
         const string referencePrefix = "refs/";
         var isLocalBranch = currentBranch.StartsWith(ReferenceName.LocalBranchPrefix);
-        var localCanonicalName = !currentBranch.StartsWith(referencePrefix)
-            ? ReferenceName.LocalBranchPrefix + currentBranch
-            : isLocalBranch
-                ? currentBranch
-                : ReferenceName.LocalBranchPrefix + currentBranch[referencePrefix.Length..];
+        string localCanonicalName;
+        if (!currentBranch.StartsWith(referencePrefix))
+            localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch;
+        else if (isLocalBranch)
+            localCanonicalName = currentBranch;
+        else
+            localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch[referencePrefix.Length..];
 
         var repoTip = this.repository.Head.Tip;
 

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -41,7 +41,7 @@ internal class GitPreparer(
         this.log.Info($"DotGit directory is: {dotGitDirectory}");
         if (dotGitDirectory.IsNullOrEmpty() || projectRoot.IsNullOrEmpty())
         {
-            throw new($"Failed to prepare or find the .git directory in path '{gitVersionOptions.WorkingDirectory}'.");
+            throw new DirectoryNotFoundException($"Failed to prepare or find the .git directory in path '{gitVersionOptions.WorkingDirectory}'.");
         }
 
         PrepareInternal(gitVersionOptions);
@@ -105,7 +105,7 @@ internal class GitPreparer(
     {
         if (targetBranch.IsNullOrWhiteSpace())
         {
-            throw new("Dynamic Git repositories must have a target branch (/b)");
+            throw new InvalidOperationException("Dynamic Git repositories must have a target branch (/b)");
         }
 
         var gitDirectory = this.repositoryInfo.DynamicGitRepositoryPath;
@@ -116,7 +116,7 @@ internal class GitPreparer(
             var authentication = gitVersionOptions.AuthenticationInfo;
             if (string.IsNullOrWhiteSpace(gitDirectory))
             {
-                throw new("Dynamic Git repositories should have a path specified");
+                throw new InvalidOperationException("Dynamic Git repositories should have a path specified");
             }
             if (!this.fileSystem.Directory.Exists(gitDirectory))
             {

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -129,20 +129,20 @@ internal class GitPreparer(
         }
     }
 
+    private void CloneRepository(string? repositoryUrl, string? gitDirectory, AuthenticationInfo auth)
+    {
+        using (this.log.IndentLog($"Cloning repository from url '{repositoryUrl}'"))
+        {
+            this.retryAction.Execute(() => this.repository.Clone(repositoryUrl, gitDirectory, auth));
+        }
+    }
+
     private void NormalizeGitDirectory(string? targetBranch, bool isDynamicRepository)
     {
         using (this.log.IndentLog($"Normalizing git directory for branch '{targetBranch}'"))
         {
             // Normalize (download branches) before using the branch
             NormalizeGitDirectory(this.options.Value.Settings.NoFetch, targetBranch, isDynamicRepository);
-        }
-    }
-
-    private void CloneRepository(string? repositoryUrl, string? gitDirectory, AuthenticationInfo auth)
-    {
-        using (this.log.IndentLog($"Cloning repository from url '{repositoryUrl}'"))
-        {
-            this.retryAction.Execute(() => this.repository.Clone(repositoryUrl, gitDirectory, auth));
         }
     }
 

--- a/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
+++ b/src/GitVersion.Core/Core/GitVersionCalculateTool.cs
@@ -39,7 +39,10 @@ internal class GitVersionCalculateTool(
             ? this.gitVersionCacheProvider.LoadVersionVariablesFromDiskCache()
             : null;
 
-        if (versionVariables != null) return versionVariables;
+        if (versionVariables != null)
+        {
+            return versionVariables;
+        }
 
         var semanticVersion = this.nextVersionCalculator.FindVersion();
 
@@ -48,7 +51,11 @@ internal class GitVersionCalculateTool(
         versionVariables = this.variableProvider.GetVariablesFor(
             semanticVersion, Context.Configuration, effectiveConfiguration.PreReleaseWeight);
 
-        if (gitVersionOptions.Settings.NoCache) return versionVariables;
+        if (gitVersionOptions.Settings.NoCache)
+        {
+            return versionVariables;
+        }
+
         try
         {
             this.gitVersionCacheProvider.WriteVariablesToDiskCache(versionVariables);

--- a/src/GitVersion.Core/Core/MergeBaseFinder.cs
+++ b/src/GitVersion.Core/Core/MergeBaseFinder.cs
@@ -30,7 +30,9 @@ internal class MergeBaseFinder(IRepositoryStore repositoryStore, ILog log)
             var commit = first.Tip;
 
             if (commit == null)
+            {
                 return null;
+            }
 
             if (commitToFindCommonBase?.Parents.Contains(commit) == true)
             {
@@ -38,7 +40,9 @@ internal class MergeBaseFinder(IRepositoryStore repositoryStore, ILog log)
             }
 
             if (commitToFindCommonBase == null)
+            {
                 return null;
+            }
 
             var findMergeBase = FindMergeBase(commit, commitToFindCommonBase);
 
@@ -60,7 +64,9 @@ internal class MergeBaseFinder(IRepositoryStore repositoryStore, ILog log)
     {
         var findMergeBase = this.repositoryStore.FindMergeBase(commit, commitToFindCommonBase);
         if (findMergeBase == null)
+        {
             return null;
+        }
 
         this.log.Info($"Found merge base of '{findMergeBase}'");
 
@@ -72,7 +78,9 @@ internal class MergeBaseFinder(IRepositoryStore repositoryStore, ILog log)
             forwardMerge = this.repositoryStore.GetForwardMerge(commitToFindCommonBase, findMergeBase);
 
             if (forwardMerge == null)
+            {
                 continue;
+            }
 
             // TODO Fix the logging up in this section
             var second = forwardMerge.Parents[0];

--- a/src/GitVersion.Core/Core/MergeCommitFinder.cs
+++ b/src/GitVersion.Core/Core/MergeCommitFinder.cs
@@ -47,7 +47,9 @@ internal class MergeCommitFinder(IRepositoryStore repositoryStore, IGitVersionCo
 
             var findMergeBase = this.repositoryStore.FindMergeBase(branch, sourceBranch);
             if (findMergeBase != null)
+            {
                 yield return new(findMergeBase, sourceBranch);
+            }
         }
     }
 }

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -129,10 +129,8 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
             }
         }
 
-        foreach (var item in commitBranches.Skip(1).Reverse())
+        foreach (var item in commitBranches.Skip(1).Reverse().Where(item => !ignore.Contains(item)))
         {
-            if (ignore.Contains(item)) continue;
-
             foreach (var commitBranch in commitBranches)
             {
                 if (item.Commit.Equals(commitBranch.Commit)) break;
@@ -152,9 +150,8 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
             var referenceMatchFound = false;
             var referenceNames = referenceLookup[branchGrouping.Key.Sha].Select(element => element.Name).ToHashSet();
 
-            foreach (var item in branchGrouping)
+            foreach (var item in branchGrouping.Where(item => referenceNames.Contains(item.Name)))
             {
-                if (!referenceNames.Contains(item.Name)) continue;
                 if (returnedBranches.Add(item)) yield return item;
                 referenceMatchFound = true;
             }

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -72,7 +72,9 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
 
         // Make sure the desired branch has been specified
         if (targetBranchName.IsNullOrEmpty())
+        {
             return desiredBranch;
+        }
 
         // There are some edge cases where HEAD is not pointing to the desired branch.
         // Therefore, it's important to verify if 'currentBranch' is indeed the desired branch.
@@ -80,7 +82,9 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
 
         // CanonicalName can be "refs/heads/develop", so we need to check for "/{TargetBranch}" as well
         if (desiredBranch.Equals(targetBranch))
+        {
             return desiredBranch;
+        }
 
         // In the case where HEAD is not the desired branch, try to find the branch with matching name
         desiredBranch = this.repository.Branches.Where(b => b.Name.EquivalentTo(targetBranchName)).MinBy(b => b.IsRemote);
@@ -133,7 +137,10 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
         {
             foreach (var commitBranch in commitBranches)
             {
-                if (item.Commit.Equals(commitBranch.Commit)) break;
+                if (item.Commit.Equals(commitBranch.Commit))
+                {
+                    break;
+                }
 
                 foreach (var commit in commitBranch.Branch.Commits.Where(element => element.When >= item.Commit.When))
                 {
@@ -152,14 +159,25 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
 
             foreach (var item in branchGrouping.Where(item => referenceNames.Contains(item.Name)))
             {
-                if (returnedBranches.Add(item)) yield return item;
+                if (returnedBranches.Add(item))
+                {
+                    yield return item;
+                }
+
                 referenceMatchFound = true;
             }
 
-            if (referenceMatchFound) continue;
+            if (referenceMatchFound)
+            {
+                continue;
+            }
+
             foreach (var item in branchGrouping)
             {
-                if (returnedBranches.Add(item)) yield return item;
+                if (returnedBranches.Add(item))
+                {
+                    yield return item;
+                }
             }
         }
     }
@@ -187,7 +205,9 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
                     .ToList();
 
             if (possibleBranches.Count <= 1)
+            {
                 return possibleBranches.SingleOrDefault();
+            }
 
             var first = possibleBranches[0];
             this.log.Info($"Multiple source branches have been found, picking the first one ({first.Branch}).{FileSystemHelper.Path.NewLine}" +
@@ -265,7 +285,11 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
     {
         using (this.log.IndentLog($"Finding branches source of '{branch}'"))
         {
-            if (branch.Tip != null) return [.. new MergeCommitFinder(this, configuration, excludedBranches, this.log).FindMergeCommitsFor(branch)];
+            if (branch.Tip != null)
+            {
+                return [.. new MergeCommitFinder(this, configuration, excludedBranches, this.log).FindMergeCommitsFor(branch)];
+            }
+
             this.log.Warning($"{branch} has no tip.");
             return [];
         }

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -28,6 +28,8 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
         return mergeBaseFinder.FindMergeBaseOf(branch, otherBranch);
     }
 
+    public ICommit? FindMergeBase(ICommit commit, ICommit mainlineTip) => this.repository.FindMergeBase(commit, mainlineTip);
+
     public ICommit? GetCurrentCommit(IBranch currentBranch, string? commitId, IIgnoreConfiguration ignore)
     {
         currentBranch.NotNull();
@@ -258,8 +260,6 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
     }
 
     private IEnumerable<ICommit> FilterCommits(CommitFilter filter) => this.repository.Commits.QueryBy(filter);
-
-    public ICommit? FindMergeBase(ICommit commit, ICommit mainlineTip) => this.repository.FindMergeBase(commit, mainlineTip);
 
     private IBranch? FindBranch(string branchName) => this.repository.Branches.FirstOrDefault(x => x.Name.EquivalentTo(branchName));
 

--- a/src/GitVersion.Core/Core/SourceBranchFinder.cs
+++ b/src/GitVersion.Core/Core/SourceBranchFinder.cs
@@ -23,7 +23,9 @@ internal class SourceBranchFinder(IEnumerable<IBranch> excludedBranches, IGitVer
         public bool IsSourceBranch(INamedReference sourceBranchCandidate)
         {
             if (Equals(sourceBranchCandidate, branch))
+            {
                 return false;
+            }
 
             var branchName = sourceBranchCandidate.Name.WithoutOrigin;
 
@@ -44,7 +46,9 @@ internal class SourceBranchFinder(IEnumerable<IBranch> excludedBranches, IGitVer
                 {
                     var regex = branches[sourceBranch].RegularExpression;
                     if (regex != null)
+                    {
                         yield return RegexPatterns.Cache.GetOrAdd(regex);
+                    }
                 }
             }
         }

--- a/src/GitVersion.Core/Core/SourceBranchFinder.cs
+++ b/src/GitVersion.Core/Core/SourceBranchFinder.cs
@@ -16,7 +16,7 @@ internal class SourceBranchFinder(IEnumerable<IBranch> excludedBranches, IGitVer
         return this.excludedBranches.Where(predicate.IsSourceBranch);
     }
 
-    private class SourceBranchPredicate(IBranch branch, IGitVersionConfiguration configuration)
+    private sealed class SourceBranchPredicate(IBranch branch, IGitVersionConfiguration configuration)
     {
         private readonly IEnumerable<Regex> sourceBranchRegexes = GetSourceBranchRegexes(branch, configuration);
 

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
@@ -77,8 +77,8 @@ internal sealed class TaggedSemanticVersionService(
         string? tagPrefix,
         SemanticVersionFormat format,
         IIgnoreConfiguration ignore,
-        string? label,
-        DateTimeOffset? notOlderThan)
+        string? label = null,
+        DateTimeOffset? notOlderThan = null)
     {
         var result = GetTaggedSemanticVersionsOfBranchInternal(
             branch: branch,
@@ -122,8 +122,8 @@ internal sealed class TaggedSemanticVersionService(
          string? tagPrefix,
          SemanticVersionFormat format,
          IIgnoreConfiguration ignore,
-         string? label,
-         DateTimeOffset? notOlderThan)
+         string? label = null,
+         DateTimeOffset? notOlderThan = null)
     {
         var result = GetTaggedSemanticVersionsOfMergeTargetInternal(
             branch: branch,
@@ -168,8 +168,8 @@ internal sealed class TaggedSemanticVersionService(
 
     public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfMainBranches(
         IGitVersionConfiguration configuration,
-        DateTimeOffset? notOlderThan,
-        string? label,
+        DateTimeOffset? notOlderThan = null,
+        string? label = null,
         params IBranch[] excludeBranches)
     {
         var result = GetTaggedSemanticVersionsOfMainBranchesInternal(
@@ -208,8 +208,8 @@ internal sealed class TaggedSemanticVersionService(
 
     public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfReleaseBranches(
         IGitVersionConfiguration configuration,
-        DateTimeOffset? notOlderThan,
-        string? label,
+        DateTimeOffset? notOlderThan = null,
+        string? label = null,
         params IBranch[] excludeBranches)
     {
         var result = GetTaggedSemanticVersionsOfReleaseBranchesInternal(

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
@@ -105,7 +105,10 @@ internal sealed class TaggedSemanticVersionService(
         );
         foreach (var grouping in semanticVersionsOfBranch)
         {
-            if (grouping.Key.When > notOlderThan) continue;
+            if (grouping.Key.When > notOlderThan)
+            {
+                continue;
+            }
 
             foreach (var semanticVersion in grouping.Where(semanticVersion => semanticVersion.Value.IsMatchForBranchSpecificLabel(label)))
             {
@@ -151,7 +154,10 @@ internal sealed class TaggedSemanticVersionService(
         );
         foreach (var grouping in semanticVersionsOfMergeTarget)
         {
-            if (grouping.Key.When > notOlderThan) continue;
+            if (grouping.Key.When > notOlderThan)
+            {
+                continue;
+            }
 
             foreach (var semanticVersion in grouping.Where(semanticVersion => semanticVersion.Value.IsMatchForBranchSpecificLabel(label)))
             {

--- a/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
+++ b/src/GitVersion.Core/Core/TaggedSemanticVersionService.cs
@@ -107,12 +107,9 @@ internal sealed class TaggedSemanticVersionService(
         {
             if (grouping.Key.When > notOlderThan) continue;
 
-            foreach (var semanticVersion in grouping)
+            foreach (var semanticVersion in grouping.Where(semanticVersion => semanticVersion.Value.IsMatchForBranchSpecificLabel(label)))
             {
-                if (semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
-                {
-                    yield return (grouping.Key, semanticVersion);
-                }
+                yield return (grouping.Key, semanticVersion);
             }
         }
     }
@@ -156,12 +153,9 @@ internal sealed class TaggedSemanticVersionService(
         {
             if (grouping.Key.When > notOlderThan) continue;
 
-            foreach (var semanticVersion in grouping)
+            foreach (var semanticVersion in grouping.Where(semanticVersion => semanticVersion.Value.IsMatchForBranchSpecificLabel(label)))
             {
-                if (semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
-                {
-                    yield return new(grouping.Key, semanticVersion);
-                }
+                yield return new(grouping.Key, semanticVersion);
             }
         }
     }

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -40,7 +40,11 @@ internal static class ConfigurationExtensions
                 IBranchConfiguration? unknownBranchConfiguration = null;
                 foreach (var (key, branchConfiguration) in configuration.Branches)
                 {
-                    if (!branchConfiguration.IsMatch(branchName)) continue;
+                    if (!branchConfiguration.IsMatch(branchName))
+                    {
+                        continue;
+                    }
+
                     if (key == "unknown")
                     {
                         unknownBranchConfiguration = branchConfiguration;
@@ -51,7 +55,10 @@ internal static class ConfigurationExtensions
                     }
                 }
 
-                if (unknownBranchConfiguration != null) yield return unknownBranchConfiguration;
+                if (unknownBranchConfiguration != null)
+                {
+                    yield return unknownBranchConfiguration;
+                }
             }
         }
 
@@ -70,9 +77,20 @@ internal static class ConfigurationExtensions
         {
             ignoreConfig.NotNull();
 
-            if (ignoreConfig.Shas.Count != 0) yield return new ShaVersionFilter(ignoreConfig.Shas);
-            if (ignoreConfig.Before.HasValue) yield return new MinDateVersionFilter(ignoreConfig.Before.Value);
-            if (ignoreConfig.Paths.Count != 0) yield return new PathFilter([.. ignoreConfig.Paths]);
+            if (ignoreConfig.Shas.Count != 0)
+            {
+                yield return new ShaVersionFilter(ignoreConfig.Shas);
+            }
+
+            if (ignoreConfig.Before.HasValue)
+            {
+                yield return new MinDateVersionFilter(ignoreConfig.Before.Value);
+            }
+
+            if (ignoreConfig.Paths.Count != 0)
+            {
+                yield return new PathFilter([.. ignoreConfig.Paths]);
+            }
         }
 
         public IEnumerable<ITag> Filter(ITag[] source)
@@ -146,13 +164,17 @@ internal static class ConfigurationExtensions
             var placeholders = new Dictionary<string, object>();
 
             if (regularExpression.IsNullOrWhiteSpace() || effectiveBranchName.IsNullOrEmpty())
+            {
                 return placeholders;
+            }
 
             var regex = RegexPatterns.Cache.GetOrAdd(regularExpression);
             var match = regex.Match(effectiveBranchName);
 
             if (!match.Success)
+            {
                 return placeholders;
+            }
 
             var namedGroups = regex.GetGroupNames()
                 .Where(name => !int.TryParse(name, out _));

--- a/src/GitVersion.Core/Extensions/DictionaryExtensions.cs
+++ b/src/GitVersion.Core/Extensions/DictionaryExtensions.cs
@@ -9,7 +9,11 @@ internal static class DictionaryExtensions
             ArgumentNullException.ThrowIfNull(dict);
             ArgumentNullException.ThrowIfNull(getValue);
 
-            if (dict.TryGetValue(key, out var value)) return value;
+            if (dict.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
             value = getValue();
             dict.Add(key, value);
             return value;

--- a/src/GitVersion.Core/Extensions/EnumerableExtensions.cs
+++ b/src/GitVersion.Core/Extensions/EnumerableExtensions.cs
@@ -15,7 +15,10 @@ public static class EnumerableExtensions
 
         using var e = source.GetEnumerator();
         if (!e.MoveNext())
+        {
             return default;
+        }
+
         var current = e.Current;
         return !e.MoveNext() ? current : default;
     }

--- a/src/GitVersion.Core/Extensions/ReferenceNameExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ReferenceNameExtensions.cs
@@ -29,7 +29,10 @@ public static class ReferenceNameExtensions
             var length = 0;
             foreach (var branchPart in source.WithoutOrigin.Split(GetBranchSeparator()))
             {
-                if (string.IsNullOrEmpty(branchPart)) return false;
+                if (string.IsNullOrEmpty(branchPart))
+                {
+                    return false;
+                }
 
                 var match = versionPatternRegex.Match(branchPart);
                 if (match.Success)
@@ -53,7 +56,11 @@ public static class ReferenceNameExtensions
 
             static string GetVersionInBranchPattern(string? versionInBranchPattern)
             {
-                if (versionInBranchPattern.IsNullOrEmpty()) versionInBranchPattern = RegexPatterns.Configuration.DefaultVersionInBranchRegexPattern;
+                if (versionInBranchPattern.IsNullOrEmpty())
+                {
+                    versionInBranchPattern = RegexPatterns.Configuration.DefaultVersionInBranchRegexPattern;
+                }
+
                 return $"^{versionInBranchPattern.TrimStart('^')}";
             }
         }

--- a/src/GitVersion.Core/Extensions/VersionFieldExtensions.cs
+++ b/src/GitVersion.Core/Extensions/VersionFieldExtensions.cs
@@ -7,9 +7,9 @@ internal static class VersionFieldExtensions
         public VersionField Consolidate(VersionField? item, params VersionField?[] items)
         {
             var result = source;
-            foreach (var increment in new[] { item }.Concat(items))
+            foreach (var increment in new[] { item }.Concat(items).Where(increment => result < increment))
             {
-                if (result < increment) result = increment.Value;
+                result = increment!.Value;
             }
             return result;
         }

--- a/src/GitVersion.Core/Formatting/FormattableFormatter.cs
+++ b/src/GitVersion.Core/Formatting/FormattableFormatter.cs
@@ -11,7 +11,9 @@ internal class FormattableFormatter : InvariantFormatter, IValueFormatter
         result = string.Empty;
 
         if (string.IsNullOrWhiteSpace(format))
+        {
             return false;
+        }
 
         if (value is IFormattable formattable)
         {

--- a/src/GitVersion.Core/Formatting/InputSanitizer.cs
+++ b/src/GitVersion.Core/Formatting/InputSanitizer.cs
@@ -6,13 +6,19 @@ internal class InputSanitizer : IInputSanitizer
     public string SanitizeFormat(string format)
     {
         if (string.IsNullOrWhiteSpace(format))
+        {
             throw new FormatException("Format string cannot be empty.");
+        }
 
         if (format.Length > 50)
+        {
             throw new FormatException($"Format string too long: '{format[..20]}...'");
+        }
 
         if (format.Any(c => char.IsControl(c) && c != '\t'))
+        {
             throw new FormatException("Format string contains invalid control characters");
+        }
 
         return format;
     }
@@ -20,13 +26,19 @@ internal class InputSanitizer : IInputSanitizer
     public string SanitizeEnvVarName(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
+        {
             throw new ArgumentException("Environment variable name cannot be null or empty.");
+        }
 
         if (name.Length > 200)
+        {
             throw new ArgumentException($"Environment variable name too long: '{name[..20]}...'");
+        }
 
         if (!RegexPatterns.Cache.GetOrAdd(RegexPatterns.SanitizeEnvVarNameRegexPattern).IsMatch(name))
+        {
             throw new ArgumentException($"Environment variable name contains disallowed characters: '{name}'");
+        }
 
         return name;
     }
@@ -34,13 +46,19 @@ internal class InputSanitizer : IInputSanitizer
     public string SanitizeMemberName(string memberName)
     {
         if (string.IsNullOrWhiteSpace(memberName))
+        {
             throw new ArgumentException("Member name cannot be empty.");
+        }
 
         if (memberName.Length > 100)
+        {
             throw new ArgumentException($"Member name too long: '{memberName[..20]}...'");
+        }
 
         if (!RegexPatterns.Cache.GetOrAdd(RegexPatterns.SanitizeMemberNameRegexPattern).IsMatch(memberName))
+        {
             throw new ArgumentException($"Member name contains disallowed characters: '{memberName}'");
+        }
 
         return memberName;
     }

--- a/src/GitVersion.Core/Formatting/MemberResolver.cs
+++ b/src/GitVersion.Core/Formatting/MemberResolver.cs
@@ -29,11 +29,15 @@ internal class MemberResolver : IMemberResolver
     public static List<MemberInfo>? FindMemberRecursive(Type type, string memberName, HashSet<Type> visited)
     {
         if (!visited.Add(type))
+        {
             return null;
+        }
 
         var member = FindDirectMember(type, memberName);
         if (member != null)
+        {
             return [member];
+        }
 
         foreach (var prop in type.GetProperties())
         {

--- a/src/GitVersion.Core/Formatting/NumericFormatter.cs
+++ b/src/GitVersion.Core/Formatting/NumericFormatter.cs
@@ -11,7 +11,9 @@ internal class NumericFormatter : InvariantFormatter, IValueFormatter
         result = string.Empty;
 
         if (value is not string s)
+        {
             return false;
+        }
 
         // Integer formatting
         if (format.All(char.IsDigit) && int.TryParse(s, NumberStyles.Integer, cultureInfo, out var integerValue))

--- a/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
+++ b/src/GitVersion.Core/Formatting/StringFormatWithExtension.cs
@@ -141,7 +141,9 @@ internal static class StringFormatWithExtension
         var safeMember = InputSanitizer.SanitizeMemberName(member);
 
         if (!source.TryGetValue(safeMember, out var value))
+        {
             throw new ArgumentException($"'{safeMember}' is not a valid placeholder");
+        }
 
         return value?.ToString();
     }

--- a/src/GitVersion.Core/Formatting/ValueFormatter.cs
+++ b/src/GitVersion.Core/Formatting/ValueFormatter.cs
@@ -30,7 +30,9 @@ internal class ValueFormatter : InvariantFormatter, IValueFormatterCombiner
         foreach (var formatter in this.formatters.OrderBy(f => f.Priority))
         {
             if (formatter.TryFormat(value, format, out result))
+            {
                 return true;
+            }
         }
 
         return false;

--- a/src/GitVersion.Core/Git/BranchCommit.cs
+++ b/src/GitVersion.Core/Git/BranchCommit.cs
@@ -21,7 +21,9 @@ public readonly struct BranchCommit(ICommit commit, IBranch branch) : IEquatable
     public bool Equals(BranchCommit? other)
     {
         if (other is null)
+        {
             return false;
+        }
 
         return Equals(Branch, other.Value.Branch) && Equals(Commit, other.Value.Commit);
     }

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -74,11 +74,11 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     /// <summary>Gets a value indicating whether this reference corresponds to a pull request.</summary>
     public bool IsPullRequest { get; }
 
-    /// <summary>Returns <see langword="true"/> when the canonical name of this instance equals that of <paramref name="other"/>.</summary>
-    public bool Equals(ReferenceName? other) => equalityHelper.Equals(this, other);
-
     /// <summary>Compares this instance to <paramref name="other"/> by canonical name.</summary>
     public int CompareTo(ReferenceName? other) => comparerHelper.Compare(this, other);
+
+    /// <summary>Returns <see langword="true"/> when the canonical name of this instance equals that of <paramref name="other"/>.</summary>
+    public bool Equals(ReferenceName? other) => equalityHelper.Equals(this, other);
 
     /// <summary>Returns <see langword="true"/> when <paramref name="obj"/> is a <see cref="ReferenceName"/> with the same canonical name.</summary>
     public override bool Equals(object? obj) => Equals(obj as ReferenceName);

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -5,7 +5,7 @@ using GitVersion.Helpers;
 namespace GitVersion.Git;
 
 /// <summary>Represents a Git reference name in both its canonical (<c>refs/heads/main</c>) and friendly (<c>main</c>) forms.</summary>
-public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceName>
+public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceName>
 {
     private static readonly LambdaEqualityHelper<ReferenceName> equalityHelper = new(x => x.Canonical);
     private static readonly LambdaKeyComparer<ReferenceName, string> comparerHelper = new(x => x.Canonical);

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -43,7 +43,11 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
     /// <summary>Parses <paramref name="canonicalName"/> as a canonical Git reference name, throwing when the input is not a valid canonical form.</summary>
     public static ReferenceName Parse(string canonicalName)
     {
-        if (TryParse(out var value, canonicalName)) return value;
+        if (TryParse(out var value, canonicalName))
+        {
+            return value;
+        }
+
         throw new ArgumentException($"The {nameof(canonicalName)} is not a Canonical name");
     }
 
@@ -92,8 +96,16 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
     /// <summary>Returns <see langword="true"/> when <paramref name="left"/> and <paramref name="right"/> have equal canonical names.</summary>
     public static bool operator ==(ReferenceName? left, ReferenceName? right)
     {
-        if (ReferenceEquals(left, right)) return true;
-        if (left is null || right is null) return false;
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
         return left.Equals(right);
     }
 
@@ -121,10 +133,14 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
     private string Shorten()
     {
         if (IsLocalBranch)
+        {
             return Canonical[LocalBranchPrefix.Length..];
+        }
 
         if (IsRemoteBranch)
+        {
             return Canonical[RemoteTrackingBranchPrefix.Length..];
+        }
 
         return IsTag ? Canonical[TagPrefix.Length..] : Canonical;
     }

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -100,6 +100,18 @@ public class ReferenceName : IEquatable<ReferenceName?>, IComparable<ReferenceNa
     /// <summary>Returns <see langword="true"/> when <paramref name="left"/> and <paramref name="right"/> have different canonical names.</summary>
     public static bool operator !=(ReferenceName? left, ReferenceName? right) => !(left == right);
 
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts before <paramref name="right"/> by canonical name.</summary>
+    public static bool operator <(ReferenceName? left, ReferenceName? right) => Comparer<ReferenceName>.Default.Compare(left, right) < 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts before or equal to <paramref name="right"/> by canonical name.</summary>
+    public static bool operator <=(ReferenceName? left, ReferenceName? right) => Comparer<ReferenceName>.Default.Compare(left, right) <= 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts after <paramref name="right"/> by canonical name.</summary>
+    public static bool operator >(ReferenceName? left, ReferenceName? right) => Comparer<ReferenceName>.Default.Compare(left, right) > 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts after or equal to <paramref name="right"/> by canonical name.</summary>
+    public static bool operator >=(ReferenceName? left, ReferenceName? right) => Comparer<ReferenceName>.Default.Compare(left, right) >= 0;
+
     /// <summary>Returns <see langword="true"/> when <paramref name="name"/> matches any of the canonical, friendly, or origin-stripped forms of this reference.</summary>
     public bool EquivalentTo(string? name) =>
         Canonical.Equals(name, StringComparison.OrdinalIgnoreCase)

--- a/src/GitVersion.Core/Helpers/LambdaKeyComparer.cs
+++ b/src/GitVersion.Core/Helpers/LambdaKeyComparer.cs
@@ -13,11 +13,19 @@ public class LambdaKeyComparer<TSource, TKey>(
     public override int Compare(TSource? x, TSource? y)
     {
         if (ReferenceEquals(x, y))
+        {
             return 0;
+        }
+
         if (x == null)
+        {
             return -1;
+        }
+
         if (y == null)
+        {
             return 1;
+        }
 
         var xKey = keySelector(x);
         var yKey = keySelector(y);

--- a/src/GitVersion.Core/Helpers/RetryAction.cs
+++ b/src/GitVersion.Core/Helpers/RetryAction.cs
@@ -36,9 +36,20 @@ public class RetryAction<T, Result> where T : Exception
 
     private static IEnumerable<TimeSpan> LinearBackoff(TimeSpan initialDelay, int retryCount, double factor = 1.0, bool fastFirst = false)
     {
-        if (initialDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(initialDelay), initialDelay, "should be >= 0ms");
-        if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), retryCount, "should be >= 0");
-        if (factor < 0) throw new ArgumentOutOfRangeException(nameof(factor), factor, "should be >= 0");
+        if (initialDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(initialDelay), initialDelay, "should be >= 0ms");
+        }
+
+        if (retryCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(retryCount), retryCount, "should be >= 0");
+        }
+
+        if (factor < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(factor), factor, "should be >= 0");
+        }
 
         return retryCount == 0 ? Empty() : Enumerate(initialDelay, retryCount, fastFirst, factor);
 

--- a/src/GitVersion.Core/Logging/LogExtensions.cs
+++ b/src/GitVersion.Core/Logging/LogExtensions.cs
@@ -62,7 +62,9 @@ public static class LogExtensions
         private void Write(Verbosity verbosity, LogLevel level, LogAction? logAction)
         {
             if (logAction == null)
+            {
                 return;
+            }
 
             if (verbosity > log.Verbosity)
             {
@@ -78,7 +80,9 @@ public static class LogExtensions
         private void Write(LogLevel level, LogAction? logAction)
         {
             if (logAction == null)
+            {
                 return;
+            }
 
             var verbosity = GetVerbosityForLevel(level);
             if (verbosity > log.Verbosity)

--- a/src/GitVersion.Core/MergeMessage.cs
+++ b/src/GitVersion.Core/MergeMessage.cs
@@ -26,7 +26,10 @@ public class MergeMessage
     {
         mergeMessage.NotNull();
 
-        if (mergeMessage.Length == 0) return;
+        if (mergeMessage.Length == 0)
+        {
+            return;
+        }
 
         // Concatenate configuration formats with the defaults.
         // Ensure configurations are processed first.
@@ -38,7 +41,9 @@ public class MergeMessage
         {
             var match = Pattern.Match(mergeMessage);
             if (!match.Success)
+            {
                 continue;
+            }
 
             FormatName = Name;
             var sourceBranch = match.Groups["SourceBranch"].Value;

--- a/src/GitVersion.Core/Options/AssemblySettingsInfo.cs
+++ b/src/GitVersion.Core/Options/AssemblySettingsInfo.cs
@@ -4,14 +4,14 @@ namespace GitVersion;
 public class AssemblySettingsInfo
 {
     /// <summary>Gets or sets a value indicating whether <c>AssemblyInfo.cs</c> files should be updated with the calculated version.</summary>
-    public bool UpdateAssemblyInfo;
+    public bool UpdateAssemblyInfo { get; set; }
 
     /// <summary>Gets or sets a value indicating whether SDK-style project files (<c>.csproj</c>) should be updated with the calculated version.</summary>
-    public bool UpdateProjectFiles;
+    public bool UpdateProjectFiles { get; set; }
 
     /// <summary>Gets or sets a value indicating whether missing <c>AssemblyInfo.cs</c> files should be created automatically.</summary>
-    public bool EnsureAssemblyInfo;
+    public bool EnsureAssemblyInfo { get; set; }
 
     /// <summary>Gets or sets the set of specific assembly-info or project file paths to update.</summary>
-    public ISet<string> Files = new HashSet<string>();
+    public ISet<string> Files { get; set; } = new HashSet<string>();
 }

--- a/src/GitVersion.Core/Options/ConfigurationInfo.cs
+++ b/src/GitVersion.Core/Options/ConfigurationInfo.cs
@@ -4,11 +4,11 @@ namespace GitVersion;
 public record ConfigurationInfo
 {
     /// <summary>Gets or sets an explicit path to the GitVersion configuration file, overriding automatic discovery.</summary>
-    public string? ConfigurationFile;
+    public string? ConfigurationFile { get; set; }
 
     /// <summary>Gets or sets a value indicating whether the effective configuration should be printed to the output.</summary>
-    public bool ShowConfiguration;
+    public bool ShowConfiguration { get; set; }
 
     /// <summary>Gets or sets a dictionary of key/value pairs that override specific configuration values at runtime.</summary>
-    public IReadOnlyDictionary<object, object?>? OverrideConfiguration;
+    public IReadOnlyDictionary<object, object?>? OverrideConfiguration { get; set; }
 }

--- a/src/GitVersion.Core/Options/GitVersionOptions.cs
+++ b/src/GitVersion.Core/Options/GitVersionOptions.cs
@@ -28,29 +28,29 @@ public class GitVersionOptions
     public Settings Settings { get; } = new();
 
     /// <summary>Gets or sets a value indicating whether extended diagnostic output should be emitted.</summary>
-    public bool Diag;
+    public bool Diag { get; set; }
 
     /// <summary>Gets or sets a value indicating whether the GitVersion version number should be printed and execution should stop.</summary>
-    public bool IsVersion;
+    public bool IsVersion { get; set; }
 
     /// <summary>Gets or sets a value indicating whether help text should be printed and execution should stop.</summary>
-    public bool IsHelp;
+    public bool IsHelp { get; set; }
 
     /// <summary>Gets or sets the path to a file where log output should be written.</summary>
-    public string? LogFilePath;
+    public string? LogFilePath { get; set; }
 
     /// <summary>Gets or sets the name of a single version variable to output.</summary>
-    public string? ShowVariable;
+    public string? ShowVariable { get; set; }
 
     /// <summary>Gets or sets the output format string used when writing a single variable.</summary>
-    public string? Format;
+    public string? Format { get; set; }
 
     /// <summary>Gets or sets the path of the file to which version output is written when the <see cref="OutputType.File"/> output type is selected.</summary>
-    public string? OutputFile;
+    public string? OutputFile { get; set; }
 
     /// <summary>Gets or sets the set of output types to produce (JSON, build-server, file, dotenv).</summary>
-    public ISet<OutputType> Output = new HashSet<OutputType>();
+    public ISet<OutputType> Output { get; set; } = new HashSet<OutputType>();
 
     /// <summary>Gets or sets the minimum log verbosity level.</summary>
-    public Verbosity Verbosity = Verbosity.Normal;
+    public Verbosity Verbosity { get; set; } = Verbosity.Normal;
 }

--- a/src/GitVersion.Core/Options/RepositoryInfo.cs
+++ b/src/GitVersion.Core/Options/RepositoryInfo.cs
@@ -4,14 +4,14 @@ namespace GitVersion;
 public record RepositoryInfo
 {
     /// <summary>Gets or sets the URL of the remote repository to clone or fetch from.</summary>
-    public string? TargetUrl;
+    public string? TargetUrl { get; set; }
 
     /// <summary>Gets or sets the name of the branch to calculate the version for.</summary>
-    public string? TargetBranch;
+    public string? TargetBranch { get; set; }
 
     /// <summary>Gets or sets a specific commit SHA to use instead of the current HEAD.</summary>
-    public string? CommitId;
+    public string? CommitId { get; set; }
 
     /// <summary>Gets or sets the local path to which the repository should be cloned when using dynamic repositories.</summary>
-    public string? ClonePath;
+    public string? ClonePath { get; set; }
 }

--- a/src/GitVersion.Core/Options/Settings.cs
+++ b/src/GitVersion.Core/Options/Settings.cs
@@ -4,17 +4,17 @@ namespace GitVersion;
 public record Settings
 {
     /// <summary>Gets or sets a value indicating whether fetching from the remote should be skipped.</summary>
-    public bool NoFetch;
+    public bool NoFetch { get; set; }
 
     /// <summary>Gets or sets a value indicating whether the on-disk version cache should be ignored.</summary>
-    public bool NoCache;
+    public bool NoCache { get; set; }
 
     /// <summary>Gets or sets a value indicating whether branch normalisation should be skipped.</summary>
-    public bool NoNormalize;
+    public bool NoNormalize { get; set; }
 
     /// <summary>Gets or sets a value indicating whether only tracked (remote-tracking) branches are considered during version calculation.</summary>
-    public bool OnlyTrackedBranches = false;
+    public bool OnlyTrackedBranches { get; set; }
 
     /// <summary>Gets or sets a value indicating whether GitVersion should continue even when a shallow clone is detected.</summary>
-    public bool AllowShallow = false;
+    public bool AllowShallow { get; set; }
 }

--- a/src/GitVersion.Core/Options/WixInfo.cs
+++ b/src/GitVersion.Core/Options/WixInfo.cs
@@ -4,5 +4,5 @@ namespace GitVersion;
 public record WixInfo
 {
     /// <summary>Gets or sets a value indicating whether the WiX version file should be updated with the calculated version.</summary>
-    public bool UpdateWixVersionFile;
+    public bool UpdateWixVersionFile { get; set; }
 }

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -11,10 +11,14 @@ GitVersion.Agents.IBuildAgent.WriteIntegration(System.Action<string?>! writer, G
 GitVersion.Agents.ICurrentBuildAgent
 GitVersion.AssemblySettingsInfo
 GitVersion.AssemblySettingsInfo.AssemblySettingsInfo() -> void
-GitVersion.AssemblySettingsInfo.EnsureAssemblyInfo -> bool
-GitVersion.AssemblySettingsInfo.Files -> System.Collections.Generic.ISet<string!>!
-GitVersion.AssemblySettingsInfo.UpdateAssemblyInfo -> bool
-GitVersion.AssemblySettingsInfo.UpdateProjectFiles -> bool
+GitVersion.AssemblySettingsInfo.EnsureAssemblyInfo.get -> bool
+GitVersion.AssemblySettingsInfo.EnsureAssemblyInfo.set -> void
+GitVersion.AssemblySettingsInfo.Files.get -> System.Collections.Generic.ISet<string!>!
+GitVersion.AssemblySettingsInfo.Files.set -> void
+GitVersion.AssemblySettingsInfo.UpdateAssemblyInfo.get -> bool
+GitVersion.AssemblySettingsInfo.UpdateAssemblyInfo.set -> void
+GitVersion.AssemblySettingsInfo.UpdateProjectFiles.get -> bool
+GitVersion.AssemblySettingsInfo.UpdateProjectFiles.set -> void
 GitVersion.BugException
 GitVersion.BugException.BugException() -> void
 GitVersion.BugException.BugException(string! message) -> void
@@ -155,11 +159,14 @@ GitVersion.Configuration.ReferenceNameExtensions.extension(GitVersion.Git.Refere
 GitVersion.Configuration.ReferenceNameExtensions.extension(GitVersion.Git.ReferenceName!).TryGetSemanticVersion(GitVersion.Configuration.EffectiveConfiguration! configuration, out (GitVersion.SemanticVersion! Value, string? Name) result) -> bool
 GitVersion.Configuration.ReferenceNameExtensions.extension(GitVersion.Git.ReferenceName!).TryGetSemanticVersion(GitVersion.Configuration.IGitVersionConfiguration! configuration, out (GitVersion.SemanticVersion! Value, string? Name) result) -> bool
 GitVersion.ConfigurationInfo
-GitVersion.ConfigurationInfo.ConfigurationFile -> string?
+GitVersion.ConfigurationInfo.ConfigurationFile.get -> string?
+GitVersion.ConfigurationInfo.ConfigurationFile.set -> void
 GitVersion.ConfigurationInfo.ConfigurationInfo() -> void
 GitVersion.ConfigurationInfo.ConfigurationInfo(GitVersion.ConfigurationInfo! original) -> void
-GitVersion.ConfigurationInfo.OverrideConfiguration -> System.Collections.Generic.IReadOnlyDictionary<object!, object?>?
-GitVersion.ConfigurationInfo.ShowConfiguration -> bool
+GitVersion.ConfigurationInfo.OverrideConfiguration.get -> System.Collections.Generic.IReadOnlyDictionary<object!, object?>?
+GitVersion.ConfigurationInfo.OverrideConfiguration.set -> void
+GitVersion.ConfigurationInfo.ShowConfiguration.get -> bool
+GitVersion.ConfigurationInfo.ShowConfiguration.set -> void
 GitVersion.Extensions.AssemblyVersionsGeneratorExtensions
 GitVersion.Extensions.AssemblyVersionsGeneratorExtensions.extension(GitVersion.SemanticVersion!)
 GitVersion.Extensions.AssemblyVersionsGeneratorExtensions.extension(GitVersion.SemanticVersion!).GetAssemblyFileVersion(GitVersion.Configuration.AssemblyFileVersioningScheme scheme) -> string?
@@ -345,18 +352,27 @@ GitVersion.GitVersionOptions
 GitVersion.GitVersionOptions.AssemblySettingsInfo.get -> GitVersion.AssemblySettingsInfo!
 GitVersion.GitVersionOptions.AuthenticationInfo.get -> GitVersion.Git.AuthenticationInfo!
 GitVersion.GitVersionOptions.ConfigurationInfo.get -> GitVersion.ConfigurationInfo!
-GitVersion.GitVersionOptions.Diag -> bool
-GitVersion.GitVersionOptions.Format -> string?
+GitVersion.GitVersionOptions.Diag.get -> bool
+GitVersion.GitVersionOptions.Diag.set -> void
+GitVersion.GitVersionOptions.Format.get -> string?
+GitVersion.GitVersionOptions.Format.set -> void
 GitVersion.GitVersionOptions.GitVersionOptions() -> void
-GitVersion.GitVersionOptions.IsHelp -> bool
-GitVersion.GitVersionOptions.IsVersion -> bool
-GitVersion.GitVersionOptions.LogFilePath -> string?
-GitVersion.GitVersionOptions.Output -> System.Collections.Generic.ISet<GitVersion.OutputType>!
-GitVersion.GitVersionOptions.OutputFile -> string?
+GitVersion.GitVersionOptions.IsHelp.get -> bool
+GitVersion.GitVersionOptions.IsHelp.set -> void
+GitVersion.GitVersionOptions.IsVersion.get -> bool
+GitVersion.GitVersionOptions.IsVersion.set -> void
+GitVersion.GitVersionOptions.LogFilePath.get -> string?
+GitVersion.GitVersionOptions.LogFilePath.set -> void
+GitVersion.GitVersionOptions.Output.get -> System.Collections.Generic.ISet<GitVersion.OutputType>!
+GitVersion.GitVersionOptions.Output.set -> void
+GitVersion.GitVersionOptions.OutputFile.get -> string?
+GitVersion.GitVersionOptions.OutputFile.set -> void
 GitVersion.GitVersionOptions.RepositoryInfo.get -> GitVersion.RepositoryInfo!
 GitVersion.GitVersionOptions.Settings.get -> GitVersion.Settings!
-GitVersion.GitVersionOptions.ShowVariable -> string?
-GitVersion.GitVersionOptions.Verbosity -> GitVersion.Logging.Verbosity
+GitVersion.GitVersionOptions.ShowVariable.get -> string?
+GitVersion.GitVersionOptions.ShowVariable.set -> void
+GitVersion.GitVersionOptions.Verbosity.get -> GitVersion.Logging.Verbosity
+GitVersion.GitVersionOptions.Verbosity.set -> void
 GitVersion.GitVersionOptions.WixInfo.get -> GitVersion.WixInfo!
 GitVersion.GitVersionOptions.WorkingDirectory.get -> string!
 GitVersion.GitVersionOptions.WorkingDirectory.set -> void
@@ -539,12 +555,16 @@ GitVersion.OutputVariables.IVersionVariableSerializer.FromFile(string! filePath)
 GitVersion.OutputVariables.IVersionVariableSerializer.ToFile(GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables, string! filePath) -> void
 GitVersion.OutputVariables.IVersionVariableSerializer.ToJson(GitVersion.OutputVariables.GitVersionVariables! gitVersionVariables) -> string!
 GitVersion.RepositoryInfo
-GitVersion.RepositoryInfo.ClonePath -> string?
-GitVersion.RepositoryInfo.CommitId -> string?
+GitVersion.RepositoryInfo.ClonePath.get -> string?
+GitVersion.RepositoryInfo.ClonePath.set -> void
+GitVersion.RepositoryInfo.CommitId.get -> string?
+GitVersion.RepositoryInfo.CommitId.set -> void
 GitVersion.RepositoryInfo.RepositoryInfo() -> void
 GitVersion.RepositoryInfo.RepositoryInfo(GitVersion.RepositoryInfo! original) -> void
-GitVersion.RepositoryInfo.TargetBranch -> string?
-GitVersion.RepositoryInfo.TargetUrl -> string?
+GitVersion.RepositoryInfo.TargetBranch.get -> string?
+GitVersion.RepositoryInfo.TargetBranch.set -> void
+GitVersion.RepositoryInfo.TargetUrl.get -> string?
+GitVersion.RepositoryInfo.TargetUrl.set -> void
 GitVersion.SemanticVersion
 GitVersion.SemanticVersion.BuildMetaData.get -> GitVersion.SemanticVersionBuildMetaData!
 GitVersion.SemanticVersion.BuildMetaData.init -> void
@@ -669,11 +689,16 @@ GitVersion.SemanticVersionWithTag.Tag.init -> void
 GitVersion.SemanticVersionWithTag.Value.get -> GitVersion.SemanticVersion!
 GitVersion.SemanticVersionWithTag.Value.init -> void
 GitVersion.Settings
-GitVersion.Settings.AllowShallow -> bool
-GitVersion.Settings.NoCache -> bool
-GitVersion.Settings.NoFetch -> bool
-GitVersion.Settings.NoNormalize -> bool
-GitVersion.Settings.OnlyTrackedBranches -> bool
+GitVersion.Settings.AllowShallow.get -> bool
+GitVersion.Settings.AllowShallow.set -> void
+GitVersion.Settings.NoCache.get -> bool
+GitVersion.Settings.NoCache.set -> void
+GitVersion.Settings.NoFetch.get -> bool
+GitVersion.Settings.NoFetch.set -> void
+GitVersion.Settings.NoNormalize.get -> bool
+GitVersion.Settings.NoNormalize.set -> void
+GitVersion.Settings.OnlyTrackedBranches.get -> bool
+GitVersion.Settings.OnlyTrackedBranches.set -> void
 GitVersion.Settings.Settings() -> void
 GitVersion.Settings.Settings(GitVersion.Settings! original) -> void
 GitVersion.VersionCalculation.BaseVersion
@@ -794,7 +819,8 @@ GitVersion.WarningException.WarningException() -> void
 GitVersion.WarningException.WarningException(string! message) -> void
 GitVersion.WarningException.WarningException(string? message, System.Exception? innerException) -> void
 GitVersion.WixInfo
-GitVersion.WixInfo.UpdateWixVersionFile -> bool
+GitVersion.WixInfo.UpdateWixVersionFile.get -> bool
+GitVersion.WixInfo.UpdateWixVersionFile.set -> void
 GitVersion.WixInfo.WixInfo() -> void
 GitVersion.WixInfo.WixInfo(GitVersion.WixInfo! original) -> void
 override GitVersion.Configuration.EffectiveBranchConfiguration.Equals(object? obj) -> bool

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -880,7 +880,7 @@ override GitVersion.VersionCalculation.BaseVersionOperator.ToString() -> string!
 override GitVersion.VersionCalculation.Caching.GitVersionCacheKey.Equals(object? obj) -> bool
 override GitVersion.VersionCalculation.Caching.GitVersionCacheKey.GetHashCode() -> int
 override GitVersion.VersionCalculation.Caching.GitVersionCacheKey.ToString() -> string!
-override GitVersion.VersionCalculation.NextVersion.Equals(object? other) -> bool
+override GitVersion.VersionCalculation.NextVersion.Equals(object? obj) -> bool
 override GitVersion.VersionCalculation.NextVersion.GetHashCode() -> int
 override GitVersion.VersionCalculation.NextVersion.ToString() -> string!
 override GitVersion.WixInfo.Equals(object? obj) -> bool

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+static GitVersion.Git.ReferenceName.operator <(GitVersion.Git.ReferenceName? left, GitVersion.Git.ReferenceName? right) -> bool
+static GitVersion.Git.ReferenceName.operator <=(GitVersion.Git.ReferenceName? left, GitVersion.Git.ReferenceName? right) -> bool
+static GitVersion.Git.ReferenceName.operator >(GitVersion.Git.ReferenceName? left, GitVersion.Git.ReferenceName? right) -> bool
+static GitVersion.Git.ReferenceName.operator >=(GitVersion.Git.ReferenceName? left, GitVersion.Git.ReferenceName? right) -> bool
+static GitVersion.SemanticVersionWithTag.operator <(GitVersion.SemanticVersionWithTag? left, GitVersion.SemanticVersionWithTag? right) -> bool
+static GitVersion.SemanticVersionWithTag.operator <=(GitVersion.SemanticVersionWithTag? left, GitVersion.SemanticVersionWithTag? right) -> bool
+static GitVersion.SemanticVersionWithTag.operator >(GitVersion.SemanticVersionWithTag? left, GitVersion.SemanticVersionWithTag? right) -> bool
+static GitVersion.SemanticVersionWithTag.operator >=(GitVersion.SemanticVersionWithTag? left, GitVersion.SemanticVersionWithTag? right) -> bool

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -58,6 +58,9 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
         BuildMetaData = semanticVersion.BuildMetaData;
     }
 
+    /// <summary>Returns <see langword="true"/> when this instance equals <see cref="Empty"/>.</summary>
+    public bool IsEmpty() => Equals(Empty);
+
     /// <summary>Returns <see langword="true"/> when this version is equal to <paramref name="obj"/>.</summary>
     public bool Equals(SemanticVersion? obj)
     {
@@ -71,9 +74,6 @@ public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEqua
             && PreReleaseTag == obj.PreReleaseTag
             && BuildMetaData == obj.BuildMetaData;
     }
-
-    /// <summary>Returns <see langword="true"/> when this instance equals <see cref="Empty"/>.</summary>
-    public bool IsEmpty() => Equals(Empty);
 
     /// <summary>Returns <see langword="true"/> when <paramref name="obj"/> is a <see cref="SemanticVersion"/> equal to this instance.</summary>
     public override bool Equals(object? obj)

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -5,7 +5,7 @@ using GitVersion.Extensions;
 namespace GitVersion;
 
 /// <summary>Represents a semantic version with optional pre-release tag and build metadata.</summary>
-public class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEquatable<SemanticVersion?>
+public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>, IEquatable<SemanticVersion?>
 {
     /// <summary>A zero-valued semantic version with no pre-release tag or build metadata.</summary>
     public static readonly SemanticVersion Empty = new();

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -146,7 +146,9 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
         string version, string? tagPrefixRegex, SemanticVersionFormat versionFormat = SemanticVersionFormat.Strict)
     {
         if (!TryParse(version, tagPrefixRegex, out var semanticVersion, versionFormat))
+        {
             throw new WarningException($"Failed to parse {version} into a Semantic Version");
+        }
 
         return semanticVersion;
     }
@@ -279,7 +281,11 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
             return -1;
         }
 
-        if (!includePreRelease || PreReleaseTag == value.PreReleaseTag) return 0;
+        if (!includePreRelease || PreReleaseTag == value.PreReleaseTag)
+        {
+            return 0;
+        }
+
         if (PreReleaseTag > value.PreReleaseTag)
         {
             return 1;
@@ -303,10 +309,14 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         if (format.IsNullOrEmpty())
+        {
             format = "s";
+        }
 
         if (formatProvider?.GetFormat(GetType()) is ICustomFormatter formatter)
+        {
             return formatter.Format(format, this, formatProvider);
+        }
 
         // Check for lp first because the param can vary
         format = format.ToLower();
@@ -374,7 +384,10 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
                 else
                 {
                     patch++;
-                    if (preReleaseNumber.HasValue) preReleaseNumber = 1;
+                    if (preReleaseNumber.HasValue)
+                    {
+                        preReleaseNumber = 1;
+                    }
                 }
                 break;
 
@@ -388,7 +401,10 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
                 {
                     minor++;
                     patch = 0;
-                    if (preReleaseNumber.HasValue) preReleaseNumber = 1;
+                    if (preReleaseNumber.HasValue)
+                    {
+                        preReleaseNumber = 1;
+                    }
                 }
                 break;
 
@@ -403,7 +419,10 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
                     major++;
                     minor = 0;
                     patch = 0;
-                    if (preReleaseNumber.HasValue) preReleaseNumber = 1;
+                    if (preReleaseNumber.HasValue)
+                    {
+                        preReleaseNumber = 1;
+                    }
                 }
                 break;
 
@@ -416,7 +435,11 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
         var foundAlternativeSemanticVersion = false;
         foreach (var alternativeSemanticVersion in alternativeSemanticVersions)
         {
-            if (!semanticVersion.IsLessThan(alternativeSemanticVersion, includePreRelease: false)) continue;
+            if (!semanticVersion.IsLessThan(alternativeSemanticVersion, includePreRelease: false))
+            {
+                continue;
+            }
+
             semanticVersion = alternativeSemanticVersion!;
             foundAlternativeSemanticVersion = true;
         }

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -121,10 +121,14 @@ public sealed class SemanticVersionBuildMetaData : IFormattable, IEquatable<Sema
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         if (formatProvider?.GetFormat(GetType()) is ICustomFormatter formatter)
+        {
             return formatter.Format(format, this, formatProvider);
+        }
 
         if (format.IsNullOrEmpty())
+        {
             format = "b";
+        }
 
         format = format.ToLower();
         return format.ToLower() switch
@@ -154,7 +158,9 @@ public sealed class SemanticVersionBuildMetaData : IFormattable, IEquatable<Sema
     public static SemanticVersionBuildMetaData Parse(string? buildMetaData)
     {
         if (buildMetaData.IsNullOrEmpty())
+        {
             return Empty;
+        }
 
         var parsed = RegexPatterns.SemanticVersion.ParseBuildMetaDataRegex.Match(buildMetaData);
 
@@ -163,21 +169,30 @@ public sealed class SemanticVersionBuildMetaData : IFormattable, IEquatable<Sema
         if (parsed.Groups["BuildNumber"].Success)
         {
             if (long.TryParse(parsed.Groups["BuildNumber"].Value, out var buildNumber))
+            {
                 buildMetaDataCommitsSinceTag = buildNumber;
+            }
+
             buildMetaDataVersionSourceDistance = buildMetaDataCommitsSinceTag ?? 0;
         }
 
         string? buildMetaDataBranch = null;
         if (parsed.Groups["BranchName"].Success)
+        {
             buildMetaDataBranch = parsed.Groups["BranchName"].Value;
+        }
 
         string? buildMetaDataSha = null;
         if (parsed.Groups["Sha"].Success)
+        {
             buildMetaDataSha = parsed.Groups["Sha"].Value;
+        }
 
         string? buildMetaDataOtherMetaData = null;
         if (parsed.Groups["Other"].Success && !parsed.Groups["Other"].Value.IsNullOrEmpty())
+        {
             buildMetaDataOtherMetaData = parsed.Groups["Other"].Value.TrimStart('.');
+        }
 
         return new()
         {
@@ -192,7 +207,10 @@ public sealed class SemanticVersionBuildMetaData : IFormattable, IEquatable<Sema
     private static string FormatMetaDataPart(string value)
     {
         if (!value.IsNullOrEmpty())
+        {
             value = RegexPatterns.SemanticVersion.FormatBuildMetaDataRegex.Replace(value, "-");
+        }
+
         return value;
     }
 }

--- a/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionBuildMetaData.cs
@@ -5,7 +5,7 @@ using GitVersion.Helpers;
 namespace GitVersion;
 
 /// <summary>Holds the build metadata attached to a semantic version (commits-since-tag, branch, SHA, commit date, etc.).</summary>
-public class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVersionBuildMetaData?>
+public sealed class SemanticVersionBuildMetaData : IFormattable, IEquatable<SemanticVersionBuildMetaData?>
 {
     /// <summary>An empty build metadata instance with no fields set.</summary>
     public static readonly SemanticVersionBuildMetaData Empty = new();

--- a/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
@@ -141,11 +141,13 @@ public sealed class SemanticVersionPreReleaseTag :
 
         format = format.ToLower();
 
-        return format switch
-        {
-            "t" => (Number.HasValue ? Name.IsNullOrEmpty() ? $"{Number}" : $"{Name}.{Number}" : Name),
-            _ => throw new FormatException($"Unknown format '{format}'.")
-        };
+        if (format != "t")
+            throw new FormatException($"Unknown format '{format}'.");
+
+        if (!Number.HasValue)
+            return Name;
+
+        return Name.IsNullOrEmpty() ? $"{Number}" : $"{Name}.{Number}";
     }
 
     /// <summary>Returns <see langword="true"/> when this tag has a non-empty name or a number with the promotion flag set.</summary>

--- a/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersionPreReleaseTag.cs
@@ -88,7 +88,10 @@ public sealed class SemanticVersionPreReleaseTag :
     /// <summary>Parses a pre-release tag string, returning <see cref="Empty"/> when the input is null or empty.</summary>
     public static SemanticVersionPreReleaseTag Parse(string? preReleaseTag)
     {
-        if (preReleaseTag.IsNullOrEmpty()) return Empty;
+        if (preReleaseTag.IsNullOrEmpty())
+        {
+            return Empty;
+        }
 
         var match = RegexPatterns.SemanticVersion.ParsePreReleaseTagRegex.Match(preReleaseTag);
         if (!match.Success)
@@ -134,18 +137,26 @@ public sealed class SemanticVersionPreReleaseTag :
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         if (formatProvider?.GetFormat(GetType()) is ICustomFormatter formatter)
+        {
             return formatter.Format(format, this, formatProvider);
+        }
 
         if (format.IsNullOrEmpty())
+        {
             format = "t";
+        }
 
         format = format.ToLower();
 
         if (format != "t")
+        {
             throw new FormatException($"Unknown format '{format}'.");
+        }
 
         if (!Number.HasValue)
+        {
             return Name;
+        }
 
         return Name.IsNullOrEmpty() ? $"{Number}" : $"{Name}.{Number}";
     }

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -115,7 +115,11 @@ internal class GitVersionCacheKeyFactory(
             {
                 try
                 {
-                    if (!this.fileSystem.File.Exists(file)) continue;
+                    if (!this.fileSystem.File.Exists(file))
+                    {
+                        continue;
+                    }
+
                     result.Add(FileSystemHelper.Path.GetFileName(file));
                     result.Add(this.fileSystem.File.ReadAllText(file));
                 }
@@ -172,7 +176,10 @@ internal class GitVersionCacheKeyFactory(
 
         var configFilePath = this.configFileLocator.GetConfigurationFile(workingDirectory)
                              ?? this.configFileLocator.GetConfigurationFile(projectRootDirectory);
-        if (configFilePath == null || !this.fileSystem.File.Exists(configFilePath)) return string.Empty;
+        if (configFilePath == null || !this.fileSystem.File.Exists(configFilePath))
+        {
+            return string.Empty;
+        }
 
         var configFileContent = this.fileSystem.File.ReadAllText(configFilePath);
         return GetHash(configFileContent);

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -21,7 +21,10 @@ internal sealed class EffectiveBranchConfigurationFinder(ILog log, IRepositorySt
     private IEnumerable<EffectiveBranchConfiguration> GetEffectiveConfigurationsRecursive(
         IBranch branch, IGitVersionConfiguration configuration, IBranchConfiguration? childBranchConfiguration, HashSet<IBranch> traversedBranches)
     {
-        if (!traversedBranches.Add(branch)) yield break; // This should never happen!! But it is good to have a circuit breaker.
+        if (!traversedBranches.Add(branch))
+        {
+            yield break; // This should never happen!! But it is good to have a circuit breaker.
+        }
 
         var branchConfiguration = configuration.GetBranchConfiguration(branch.Name);
         if (childBranchConfiguration != null)
@@ -43,7 +46,10 @@ internal sealed class EffectiveBranchConfigurationFinder(ILog log, IRepositorySt
                 this.log.Info(
                     $"An orphaned branch '{branch}' has been detected and will be skipped={skipTraversingOfOrphanedBranches}."
                 );
-                if (skipTraversingOfOrphanedBranches) yield break;
+                if (skipTraversingOfOrphanedBranches)
+                {
+                    yield break;
+                }
             }
         }
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -110,7 +110,11 @@ internal class IncrementStrategyFinder(
 
         foreach (var intermediateCommit in intermediateCommits.Reverse())
         {
-            if (!targetShas.Value.Contains(intermediateCommit.Sha) || !commitLog.Remove(intermediateCommit.Sha)) continue;
+            if (!targetShas.Value.Contains(intermediateCommit.Sha) || !commitLog.Remove(intermediateCommit.Sha))
+            {
+                continue;
+            }
+
             var parentCommits = intermediateCommit.Parents.ToList();
             while (parentCommits.Count != 0)
             {
@@ -137,7 +141,11 @@ internal class IncrementStrategyFinder(
         var commitAfterBaseIndex = 0;
         if (baseCommit != null)
         {
-            if (!map.TryGetValue(baseCommit.Sha, out var baseIndex)) return [];
+            if (!map.TryGetValue(baseCommit.Sha, out var baseIndex))
+            {
+                return [];
+            }
+
             commitAfterBaseIndex = baseIndex + 1;
         }
 
@@ -169,10 +177,26 @@ internal class IncrementStrategyFinder(
 
     private static VersionField? GetIncrementFromMessage(string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex noBumpRegex)
     {
-        if (noBumpRegex.IsMatch(message)) return VersionField.None;
-        if (majorRegex.IsMatch(message)) return VersionField.Major;
-        if (minorRegex.IsMatch(message)) return VersionField.Minor;
-        if (patchRegex.IsMatch(message)) return VersionField.Patch;
+        if (noBumpRegex.IsMatch(message))
+        {
+            return VersionField.None;
+        }
+
+        if (majorRegex.IsMatch(message))
+        {
+            return VersionField.Major;
+        }
+
+        if (minorRegex.IsMatch(message))
+        {
+            return VersionField.Minor;
+        }
+
+        if (patchRegex.IsMatch(message))
+        {
+            return VersionField.Patch;
+        }
+
         return null;
     }
 
@@ -187,7 +211,10 @@ internal class IncrementStrategyFinder(
 
         var baseCommit = mergeCommit.Parents[0];
         var mergedCommit = GetMergedHead(mergeCommit);
-        if (index == 0) (mergedCommit, baseCommit) = (baseCommit, mergedCommit);
+        if (index == 0)
+        {
+            (mergedCommit, baseCommit) = (baseCommit, mergedCommit);
+        }
 
         var findMergeBase = this.repositoryStore.FindMergeBase(baseCommit, mergedCommit)
             ?? throw new InvalidOperationException("Cannot find the base commit of merged branch.");
@@ -198,7 +225,10 @@ internal class IncrementStrategyFinder(
     {
         var parents = mergeCommit.Parents.Skip(1).ToList();
         if (parents.Count > 1)
+        {
             throw new NotSupportedException("GitVersion does not support more than one merge source in a single commit yet");
+        }
+
         return parents.Single();
     }
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
@@ -18,11 +18,17 @@ internal sealed class EnrichIncrement : IContextPreEnricher
         context.Increment = context.Increment.Consolidate(incrementForcedByBranch, incrementForcedByCommit);
 
         if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+        {
             context.Label = null;
+        }
+
         context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
 
         if (effectiveConfiguration.IsMainBranch)
+        {
             context.BaseVersionSource = commit.Predecessor?.Value;
+        }
+
         context.ForceIncrement |= effectiveConfiguration.IsMainBranch || commit.IsPredecessorTheLastCommitOnTrunk(context.Configuration);
     }
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineCommit.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineCommit.cs
@@ -58,14 +58,20 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
 
     public EffectiveConfiguration GetEffectiveConfiguration(IGitVersionConfiguration configuration)
     {
-        if (this.effectiveConfiguration is not null) return this.effectiveConfiguration;
+        if (this.effectiveConfiguration is not null)
+        {
+            return this.effectiveConfiguration;
+        }
 
         var branchConfiguration = Configuration;
 
         var last = Configuration;
         for (var i = this; i is not null; i = i.Predecessor)
         {
-            if (branchConfiguration.Increment != IncrementStrategy.Inherit) break;
+            if (branchConfiguration.Increment != IncrementStrategy.Inherit)
+            {
+                break;
+            }
 
             if (i.Configuration != last)
             {
@@ -76,7 +82,9 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
         }
 
         if (branchConfiguration.Increment != IncrementStrategy.Inherit || !HasParentIteration)
+        {
             return this.effectiveConfiguration = new EffectiveConfiguration(configuration, branchConfiguration);
+        }
 
         var parentConfiguration = ParentCommit.GetEffectiveConfiguration(configuration);
         branchConfiguration = branchConfiguration.Inherit(parentConfiguration);
@@ -106,7 +114,10 @@ internal record MainlineCommit(MainlineIteration Iteration, ICommit? value, Refe
     public MainlineCommit Append(
         ICommit? referenceValue, ReferenceName branchName, IBranchConfiguration configuration)
     {
-        if (HasPredecessor) throw new InvalidOperationException();
+        if (HasPredecessor)
+        {
+            throw new InvalidOperationException();
+        }
 
         MainlineCommit commit = new(Iteration, referenceValue, branchName, configuration);
         Predecessor = commit;

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineIteration.cs
@@ -26,7 +26,9 @@ internal record MainlineIteration
         var branchConfiguration = Configuration;
 
         if (branchConfiguration.Increment != IncrementStrategy.Inherit || Commits.FirstOrDefault() is not { } commit)
+        {
             return this.effectiveConfiguration = new EffectiveConfiguration(configuration, branchConfiguration);
+        }
 
         var parentConfiguration = commit.GetEffectiveConfiguration(configuration);
         branchConfiguration = branchConfiguration.Inherit(parentConfiguration);

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
@@ -19,12 +19,18 @@ internal sealed class CommitOnNonTrunk : IIncrementer
         MainlineIteration iteration, MainlineCommit commit, MainlineContext context)
     {
         if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+        {
             context.Label = null;
+        }
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
         context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
 
-        if (commit.Successor is not null) yield break;
+        if (commit.Successor is not null)
+        {
+            yield break;
+        }
+
         yield return new BaseVersionOperator
         {
             Source = GetType().Name,

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/FirstCommitOnRelease.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/FirstCommitOnRelease.cs
@@ -30,7 +30,11 @@ internal sealed class FirstCommitOnRelease : IIncrementer
         MainlineIteration iteration, MainlineCommit commit, MainlineContext context)
     {
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        if (!commit.BranchName.TryGetSemanticVersion(effectiveConfiguration, out var element)) yield break;
+        if (!commit.BranchName.TryGetSemanticVersion(effectiveConfiguration, out var element))
+        {
+            yield break;
+        }
+
         context.AlternativeSemanticVersions.Add(element.Value);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -12,7 +12,10 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
     public virtual IEnumerable<IBaseVersionIncrement> GetIncrements(
         MainlineIteration iteration, MainlineCommit commit, MainlineContext context)
     {
-        if (commit.ChildIteration is null) throw new InvalidOperationException("The commit child iteration is null.");
+        if (commit.ChildIteration is null)
+        {
+            throw new InvalidOperationException("The commit child iteration is null.");
+        }
 
         return GetIncrementsInternal();
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/RemoveIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/RemoveIncrement.cs
@@ -4,7 +4,11 @@ internal sealed class RemoveIncrement : IContextPostEnricher
 {
     public void Enrich(MainlineCommit commit, MainlineContext context)
     {
-        if (!commit.GetEffectiveConfiguration(context.Configuration).IsMainBranch) return;
+        if (!commit.GetEffectiveConfiguration(context.Configuration).IsMainBranch)
+        {
+            return;
+        }
+
         context.Increment = VersionField.None;
         context.Label = null;
         context.AlternativeSemanticVersions.Clear();

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
@@ -18,7 +18,9 @@ internal sealed class CommitOnTrunk : IIncrementer
         MainlineIteration iteration, MainlineCommit commit, MainlineContext context)
     {
         if (commit.Predecessor is not null && commit.Predecessor.BranchName != commit.BranchName)
+        {
             context.Label = null;
+        }
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
         context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
@@ -18,7 +18,11 @@ internal sealed class LastCommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreR
             yield return item;
         }
 
-        if (!iteration.GetEffectiveConfiguration(context.Configuration).IsMainBranch) yield break;
+        if (!iteration.GetEffectiveConfiguration(context.Configuration).IsMainBranch)
+        {
+            yield break;
+        }
+
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithStableTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithStableTag.cs
@@ -16,7 +16,11 @@ internal sealed class LastCommitOnTrunkWithStableTag : CommitOnTrunkWithStableTa
             yield return item;
         }
 
-        if (!iteration.GetEffectiveConfiguration(context.Configuration).IsMainBranch) yield break;
+        if (!iteration.GetEffectiveConfiguration(context.Configuration).IsMainBranch)
+        {
+            yield break;
+        }
+
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -10,7 +10,10 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
     public virtual IEnumerable<IBaseVersionIncrement> GetIncrements(
         MainlineIteration iteration, MainlineCommit commit, MainlineContext context)
     {
-        if (commit.ChildIteration is null) throw new InvalidOperationException("The commit child iteration is null.");
+        if (commit.ChildIteration is null)
+        {
+            throw new InvalidOperationException("The commit child iteration is null.");
+        }
 
         return GetIncrementsInternal();
 

--- a/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/MinDateVersionFilter.cs
@@ -13,7 +13,9 @@ internal class MinDateVersionFilter(DateTimeOffset minimum) : IVersionFilter
         reason = null;
 
         if (baseVersion.BaseVersionSource == null || baseVersion.BaseVersionSource.When >= minimum)
+        {
             return false;
+        }
 
         reason = "Source was ignored due to commit date being outside of configured range";
         return true;
@@ -24,7 +26,9 @@ internal class MinDateVersionFilter(DateTimeOffset minimum) : IVersionFilter
         reason = null;
 
         if (commit == null || commit.When >= minimum)
+        {
             return false;
+        }
 
         reason = "Source was ignored due to commit date being outside of configured range";
         return true;

--- a/src/GitVersion.Core/VersionCalculation/NextVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersion.cs
@@ -4,7 +4,7 @@ using GitVersion.Extensions;
 namespace GitVersion.VersionCalculation;
 
 /// <summary>Represents the next calculated version together with its base version and branch configuration.</summary>
-public class NextVersion(
+public sealed class NextVersion(
     SemanticVersion incrementedVersion,
     IBaseVersion baseVersion,
     EffectiveBranchConfiguration configuration)

--- a/src/GitVersion.Core/VersionCalculation/NextVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/NextVersion.cs
@@ -46,8 +46,8 @@ public class NextVersion(
     /// <summary>Returns <see langword="true"/> when this instance equals <paramref name="other"/>.</summary>
     public bool Equals(NextVersion? other) => this == other;
 
-    /// <summary>Returns <see langword="true"/> when <paramref name="other"/> is a <see cref="NextVersion"/> equal to this instance.</summary>
-    public override bool Equals(object? other) => other is NextVersion nextVersion && Equals(nextVersion);
+    /// <summary>Returns <see langword="true"/> when <paramref name="obj"/> is a <see cref="NextVersion"/> equal to this instance.</summary>
+    public override bool Equals(object? obj) => obj is NextVersion nextVersion && Equals(nextVersion);
 
     /// <summary>Returns a human-readable representation showing the base version and incremented version.</summary>
     public override string ToString() => $"{BaseVersion} | {IncrementedVersion}";

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -16,12 +16,6 @@ internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = Pat
     private readonly IReadOnlyList<Regex> pathsRegexes = [.. paths.Select(RegexPatterns.Cache.GetOrAdd)];
     private readonly ConcurrentDictionary<string, bool> pathMatchCache = [];
 
-    public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)
-    {
-        ArgumentNullException.ThrowIfNull(baseVersion);
-        return Exclude(baseVersion.BaseVersionSource, out reason);
-    }
-
     private bool IsMatch(string path)
     {
         if (!this.pathMatchCache.TryGetValue(path, out var isMatch))
@@ -30,6 +24,12 @@ internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = Pat
             this.pathMatchCache[path] = isMatch;
         }
         return isMatch;
+    }
+
+    public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)
+    {
+        ArgumentNullException.ThrowIfNull(baseVersion);
+        return Exclude(baseVersion.BaseVersionSource, out reason);
     }
 
     public bool Exclude(ICommit? commit, [NotNullWhen(true)] out string? reason)

--- a/src/GitVersion.Core/VersionCalculation/PathFilter.cs
+++ b/src/GitVersion.Core/VersionCalculation/PathFilter.cs
@@ -13,7 +13,7 @@ internal enum PathFilterMode
 
 internal class PathFilter(IReadOnlyList<string> paths, PathFilterMode mode = PathFilterMode.Inclusive) : IVersionFilter
 {
-    private readonly IReadOnlyList<Regex> pathsRegexes = [.. paths.Select(path => new Regex(path, RegexOptions.Compiled))];
+    private readonly IReadOnlyList<Regex> pathsRegexes = [.. paths.Select(RegexPatterns.Cache.GetOrAdd)];
     private readonly ConcurrentDictionary<string, bool> pathMatchCache = [];
 
     public bool Exclude(IBaseVersion baseVersion, [NotNullWhen(true)] out string? reason)

--- a/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/SemanticVersioning/SemanticVersionWithTag.cs
@@ -8,6 +8,18 @@ public sealed record SemanticVersionWithTag(SemanticVersion Value, ITag Tag) : I
     /// <summary>Compares this instance to <paramref name="other"/> by semantic version.</summary>
     public int CompareTo(SemanticVersionWithTag? other) => Value.CompareTo(other?.Value);
 
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts before <paramref name="right"/>.</summary>
+    public static bool operator <(SemanticVersionWithTag? left, SemanticVersionWithTag? right) => Comparer<SemanticVersionWithTag>.Default.Compare(left, right) < 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts before or equal to <paramref name="right"/>.</summary>
+    public static bool operator <=(SemanticVersionWithTag? left, SemanticVersionWithTag? right) => Comparer<SemanticVersionWithTag>.Default.Compare(left, right) <= 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts after <paramref name="right"/>.</summary>
+    public static bool operator >(SemanticVersionWithTag? left, SemanticVersionWithTag? right) => Comparer<SemanticVersionWithTag>.Default.Compare(left, right) > 0;
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="left"/> sorts after or equal to <paramref name="right"/>.</summary>
+    public static bool operator >=(SemanticVersionWithTag? left, SemanticVersionWithTag? right) => Comparer<SemanticVersionWithTag>.Default.Compare(left, right) >= 0;
+
     /// <summary>Returns a human-readable representation showing the tag, its commit, and the parsed version.</summary>
     public override string ToString() => $"{Tag} | {Tag.Commit} | {Value}";
 }

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -113,7 +113,11 @@ internal class NextVersionCalculator(
         var currentCommitTaggedVersion = taggedSemanticVersionsOfCurrentCommit
             .Where(element => element.Value.IsMatchForBranchSpecificLabel(label)).Max();
 
-        if (currentCommitTaggedVersion is null) return result is not null;
+        if (currentCommitTaggedVersion is null)
+        {
+            return result is not null;
+        }
+
         SemanticVersionBuildMetaData semanticVersionBuildMetaData = new(
             versionSourceSemVer: currentCommitTaggedVersion.Value,
             versionSourceSha: Context.CurrentCommit.Sha,
@@ -219,10 +223,14 @@ internal class NextVersionCalculator(
     private static NextVersion CompareVersions(NextVersion version1, NextVersion version2)
     {
         if (version1.BaseVersion.BaseVersionSource == null)
+        {
             return version2;
+        }
 
         if (version2.BaseVersion.BaseVersionSource == null)
+        {
             return version1;
+        }
 
         return version1.BaseVersion.BaseVersionSource.When >= version2.BaseVersion.BaseVersionSource.When
             ? version1
@@ -234,7 +242,9 @@ internal class NextVersionCalculator(
         using (this.log.IndentLog("Fetching the base versions for version calculation..."))
         {
             if (branch.Tip == null)
+            {
                 throw new GitVersionException("No commits found on the current branch.");
+            }
 
             return [.. GetNextVersionsInternal()];
         }
@@ -257,14 +267,21 @@ internal class NextVersionCalculator(
                     var atLeastOneBaseVersionReturned = false;
                     foreach (var versionStrategy in strategies)
                     {
-                        if (atLeastOneBaseVersionReturned && versionStrategy is FallbackVersionStrategy) continue;
+                        if (atLeastOneBaseVersionReturned && versionStrategy is FallbackVersionStrategy)
+                        {
+                            continue;
+                        }
 
                         using (this.log.IndentLog($"[Using '{versionStrategy.GetType().Name}' strategy]"))
                         {
                             foreach (var baseVersion in versionStrategy.GetBaseVersions(effectiveBranchConfiguration))
                             {
                                 this.log.Info(baseVersion.ToString());
-                                if (!IncludeVersion(baseVersion, configuration.Ignore)) continue;
+                                if (!IncludeVersion(baseVersion, configuration.Ignore))
+                                {
+                                    continue;
+                                }
+
                                 atLeastOneBaseVersionReturned = true;
 
                                 yield return new NextVersion(
@@ -284,7 +301,11 @@ internal class NextVersionCalculator(
     {
         foreach (var versionFilter in ignoreConfiguration.ToFilters())
         {
-            if (!versionFilter.Exclude(baseVersion, out var reason)) continue;
+            if (!versionFilter.Exclude(baseVersion, out var reason))
+            {
+                continue;
+            }
+
             if (reason != null)
             {
                 this.log.Info(reason);

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersion.cs
@@ -87,7 +87,10 @@ public sealed record BaseVersion(BaseVersionOperand Operand) : IBaseVersion
         }
 
         if (BaseVersionSource is not null)
+        {
             stringBuilder.Append($" based on commit '{commitSource}'.");
+        }
+
         return stringBuilder.ToString();
     }
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersionOperand.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersionOperand.cs
@@ -26,7 +26,9 @@ public sealed record BaseVersionOperand(string Source, SemanticVersion SemanticV
         stringBuilder.Append($"{Source}: Take '{SemanticVersion:f}'");
 
         if (BaseVersionSource is not null)
+        {
             stringBuilder.Append($" based on commit '{BaseVersionSource.Id.ToString(7)}'.");
+        }
 
         return stringBuilder.ToString();
     }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersionOperator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/BaseVersionOperator.cs
@@ -43,7 +43,9 @@ public sealed record BaseVersionOperator : IBaseVersionIncrement
         }
 
         if (BaseVersionSource is not null)
+        {
             stringBuilder.Append($" based on commit '{BaseVersionSource.Id.ToString(7)}'.");
+        }
 
         return stringBuilder.ToString();
     }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -20,16 +20,26 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
         configuration.NotNull();
 
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.ConfiguredNextVersion))
+        {
             yield break;
+        }
 
         var nextVersion = Context.Configuration.NextVersion;
-        if (nextVersion.IsNullOrEmpty()) yield break;
+        if (nextVersion.IsNullOrEmpty())
+        {
+            yield break;
+        }
+
         var semanticVersion = SemanticVersion.Parse(
             nextVersion, Context.Configuration.TagPrefixPattern, Context.Configuration.SemanticVersionFormat
         );
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 
-        if (!semanticVersion.IsMatchForBranchSpecificLabel(label)) yield break;
+        if (!semanticVersion.IsMatchForBranchSpecificLabel(label))
+        {
+            yield break;
+        }
+
         BaseVersionOperator? operation = null;
         if (!semanticVersion.IsPreRelease || (label is not null && semanticVersion.PreReleaseTag.Name != label))
         {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbacktVersionStrategy.cs
@@ -30,7 +30,9 @@ internal sealed class FallbackVersionStrategy(
         configuration.NotNull();
 
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.Fallback))
+        {
             yield break;
+        }
 
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -74,7 +74,9 @@ internal sealed class MainlineVersionStrategy(
         configuration.NotNull();
 
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.Mainline))
+        {
             yield break;
+        }
 
         var branchConfiguration = Context.Configuration.GetBranchConfiguration(Context.CurrentBranch);
 
@@ -86,7 +88,11 @@ internal sealed class MainlineVersionStrategy(
         var commitsInReverseOrder = Context.Configuration.Ignore.Filter(Context.CurrentBranchCommits.ToArray());
 
         var taggedSemanticVersion = TaggedSemanticVersions.OfBranch;
-        if (branchConfiguration.TrackMergeTarget == true) taggedSemanticVersion |= TaggedSemanticVersions.OfMergeTargets;
+        if (branchConfiguration.TrackMergeTarget == true)
+        {
+            taggedSemanticVersion |= TaggedSemanticVersions.OfMergeTargets;
+        }
+
         if (branchConfiguration.TracksReleaseBranches == true)
         {
             taggedSemanticVersion |= TaggedSemanticVersions.OfReleaseBranches;
@@ -147,7 +153,10 @@ internal sealed class MainlineVersionStrategy(
 
         foreach (var item in commitsInReverseOrder)
         {
-            if (!traversedCommits.Add(item)) continue;
+            if (!traversedCommits.Add(item))
+            {
+                continue;
+            }
 
             if (commitsWasBranchedFromLazy.Value.TryGetValue(item, out var effectiveConfigurationsWasBranchedFrom))
             {
@@ -209,7 +218,11 @@ internal sealed class MainlineVersionStrategy(
 
             foreach (var semanticVersion in semanticVersions)
             {
-                if (!semanticVersion.Value.IsMatchForBranchSpecificLabel(label)) continue;
+                if (!semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
+                {
+                    continue;
+                }
+
                 if (configuration.Increment != IncrementStrategy.Inherit)
                 {
                     return true;
@@ -223,7 +236,11 @@ internal sealed class MainlineVersionStrategy(
                 return true;
             }
 
-            if (!item.IsMergeCommit) continue;
+            if (!item.IsMergeCommit)
+            {
+                continue;
+            }
+
             Lazy<IReadOnlyCollection<ICommit>> mergedCommitsInReverseOrderLazy = new(
                 () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 1, Context.Configuration.Ignore).Reverse()]
             );
@@ -244,7 +261,10 @@ internal sealed class MainlineVersionStrategy(
 
             if (childConfiguration.IsMainBranch == true)
             {
-                if (configuration.IsMainBranch == true) throw new NotImplementedException();
+                if (configuration.IsMainBranch == true)
+                {
+                    throw new NotImplementedException();
+                }
 
                 mergedCommitsInReverseOrderLazy = new(
                     () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 0, Context.Configuration.Ignore).Reverse()]
@@ -269,7 +289,10 @@ internal sealed class MainlineVersionStrategy(
                 traversedCommits: traversedCommits);
 
             commit.AddChildIteration(childIteration);
-            if (done) return true;
+            if (done)
+            {
+                return true;
+            }
 
             traversedCommits.AddRange(mergedCommitsInReverseOrderLazy.Value);
         }

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -168,9 +168,10 @@ internal sealed class MainlineVersionStrategy(
                     branch = this.repositoryStore.FindBranch(branchName);
 
                     var branchPointer = branch;
+                    IBranch[] excludeBranches = excludeBranch is null ? [] : [excludeBranch];
                     commitsWasBranchedFromLazy = new Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Configuration)>>>
                         (() => branchPointer is null ? []
-                            : GetCommitsWasBranchedFrom(branchPointer, excludeBranch is null ? [] : [excludeBranch])
+                            : GetCommitsWasBranchedFrom(branchPointer, excludeBranches)
                     );
 
                     var taggedSemanticVersion = TaggedSemanticVersions.OfBranch;

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -33,7 +33,9 @@ internal sealed class TaggedCommitVersionStrategy(
         configuration.NotNull();
 
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.TaggedCommit))
+        {
             yield break;
+        }
 
         var taggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -27,9 +27,15 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
         configuration.NotNull();
 
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.TrackReleaseBranches))
+        {
             yield break;
+        }
 
-        if (!configuration.Value.TracksReleaseBranches) yield break;
+        if (!configuration.Value.TracksReleaseBranches)
+        {
+            yield break;
+        }
+
         foreach (var releaseBranch in this.branchRepository.GetReleaseBranches(Context.Configuration))
         {
             if (TryGetBaseVersion(releaseBranch, configuration, out var baseVersion))
@@ -45,7 +51,10 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
         result = null;
 
         var releaseBranchConfiguration = Context.Configuration.GetEffectiveBranchConfiguration(releaseBranch);
-        if (!this.releaseVersionStrategy.TryGetBaseVersion(releaseBranchConfiguration, out var baseVersion)) return result is not null;
+        if (!this.releaseVersionStrategy.TryGetBaseVersion(releaseBranchConfiguration, out var baseVersion))
+        {
+            return result is not null;
+        }
         // Find the commit where the child branch was created.
         var baseVersionSource = this.repositoryStore.FindMergeBase(releaseBranch, Context.CurrentBranch);
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -19,7 +19,9 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
     public IEnumerable<BaseVersion> GetBaseVersions(EffectiveBranchConfiguration configuration)
     {
         if (!Context.Configuration.VersionStrategy.HasFlag(VersionStrategies.VersionInBranchName))
+        {
             yield break;
+        }
 
         if (TryGetBaseVersion(configuration, out var baseVersion))
         {
@@ -32,11 +34,17 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
         baseVersion = null;
 
         if (!configuration.Value.IsReleaseBranch)
+        {
             return false;
+        }
 
         foreach (var branchName in new[] { Context.CurrentBranch, configuration.Branch }.Select(branch => branch.Name))
         {
-            if (!branchName.TryGetSemanticVersion(configuration.Value, out var result)) continue;
+            if (!branchName.TryGetSemanticVersion(configuration.Value, out var result))
+            {
+                continue;
+            }
+
             string? branchNameOverride = null;
             if (!result.Name.IsNullOrEmpty() && (Context.CurrentBranch.Name.Equals(branchName)
                                                  || Context.Configuration.GetBranchConfiguration(Context.CurrentBranch.Name).Label is null))

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -34,11 +34,11 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
         if (!configuration.Value.IsReleaseBranch)
             return false;
 
-        foreach (var branch in new[] { Context.CurrentBranch, configuration.Branch })
+        foreach (var branchName in new[] { Context.CurrentBranch, configuration.Branch }.Select(branch => branch.Name))
         {
-            if (!branch.Name.TryGetSemanticVersion(configuration.Value, out var result)) continue;
+            if (!branchName.TryGetSemanticVersion(configuration.Value, out var result)) continue;
             string? branchNameOverride = null;
-            if (!result.Name.IsNullOrEmpty() && (Context.CurrentBranch.Name.Equals(branch.Name)
+            if (!result.Name.IsNullOrEmpty() && (Context.CurrentBranch.Name.Equals(branchName)
                                                  || Context.Configuration.GetBranchConfiguration(Context.CurrentBranch.Name).Label is null))
             {
                 branchNameOverride = result.Name;

--- a/src/GitVersion.LibGit2Sharp/Git/Branch.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Branch.cs
@@ -28,10 +28,10 @@ internal sealed class Branch : IBranch
     public ICommit? Tip { get; }
     public ICommitCollection Commits { get; }
     public int CompareTo(IBranch? other) => comparerHelper.Compare(this, other);
-    public bool Equals(IBranch? other) => equalityHelper.Equals(this, other);
     public bool IsDetachedHead => Name.Canonical.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
     public bool IsRemote => this.innerBranch.IsRemote;
     public bool IsTracking => this.innerBranch.IsTracking;
+    public bool Equals(IBranch? other) => equalityHelper.Equals(this, other);
     public override bool Equals(object? obj) => Equals(obj as IBranch);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => Name.ToString();

--- a/src/GitVersion.LibGit2Sharp/Git/Commit.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Commit.cs
@@ -27,7 +27,6 @@ internal sealed class Commit : ICommit
     }
 
     public int CompareTo(ICommit? other) => comparerHelper.Compare(this, other);
-    public bool Equals(ICommit? other) => equalityHelper.Equals(this, other);
     public IReadOnlyList<ICommit> Parents => this.parentsLazy.Value;
     public IObjectId Id { get; }
     public string Sha { get; }
@@ -47,6 +46,7 @@ internal sealed class Commit : ICommit
             return paths;
         }
     }
+    public bool Equals(ICommit? other) => equalityHelper.Equals(this, other);
     public override bool Equals(object? obj) => Equals(obj as ICommit);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => $"'{Id.ToString(7)}' - {this.innerCommit.MessageShort}";

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -69,7 +69,11 @@ internal sealed partial class GitRepository
 
     public void Dispose()
     {
-        if (this.repositoryLazy is not { IsValueCreated: true }) return;
+        if (this.repositoryLazy is not { IsValueCreated: true })
+        {
+            return;
+        }
+
         RepositoryInstance.Dispose();
         this.repositoryLazy = null;
     }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -13,7 +13,7 @@ internal sealed partial class GitRepository
     {
         get
         {
-            var lazy = this.repositoryLazy ?? throw new NullReferenceException("Repository not initialized. Call DiscoverRepository() first.");
+            var lazy = this.repositoryLazy ?? throw new InvalidOperationException("Repository not initialized. Call DiscoverRepository() first.");
             return lazy.Value;
         }
     }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
@@ -54,7 +54,9 @@ internal partial class GitRepository(ILog log) : IMutatingGitRepository
 
         // FIX ME: What to do when Tip is null?
         if (Head.Tip == null)
+        {
             return;
+        }
 
         var headTipSha = Head.Tip.Sha;
         var remote = RepositoryInstance.Network.Remotes.Single();

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
@@ -26,20 +26,20 @@ internal partial class GitRepository(ILog log) : IMutatingGitRepository
             var message = ex.Message;
             if (message.Contains("401"))
             {
-                throw new Exception("Unauthorized: Incorrect username/password", ex);
+                throw new InvalidOperationException("Unauthorized: Incorrect username/password", ex);
             }
 
             if (message.Contains("403"))
             {
-                throw new Exception("Forbidden: Possibly Incorrect username/password", ex);
+                throw new InvalidOperationException("Forbidden: Possibly Incorrect username/password", ex);
             }
 
             if (message.Contains("404"))
             {
-                throw new Exception("Not found: The repository was not found", ex);
+                throw new InvalidOperationException("Not found: The repository was not found", ex);
             }
 
-            throw new Exception("There was an unknown problem with the Git repository you provided", ex);
+            throw new InvalidOperationException("There was an unknown problem with the Git repository you provided", ex);
         }
     }
     public void Checkout(string commitOrBranchSpec) =>

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -7,6 +7,8 @@ namespace GitVersion.Git;
 
 public class GitRepositoryInfo : IGitRepositoryInfo
 {
+    private static readonly char[] DirectorySeparators = ['/', '\\'];
+
     private readonly IFileSystem fileSystem;
     private readonly GitVersionOptions gitVersionOptions;
 
@@ -43,7 +45,7 @@ public class GitRepositoryInfo : IGitRepositoryInfo
         var clonePath = repositoryInfo.ClonePath;
 
         var userTemp = clonePath ?? FileSystemHelper.Path.GetTempPath();
-        var repositoryName = targetUrl.Split('/', '\\')[^1].Replace(".git", string.Empty);
+        var repositoryName = targetUrl.Split(DirectorySeparators)[^1].Replace(".git", string.Empty);
         var possiblePath = FileSystemHelper.Path.Combine(userTemp, repositoryName);
 
         // Verify that the existing directory is ok for us to use

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -34,7 +34,10 @@ public class GitRepositoryInfo : IGitRepositoryInfo
     private string? GetDynamicGitRepositoryPath()
     {
         var repositoryInfo = this.gitVersionOptions.RepositoryInfo;
-        if (repositoryInfo.TargetUrl.IsNullOrWhiteSpace()) return null;
+        if (repositoryInfo.TargetUrl.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
 
         var targetUrl = repositoryInfo.TargetUrl;
         var clonePath = repositoryInfo.ClonePath;
@@ -68,7 +71,9 @@ public class GitRepositoryInfo : IGitRepositoryInfo
 
         gitDirectory = gitDirectory?.TrimEnd('/', '\\');
         if (gitDirectory.IsNullOrEmpty())
+        {
             throw new DirectoryNotFoundException("Cannot find the .git directory");
+        }
 
         var directoryInfo = this.fileSystem.Directory.GetParent(gitDirectory) ?? throw new DirectoryNotFoundException("Cannot find the .git directory");
         return gitDirectory.Contains(FileSystemHelper.Path.Combine(".git", "worktrees"))
@@ -86,7 +91,9 @@ public class GitRepositoryInfo : IGitRepositoryInfo
         var gitDirectory = Repository.Discover(this.gitVersionOptions.WorkingDirectory);
 
         if (gitDirectory.IsNullOrEmpty())
+        {
             throw new DirectoryNotFoundException("Cannot find the .git directory");
+        }
 
         using var repo = new Repository(gitDirectory);
         return repo.Info.WorkingDirectory;

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -40,7 +40,7 @@ public class GitRepositoryInfo : IGitRepositoryInfo
         var clonePath = repositoryInfo.ClonePath;
 
         var userTemp = clonePath ?? FileSystemHelper.Path.GetTempPath();
-        var repositoryName = targetUrl.Split('/', '\\').Last().Replace(".git", string.Empty);
+        var repositoryName = targetUrl.Split('/', '\\')[^1].Replace(".git", string.Empty);
         var possiblePath = FileSystemHelper.Path.Combine(userTemp, repositoryName);
 
         // Verify that the existing directory is ok for us to use

--- a/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/RefSpec.cs
@@ -11,11 +11,11 @@ internal sealed class RefSpec : IRefSpec
 
     internal RefSpec(LibGit2Sharp.RefSpec refSpec) => this.innerRefSpec = refSpec.NotNull();
     public int CompareTo(IRefSpec? other) => comparerHelper.Compare(this, other);
-    public bool Equals(IRefSpec? other) => equalityHelper.Equals(this, other);
     public string Specification => this.innerRefSpec.Specification;
     public RefSpecDirection Direction => (RefSpecDirection)this.innerRefSpec.Direction;
     public string Source => this.innerRefSpec.Source;
     public string Destination => this.innerRefSpec.Destination;
+    public bool Equals(IRefSpec? other) => equalityHelper.Equals(this, other);
     public override bool Equals(object? obj) => Equals(obj as IRefSpec);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => Specification;

--- a/src/GitVersion.LibGit2Sharp/Git/Reference.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Reference.cs
@@ -16,7 +16,9 @@ internal sealed class Reference : IReference
         Name = new ReferenceName(reference.CanonicalName);
 
         if (reference is DirectReference)
+        {
             ReferenceTargetId = new ObjectId(reference.TargetIdentifier);
+        }
     }
 
     public ReferenceName Name { get; }

--- a/src/GitVersion.LibGit2Sharp/Git/Remote.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Remote.cs
@@ -18,7 +18,6 @@ internal sealed class Remote : IRemote
     }
 
     public int CompareTo(IRemote? other) => comparerHelper.Compare(this, other);
-    public bool Equals(IRemote? other) => equalityHelper.Equals(this, other);
     public string Name => this.innerRemote.Name;
     public string Url => this.innerRemote.Url;
 
@@ -35,6 +34,7 @@ internal sealed class Remote : IRemote
 
     public IEnumerable<IRefSpec> FetchRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Fetch);
     public IEnumerable<IRefSpec> PushRefSpecs => RefSpecs.Where(x => x.Direction == RefSpecDirection.Push);
+    public bool Equals(IRemote? other) => equalityHelper.Equals(this, other);
     public override bool Equals(object? obj) => Equals(obj as IRemote);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => Name;

--- a/src/GitVersion.LibGit2Sharp/Git/Tag.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/Tag.cs
@@ -24,7 +24,6 @@ internal sealed class Tag : ITag
 
     public ReferenceName Name { get; }
     public int CompareTo(ITag? other) => comparerHelper.Compare(this, other);
-    public bool Equals(ITag? other) => equalityHelper.Equals(this, other);
     public string TargetSha => this.innerTag.Target.Sha;
     public ICommit Commit => this.commitLazy.Value.NotNull();
 
@@ -40,6 +39,7 @@ internal sealed class Tag : ITag
         return target is LibGit2Sharp.Commit commit ? this.repositoryCache.GetOrWrap(commit, this.diff) : null;
     }
 
+    public bool Equals(ITag? other) => equalityHelper.Equals(this, other);
     public override bool Equals(object? obj) => Equals(obj as ITag);
     public override int GetHashCode() => equalityHelper.GetHashCode(this);
     public override string ToString() => Name.ToString();

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
@@ -70,7 +70,11 @@ public class MsBuildTaskFixture(RepositoryFixtureBase fixture)
 
     private static void SetEnvironmentVariables(KeyValuePair<string, string?>[]? envs)
     {
-        if (envs == null) return;
+        if (envs == null)
+        {
+            return;
+        }
+
         foreach (var (key, value) in envs)
         {
             SysEnv.SetEnvironmentVariable(key, value);

--- a/src/GitVersion.MsBuild.Tests/Mocks/MockEngine.cs
+++ b/src/GitVersion.MsBuild.Tests/Mocks/MockEngine.cs
@@ -43,7 +43,9 @@ internal sealed class MockEngine : IBuildEngine4
     {
         // Only if the message is above the minimum importance should we record the log message
         if (e.Importance > MinimumMessageImportance)
+        {
             return;
+        }
 
         Console.WriteLine(e.Message);
         this.log.AppendLine(e.Message);

--- a/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
@@ -34,7 +34,11 @@ public abstract class TestTaskBase : TestBase
         task.SolutionDirectory = fixture.RepositoryPath;
         var msbuildFixture = new MsBuildTaskFixture(fixture);
         var result = msbuildFixture.Execute(task);
-        if (!result.Success) Console.WriteLine(result.Log);
+        if (!result.Success)
+        {
+            Console.WriteLine(result.Log);
+        }
+
         return result;
     }
 
@@ -47,7 +51,11 @@ public abstract class TestTaskBase : TestBase
         msbuildFixture.CreateTestProject(extendProject);
 
         var result = msbuildFixture.Execute();
-        if (!result.MsBuild.OverallSuccess) Console.WriteLine(result.Output);
+        if (!result.MsBuild.OverallSuccess)
+        {
+            Console.WriteLine(result.Output);
+        }
+
         return result;
     }
 
@@ -69,7 +77,11 @@ public abstract class TestTaskBase : TestBase
 
         var result = msbuildFixture.Execute(task);
 
-        if (!result.Success) Console.WriteLine(result.Log);
+        if (!result.Success)
+        {
+            Console.WriteLine(result.Log);
+        }
+
         return result;
     }
 
@@ -81,7 +93,9 @@ public abstract class TestTaskBase : TestBase
         msbuildFixture.WithEnv(new KeyValuePair<string, string?>("GITHUB_ACTIONS", "true"));
         var result = msbuildFixture.Execute(task);
         if (!result.Success)
+        {
             Console.WriteLine(result.Log);
+        }
 
         return result;
     }
@@ -96,7 +110,11 @@ public abstract class TestTaskBase : TestBase
         msbuildFixture.WithEnv([.. env]);
 
         var result = msbuildFixture.Execute();
-        if (!result.MsBuild.OverallSuccess) Console.WriteLine(result.Output);
+        if (!result.MsBuild.OverallSuccess)
+        {
+            Console.WriteLine(result.Output);
+        }
+
         return result;
     }
 

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -84,7 +84,11 @@ internal class GitVersionTaskExecutor(
         static string? GetTargetNamespace(GenerateGitVersionInformation task)
         {
             string? targetNamespace = null;
-            if (!bool.TryParse(task.UseProjectNamespaceForGitVersionInformation, out var useTargetPathAsRootNamespace) || !useTargetPathAsRootNamespace) return targetNamespace;
+            if (!bool.TryParse(task.UseProjectNamespaceForGitVersionInformation, out var useTargetPathAsRootNamespace) || !useTargetPathAsRootNamespace)
+            {
+                return targetNamespace;
+            }
+
             targetNamespace = task.RootNamespace;
             if (string.IsNullOrWhiteSpace(targetNamespace))
             {

--- a/src/GitVersion.MsBuild/Helpers/MsBuildAppender.cs
+++ b/src/GitVersion.MsBuild/Helpers/MsBuildAppender.cs
@@ -14,7 +14,7 @@ internal class MsBuildAppender(TaskLoggingHelper taskLog) : ILogAppender
         }
         catch
         {
-            //
+            // Logging failures must not break the build.
         }
     }
 

--- a/src/GitVersion.Output.Tests/Output/GitVersionInfoGeneratorTests.cs
+++ b/src/GitVersion.Output.Tests/Output/GitVersionInfoGeneratorTests.cs
@@ -70,7 +70,9 @@ public class GitVersionInfoGeneratorTests : TestBase
             Guid.NewGuid().ToString());
 
         if (!fileSystem.Directory.Exists(directory))
+        {
             fileSystem.Directory.CreateDirectory(directory);
+        }
 
         var fileName = "GitVersionInformation.g." + fileExtension;
         var fullPath = FileSystemHelper.Path.Combine(directory, fileName);

--- a/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
@@ -129,16 +129,26 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
             {
                 var lastMatch = assemblyMatches[^1];
                 var replacementString = lastMatch.Value;
-                if (!lastMatch.Value.EndsWith(NewLine)) replacementString += NewLine;
+                if (!lastMatch.Value.EndsWith(NewLine))
+                {
+                    replacementString += NewLine;
+                }
+
                 if (assemblyAddFormat != null)
+                {
                     replacementString += string.Format(assemblyAddFormat, replaceString);
+                }
+
                 replacementString += NewLine;
                 return inputString.Replace(lastMatch.Value, replacementString);
             }
         }
 
         if (assemblyAddFormat != null)
+        {
             inputString += NewLine + string.Format(assemblyAddFormat, replaceString);
+        }
+
         appendedAttributes = true;
         return inputString;
     }

--- a/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
@@ -33,10 +33,8 @@ internal sealed class ProjectFileUpdater(ILog log, IFileSystem fileSystem) : IPr
         var assemblyFileVersion = variables.AssemblySemFileVer;
         var packageVersion = variables.SemVer;
 
-        foreach (var projectFile in projectFilesToUpdate)
+        foreach (var localProjectFile in projectFilesToUpdate.Select(projectFile => projectFile.FullName))
         {
-            var localProjectFile = projectFile.FullName;
-
             var originalFileContents = fileSystem.File.ReadAllText(localProjectFile);
             XElement fileXml;
             try

--- a/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
@@ -24,7 +24,9 @@ internal sealed class ProjectFileUpdater(ILog log, IFileSystem fileSystem) : IPr
     public void Execute(GitVersionVariables variables, AssemblyInfoContext context)
     {
         if (context.EnsureAssemblyInfo)
+        {
             throw new WarningException($"Configuration setting {nameof(context.EnsureAssemblyInfo)} is not valid when updating project files!");
+        }
 
         var projectFilesToUpdate = GetProjectFiles(context).ToList();
 
@@ -123,7 +125,11 @@ internal sealed class ProjectFileUpdater(ILog log, IFileSystem fileSystem) : IPr
         }
 
         var lastGenerateAssemblyInfoElement = propertyGroups.SelectMany(s => s.Elements("GenerateAssemblyInfo")).LastOrDefault();
-        if (lastGenerateAssemblyInfoElement == null || (bool)lastGenerateAssemblyInfoElement) return true;
+        if (lastGenerateAssemblyInfoElement == null || (bool)lastGenerateAssemblyInfoElement)
+        {
+            return true;
+        }
+
         log.Warning("Project file specifies <GenerateAssemblyInfo>false</GenerateAssemblyInfo>: versions set in this project file will not affect the output artifacts.");
         return false;
     }

--- a/src/GitVersion.Output/GitVersionInfo/GitVersionInfoGenerator.cs
+++ b/src/GitVersion.Output/GitVersionInfo/GitVersionInfoGenerator.cs
@@ -34,7 +34,9 @@ internal sealed class GitVersionInfoGenerator(IFileSystem fileSystem) : IGitVers
         var targetNamespace = getTargetNamespace(fileExtension);
 
         if (string.IsNullOrWhiteSpace(template) || string.IsNullOrWhiteSpace(addFormat) || targetNamespace == targetNamespaceSentinelValue)
+        {
             return;
+        }
 
         var indentation = GetIndentation(fileExtension);
         string? closeBracket = null;

--- a/src/GitVersion.Output/GitVersionOutputTool.cs
+++ b/src/GitVersion.Output/GitVersionOutputTool.cs
@@ -53,7 +53,11 @@ internal class GitVersionOutputTool(
 
     public void UpdateWixVersionFile(GitVersionVariables variables)
     {
-        if (!this.gitVersionOptions.WixInfo.UpdateWixVersionFile) return;
+        if (!this.gitVersionOptions.WixInfo.UpdateWixVersionFile)
+        {
+            return;
+        }
+
         using (this.wixVersionFileUpdater)
         {
             this.wixVersionFileUpdater.Execute(variables, new WixVersionContext(this.gitVersionOptions.WorkingDirectory));

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -62,11 +62,17 @@ internal sealed class OutputGenerator(
             var retryOperation = new RetryAction<IOException>();
             retryOperation.Execute(() =>
             {
-                if (context.OutputFile != null) this.fileSystem.File.WriteAllText(context.OutputFile, json);
+                if (context.OutputFile != null)
+                {
+                    this.fileSystem.File.WriteAllText(context.OutputFile, json);
+                }
             });
         }
 
-        if (!gitVersionOptions.Output.Contains(OutputType.Json)) return;
+        if (!gitVersionOptions.Output.Contains(OutputType.Json))
+        {
+            return;
+        }
 
         if (gitVersionOptions.ShowVariable is null && gitVersionOptions.Format is null)
         {

--- a/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariableSerializer.cs
@@ -92,7 +92,11 @@ internal class VersionVariableSerializer(IFileSystem fileSystem) : IVersionVaria
 
     private static object? ChangeType(object? value, Type type)
     {
-        if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(Nullable<>)) return Convert.ChangeType(value, type);
+        if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(Nullable<>))
+        {
+            return Convert.ChangeType(value, type);
+        }
+
         if (value == null || value.ToString()?.Length == 0)
         {
             return null;

--- a/src/GitVersion.Output/Serializer/VersionVariablesJsonStringConverter.cs
+++ b/src/GitVersion.Output/Serializer/VersionVariablesJsonStringConverter.cs
@@ -11,11 +11,15 @@ internal class VersionVariablesJsonStringConverter : JsonConverter<string>
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.Number && typeToConvert == typeof(string))
+        {
             return reader.GetString() ?? "";
+        }
 
         var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
         if (Utf8Parser.TryParse(span, out long number, out var bytesConsumed) && span.Length == bytesConsumed)
+        {
             return number.ToString();
+        }
 
         var data = reader.GetString();
 

--- a/src/GitVersion.Output/TemplateManager.cs
+++ b/src/GitVersion.Output/TemplateManager.cs
@@ -55,7 +55,11 @@ internal class TemplateManager(TemplateType templateType)
 
         foreach (var name in assembly.GetManifestResourceNames())
         {
-            if (!name.Contains(templateType.ToString()) || !name.Contains(templateCategory)) continue;
+            if (!name.Contains(templateType.ToString()) || !name.Contains(templateCategory))
+            {
+                continue;
+            }
+
             var extension = FileSystemHelper.Path.GetExtension(name);
             if (string.IsNullOrWhiteSpace(extension))
             {

--- a/src/GitVersion.Output/WixUpdater/WixVersionFileUpdater.cs
+++ b/src/GitVersion.Output/WixUpdater/WixVersionFileUpdater.cs
@@ -11,12 +11,11 @@ internal sealed class WixVersionFileUpdater(ILog log, IFileSystem fileSystem) : 
 {
     private readonly IFileSystem fileSystem = fileSystem.NotNull();
     private readonly ILog log = log.NotNull();
-    private string? wixVersionFile;
     public const string WixVersionFileName = "GitVersion_WixVersion.wxi";
 
     public void Execute(GitVersionVariables variables, WixVersionContext context)
     {
-        this.wixVersionFile = FileSystemHelper.Path.Combine(context.WorkingDirectory, WixVersionFileName);
+        var wixVersionFile = FileSystemHelper.Path.Combine(context.WorkingDirectory, WixVersionFileName);
         this.log.Info("Updating GitVersion_WixVersion.wxi");
 
         var doc = new XmlDocument();
@@ -26,16 +25,16 @@ internal sealed class WixVersionFileUpdater(ILog log, IFileSystem fileSystem) : 
         var root = doc.DocumentElement;
         doc.InsertBefore(xmlDecl, root);
 
-        if (this.fileSystem.File.Exists(this.wixVersionFile))
+        if (this.fileSystem.File.Exists(wixVersionFile))
         {
-            this.fileSystem.File.Delete(this.wixVersionFile);
+            this.fileSystem.File.Delete(wixVersionFile);
         }
 
         if (!this.fileSystem.Directory.Exists(context.WorkingDirectory))
         {
             this.fileSystem.Directory.CreateDirectory(context.WorkingDirectory);
         }
-        using var fs = this.fileSystem.File.OpenWrite(this.wixVersionFile);
+        using var fs = this.fileSystem.File.OpenWrite(wixVersionFile);
         doc.Save(fs);
     }
 

--- a/src/GitVersion.Schema/FormatAttributeHandler.cs
+++ b/src/GitVersion.Schema/FormatAttributeHandler.cs
@@ -10,7 +10,11 @@ internal class FormatAttributeHandler : IAttributeHandler<FormatAttribute>
 {
     void IAttributeHandler.AddConstraints(SchemaGenerationContextBase context, Attribute attribute)
     {
-        if (attribute is not FormatAttribute formatAttribute) return;
+        if (attribute is not FormatAttribute formatAttribute)
+        {
+            return;
+        }
+
         var format = formatAttribute.Format switch
         {
             Format.Date => Formats.Date,
@@ -36,6 +40,8 @@ internal class FormatAttributeHandler : IAttributeHandler<FormatAttribute>
         };
 
         if (format != null)
+        {
             context.Intents.Insert(0, new FormatIntent(format));
+        }
     }
 }

--- a/src/GitVersion.Testing/Extensions/StringExtensions.cs
+++ b/src/GitVersion.Testing/Extensions/StringExtensions.cs
@@ -6,7 +6,10 @@ public static class StringExtensions
     {
         public IEnumerable<string> SplitIntoLines(int maxLineLength)
         {
-            if (string.IsNullOrEmpty(str)) yield break;
+            if (string.IsNullOrEmpty(str))
+            {
+                yield break;
+            }
 
             foreach (var line in SplitByNewlines(str))
             {

--- a/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
+++ b/src/GitVersion.Testing/Fixtures/SequenceDiagram.cs
@@ -44,9 +44,13 @@ public class SequenceDiagram
         var cleanParticipant = ParticipantSanitizer.SanitizeParticipant(@as ?? participant);
         this.participants.Add(participant, cleanParticipant);
         if (participant == cleanParticipant)
+        {
             DiagramBuilder.AppendLineFormat("participant {0}", participant);
+        }
         else
+        {
             DiagramBuilder.AppendLineFormat("participant \"{0}\" as {1}", participant, cleanParticipant);
+        }
     }
 
     /// <summary>

--- a/src/GitVersion.Testing/Helpers/ProcessHelper.cs
+++ b/src/GitVersion.Testing/Helpers/ProcessHelper.cs
@@ -127,23 +127,33 @@ public static partial class ProcessHelper
         {
             // ReSharper disable once AccessToDisposedClosure
             if (e.Data == null)
+            {
                 mreOut.Set();
+            }
             else
+            {
                 output(e.Data);
+            }
         };
         process.BeginOutputReadLine();
         process.ErrorDataReceived += (_, e) =>
         {
             // ReSharper disable once AccessToDisposedClosure
             if (e.Data == null)
+            {
                 mreErr.Set();
+            }
             else
+            {
                 errorOutput(e.Data);
+            }
         };
         process.BeginErrorReadLine();
 
         while (input?.ReadLine() is { } line)
+        {
             process.StandardInput.WriteLine(line);
+        }
 
         process.StandardInput.Close();
         process.WaitForExit();

--- a/tests/integration/Program.cs
+++ b/tests/integration/Program.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace App
 {
-    class Program
+    static class Program
     {
         static void Main(string[] args)
         {

--- a/tests/scripts/test-global-tool.sh
+++ b/tests/scripts/test-global-tool.sh
@@ -12,6 +12,8 @@ do
     --repoPath)
         repoPath="$2"
         ;;
+    *)
+        ;;
     esac
     shift
 done

--- a/tests/scripts/test-msbuild-task.sh
+++ b/tests/scripts/test-msbuild-task.sh
@@ -15,6 +15,8 @@ do
     --targetframework)
         targetframework="$2"
         ;;
+    *)
+        ;;
     esac
     shift
 done

--- a/tests/scripts/test-native-tool.sh
+++ b/tests/scripts/test-native-tool.sh
@@ -12,6 +12,8 @@ do
     --repoPath)
         repoPath="$2"
         ;;
+    *)
+        ;;
     esac
     shift
 done


### PR DESCRIPTION
Comprehensive SonarCloud cleanup across `src`, `new-cli`, and the `build`/`ci` solutions, plus two style-policy additions to `.editorconfig`. Code fixes are in this PR; analyzer false-positive / won't-fix dispositions were applied on SonarCloud directly.

## Code fixes

### GitVersion.Core
- **S1104 ×26** — public `Options` fields (`GitVersionOptions`, `Settings`, `RepositoryInfo`, …) encapsulated as auto-properties
- **S1006 ×9** — implementations now repeat the interface's default parameter values (`TaggedSemanticVersionService`, `ConfigurationProvider`)
- **S112 ×9** — throw `InvalidOperationException` / `DirectoryNotFoundException` instead of bare `System.Exception` (`EffectiveConfiguration`, `GitPreparer`)
- **S4035 ×4** — sealed the equality types `SemanticVersion`, `SemanticVersionBuildMetaData`, `ReferenceName`, `NextVersion`
- **S3267 ×6** — `foreach` + `if` simplified with LINQ `Where`/`Select`
- **S4136 ×5** — overloaded methods made adjacent
- **S3358 ×3** — nested ternaries extracted to `if`/`else` or locals
- **S3925 ×2** — dropped `[Serializable]` (`GitVersionException`, `WarningException`)
- **S1210 ×2** — comparison operators added to `IComparable<T>` types (`ReferenceName`, `SemanticVersionWithTag`)
- **S927 / S1066 / S3260** — parameter name aligned with base, nested `if` merged, private class sealed

### Other projects
- **GitVersion.LibGit2Sharp** — S112, S4136, S6608, S3220 (incl. fixing a latent `Split('/', '\\')` overload bug where `'\\'` bound to the `int count` parameter; now uses a cached `char[]` separator)
- **GitVersion.Configuration** — S1006, S3267, S3220, S3925
- **GitVersion.App** — S108, S4663
- **GitVersion.Output** — S3267, S1450
- **GitVersion.BuildAgents** — S112, S1125
- **new-cli (Cli.Generator)** — S1125
- **build / ci** — collection-expression conversions

### Style policy (`.editorconfig`)
- Enforce **collection expressions** (IDE0305) as error and apply across all solutions
- Enforce **braces** on all control-flow statements (IDE0011) as error and apply across all solutions
- Disable **S1192** (duplicate string literals) in `*.Tests` projects — repeated literals there are intentional test data

## Dispositions on SonarCloud (not code)
- **False Positive** — analyzer limitations rather than real problems: C# 14 `extension` blocks; `ArgumentParser` S2259/S2325 (null-safe `string?` extension members; instance-method call); `ConfigurationSerializer` S2325 ×2 (interface implementations can't be static); `TaggedSemanticVersionRepository` S2589 ×3 (`isCached` flips inside the `GetOrAdd` factory); `GitVersionCacheKeyFactory` S3220 (collection-expression call is not actually ambiguous); `JsonPropertyDescriptionAttribute` S3903; `GitVersionInformation` template S1199
- **Won't Fix / Accept** — S107 on DI constructors (parameter-object bundles intentionally avoided)

## Out of scope (deferred)
- **S3776** cognitive complexity ×12
- **S1135** TODO comments ×4 (INFO)
- Duplicated-lines metric on test projects — handled via SonarCloud Duplication Exclusions in project settings

## Verification
- `dotnet build` — 0 warnings / 0 errors on `src`, `new-cli`, and `build/CI` solutions
- `dotnet format --verify-no-changes` — clean on all three solutions
- Tests green (two environment-sensitive integration tests — a wall-clock perf assertion and a live-clone dynamic-repo test — flake only under full-suite load and pass in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
