### PR TITLE
test: localise per-method fileSystem fields (S1450)

### DIFF
--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationFileLocatorTests.cs
@@ -90,7 +90,6 @@ public static class ConfigurationFileLocatorTests
     {
         private string repoPath = null!;
         private string workingPath = null!;
-        private IFileSystem fileSystem = null!;
         private IConfigurationFileLocator configFileLocator = null!;
         private GitVersionOptions gitVersionOptions = null!;
         private string ConfigFile => this.gitVersionOptions.ConfigurationInfo.ConfigurationFile!;
@@ -110,10 +109,10 @@ public static class ConfigurationFileLocatorTests
         {
             var sp = GetServiceProvider(this.gitVersionOptions);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
-            using var repositoryConfigFilePath = this.fileSystem.SetupConfigFile(path: this.repoPath, fileName: ConfigFile);
-            using var workDirConfigFilePath = this.fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
+            using var repositoryConfigFilePath = fileSystem.SetupConfigFile(path: this.repoPath, fileName: ConfigFile);
+            using var workDirConfigFilePath = fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
 
             var exception = Should.Throw<WarningException>(() => this.configFileLocator.Verify(this.workingPath, this.repoPath));
 
@@ -128,9 +127,9 @@ public static class ConfigurationFileLocatorTests
 
             var sp = GetServiceProvider(this.gitVersionOptions);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
-            using var _ = this.fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
+            using var _ = fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
 
             Should.NotThrow(() => this.configFileLocator.Verify(this.workingPath, this.repoPath));
         }
@@ -142,9 +141,9 @@ public static class ConfigurationFileLocatorTests
 
             var sp = GetServiceProvider(this.gitVersionOptions);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
-            using var _ = this.fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
+            using var _ = fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
 
             Should.NotThrow(() => this.configFileLocator.Verify(this.workingPath, this.repoPath));
         }
@@ -158,9 +157,9 @@ public static class ConfigurationFileLocatorTests
             this.gitVersionOptions = new() { ConfigurationInfo = { ConfigurationFile = configurationFilePath } };
 
             var serviceProvider = GetServiceProvider(this.gitVersionOptions);
-            this.fileSystem = serviceProvider.GetRequiredService<IFileSystem>();
+            var fileSystem = serviceProvider.GetRequiredService<IFileSystem>();
 
-            using var _ = this.fileSystem.SetupConfigFile(
+            using var _ = fileSystem.SetupConfigFile(
                 path: FileSystemHelper.Path.Combine(this.workingPath, "Configuration"), fileName: "CustomConfig.yaml"
             );
             this.configFileLocator = serviceProvider.GetRequiredService<IConfigurationFileLocator>();
@@ -193,9 +192,9 @@ public static class ConfigurationFileLocatorTests
             this.gitVersionOptions = new() { ConfigurationInfo = { ConfigurationFile = "./src/my-config.yaml" } };
             var sp = GetServiceProvider(this.gitVersionOptions);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
-            using var _ = this.fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
+            using var _ = fileSystem.SetupConfigFile(path: this.workingPath, fileName: ConfigFile);
 
             Should.NotThrow(() => this.configFileLocator.Verify(this.workingPath, this.repoPath));
         }
@@ -210,9 +209,9 @@ public static class ConfigurationFileLocatorTests
 
             var sp = GetServiceProvider(this.gitVersionOptions, log);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
-            using var _ = this.fileSystem.SetupConfigFile(path: null, fileName: ConfigFile);
+            using var _ = fileSystem.SetupConfigFile(path: null, fileName: ConfigFile);
 
             var configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
 
@@ -233,10 +232,10 @@ public static class ConfigurationFileLocatorTests
 
             var sp = GetServiceProvider(this.gitVersionOptions, log);
             this.configFileLocator = sp.GetRequiredService<IConfigurationFileLocator>();
-            this.fileSystem = sp.GetRequiredService<IFileSystem>();
+            var fileSystem = sp.GetRequiredService<IFileSystem>();
 
             var path = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "unrelatedPath");
-            using var _ = this.fileSystem.SetupConfigFile(path: path, fileName: ConfigFile);
+            using var _ = fileSystem.SetupConfigFile(path: path, fileName: ConfigFile);
 
             var configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
@@ -1236,15 +1236,5 @@ public class DocumentationSamplesForGitFlow
 
         fixture.Checkout("main");
         fixture.AssertFullSemver("2.0.0-1", configuration);
-        //fixture.MergeNoFF("support/1.x");
-        //fixture.AssertFullSemver("2.0.1-6", configuration);
-
-        //fixture.Checkout("support/1.x");
-        //fixture.MakeACommit();
-        //fixture.AssertFullSemver("1.2.4-1", configuration);
-
-        //fixture.Checkout("main");
-        //fixture.MergeNoFF("support/1.x");
-        //fixture.AssertFullSemver("2.0.2-2", configuration);
     }
 }

--- a/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/ProjectFileUpdaterTests.cs
@@ -17,7 +17,6 @@ public class ProjectFileUpdaterTests : TestBase
     private const string TargetFramework = "net10.0";
     private IVariableProvider variableProvider = null!;
     private ILog log = null!;
-    private IFileSystem fileSystem = null!;
     private ProjectFileUpdater projectFileUpdater = null!;
     private List<string> logMessages = null!;
 
@@ -30,9 +29,9 @@ public class ProjectFileUpdaterTests : TestBase
         this.logMessages = [];
         this.log = new Log(new TestLogAppender(this.logMessages.Add));
 
-        this.fileSystem = sp.GetRequiredService<IFileSystem>();
+        var fileSystem = sp.GetRequiredService<IFileSystem>();
         this.variableProvider = sp.GetRequiredService<IVariableProvider>();
-        this.projectFileUpdater = new ProjectFileUpdater(this.log, this.fileSystem);
+        this.projectFileUpdater = new ProjectFileUpdater(this.log, fileSystem);
     }
 
     [TearDown]
@@ -326,9 +325,9 @@ public class ProjectFileUpdaterTests : TestBase
         var configuration = EmptyConfigurationBuilder.New.WithAssemblyVersioningScheme(versioningScheme).Build();
         var variables = this.variableProvider.GetVariablesFor(version, configuration, 0);
 
-        this.fileSystem = Substitute.For<IFileSystem>();
-        this.fileSystem.File.Returns(file);
-        this.fileSystem.FileInfo.Returns(new FileSystem().FileInfo);
-        verify?.Invoke(this.fileSystem, variables);
+        var fileSystem = Substitute.For<IFileSystem>();
+        fileSystem.File.Returns(file);
+        fileSystem.FileInfo.Returns(new FileSystem().FileInfo);
+        verify?.Invoke(fileSystem, variables);
     }
 }


### PR DESCRIPTION
Resolves the two remaining **S1450** findings (test projects).

In `ProjectFileUpdaterTests` and `NamedConfigurationFileLocatorTests`, the `fileSystem` field is assigned and used **independently within each method** (each test re-creates it; no method relies on another's value), so it should be a local variable, not a field.

- `ProjectFileUpdaterTests` — localised in `Setup` and `VerifyAssemblyInfoFile`
- `NamedConfigurationFileLocatorTests` — localised in each test method (the sibling `DefaultConfigFileLocatorTests`, which genuinely shares its `fileSystem` across methods from `Setup`, is left as a field)

## Verification
- `dotnet build ./src/GitVersion.slnx` — 0 warnings / 0 errors
- `dotnet format --verify-no-changes` — clean
- Tests: Output.Tests 369, Configuration.Tests 273 — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)