### PR TITLE
refactor: reduce cognitive complexity (S3776)

### DIFF
--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -248,9 +248,8 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
-        if (name.IsSwitch("diag"))
+        if (ParseBooleanArguments(arguments, name))
         {
-            arguments.Diag = true;
             return true;
         }
 
@@ -297,6 +296,23 @@ internal class ArgumentParser(IEnvironment environment,
             return true;
         }
 
+        if (!name.IsSwitch("verbosity"))
+        {
+            return false;
+        }
+
+        arguments.Verbosity = ParseVerbosity(value);
+        return true;
+    }
+
+    private static bool ParseBooleanArguments(Arguments arguments, string? name)
+    {
+        if (name.IsSwitch("diag"))
+        {
+            arguments.Diag = true;
+            return true;
+        }
+
         if (name.IsSwitch("nofetch"))
         {
             arguments.NoFetch = true;
@@ -318,12 +334,6 @@ internal class ArgumentParser(IEnvironment environment,
         if (name.IsSwitch("allowshallow"))
         {
             arguments.AllowShallow = true;
-            return true;
-        }
-
-        if (name.IsSwitch("verbosity"))
-        {
-            arguments.Verbosity = ParseVerbosity(value);
             return true;
         }
 

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -395,21 +395,8 @@ internal class GitPreparer(
             return;
         }
 
-        const string referencePrefix = "refs/";
         var isLocalBranch = currentBranch.StartsWith(ReferenceName.LocalBranchPrefix);
-        string localCanonicalName;
-        if (!currentBranch.StartsWith(referencePrefix))
-        {
-            localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch;
-        }
-        else if (isLocalBranch)
-        {
-            localCanonicalName = currentBranch;
-        }
-        else
-        {
-            localCanonicalName = ReferenceName.LocalBranchPrefix + currentBranch[referencePrefix.Length..];
-        }
+        var localCanonicalName = ResolveLocalCanonicalName(currentBranch, isLocalBranch);
 
         var repoTip = this.repository.Head.Tip;
 
@@ -425,27 +412,48 @@ internal class GitPreparer(
 
         if (repoTipId != null)
         {
-            var referenceName = ReferenceName.Parse(localCanonicalName);
-            if (this.repository.Branches.All(b => !b.Name.Equals(referenceName)))
-            {
-                this.log.Info(isLocalBranch
-                    ? $"Creating local branch {referenceName}"
-                    : $"Creating local branch {referenceName} pointing at {repoTipId}");
-                this.repository.References.Add(localCanonicalName, repoTipId.Sha);
-            }
-            else
-            {
-                this.log.Info(isLocalBranch
-                    ? $"Updating local branch {referenceName} to point at {repoTipId}"
-                    : $"Updating local branch {referenceName} to match ref {currentBranch}");
-                var localRef = this.repository.References[localCanonicalName];
-                if (localRef != null)
-                {
-                    this.retryAction.Execute(() => this.repository.References.UpdateTarget(localRef, repoTipId));
-                }
-            }
+            CreateOrUpdateLocalBranch(localCanonicalName, repoTipId, isLocalBranch, currentBranch);
         }
+
         Checkout(localCanonicalName);
+    }
+
+    private static string ResolveLocalCanonicalName(string currentBranch, bool isLocalBranch)
+    {
+        const string referencePrefix = "refs/";
+        if (!currentBranch.StartsWith(referencePrefix))
+        {
+            return ReferenceName.LocalBranchPrefix + currentBranch;
+        }
+
+        if (isLocalBranch)
+        {
+            return currentBranch;
+        }
+
+        return ReferenceName.LocalBranchPrefix + currentBranch[referencePrefix.Length..];
+    }
+
+    private void CreateOrUpdateLocalBranch(string localCanonicalName, IObjectId repoTipId, bool isLocalBranch, string currentBranch)
+    {
+        var referenceName = ReferenceName.Parse(localCanonicalName);
+        if (this.repository.Branches.All(b => !b.Name.Equals(referenceName)))
+        {
+            this.log.Info(isLocalBranch
+                ? $"Creating local branch {referenceName}"
+                : $"Creating local branch {referenceName} pointing at {repoTipId}");
+            this.repository.References.Add(localCanonicalName, repoTipId.Sha);
+            return;
+        }
+
+        this.log.Info(isLocalBranch
+            ? $"Updating local branch {referenceName} to point at {repoTipId}"
+            : $"Updating local branch {referenceName} to match ref {currentBranch}");
+        var localRef = this.repository.References[localCanonicalName];
+        if (localRef != null)
+        {
+            this.retryAction.Execute(() => this.repository.References.UpdateTarget(localRef, repoTipId));
+        }
     }
 
     private void Checkout(string commitOrBranchSpec) => this.retryAction.Execute(() => this.repository.Checkout(commitOrBranchSpec));

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -120,6 +120,21 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
 
         var commitBranches = FindCommitBranchesBranchedFrom(branch, configuration, excludedBranches).ToHashSet();
 
+        var ignore = CollectIgnoredMergeCommitBranches(branch, commitBranches);
+
+        RemoveCommitBranchesFoundInOtherBranches(commitBranches, ignore);
+
+        foreach (var branchGrouping in commitBranches.GroupBy(element => element.Commit, element => element.Branch))
+        {
+            foreach (var item in GetSourceBranchesForGrouping(branchGrouping, referenceLookup, returnedBranches))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private static HashSet<BranchCommit> CollectIgnoredMergeCommitBranches(IBranch branch, HashSet<BranchCommit> commitBranches)
+    {
         var ignore = new HashSet<BranchCommit>();
         foreach (var commitBranch in commitBranches)
         {
@@ -133,6 +148,11 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
             }
         }
 
+        return ignore;
+    }
+
+    private static void RemoveCommitBranchesFoundInOtherBranches(HashSet<BranchCommit> commitBranches, HashSet<BranchCommit> ignore)
+    {
         foreach (var item in commitBranches.Skip(1).Reverse().Where(item => !ignore.Contains(item)))
         {
             foreach (var commitBranch in commitBranches)
@@ -148,31 +168,32 @@ internal class RepositoryStore(ILog log, IGitRepository repository) : IRepositor
                 }
             }
         }
+    }
 
-        foreach (var branchGrouping in commitBranches.GroupBy(element => element.Commit, element => element.Branch))
+    private static IEnumerable<IBranch> GetSourceBranchesForGrouping(
+        IGrouping<ICommit, IBranch> branchGrouping, ILookup<string, IReference> referenceLookup, HashSet<IBranch> returnedBranches)
+    {
+        var referenceMatchFound = false;
+        var referenceNames = referenceLookup[branchGrouping.Key.Sha].Select(element => element.Name).ToHashSet();
+
+        foreach (var item in branchGrouping.Where(item => referenceNames.Contains(item.Name)))
         {
-            var referenceMatchFound = false;
-            var referenceNames = referenceLookup[branchGrouping.Key.Sha].Select(element => element.Name).ToHashSet();
-
-            foreach (var item in branchGrouping.Where(item => referenceNames.Contains(item.Name)))
-            {
-                if (returnedBranches.Add(item))
-                {
-                    yield return item;
-                }
-
-                referenceMatchFound = true;
-            }
-
-            if (referenceMatchFound)
-            {
-                continue;
-            }
-
-            foreach (var item in branchGrouping.Where(returnedBranches.Add))
+            if (returnedBranches.Add(item))
             {
                 yield return item;
             }
+
+            referenceMatchFound = true;
+        }
+
+        if (referenceMatchFound)
+        {
+            yield break;
+        }
+
+        foreach (var item in branchGrouping.Where(returnedBranches.Add))
+        {
+            yield return item;
         }
     }
 

--- a/src/GitVersion.Core/SemVer/SemanticVersion.cs
+++ b/src/GitVersion.Core/SemVer/SemanticVersion.cs
@@ -362,76 +362,56 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
     public SemanticVersion Increment(
         VersionField increment, string? label, IncrementMode mode, params SemanticVersion?[] alternativeSemanticVersions)
     {
-        var major = Major;
-        var minor = Minor;
-        var patch = Patch;
-        var preReleaseNumber = PreReleaseTag.Number;
-
         var hasPreReleaseTag = PreReleaseTag.HasTag();
 
-        switch (increment)
+        var (major, minor, patch, preReleaseNumber) = ApplyIncrement(increment, mode, hasPreReleaseTag);
+
+        var (semanticVersion, foundAlternativeSemanticVersion) =
+            SelectAlternativeIfGreater(new SemanticVersion(major, minor, patch), alternativeSemanticVersions);
+        major = semanticVersion.Major;
+        minor = semanticVersion.Minor;
+        patch = semanticVersion.Patch;
+
+        if (foundAlternativeSemanticVersion && increment == VersionField.None)
         {
-            case VersionField.None:
-                preReleaseNumber++;
-                break;
-
-            case VersionField.Patch:
-                if (hasPreReleaseTag && (mode == IncrementMode.Standard
-                    || (mode == IncrementMode.EnsureIntegrity && patch != 0)))
-                {
-                    preReleaseNumber++;
-                }
-                else
-                {
-                    patch++;
-                    if (preReleaseNumber.HasValue)
-                    {
-                        preReleaseNumber = 1;
-                    }
-                }
-                break;
-
-            case VersionField.Minor:
-                if (hasPreReleaseTag && (mode == IncrementMode.Standard
-                    || (mode == IncrementMode.EnsureIntegrity && minor != 0 && patch == 0)))
-                {
-                    preReleaseNumber++;
-                }
-                else
-                {
-                    minor++;
-                    patch = 0;
-                    if (preReleaseNumber.HasValue)
-                    {
-                        preReleaseNumber = 1;
-                    }
-                }
-                break;
-
-            case VersionField.Major:
-                if (hasPreReleaseTag && (mode == IncrementMode.Standard
-                    || (mode == IncrementMode.EnsureIntegrity && major != 0 && minor == 0 && patch == 0)))
-                {
-                    preReleaseNumber++;
-                }
-                else
-                {
-                    major++;
-                    minor = 0;
-                    patch = 0;
-                    if (preReleaseNumber.HasValue)
-                    {
-                        preReleaseNumber = 1;
-                    }
-                }
-                break;
-
-            default:
-                throw new ArgumentOutOfRangeException(nameof(increment));
+            preReleaseNumber = 1;
         }
 
-        SemanticVersion semanticVersion = new(major, minor, patch);
+        return BuildIncrementedVersion(major, minor, patch, preReleaseNumber, hasPreReleaseTag, label);
+    }
 
+    private (long Major, long Minor, long Patch, long? PreReleaseNumber) ApplyIncrement(
+        VersionField increment, IncrementMode mode, bool hasPreReleaseTag)
+    {
+        var preReleaseNumber = PreReleaseTag.Number;
+        return increment switch
+        {
+            VersionField.None => (Major, Minor, Patch, preReleaseNumber + 1),
+            VersionField.Patch => IncrementField(mode, hasPreReleaseTag, Patch != 0, Major, Minor, Patch + 1, preReleaseNumber),
+            VersionField.Minor => IncrementField(mode, hasPreReleaseTag, Minor != 0 && Patch == 0, Major, Minor + 1, 0, preReleaseNumber),
+            VersionField.Major => IncrementField(mode, hasPreReleaseTag, Major != 0 && Minor == 0 && Patch == 0, Major + 1, 0, 0, preReleaseNumber),
+            _ => throw new ArgumentOutOfRangeException(nameof(increment))
+        };
+    }
+
+    private (long Major, long Minor, long Patch, long? PreReleaseNumber) IncrementField(
+        IncrementMode mode, bool hasPreReleaseTag, bool integrityCondition,
+        long bumpedMajor, long bumpedMinor, long bumpedPatch, long? preReleaseNumber)
+    {
+        if (ShouldIncrementPreReleaseNumber(mode, hasPreReleaseTag, integrityCondition))
+        {
+            return (Major, Minor, Patch, preReleaseNumber + 1);
+        }
+
+        return (bumpedMajor, bumpedMinor, bumpedPatch, preReleaseNumber.HasValue ? 1 : preReleaseNumber);
+    }
+
+    private static bool ShouldIncrementPreReleaseNumber(IncrementMode mode, bool hasPreReleaseTag, bool integrityCondition)
+        => hasPreReleaseTag && (mode == IncrementMode.Standard || (mode == IncrementMode.EnsureIntegrity && integrityCondition));
+
+    private static (SemanticVersion Version, bool Found) SelectAlternativeIfGreater(
+        SemanticVersion semanticVersion, SemanticVersion?[] alternativeSemanticVersions)
+    {
         var foundAlternativeSemanticVersion = false;
         foreach (var alternativeSemanticVersion in alternativeSemanticVersions)
         {
@@ -444,15 +424,12 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
             foundAlternativeSemanticVersion = true;
         }
 
-        major = semanticVersion.Major;
-        minor = semanticVersion.Minor;
-        patch = semanticVersion.Patch;
+        return (semanticVersion, foundAlternativeSemanticVersion);
+    }
 
-        if (foundAlternativeSemanticVersion && increment == VersionField.None)
-        {
-            preReleaseNumber = 1;
-        }
-
+    private SemanticVersion BuildIncrementedVersion(
+        long major, long minor, long patch, long? preReleaseNumber, bool hasPreReleaseTag, string? label)
+    {
         string preReleaseTagName;
         if (hasPreReleaseTag)
         {
@@ -464,13 +441,11 @@ public sealed class SemanticVersion : IFormattable, IComparable<SemanticVersion>
             preReleaseTagName = string.Empty;
         }
 
-        if (label is null || preReleaseTagName == label)
+        if (label is not null && preReleaseTagName != label)
         {
-            return new SemanticVersion(this) { Major = major, Minor = minor, Patch = patch, PreReleaseTag = new SemanticVersionPreReleaseTag(preReleaseTagName, preReleaseNumber, true) };
+            preReleaseNumber = 1;
+            preReleaseTagName = label;
         }
-
-        preReleaseNumber = 1;
-        preReleaseTagName = label;
 
         return new SemanticVersion(this)
         {

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -70,64 +70,19 @@ internal class GitVersionCacheKeyFactory(
             var di = this.fileSystem.DirectoryInfo.New(currentDir);
             result.Add(di.Name);
 
-            string[] subDirs;
-            try
+            var subDirs = TryGetDirectories(currentDir);
+            if (subDirs is null)
             {
-                subDirs = this.fileSystem.Directory.GetDirectories(currentDir);
-            }
-            // An UnauthorizedAccessException exception will be thrown if we do not have
-            // discovery permission on a folder or file. It may or may not be acceptable
-            // to ignore the exception and continue enumerating the remaining files and
-            // folders. It is also possible (but unlikely) that a DirectoryNotFound exception
-            // will be raised. This will happen if currentDir has been deleted by
-            // another application or thread after our call to Directory.Exists. The
-            // choice of which exceptions to catch depends entirely on the specific task
-            // you are intending to perform and also on how much you know with certainty
-            // about the systems on which this code will run.
-            catch (UnauthorizedAccessException e)
-            {
-                this.log.Error(e.Message);
-                continue;
-            }
-            catch (DirectoryNotFoundException e)
-            {
-                this.log.Error(e.Message);
                 continue;
             }
 
-            string[] files;
-            try
+            var files = TryGetFiles(currentDir);
+            if (files is null)
             {
-                files = this.fileSystem.Directory.GetFiles(currentDir);
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                this.log.Error(e.Message);
-                continue;
-            }
-            catch (DirectoryNotFoundException e)
-            {
-                this.log.Error(e.Message);
                 continue;
             }
 
-            foreach (var file in files)
-            {
-                try
-                {
-                    if (!this.fileSystem.File.Exists(file))
-                    {
-                        continue;
-                    }
-
-                    result.Add(FileSystemHelper.Path.GetFileName(file));
-                    result.Add(this.fileSystem.File.ReadAllText(file));
-                }
-                catch (IOException e)
-                {
-                    this.log.Error(e.Message);
-                }
-            }
+            AddFileContents(files, result);
 
             // Push the subdirectories onto the stack for traversal.
             // This could also be done before handing the files.
@@ -139,6 +94,72 @@ internal class GitVersionCacheKeyFactory(
         }
 
         return result;
+    }
+
+    private string[]? TryGetDirectories(string currentDir)
+    {
+        try
+        {
+            return this.fileSystem.Directory.GetDirectories(currentDir);
+        }
+        // An UnauthorizedAccessException exception will be thrown if we do not have
+        // discovery permission on a folder or file. It may or may not be acceptable
+        // to ignore the exception and continue enumerating the remaining files and
+        // folders. It is also possible (but unlikely) that a DirectoryNotFound exception
+        // will be raised. This will happen if currentDir has been deleted by
+        // another application or thread after our call to Directory.Exists. The
+        // choice of which exceptions to catch depends entirely on the specific task
+        // you are intending to perform and also on how much you know with certainty
+        // about the systems on which this code will run.
+        catch (UnauthorizedAccessException e)
+        {
+            this.log.Error(e.Message);
+            return null;
+        }
+        catch (DirectoryNotFoundException e)
+        {
+            this.log.Error(e.Message);
+            return null;
+        }
+    }
+
+    private string[]? TryGetFiles(string currentDir)
+    {
+        try
+        {
+            return this.fileSystem.Directory.GetFiles(currentDir);
+        }
+        catch (UnauthorizedAccessException e)
+        {
+            this.log.Error(e.Message);
+            return null;
+        }
+        catch (DirectoryNotFoundException e)
+        {
+            this.log.Error(e.Message);
+            return null;
+        }
+    }
+
+    private void AddFileContents(string[] files, List<string> result)
+    {
+        foreach (var file in files)
+        {
+            try
+            {
+                if (!this.fileSystem.File.Exists(file))
+                {
+                    continue;
+                }
+
+                result.Add(FileSystemHelper.Path.GetFileName(file));
+                result.Add(this.fileSystem.File.ReadAllText(file));
+            }
+            catch (IOException e)
+            {
+                this.log.Error(e.Message);
+            }
+        }
     }
 
     private string GetRepositorySnapshotHash()

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -32,41 +32,37 @@ internal sealed class EffectiveBranchConfigurationFinder(ILog log, IRepositorySt
             branchConfiguration = childBranchConfiguration.Inherit(branchConfiguration);
         }
 
-        IBranch[] sourceBranches = [];
-        if (branchConfiguration.Increment == IncrementStrategy.Inherit)
-        {
-            // At this point we need to check if source branches are available.
-            sourceBranches = [.. this.repositoryStore.GetSourceBranches(branch, configuration, traversedBranches)];
-
-            if (sourceBranches.Length == 0)
-            {
-                // Because the actual branch is marked with the inherit increment strategy we need to either skip the iteration or go further
-                // while inheriting from the fallback branch configuration. This behavior is configurable via the increment settings of the configuration.
-                var skipTraversingOfOrphanedBranches = configuration.Increment == IncrementStrategy.Inherit;
-                this.log.Info(
-                    $"An orphaned branch '{branch}' has been detected and will be skipped={skipTraversingOfOrphanedBranches}."
-                );
-                if (skipTraversingOfOrphanedBranches)
-                {
-                    yield break;
-                }
-            }
-        }
-
-        if (branchConfiguration.Increment == IncrementStrategy.Inherit && sourceBranches.Length != 0)
-        {
-            foreach (var sourceBranch in sourceBranches)
-            {
-                foreach (var effectiveConfiguration
-                    in GetEffectiveConfigurationsRecursive(sourceBranch, configuration, branchConfiguration, traversedBranches))
-                {
-                    yield return effectiveConfiguration;
-                }
-            }
-        }
-        else
+        if (branchConfiguration.Increment != IncrementStrategy.Inherit)
         {
             yield return new(new(configuration, branchConfiguration), branch);
+            yield break;
+        }
+
+        // At this point we need to check if source branches are available.
+        IBranch[] sourceBranches = [.. this.repositoryStore.GetSourceBranches(branch, configuration, traversedBranches)];
+
+        if (sourceBranches.Length == 0)
+        {
+            // Because the actual branch is marked with the inherit increment strategy we need to either skip the iteration or go further
+            // while inheriting from the fallback branch configuration. This behavior is configurable via the increment settings of the configuration.
+            var skipTraversingOfOrphanedBranches = configuration.Increment == IncrementStrategy.Inherit;
+            this.log.Info(
+                $"An orphaned branch '{branch}' has been detected and will be skipped={skipTraversingOfOrphanedBranches}."
+            );
+            if (!skipTraversingOfOrphanedBranches)
+            {
+                yield return new(new(configuration, branchConfiguration), branch);
+            }
+            yield break;
+        }
+
+        foreach (var sourceBranch in sourceBranches)
+        {
+            foreach (var effectiveConfiguration
+                in GetEffectiveConfigurationsRecursive(sourceBranch, configuration, branchConfiguration, traversedBranches))
+            {
+                yield return effectiveConfiguration;
+            }
         }
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -30,44 +30,53 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
                );
 
             context.Label ??= baseVersion.Operator?.Label;
-
-            var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-            var increment = VersionField.None;
-            if (!effectiveConfiguration.PreventIncrementOfMergedBranch)
-            {
-                increment = increment.Consolidate(context.Increment);
-            }
-
-            if (!effectiveConfiguration.PreventIncrementWhenBranchMerged)
-            {
-                increment = increment.Consolidate(baseVersion.Operator?.Increment);
-            }
-
-            if (effectiveConfiguration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
-            {
-                increment = increment.Consolidate(commit.Increment);
-            }
-            context.Increment = increment;
-
-            if (baseVersion.BaseVersionSource is not null)
-            {
-                context.BaseVersionSource = baseVersion.BaseVersionSource;
-                context.SemanticVersion = baseVersion.SemanticVersion;
-            }
-            else
-            {
-                if (baseVersion.SemanticVersion != SemanticVersion.Empty)
-                {
-                    context.AlternativeSemanticVersions.Add(baseVersion.SemanticVersion);
-                }
-
-                if (baseVersion.Operator?.AlternativeSemanticVersion is not null)
-                {
-                    context.AlternativeSemanticVersions.Add(baseVersion.Operator.AlternativeSemanticVersion);
-                }
-            }
+            context.Increment = ConsolidateIncrement(commit, context, baseVersion);
+            ApplyBaseVersion(context, baseVersion);
 
             yield break;
+        }
+    }
+
+    private static VersionField ConsolidateIncrement(MainlineCommit commit, MainlineContext context, BaseVersion baseVersion)
+    {
+        var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
+        var increment = VersionField.None;
+
+        if (!effectiveConfiguration.PreventIncrementOfMergedBranch)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        if (!effectiveConfiguration.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(baseVersion.Operator?.Increment);
+        }
+
+        if (effectiveConfiguration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+        {
+            increment = increment.Consolidate(commit.Increment);
+        }
+
+        return increment;
+    }
+
+    private static void ApplyBaseVersion(MainlineContext context, BaseVersion baseVersion)
+    {
+        if (baseVersion.BaseVersionSource is not null)
+        {
+            context.BaseVersionSource = baseVersion.BaseVersionSource;
+            context.SemanticVersion = baseVersion.SemanticVersion;
+            return;
+        }
+
+        if (baseVersion.SemanticVersion != SemanticVersion.Empty)
+        {
+            context.AlternativeSemanticVersions.Add(baseVersion.SemanticVersion);
+        }
+
+        if (baseVersion.Operator?.AlternativeSemanticVersion is not null)
+        {
+            context.AlternativeSemanticVersions.Add(baseVersion.Operator.AlternativeSemanticVersion);
         }
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -254,47 +254,67 @@ internal class NextVersionCalculator(
             var effectiveBranchConfigurations = this.effectiveBranchConfigurationFinder.GetConfigurations(branch, configuration).ToArray();
             foreach (var effectiveBranchConfiguration in effectiveBranchConfigurations)
             {
-                using (this.log.IndentLog($"Calculating base versions for '{effectiveBranchConfiguration.Branch.Name}'"))
+                foreach (var nextVersion in GetNextVersions(effectiveBranchConfiguration, configuration))
                 {
-                    var strategies = this.versionStrategies.ToList();
-                    var fallbackVersionStrategy = strategies.Find(element => element is FallbackVersionStrategy);
-                    if (fallbackVersionStrategy is not null)
-                    {
-                        strategies.Remove(fallbackVersionStrategy);
-                        strategies.Add(fallbackVersionStrategy);
-                    }
-
-                    var atLeastOneBaseVersionReturned = false;
-                    foreach (var versionStrategy in strategies)
-                    {
-                        if (atLeastOneBaseVersionReturned && versionStrategy is FallbackVersionStrategy)
-                        {
-                            continue;
-                        }
-
-                        using (this.log.IndentLog($"[Using '{versionStrategy.GetType().Name}' strategy]"))
-                        {
-                            foreach (var baseVersion in versionStrategy.GetBaseVersions(effectiveBranchConfiguration))
-                            {
-                                this.log.Info(baseVersion.ToString());
-                                if (!IncludeVersion(baseVersion, configuration.Ignore))
-                                {
-                                    continue;
-                                }
-
-                                atLeastOneBaseVersionReturned = true;
-
-                                yield return new NextVersion(
-                                    incrementedVersion: baseVersion.GetIncrementedVersion(),
-                                    baseVersion: baseVersion,
-                                    configuration: effectiveBranchConfiguration
-                                );
-                            }
-                        }
-                    }
+                    yield return nextVersion;
                 }
             }
         }
+    }
+
+    private IEnumerable<NextVersion> GetNextVersions(EffectiveBranchConfiguration effectiveBranchConfiguration, IGitVersionConfiguration configuration)
+    {
+        using (this.log.IndentLog($"Calculating base versions for '{effectiveBranchConfiguration.Branch.Name}'"))
+        {
+            var atLeastOneBaseVersionReturned = false;
+            foreach (var versionStrategy in OrderStrategiesWithFallbackLast())
+            {
+                if (atLeastOneBaseVersionReturned && versionStrategy is FallbackVersionStrategy)
+                {
+                    continue;
+                }
+
+                foreach (var nextVersion in GetNextVersions(versionStrategy, effectiveBranchConfiguration, configuration))
+                {
+                    atLeastOneBaseVersionReturned = true;
+                    yield return nextVersion;
+                }
+            }
+        }
+    }
+
+    private IEnumerable<NextVersion> GetNextVersions(IVersionStrategy versionStrategy, EffectiveBranchConfiguration effectiveBranchConfiguration, IGitVersionConfiguration configuration)
+    {
+        using (this.log.IndentLog($"[Using '{versionStrategy.GetType().Name}' strategy]"))
+        {
+            foreach (var baseVersion in versionStrategy.GetBaseVersions(effectiveBranchConfiguration))
+            {
+                this.log.Info(baseVersion.ToString());
+                if (!IncludeVersion(baseVersion, configuration.Ignore))
+                {
+                    continue;
+                }
+
+                yield return new NextVersion(
+                    incrementedVersion: baseVersion.GetIncrementedVersion(),
+                    baseVersion: baseVersion,
+                    configuration: effectiveBranchConfiguration
+                );
+            }
+        }
+    }
+
+    private List<IVersionStrategy> OrderStrategiesWithFallbackLast()
+    {
+        var strategies = this.versionStrategies.ToList();
+        var fallbackVersionStrategy = strategies.Find(element => element is FallbackVersionStrategy);
+        if (fallbackVersionStrategy is not null)
+        {
+            strategies.Remove(fallbackVersionStrategy);
+            strategies.Add(fallbackVersionStrategy);
+        }
+
+        return strategies;
     }
 
     private bool IncludeVersion(IBaseVersion baseVersion, IIgnoreConfiguration ignoreConfiguration)

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -140,15 +140,14 @@ internal sealed class MainlineVersionStrategy(
     {
         traversedCommits ??= [];
 
-        var returnTrueWhenTheIncrementIsKnown = false;
-
-        var configuration = iteration.Configuration;
-        var branchName = iteration.BranchName;
-        var branch = this.repositoryStore.FindBranch(branchName);
-
+        var branch = this.repositoryStore.FindBranch(iteration.BranchName);
         var currentBranch = branch;
-        Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Value)>>> commitsWasBranchedFromLazy = new(
-            () => currentBranch is null ? [] : GetCommitsWasBranchedFrom(currentBranch)
+        TraversalState state = new(
+            configuration: iteration.Configuration,
+            branchName: iteration.BranchName,
+            branch: branch,
+            taggedSemanticVersions: taggedSemanticVersions,
+            commitsWasBranchedFromLazy: new(() => currentBranch is null ? [] : GetCommitsWasBranchedFrom(currentBranch))
         );
 
         foreach (var item in commitsInReverseOrder)
@@ -158,145 +157,188 @@ internal sealed class MainlineVersionStrategy(
                 continue;
             }
 
-            if (commitsWasBranchedFromLazy.Value.TryGetValue(item, out var effectiveConfigurationsWasBranchedFrom))
-            {
-                var effectiveConfigurationWasBranchedFrom = effectiveConfigurationsWasBranchedFrom[0];
+            ApplyBranchedFromTransition(item, iteration, targetBranch, state);
 
-                if (configuration.IsMainBranch != true || effectiveConfigurationWasBranchedFrom.Value.IsMainBranch == true)
-                {
-                    var excludeBranch = branch;
-                    if (effectiveConfigurationsWasBranchedFrom.Any(element =>
-                        !element.Branch.Equals(effectiveConfigurationWasBranchedFrom.Branch)
-                            && element.Branch.Equals(targetBranch)))
-                    {
-                        iteration.CreateCommit(null, targetBranch.Name, Context.Configuration.GetBranchConfiguration(targetBranch));
-                    }
-                    configuration = effectiveConfigurationWasBranchedFrom.Value;
-                    branchName = effectiveConfigurationWasBranchedFrom.Branch.Name;
-
-                    branch = this.repositoryStore.FindBranch(branchName);
-
-                    var branchPointer = branch;
-                    IBranch[] excludeBranches = excludeBranch is null ? [] : [excludeBranch];
-                    commitsWasBranchedFromLazy = new Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Configuration)>>>
-                        (() => branchPointer is null ? []
-                            : GetCommitsWasBranchedFrom(branchPointer, excludeBranches)
-                    );
-
-                    var taggedSemanticVersion = TaggedSemanticVersions.OfBranch;
-                    if ((configuration.TrackMergeTarget ?? Context.Configuration.TrackMergeTarget) == true)
-                    {
-                        taggedSemanticVersion |= TaggedSemanticVersions.OfMergeTargets;
-                    }
-                    if ((configuration.TracksReleaseBranches ?? Context.Configuration.TracksReleaseBranches) == true)
-                    {
-                        taggedSemanticVersion |= TaggedSemanticVersions.OfReleaseBranches;
-                    }
-                    if (!(configuration.IsMainBranch == true || configuration.IsReleaseBranch == true))
-                    {
-                        taggedSemanticVersion |= TaggedSemanticVersions.OfMainBranches;
-                    }
-                    taggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
-                        branch: effectiveConfigurationWasBranchedFrom.Branch,
-                        configuration: Context.Configuration,
-                        label: null,
-                        notOlderThan: Context.CurrentCommit.When,
-                        taggedSemanticVersion: taggedSemanticVersion
-                    );
-                }
-            }
-
-            var commit = iteration.CreateCommit(item, branchName, configuration);
-
-            var semanticVersions = taggedSemanticVersions[item].ToArray();
-            commit.AddSemanticVersions(semanticVersions.Select(element => element.Value));
-
-            var label = targetLabel ?? new EffectiveConfiguration(
-                configuration: Context.Configuration,
-                branchConfiguration: configuration
-            ).GetBranchSpecificLabel(branchName, null, this.environment);
-
-            foreach (var semanticVersion in semanticVersions)
-            {
-                if (!semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
-                {
-                    continue;
-                }
-
-                if (configuration.Increment != IncrementStrategy.Inherit)
-                {
-                    return true;
-                }
-
-                returnTrueWhenTheIncrementIsKnown = true;
-            }
-
-            if (returnTrueWhenTheIncrementIsKnown && configuration.Increment != IncrementStrategy.Inherit)
+            var (commit, stop) = ProcessCommit(item, iteration, targetLabel, state);
+            if (stop)
             {
                 return true;
             }
 
-            if (!item.IsMergeCommit)
-            {
-                continue;
-            }
-
-            Lazy<IReadOnlyCollection<ICommit>> mergedCommitsInReverseOrderLazy = new(
-                () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 1, Context.Configuration.Ignore).Reverse()]
-            );
-
-            if ((configuration.TrackMergeMessage ?? Context.Configuration.TrackMergeMessage) != true
-                || !MergeMessage.TryParse(item, Context.Configuration, out var mergeMessage))
-            {
-                continue;
-            }
-
-            if (mergeMessage.MergedBranch is null || mergeMessage.MergedBranch.EquivalentTo(branchName.WithoutOrigin))
-            {
-                continue;
-            }
-
-            var childConfiguration = Context.Configuration.GetBranchConfiguration(mergeMessage.MergedBranch);
-            var childBranchName = mergeMessage.MergedBranch;
-
-            if (childConfiguration.IsMainBranch == true)
-            {
-                if (configuration.IsMainBranch == true)
-                {
-                    throw new NotImplementedException();
-                }
-
-                mergedCommitsInReverseOrderLazy = new(
-                    () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 0, Context.Configuration.Ignore).Reverse()]
-                );
-                childConfiguration = configuration;
-                childBranchName = iteration.BranchName;
-            }
-
-            var childIteration = CreateIteration(
-                branchName: childBranchName,
-                configuration: childConfiguration,
-                parentIteration: iteration,
-                parentCommit: commit
-            );
-
-            var done = IterateOverCommitsRecursive(
-                commitsInReverseOrder: mergedCommitsInReverseOrderLazy.Value,
-                iteration: childIteration,
-                targetBranch: targetBranch,
-                targetLabel: targetLabel,
-                taggedSemanticVersions: taggedSemanticVersions,
-                traversedCommits: traversedCommits);
-
-            commit.AddChildIteration(childIteration);
-            if (done)
+            if (item.IsMergeCommit
+                && HandleMergeCommit(item, commit, iteration, targetBranch, targetLabel, state, traversedCommits))
             {
                 return true;
             }
