### PR TITLE
test: use FakeRepository for dynamic-repo cache tests

### DIFF
--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -54,14 +54,16 @@ public class GitVersionExecutorTests : TestBase
         }
         """;
 
+    private const string TargetUrl = "https://github.com/GitTools/FakeRepository.git";
+    private const string TargetBranch = "master";
+
     [Test]
     public void CacheKeySameAfterReNormalizing()
     {
         using var fixture = new EmptyRepositoryFixture();
-        const string targetUrl = "https://github.com/GitTools/GitVersion.git";
-        const string targetBranch = $"refs/head/{MainBranch}";
+        const string targetBranch = $"refs/head/{TargetBranch}";
 
-        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = targetUrl, TargetBranch = targetBranch }, WorkingDirectory = fixture.RepositoryPath, Settings = { NoNormalize = false } };
+        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = TargetUrl, TargetBranch = targetBranch }, WorkingDirectory = fixture.RepositoryPath, Settings = { NoNormalize = false } };
 
         var environment = new TestEnvironment();
         environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
@@ -94,9 +96,7 @@ public class GitVersionExecutorTests : TestBase
     [Test]
     public void GitPreparerShouldNotFailWhenTargetPathNotInitialized()
     {
-        const string targetUrl = "https://github.com/GitTools/GitVersion.git";
-
-        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = targetUrl }, WorkingDirectory = string.Empty };
+        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = TargetUrl }, WorkingDirectory = string.Empty };
         Should.NotThrow(() =>
         {
             this.sp = GetServiceProvider(gitVersionOptions);
@@ -119,9 +119,7 @@ public class GitVersionExecutorTests : TestBase
             var repo = new Repository(fixture.RepositoryPath);
             repo.Worktrees.Add("worktree", worktreePath, false);
 
-            const string targetUrl = "https://github.com/GitTools/GitVersion.git";
-
-            var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = targetUrl, TargetBranch = MainBranch }, WorkingDirectory = worktreePath };
+            var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = TargetUrl, TargetBranch = TargetBranch }, WorkingDirectory = worktreePath };
 
             this.sp = GetServiceProvider(gitVersionOptions);
 
@@ -339,9 +337,7 @@ public class GitVersionExecutorTests : TestBase
             var repo = new Repository(fixture.RepositoryPath);
             repo.Worktrees.Add("worktree", worktreePath, false);
 
-            const string targetUrl = "https://github.com/GitTools/GitVersion.git";
-
-            var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = targetUrl }, WorkingDirectory = worktreePath };
+            var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = TargetUrl }, WorkingDirectory = worktreePath };
 
             this.sp = GetServiceProvider(gitVersionOptions);
             var repositoryInfo = this.sp.GetRequiredService<IGitRepositoryInfo>();
@@ -357,9 +353,8 @@ public class GitVersionExecutorTests : TestBase
     public void GetProjectRootDirectoryNoWorktree()
     {
         using var fixture = new EmptyRepositoryFixture();
-        const string targetUrl = "https://github.com/GitTools/GitVersion.git";
 
-        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = targetUrl }, WorkingDirectory = fixture.RepositoryPath };
+        var gitVersionOptions = new GitVersionOptions { RepositoryInfo = { TargetUrl = TargetUrl }, WorkingDirectory = fixture.RepositoryPath };
 
         this.sp = GetServiceProvider(gitVersionOptions);
         var repositoryInfo = this.sp.GetRequiredService<IGitRepositoryInfo>();


### PR DESCRIPTION
## Problem
Local timing of `GitVersion.Core.Tests` (net10.0) showed the suite's two slowest tests by far live in `GitVersionExecutorTests`:

- `CacheKeySameAfterReNormalizing` — **~115s**
- `CacheKeyForWorktree` — **~66s**

Both set `TargetUrl = https://github.com/GitTools/GitVersion.git` and call `preparer.Prepare()`, which **clones the entire GitVersion repo over the network** (twice, in the re-normalizing test). That's ~180s of network-bound work and a flaky external dependency on the size/availability of the main repo.

## Change
Point the dynamic-repository cache tests at the small, stable **`GitTools/FakeRepository`** instead, and hoist the URL and branch into single `TargetUrl` / `TargetBranch` constants (FakeRepository's default branch is `master`, not `main`). `DynamicRepositoryTests` is left untouched — it asserts GitVersion-specific versions and must keep cloning the real repo.

## Result
`GitVersionExecutorTests`: **~184s → ~4s** (23 tests, all passing on net10.0), with the network/flakiness removed. Behaviour is unchanged — the tests only assert cache-key stability / non-emptiness, which is repo-agnostic.

Build 0/0, `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)