### PR TITLE
ci: replace homebrew bump action with brew bump-formula-pr

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -40,16 +40,28 @@ jobs:
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        name: Bump Homebrew formula
-        with:
-          formula-name: gitversion
-          tag-name: ${{ steps.get-version.outputs.version }}
-          download-url: https://github.com/GitTools/GitVersion/archive/refs/tags/${{ steps.get-version.outputs.version }}.tar.gz
-          push-to: gittools-bot/homebrew-core
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            For additional details see https://github.com/GitTools/GitVersion/releases/tag/${{ steps.get-version.outputs.version }}
+      # Uses Homebrew's own `brew bump-formula-pr` (preinstalled on the runner) rather than a
+      # third-party action. mislav/bump-homebrew-formula-action breaks when GitHub's tarball
+      # endpoint returns HTTP 303 instead of 302 (see mislav/bump-homebrew-formula-action#342);
+      # the official CLI handles the redirect correctly and removes a pinned-action dependency.
+      - name: Bump Homebrew formula
         env:
-          COMMITTER_TOKEN: ${{ steps.github-creds.outputs.github_release_token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.github-creds.outputs.github_release_token }}
+          HOMEBREW_GIT_NAME: GitTools Bot
+          HOMEBREW_GIT_EMAIL: gittoolsbot@outlook.com
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          version="${{ steps.get-version.outputs.version }}"
+          url="https://github.com/GitTools/GitVersion/archive/refs/tags/${version}.tar.gz"
+          sha256="$(curl -fsSL --proto '=https' --proto-redir '=https' "$url" | shasum -a 256 | cut -d ' ' -f 1)"
+
+          git config --global user.name "GitTools Bot"
+          git config --global user.email "gittoolsbot@outlook.com"
+
+          brew bump-formula-pr gitversion \
+            --url "$url" \
+            --sha256 "$sha256" \
+            --fork-org gittools-bot \
+            --no-audit \
+            --no-browse \
+            --message "For additional details see https://github.com/GitTools/GitVersion/releases/tag/${version}"


### PR DESCRIPTION
## Problem

The **Publish to Homebrew** workflow fails immediately with:

```
Error: unexpected HTTP 303 response
```

This is an upstream defect in `mislav/bump-homebrew-formula-action`: GitHub's tarball redirect endpoint (`HEAD /repos/{owner}/{repo}/tarball/{ref}`) began returning HTTP 303 instead of 302 around 2026-05-16, and the action's `resolveRedirect` only accepts 302. The fix ([mislav/bump-homebrew-formula-action#342](https://github.com/mislav/bump-homebrew-formula-action/pull/342)) is still unmerged, so the `6.8.0` Homebrew PR was never opened.

## Change

Replace the third-party action with Homebrew's own `brew bump-formula-pr` CLI (preinstalled on the `macos-latest` runner), which follows the redirect correctly.

Behaviour is preserved:

| Before (action) | After (`brew bump-formula-pr`) |
|---|---|
| `download-url: .../tags/${version}.tar.gz` | `--url "$url"` (same pattern) |
| action auto-computed SHA | `--sha256` from `curl … \| shasum -a 256` |
| `push-to: gittools-bot/homebrew-core` | `--fork-org gittools-bot` |
| `COMMITTER_TOKEN` (1Password) | `HOMEBREW_GITHUB_API_TOKEN` (same token) |
| committer `GitTools Bot <gittoolsbot@outlook.com>` | same, via `git config` + `HOMEBREW_GIT_*` |

Side benefits: removes a pinned third-party action dependency and uses tooling Homebrew maintains.

## Notes

- `--no-audit` preserves the previous action's behaviour (no local audit); homebrew-core's PR CI audits anyway.
- The "For additional details see …" line moves from the commit body to the PR description (`--message` prepends to the PR body); the commit subject is the standard `gitversion <version>`.
- This does **not** backfill the missing `6.8.0` Homebrew PR — after merge, re-dispatch **Publish to Homebrew** with `tag-name=6.8.0` (or run `brew bump-formula-pr` locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)