-
-            traversedCommits.AddRange(mergedCommitsInReverseOrderLazy.Value);
         }
         return false;
+    }
+
+    private void ApplyBranchedFromTransition(
+        ICommit item, MainlineIteration iteration, IBranch targetBranch, TraversalState state)
+    {
+        if (!state.CommitsWasBranchedFromLazy.Value.TryGetValue(item, out var effectiveConfigurationsWasBranchedFrom))
+        {
+            return;
+        }
+
+        var effectiveConfigurationWasBranchedFrom = effectiveConfigurationsWasBranchedFrom[0];
+
+        if (state.Configuration.IsMainBranch == true && effectiveConfigurationWasBranchedFrom.Value.IsMainBranch != true)
+        {
+            return;
+        }
+
+        var excludeBranch = state.Branch;
+        if (effectiveConfigurationsWasBranchedFrom.Any(element =>
+            !element.Branch.Equals(effectiveConfigurationWasBranchedFrom.Branch)
+                && element.Branch.Equals(targetBranch)))
+        {
+            iteration.CreateCommit(null, targetBranch.Name, Context.Configuration.GetBranchConfiguration(targetBranch));
+        }
+
+        state.Configuration = effectiveConfigurationWasBranchedFrom.Value;
+        state.BranchName = effectiveConfigurationWasBranchedFrom.Branch.Name;
+        state.Branch = this.repositoryStore.FindBranch(state.BranchName);
+
+        var branchPointer = state.Branch;
+        IBranch[] excludeBranches = excludeBranch is null ? [] : [excludeBranch];
+        state.CommitsWasBranchedFromLazy = new(
+            () => branchPointer is null ? [] : GetCommitsWasBranchedFrom(branchPointer, excludeBranches)
+        );
+
+        var taggedSemanticVersion = TaggedSemanticVersions.OfBranch;
+        if ((state.Configuration.TrackMergeTarget ?? Context.Configuration.TrackMergeTarget) == true)
+        {
+            taggedSemanticVersion |= TaggedSemanticVersions.OfMergeTargets;
+        }
+        if ((state.Configuration.TracksReleaseBranches ?? Context.Configuration.TracksReleaseBranches) == true)
+        {
+            taggedSemanticVersion |= TaggedSemanticVersions.OfReleaseBranches;
+        }
+        if (!(state.Configuration.IsMainBranch == true || state.Configuration.IsReleaseBranch == true))
+        {
+            taggedSemanticVersion |= TaggedSemanticVersions.OfMainBranches;
+        }
+        state.TaggedSemanticVersions = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
+            branch: effectiveConfigurationWasBranchedFrom.Branch,
+            configuration: Context.Configuration,
+            label: null,
+            notOlderThan: Context.CurrentCommit.When,
+            taggedSemanticVersion: taggedSemanticVersion
+        );
+    }
+
+    private (MainlineCommit Commit, bool Stop) ProcessCommit(
+        ICommit item, MainlineIteration iteration, string? targetLabel, TraversalState state)
+    {
+        var commit = iteration.CreateCommit(item, state.BranchName, state.Configuration);
+
+        var semanticVersions = state.TaggedSemanticVersions[item].ToArray();
+        commit.AddSemanticVersions(semanticVersions.Select(element => element.Value));
+
+        var label = targetLabel ?? new EffectiveConfiguration(
+            configuration: Context.Configuration,
+            branchConfiguration: state.Configuration
+        ).GetBranchSpecificLabel(state.BranchName, null, this.environment);
+
+        foreach (var semanticVersion in semanticVersions)
+        {
+            if (!semanticVersion.Value.IsMatchForBranchSpecificLabel(label))
+            {
+                continue;
+            }
+
+            if (state.Configuration.Increment != IncrementStrategy.Inherit)
+            {
+                return (commit, true);
+            }
+
+            state.ReturnTrueWhenTheIncrementIsKnown = true;
+        }
+
+        if (state.ReturnTrueWhenTheIncrementIsKnown && state.Configuration.Increment != IncrementStrategy.Inherit)
+        {
+            return (commit, true);
+        }
+
+        return (commit, false);
+    }
+
+    private bool HandleMergeCommit(
+        ICommit item, MainlineCommit commit, MainlineIteration iteration, IBranch targetBranch,
+        string? targetLabel, TraversalState state, HashSet<ICommit> traversedCommits)
+    {
+        Lazy<IReadOnlyCollection<ICommit>> mergedCommitsInReverseOrderLazy = new(
+            () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 1, Context.Configuration.Ignore).Reverse()]
+        );
+
+        if ((state.Configuration.TrackMergeMessage ?? Context.Configuration.TrackMergeMessage) != true
+            || !MergeMessage.TryParse(item, Context.Configuration, out var mergeMessage))
+        {
+            return false;
+        }
+
+        if (mergeMessage.MergedBranch is null || mergeMessage.MergedBranch.EquivalentTo(state.BranchName.WithoutOrigin))
+        {
+            return false;
+        }
+
+        var childConfiguration = Context.Configuration.GetBranchConfiguration(mergeMessage.MergedBranch);
+        var childBranchName = mergeMessage.MergedBranch;
+
+        if (childConfiguration.IsMainBranch == true)
+        {
+            if (state.Configuration.IsMainBranch == true)
+            {
+                throw new NotImplementedException();
+            }
+
+            mergedCommitsInReverseOrderLazy = new(
+                () => [.. this.incrementStrategyFinder.GetMergedCommits(item, 0, Context.Configuration.Ignore).Reverse()]
+            );
+            childConfiguration = state.Configuration;
+            childBranchName = iteration.BranchName;
+        }
+
+        var childIteration = CreateIteration(
+            branchName: childBranchName,
+            configuration: childConfiguration,
+            parentIteration: iteration,
+            parentCommit: commit
+        );
+
+        var done = IterateOverCommitsRecursive(
+            commitsInReverseOrder: mergedCommitsInReverseOrderLazy.Value,
+            iteration: childIteration,
+            targetBranch: targetBranch,
+            targetLabel: targetLabel,
+            taggedSemanticVersions: state.TaggedSemanticVersions,
+            traversedCommits: traversedCommits);
+
+        commit.AddChildIteration(childIteration);
+        if (done)
+        {
+            return true;
+        }
+
+        traversedCommits.AddRange(mergedCommitsInReverseOrderLazy.Value);
+        return false;
+    }
+
+    private sealed class TraversalState(
+        IBranchConfiguration configuration,
+        ReferenceName branchName,
+        IBranch? branch,
+        ILookup<ICommit, SemanticVersionWithTag> taggedSemanticVersions,
+        Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Value)>>> commitsWasBranchedFromLazy)
+    {
+        public IBranchConfiguration Configuration { get; set; } = configuration;
+        public ReferenceName BranchName { get; set; } = branchName;
+        public IBranch? Branch { get; set; } = branch;
+        public ILookup<ICommit, SemanticVersionWithTag> TaggedSemanticVersions { get; set; } = taggedSemanticVersions;
+        public Lazy<IReadOnlyDictionary<ICommit, List<(IBranch Branch, IBranchConfiguration Value)>>> CommitsWasBranchedFromLazy { get; set; } = commitsWasBranchedFromLazy;
+        public bool ReturnTrueWhenTheIncrementIsKnown { get; set; }
     }
 
     private Dictionary<ICommit, List<(IBranch, IBranchConfiguration)>> GetCommitsWasBranchedFrom(

--- a/src/GitVersion.MsBuild.Tests/Helpers/EventArgsFormatting.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/EventArgsFormatting.cs
@@ -155,29 +155,7 @@ internal static class EventArgsFormatting
         else
         {
             format.Append("{1}");
-
-            if (lineNumber == 0)
-            {
-                format.Append(" : ");
-            }
-            else
-            {
-                if (columnNumber == 0)
-                {
-                    format.Append(endLineNumber == 0 ? "({2}): " : "({2}-{7}): ");
-                }
-                else
-                {
-                    if (endLineNumber == 0)
-                    {
-                        format.Append(endColumnNumber == 0 ? "({2},{3}): " : "({2},{3}-{8}): ");
-                    }
-                    else
-                    {
-                        format.Append(endColumnNumber == 0 ? "({2}-{7},{3}): " : "({2},{3},{7},{8}): ");
-                    }
-                }
-            }
+            format.Append(GetPositionFormat(lineNumber, endLineNumber, columnNumber, endColumnNumber));
         }
 
         if (!string.IsNullOrWhiteSpace(subcategory))
@@ -228,6 +206,29 @@ internal static class EventArgsFormatting
         }
 
         return formattedMessage.ToString();
