### PR TITLE
ci: fix homebrew publish — drop --fork-org (gittools-bot is a user)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -58,10 +58,13 @@ jobs:
           git config --global user.name "GitTools Bot"
           git config --global user.email "gittoolsbot@outlook.com"
 
+          # No --fork-org: that flag requires an *organization* login, but the
+          # publish runs as the gittools-bot *user*. Omitting it makes brew fork
+          # to the authenticated user (gittools-bot/homebrew-core) — the same
+          # target the old action used via push-to.
           brew bump-formula-pr gitversion \
             --url "$url" \
             --sha256 "$sha256" \
-            --fork-org gittools-bot \
             --no-audit \
             --no-browse \
             --message "For additional details see https://github.com/GitTools/GitVersion/releases/tag/${version}"


### PR DESCRIPTION
## Problem

The **Publish to Homebrew** run after #5004 failed:

```
Unable to fork: 'gittools-bot' is the login for a user account.
You must pass the login for an organization account.
(resource: Fork, code: invalid, field: organization)
```

`brew bump-formula-pr --fork-org` requires an **organization** login, but `gittools-bot` is a **user** account (`gh api users/gittools-bot` → `"type": "User"`), and the publish authenticates as that user.

## Fix

Drop `--fork-org gittools-bot`. With no `--fork-org`, `brew bump-formula-pr` forks `Homebrew/homebrew-core` to the **authenticated user** — i.e. `gittools-bot/homebrew-core`, the exact fork the previous `mislav` action targeted via `push-to`. No behavioural change beyond removing the invalid flag.

Follow-up to #5004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)