### PR TITLE
fix: resolve S3267 and a batch of test-project SonarCloud issues

### DIFF
--- a/src/GitVersion.App.Tests/ArgumentParserOnBuildServerTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserOnBuildServerTests.cs
@@ -28,7 +28,7 @@ public class ArgumentParserOnBuildServerTests : TestBase
         arguments.NoFetch.ShouldBe(true);
     }
 
-    private class MockBuildAgent : ICurrentBuildAgent
+    private sealed class MockBuildAgent : ICurrentBuildAgent
     {
         public bool IsDefault => false;
         public bool CanApplyToCurrentContext() => throw new NotImplementedException();

--- a/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
@@ -91,7 +91,7 @@ public class ExecCmdLineArgumentTest
     public void WorkingDirectoryDoesNotExistFailsWithInformativeMessage()
     {
         var workingDirectory = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetCurrentDirectory(), Guid.NewGuid().ToString("N"));
-        var executable = ExecutableHelper.GetDotNetExecutable();
+        var executable = ExecutableHelper.DotNetExecutable;
 
         var output = new StringBuilder();
         var args = ExecutableHelper.GetExecutableArgs($" /targetpath {workingDirectory} ");

--- a/src/GitVersion.App.Tests/Helpers/ExecutableHelper.cs
+++ b/src/GitVersion.App.Tests/Helpers/ExecutableHelper.cs
@@ -4,7 +4,7 @@ namespace GitVersion.App.Tests.Helpers;
 
 public static class ExecutableHelper
 {
-    public static string GetDotNetExecutable() => "dotnet";
+    public const string DotNetExecutable = "dotnet";
 
     public static string GetExecutableArgs(string args) => $"{FileSystemHelper.Path.Combine(GetExeDirectory(), "gitversion.dll")} {args}";
 

--- a/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
+++ b/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
@@ -22,7 +22,7 @@ public static class GitVersionHelper
         params KeyValuePair<string, string?>[] environments
     )
     {
-        var executable = ExecutableHelper.GetDotNetExecutable();
+        var executable = ExecutableHelper.DotNetExecutable;
         var output = new StringBuilder();
 
         var environmentalVariables = new Dictionary<string, string?>

--- a/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
@@ -50,7 +50,7 @@ public class BuildServerBaseTests : TestBase
         writes.ShouldNotContain(x => x != null && x.StartsWith("Set Build Number for "));
     }
 
-    private class BuildAgent(IEnvironment environment, ILog log, IFileSystem fileSystem) : BuildAgentBase(environment, log, fileSystem)
+    private sealed class BuildAgent(IEnvironment environment, ILog log, IFileSystem fileSystem) : BuildAgentBase(environment, log, fileSystem)
     {
         protected override string EnvironmentVariable => throw new NotImplementedException();
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/BuildServerBaseTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
@@ -34,7 +35,7 @@ public class BuildServerBaseTests : TestBase
             BuildMetaData = new SemanticVersionBuildMetaData("5")
             {
                 Sha = "commitSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/CodeBuildTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/CodeBuildTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
@@ -81,7 +82,7 @@ public sealed class CodeBuildTests : TestBase
             BuildMetaData = new SemanticVersionBuildMetaData("5")
             {
                 Sha = "commitSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/DroneTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/DroneTests.cs
@@ -7,15 +7,14 @@ namespace GitVersion.BuildAgents.Tests;
 public class DroneTests : TestBase
 {
     private IEnvironment environment = null!;
-    private IServiceProvider sp = null!;
     private Drone buildServer = null!;
 
     [SetUp]
     public void SetUp()
     {
-        this.sp = ConfigureServices(services => services.AddSingleton<Drone>());
-        this.environment = this.sp.GetRequiredService<IEnvironment>();
-        this.buildServer = this.sp.GetRequiredService<Drone>();
+        var sp = ConfigureServices(services => services.AddSingleton<Drone>());
+        this.environment = sp.GetRequiredService<IEnvironment>();
+        this.buildServer = sp.GetRequiredService<Drone>();
         this.environment.SetEnvironmentVariable("DRONE", "true");
     }
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
@@ -121,7 +122,7 @@ public class GitLabCiTests : TestBase
             BuildMetaData = new SemanticVersionBuildMetaData("5")
             {
                 Sha = "commitSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 

--- a/src/GitVersion.BuildAgents.Tests/Agents/JenkinsTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/JenkinsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
@@ -134,7 +135,7 @@ public class JenkinsTests : TestBase
             Minor = 2,
             Patch = 3,
             PreReleaseTag = "beta1",
-            BuildMetaData = new SemanticVersionBuildMetaData("5") { Sha = "commitSha", CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z") }
+            BuildMetaData = new SemanticVersionBuildMetaData("5") { Sha = "commitSha", CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture) }
         };
 
         var variableProvider = this.sp.GetRequiredService<IVariableProvider>();

--- a/src/GitVersion.Core.Tests/CommitDateTests.cs
+++ b/src/GitVersion.Core.Tests/CommitDateTests.cs
@@ -12,7 +12,7 @@ public class CommitDateTests : TestBase
     [TestCase("yyyy-MM", "2017-10")]
     public void CommitDateFormatTest(string format, string expectedOutcome)
     {
-        var date = new DateTime(2017, 10, 6);
+        var date = new DateTime(2017, 10, 6, 0, 0, 0, DateTimeKind.Utc);
         var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(
             new SemanticVersion(1, 2, 2),
             "950d2f830f5a2af12a6779a48d20dcbb02351f25",

--- a/src/GitVersion.Core.Tests/Core/DynamicRepositoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/DynamicRepositoryTests.cs
@@ -11,11 +11,6 @@ public class DynamicRepositoryTests : TestBase
     [SetUp]
     public void SetUp() => this.workDirectory = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPathLegacy(), "GV");
 
-    [TearDown]
-    public void TearDown()
-    {
-    }
-
     // Note: use same name twice to see if changing commits works on same (cached) repository
     [NonParallelizable]
     [TestCase("GV_main", "https://github.com/GitTools/GitVersion", MainBranch, "2dc142a4a4df77db61a00d9fb7510b18b3c2c85a", "5.8.2-47")]

--- a/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionToolDirectoryTests.cs
@@ -7,7 +7,6 @@ namespace GitVersion.Tests;
 [TestFixture]
 public class GitVersionTaskDirectoryTests : TestBase
 {
-    private string gitDirectory = null!;
     private string workDirectory = null!;
     private IFileSystem fileSystem = null!;
 
@@ -17,8 +16,8 @@ public class GitVersionTaskDirectoryTests : TestBase
         var sp = ConfigureServices();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
         this.workDirectory = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), Guid.NewGuid().ToString());
-        this.gitDirectory = Repository.Init(this.workDirectory).TrimEnd(FileSystemHelper.Path.DirectorySeparatorChar);
-        Assert.That(this.gitDirectory, Is.Not.Null);
+        var gitDirectory = Repository.Init(this.workDirectory).TrimEnd(FileSystemHelper.Path.DirectorySeparatorChar);
+        Assert.That(gitDirectory, Is.Not.Null);
     }
 
     [TearDown]

--- a/src/GitVersion.Core.Tests/Formatting/DateFormatterTests.cs
+++ b/src/GitVersion.Core.Tests/Formatting/DateFormatterTests.cs
@@ -24,7 +24,7 @@ public class DateFormatterTests
     {
         // For UTC datetime strings, parse as UTC to ensure consistent behavior across timezones
         DateTime date;
-        if (input.EndsWith("Z"))
+        if (input.EndsWith('Z'))
         {
             date = DateTime.Parse(input, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         }

--- a/src/GitVersion.Core.Tests/Helpers/GitVersionContextBuilder.cs
+++ b/src/GitVersion.Core.Tests/Helpers/GitVersionContextBuilder.cs
@@ -3,13 +3,13 @@ using GitVersion.Git;
 
 namespace GitVersion.Tests;
 
-public class GitVersionContextBuilder : IDisposable
+public sealed class GitVersionContextBuilder : IDisposable
 {
     private IGitRepository? repository;
     private EmptyRepositoryFixture? emptyRepositoryFixture;
     private IReadOnlyDictionary<object, object?>? overrideConfiguration;
     private Action<IServiceCollection>? overrideServices;
-    public IServiceProvider? ServicesProvider;
+    public IServiceProvider? ServicesProvider { get; private set; }
 
     public GitVersionContextBuilder WithRepository(IGitRepository gitRepository)
     {
@@ -58,7 +58,7 @@ public class GitVersionContextBuilder : IDisposable
         this.emptyRepositoryFixture = new();
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.emptyRepositoryFixture.RepositoryPath, ConfigurationInfo = { OverrideConfiguration = this.overrideConfiguration } });
 
-        this.ServicesProvider = ConfigureServices(services =>
+        ServicesProvider = ConfigureServices(services =>
         {
             services.AddSingleton(options);
             services.AddSingleton(repo);
@@ -93,17 +93,6 @@ public class GitVersionContextBuilder : IDisposable
 
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (!disposing)
-        {
-            return;
-        }
-
         this.repository?.Dispose();
         this.emptyRepositoryFixture?.Dispose();
     }

--- a/src/GitVersion.Core.Tests/Helpers/TestBase.cs
+++ b/src/GitVersion.Core.Tests/Helpers/TestBase.cs
@@ -7,6 +7,10 @@ public class TestBase
 {
     public const string MainBranch = "main";
 
+    protected TestBase()
+    {
+    }
+
     protected static IServiceProvider ConfigureServices(Action<IServiceCollection>? overrideServices = null)
     {
         var services = new ServiceCollection()

--- a/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -193,7 +193,7 @@ public class MergeMessageBaseVersionStrategyTests : TestBase
             ? [new MockCommit(), new MockCommit()]
             : [new MockCommit()];
 
-    private class MockCommit : ICommit
+    private sealed class MockCommit : ICommit
     {
         public bool Equals(ICommit? other) => throw new NotImplementedException();
         public int CompareTo(ICommit? other) => throw new NotImplementedException();

--- a/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/VariableProviderTests.cs
@@ -42,7 +42,7 @@ public class VariableProviderTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -68,7 +68,7 @@ public class VariableProviderTests : TestBase
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
                 VersionSourceDistance = 5,
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -92,7 +92,7 @@ public class VariableProviderTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -118,7 +118,7 @@ public class VariableProviderTests : TestBase
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
                 VersionSourceDistance = 5,
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -144,7 +144,7 @@ public class VariableProviderTests : TestBase
                 VersionSourceDistance = 5,
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -169,7 +169,7 @@ public class VariableProviderTests : TestBase
                 Branch = "pull/2/merge",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -194,7 +194,7 @@ public class VariableProviderTests : TestBase
                 Branch = "feature",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -219,7 +219,7 @@ public class VariableProviderTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -244,7 +244,7 @@ public class VariableProviderTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -281,7 +281,7 @@ public class VariableProviderTests : TestBase
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
                 VersionSourceDistance = 5,
-                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2014-03-06 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -142,12 +142,9 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
                     break;
                 }
 
-                foreach (var commit in commitBranch.Branch.Commits.Where(element => element.When >= item.Commit.When))
+                if (commitBranch.Branch.Commits.Any(element => element.When >= item.Commit.When && element.Equals(item.Commit)))
                 {
-                    if (commit.Equals(item.Commit))
-                    {
-                        commitBranches.Remove(item);
-                    }
+                    commitBranches.Remove(item);
                 }
             }
         }
@@ -172,12 +169,9 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
                 continue;
             }
 
-            foreach (var item in branchGrouping)
+            foreach (var item in branchGrouping.Where(returnedBranches.Add))
             {
-                if (returnedBranches.Add(item))
-                {
-                    yield return item;
-                }
+                yield return item;
             }
         }
     }

--- a/src/GitVersion.Output.Tests/Output/WixFileTests.cs
+++ b/src/GitVersion.Output.Tests/Output/WixFileTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Abstractions;
 using GitVersion.Configuration;
 using GitVersion.Helpers;
@@ -36,7 +37,7 @@ internal class WixFileTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2019-02-20 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2019-02-20 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 
@@ -77,7 +78,7 @@ internal class WixFileTests : TestBase
                 VersionSourceSha = "versionSourceSha",
                 Sha = "commitSha",
                 ShortSha = "commitShortSha",
-                CommitDate = DateTimeOffset.Parse("2019-02-20 23:59:59Z")
+                CommitDate = DateTimeOffset.Parse("2019-02-20 23:59:59Z", CultureInfo.InvariantCulture)
             }
         };
 


### PR DESCRIPTION
Follow-up SonarCloud cleanup after #4990: a production fix plus a batch of test-project findings. Code fixes here; analyzer false-positives were dispositioned on SonarCloud.

## Production (GitVersion.Core)
- **S3267 ×2** (`RepositoryStore.GetCommitBranches`) — `foreach`+`if` simplified to `Any(...)` / `Where(returnedBranches.Add)`

## Test projects
- **S6580 ×16** — pass `CultureInfo.InvariantCulture` to `DateTimeOffset.Parse`
- **S3260 ×3** — seal private test helper classes (`MockBuildAgent`, `BuildAgent`, `MockCommit`)
- **S1450 ×2** — localise single-method fields (`DroneTests.sp`, `GitVersionTaskDirectoryTests.gitDirectory`)
- **S1118** — `protected` constructor on `TestBase`
- **S1104 / S3881** — encapsulate `GitVersionContextBuilder.ServicesProvider` as a property; seal the class + simple sealed-disposable pattern
- **S3400** — `ExecutableHelper.GetDotNetExecutable()` → `const`
- **S1186** — remove empty `DynamicRepositoryTests` teardown
- **S6562** — `DateTimeKind.Utc` in `CommitDateTests`
- **S6610** — char `EndsWith` overload in `DateFormatterTests`

## Dispositioned on SonarCloud (not code)
- **False Positive** — `MockEngine`/`MockTaskItem` **S2325 ×5** (interface implementations can't be static); `BuildServerBaseTests` **S1172 ×2** (`override` params can't be removed); `MergeMessageBaseVersionStrategyTests` **S2259** (guarded by Shouldly `ShouldNotBeNull`); `GenerateGitVersionInformationTest` **S3241** (callers do chain off the return)

## Verification
- `dotnet build ./src/GitVersion.slnx` — 0 warnings / 0 errors
- `dotnet format --verify-no-changes` — clean
- Tests green: BuildAgents 276, App 663, MsBuild 453, Output 369, Configuration 273, and the touched Core fixtures 75/75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