+    }
+
+    /// <summary>
+    /// Selects the line/column position format placeholder for the given coordinates.
+    /// </summary>
+    private static string GetPositionFormat(int lineNumber, int endLineNumber, int columnNumber, int endColumnNumber)
+    {
+        if (lineNumber == 0)
+        {
+            return " : ";
+        }
+
+        if (columnNumber == 0)
+        {
+            return endLineNumber == 0 ? "({2}): " : "({2}-{7}): ";
+        }
+
+        if (endLineNumber == 0)
+        {
+            return endColumnNumber == 0 ? "({2},{3}): " : "({2},{3}-{8}): ";
+        }
+
+        return endColumnNumber == 0 ? "({2}-{7},{3}): " : "({2},{3},{7},{8}): ";
     }
 
     /// <summary>

--- a/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
@@ -31,64 +31,62 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
         log.Info("Updating assembly info files");
         log.Info($"Found {assemblyInfoFiles.Count} files");
 
-        var assemblyVersion = variables.AssemblySemVer;
-        var assemblyVersionString = !assemblyVersion.IsNullOrWhiteSpace() ? $"AssemblyVersion(\"{assemblyVersion}\")" : null;
-
-        var assemblyInfoVersion = variables.InformationalVersion;
-        var assemblyInfoVersionString = !assemblyInfoVersion.IsNullOrWhiteSpace() ? $"AssemblyInformationalVersion(\"{assemblyInfoVersion}\")" : null;
-
-        var assemblyFileVersion = variables.AssemblySemFileVer;
-        var assemblyFileVersionString = !assemblyFileVersion.IsNullOrWhiteSpace() ? $"AssemblyFileVersion(\"{assemblyFileVersion}\")" : null;
-
         foreach (var assemblyInfoFile in assemblyInfoFiles)
         {
-            var localAssemblyInfo = assemblyInfoFile.FullName;
-            var backupAssemblyInfo = localAssemblyInfo + ".bak";
-            fileSystem.File.Copy(localAssemblyInfo, backupAssemblyInfo, true);
-
-            this.restoreBackupTasks.Add(() =>
-            {
-                if (fileSystem.File.Exists(localAssemblyInfo))
-                {
-                    fileSystem.File.Delete(localAssemblyInfo);
-                }
-
-                fileSystem.File.Move(backupAssemblyInfo, localAssemblyInfo);
-            });
-
-            this.cleanupBackupTasks.Add(() => fileSystem.File.Delete(backupAssemblyInfo));
-
-            var originalFileContents = fileSystem.File.ReadAllText(localAssemblyInfo);
-            var fileContents = originalFileContents;
-            var appendedAttributes = false;
-
-            if (!assemblyVersion.IsNullOrWhiteSpace())
-            {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyVersionRegex, fileContents, assemblyVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
-            }
-
-            if (!assemblyFileVersion.IsNullOrWhiteSpace())
-            {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyFileVersionRegex, fileContents, assemblyFileVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
-            }
-
-            if (!assemblyInfoVersion.IsNullOrWhiteSpace())
-            {
-                fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyInfoVersionRegex, fileContents, assemblyInfoVersionString, assemblyInfoFile.Extension, ref appendedAttributes);
-            }
-
-            if (appendedAttributes)
-            {
-                // If we appended any attributes, put a new line after them
-                fileContents += NewLine;
-            }
-
-            if (originalFileContents != fileContents)
-            {
-                fileSystem.File.WriteAllText(localAssemblyInfo, fileContents);
-            }
+            UpdateAssemblyInfoFile(assemblyInfoFile, variables);
         }
