### PR TITLE
ci: download native packages in a single pattern-matched step

### DIFF
--- a/.github/actions/artifacts-restore/action.yml
+++ b/.github/actions/artifacts-restore/action.yml
@@ -5,21 +5,10 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      name: Download native linux packages
+      name: Download native packages
       with:
-        name: native-Linux
-        path: ${{ github.workspace }}/artifacts/packages/native
-
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      name: Download native windows packages
-      with:
-        name: native-Windows
-        path: ${{ github.workspace }}/artifacts/packages/native
-
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      name: Download native macos packages
-      with:
-        name: native-macOS
+        pattern: native-*
+        merge-multiple: true
         path: ${{ github.workspace }}/artifacts/packages/native
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Collapses the three per-OS `native-*` `download-artifact` steps in `.github/actions/artifacts-restore` into a single step using `pattern: native-*` with `merge-multiple: true`.

`actions/download-artifact@v8` fetches the matched artifacts concurrently and extracts them flat into the same `artifacts/packages/native` path — preserving the previous layout (the native artifacts are distinct `*.tar.gz`/`*.zip` files, so no collision). This trims the per-OS download sequence (used by the `release`, `publish`, and docs jobs) into one concurrent fetch.

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)