+
         CommitChanges();
+    }
+
+    private void UpdateAssemblyInfoFile(IFileInfo assemblyInfoFile, GitVersionVariables variables)
+    {
+        var localAssemblyInfo = assemblyInfoFile.FullName;
+        var backupAssemblyInfo = localAssemblyInfo + ".bak";
+        fileSystem.File.Copy(localAssemblyInfo, backupAssemblyInfo, true);
+
+        this.restoreBackupTasks.Add(() =>
+        {
+            if (fileSystem.File.Exists(localAssemblyInfo))
+            {
+                fileSystem.File.Delete(localAssemblyInfo);
+            }
+
+            fileSystem.File.Move(backupAssemblyInfo, localAssemblyInfo);
+        });
+
+        this.cleanupBackupTasks.Add(() => fileSystem.File.Delete(backupAssemblyInfo));
+
+        var originalFileContents = fileSystem.File.ReadAllText(localAssemblyInfo);
+        var fileContents = originalFileContents;
+        var appendedAttributes = false;
+        var extension = assemblyInfoFile.Extension;
+
+        if (!variables.AssemblySemVer.IsNullOrWhiteSpace())
+        {
+            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyVersionRegex, fileContents, $"AssemblyVersion(\"{variables.AssemblySemVer}\")", extension, ref appendedAttributes);
+        }
+
+        if (!variables.AssemblySemFileVer.IsNullOrWhiteSpace())
+        {
+            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyFileVersionRegex, fileContents, $"AssemblyFileVersion(\"{variables.AssemblySemFileVer}\")", extension, ref appendedAttributes);
+        }
+
+        if (!variables.InformationalVersion.IsNullOrWhiteSpace())
+        {
+            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyInfoVersionRegex, fileContents, $"AssemblyInformationalVersion(\"{variables.InformationalVersion}\")", extension, ref appendedAttributes);
+        }
+
+        if (appendedAttributes)
+        {
+            // If we appended any attributes, put a new line after them
+            fileContents += NewLine;
+        }
+
+        if (originalFileContents != fileContents)
+        {
+            fileSystem.File.WriteAllText(localAssemblyInfo, fileContents);
+        }
     }
 
     public void Dispose()

--- a/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/AssemblyInfoFileUpdater.cs
@@ -64,17 +64,23 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
 
         if (!variables.AssemblySemVer.IsNullOrWhiteSpace())
         {
-            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyVersionRegex, fileContents, $"AssemblyVersion(\"{variables.AssemblySemVer}\")", extension, ref appendedAttributes);
+            var result = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyVersionRegex, fileContents, $"AssemblyVersion(\"{variables.AssemblySemVer}\")", extension);
+            fileContents = result.Content;
+            appendedAttributes |= result.Appended;
         }
 
         if (!variables.AssemblySemFileVer.IsNullOrWhiteSpace())
         {
-            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyFileVersionRegex, fileContents, $"AssemblyFileVersion(\"{variables.AssemblySemFileVer}\")", extension, ref appendedAttributes);
+            var result = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyFileVersionRegex, fileContents, $"AssemblyFileVersion(\"{variables.AssemblySemFileVer}\")", extension);
+            fileContents = result.Content;
+            appendedAttributes |= result.Appended;
         }
 
         if (!variables.InformationalVersion.IsNullOrWhiteSpace())
         {
-            fileContents = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyInfoVersionRegex, fileContents, $"AssemblyInformationalVersion(\"{variables.InformationalVersion}\")", extension, ref appendedAttributes);
+            var result = ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(RegexPatterns.Output.AssemblyInfoVersionRegex, fileContents, $"AssemblyInformationalVersion(\"{variables.InformationalVersion}\")", extension);
+            fileContents = result.Content;
+            appendedAttributes |= result.Appended;
         }
 
         if (appendedAttributes)
@@ -111,13 +117,13 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
         this.restoreBackupTasks.Clear();
     }
 
-    private string ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(Regex replaceRegex, string inputString, string? replaceString, string fileExtension, ref bool appendedAttributes)
+    private (string Content, bool Appended) ReplaceOrInsertAfterLastAssemblyAttributeOrAppend(Regex replaceRegex, string inputString, string? replaceString, string fileExtension)
     {
         var assemblyAddFormat = this.templateManager.GetAddFormatFor(fileExtension);
 
         if (replaceRegex.IsMatch(inputString) && replaceString != null)
         {
-            return replaceRegex.Replace(inputString, replaceString);
+            return (replaceRegex.Replace(inputString, replaceString), false);
         }
 
         if (this.assemblyAttributeRegexes.TryGetValue(fileExtension, out var assemblyRegex))
@@ -138,7 +144,7 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
                 }
 
                 replacementString += NewLine;
-                return inputString.Replace(lastMatch.Value, replacementString);
+                return (inputString.Replace(lastMatch.Value, replacementString), false);
             }
         }
 
@@ -147,8 +153,7 @@ internal sealed class AssemblyInfoFileUpdater(ILog log, IFileSystem fileSystem) 
             inputString += NewLine + string.Format(assemblyAddFormat, replaceString);
         }
 
-        appendedAttributes = true;
-        return inputString;
+        return (inputString, true);
     }
 
     private IEnumerable<IFileInfo> GetAssemblyInfoFiles(AssemblyInfoContext context)

--- a/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
+++ b/src/GitVersion.Output/AssemblyInfo/ProjectFileUpdater.cs
@@ -30,75 +30,80 @@ internal sealed class ProjectFileUpdater(ILog log, IFileSystem fileSystem) : IPr
 
         var projectFilesToUpdate = GetProjectFiles(context).ToList();
 
+        foreach (var localProjectFile in projectFilesToUpdate.Select(projectFile => projectFile.FullName))
+        {
+            UpdateProjectFile(localProjectFile, variables);
+        }
+
+        CommitChanges();
+    }
+
+    private void UpdateProjectFile(string localProjectFile, GitVersionVariables variables)
+    {
         var assemblyVersion = variables.AssemblySemVer;
         var assemblyInfoVersion = variables.InformationalVersion;
         var assemblyFileVersion = variables.AssemblySemFileVer;
         var packageVersion = variables.SemVer;
 
-        foreach (var localProjectFile in projectFilesToUpdate.Select(projectFile => projectFile.FullName))
+        var originalFileContents = fileSystem.File.ReadAllText(localProjectFile);
+        XElement fileXml;
+        try
         {
-            var originalFileContents = fileSystem.File.ReadAllText(localProjectFile);
-            XElement fileXml;
-            try
-            {
-                fileXml = XElement.Parse(originalFileContents);
-            }
-            catch (XmlException e)
-            {
-                throw new XmlException($"Unable to parse file as xml: {localProjectFile}", e);
-            }
-
-            if (!CanUpdateProjectFile(fileXml))
-            {
-                log.Warning($"Unable to update file: {localProjectFile}");
-                continue;
-            }
-
-            log.Debug($"Update file: {localProjectFile}");
-
-            var backupProjectFile = localProjectFile + ".bak";
-            fileSystem.File.Copy(localProjectFile, backupProjectFile, true);
-
-            this.restoreBackupTasks.Add(() =>
-            {
-                if (fileSystem.File.Exists(localProjectFile))
-                {
-                    fileSystem.File.Delete(localProjectFile);
-                }
-
-                fileSystem.File.Move(backupProjectFile, localProjectFile);
-            });
-
-            this.cleanupBackupTasks.Add(() => fileSystem.File.Delete(backupProjectFile));
-
-            if (!assemblyVersion.IsNullOrWhiteSpace())
-            {
-                UpdateProjectVersionElement(fileXml, AssemblyVersionElement, assemblyVersion);
-            }
-
-            if (!assemblyFileVersion.IsNullOrWhiteSpace())
-            {
-                UpdateProjectVersionElement(fileXml, FileVersionElement, assemblyFileVersion);
-            }
-
-            if (!assemblyInfoVersion.IsNullOrWhiteSpace())
-            {
-                UpdateProjectVersionElement(fileXml, InformationalVersionElement, assemblyInfoVersion);
-            }
-
-            if (!packageVersion.IsNullOrWhiteSpace())
-            {
-                UpdateProjectVersionElement(fileXml, VersionElement, packageVersion);
-            }
-
-            var outputXmlString = fileXml.ToString();
-            if (originalFileContents != outputXmlString)
-            {
-                fileSystem.File.WriteAllText(localProjectFile, outputXmlString);
-            }
+            fileXml = XElement.Parse(originalFileContents);
+        }
+        catch (XmlException e)
+        {
+            throw new XmlException($"Unable to parse file as xml: {localProjectFile}", e);
         }
 
-        CommitChanges();
+        if (!CanUpdateProjectFile(fileXml))
+        {
+            log.Warning($"Unable to update file: {localProjectFile}");
+            return;
+        }
+
+        log.Debug($"Update file: {localProjectFile}");
+
+        var backupProjectFile = localProjectFile + ".bak";
+        fileSystem.File.Copy(localProjectFile, backupProjectFile, true);
+
+        this.restoreBackupTasks.Add(() =>
+        {
+            if (fileSystem.File.Exists(localProjectFile))
+            {
+                fileSystem.File.Delete(localProjectFile);
+            }
+
+            fileSystem.File.Move(backupProjectFile, localProjectFile);
+        });
+
+        this.cleanupBackupTasks.Add(() => fileSystem.File.Delete(backupProjectFile));
+
+        if (!assemblyVersion.IsNullOrWhiteSpace())
+        {
+            UpdateProjectVersionElement(fileXml, AssemblyVersionElement, assemblyVersion);
+        }
+
+        if (!assemblyFileVersion.IsNullOrWhiteSpace())
+        {
+            UpdateProjectVersionElement(fileXml, FileVersionElement, assemblyFileVersion);
+        }
+
+        if (!assemblyInfoVersion.IsNullOrWhiteSpace())
+        {
+            UpdateProjectVersionElement(fileXml, InformationalVersionElement, assemblyInfoVersion);
+        }
+
+        if (!packageVersion.IsNullOrWhiteSpace())
+        {
+            UpdateProjectVersionElement(fileXml, VersionElement, packageVersion);
+        }
+
+        var outputXmlString = fileXml.ToString();
+        if (originalFileContents != outputXmlString)
+        {
+            fileSystem.File.WriteAllText(localProjectFile, outputXmlString);
+        }
     }
 
     public bool CanUpdateProjectFile(XElement xmlRoot)

--- a/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
+++ b/src/GitVersion.Output/OutputGenerator/OutputGenerator.cs
@@ -36,44 +36,57 @@ internal sealed class OutputGenerator(
 
         if (gitVersionOptions.Output.Contains(OutputType.DotEnv))
         {
-            List<string> dotEnvEntries = [];
-            foreach (var (key, value) in variables.OrderBy(x => x.Key))
-            {
-                var prefixedKey = "GitVersion_" + key;
-                var environmentValue = "";
-                if (!value.IsNullOrEmpty())
-                {
-                    environmentValue = value;
-                }
-                dotEnvEntries.Add($"{prefixedKey}='{environmentValue}'");
-            }
-
-            foreach (var dotEnvEntry in dotEnvEntries)
-            {
-                this.console.WriteLine(dotEnvEntry);
-            }
-
+            WriteDotEnv(variables);
             return;
         }
 
         var json = this.serializer.ToJson(variables);
+
         if (gitVersionOptions.Output.Contains(OutputType.File))
         {
-            var retryOperation = new RetryAction<IOException>();
-            retryOperation.Execute(() =>
-            {
-                if (context.OutputFile != null)
-                {
-                    this.fileSystem.File.WriteAllText(context.OutputFile, json);
-                }
-            });
+            WriteJsonToFile(json, context);
         }
 
-        if (!gitVersionOptions.Output.Contains(OutputType.Json))
+        if (gitVersionOptions.Output.Contains(OutputType.Json))
         {
-            return;
+            WriteJsonToConsole(json, variables, gitVersionOptions);
+        }
+    }
+
+    private void WriteDotEnv(GitVersionVariables variables)
+    {
+        List<string> dotEnvEntries = [];
+        foreach (var (key, value) in variables.OrderBy(x => x.Key))
+        {
+            var prefixedKey = "GitVersion_" + key;
+            var environmentValue = "";
+            if (!value.IsNullOrEmpty())
+            {
+                environmentValue = value;
+            }
+            dotEnvEntries.Add($"{prefixedKey}='{environmentValue}'");
         }
 
+        foreach (var dotEnvEntry in dotEnvEntries)
+        {
+            this.console.WriteLine(dotEnvEntry);
+        }
+    }
+
+    private void WriteJsonToFile(string json, OutputContext context)
+    {
+        var retryOperation = new RetryAction<IOException>();
+        retryOperation.Execute(() =>
+        {
+            if (context.OutputFile != null)
+            {
+                this.fileSystem.File.WriteAllText(context.OutputFile, json);
+            }
+        });
+    }
+
+    private void WriteJsonToConsole(string json, GitVersionVariables variables, GitVersionOptions gitVersionOptions)
+    {
         if (gitVersionOptions.ShowVariable is null && gitVersionOptions.Format is null)
         {
             this.console.WriteLine(json);
@@ -98,26 +111,8 @@ internal sealed class OutputGenerator(
 
         if (gitVersionOptions.Format is not null)
         {
-            var format = gitVersionOptions.Format;
-            var formatted = format.FormatWith(variables, environment);
+            var formatted = gitVersionOptions.Format.FormatWith(variables, environment);
             this.console.WriteLine(formatted);
-            return;
-        }
-
-        switch (gitVersionOptions.ShowVariable)
-        {
-            case null:
-                this.console.WriteLine(variables.ToString());
-                break;
-
-            default:
-                if (!variables.TryGetValue(gitVersionOptions.ShowVariable, out var part))
-                {
-                    throw new WarningException($"'{gitVersionOptions.ShowVariable}' variable does not exist");
-                }
-
-                this.console.WriteLine(part);
-                break;
         }
     }
 


### PR DESCRIPTION
Reduces SonarCloud **S3776** (cognitive complexity > 15) on several methods, one commit per method. All changes are behaviour-preserving refactors — no logic changes.

| Method | Before | Approach |
|---|--:|---|
| `MergeCommitOnNonTrunkBase.GetIncrements` | 16 | extract `ConsolidateIncrement` / `ApplyBaseVersion` |
| `EffectiveBranchConfigurationFinder.GetEffectiveConfigurationsRecursive` | 17 | flatten nested `if`s into early `yield break`s |
| `AssemblyInfoFileUpdater.Execute` | 17 | extract per-file `UpdateAssemblyInfoFile` |
| `ProjectFileUpdater.Execute` | 19 | extract per-file `UpdateProjectFile` |
| `OutputGenerator.Execute` | 22 | split into `WriteDotEnv`/`WriteJsonToFile`/`WriteJsonToConsole`; remove an unreachable trailing `switch` |

More S3776 fixes will follow on top of this branch (GitVersionCacheKeyFactory, NextVersionCalculator, RepositoryStore, GitPreparer, ArgumentParser, SemanticVersion, MainlineVersionStrategy).

## Verification
- `dotnet build` — 0 warnings / 0 errors
- `dotnet format --verify-no-changes` — clean
- Tests green: full Core suite 36119, Output.Tests 369, App.Tests 663 (per method, on the relevant suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)