### PR TITLE
feat(buildagents): read CI_MERGE_REQUEST_REF_PATH in GitLabCi

### DIFF
--- a/docs/input/docs/reference/build-servers/gitlab.md
+++ b/docs/input/docs/reference/build-servers/gitlab.md
@@ -9,6 +9,37 @@ To use GitVersion with GitLab CI, either use the [MSBuild
 Task](/docs/usage/msbuild) or put the GitVersion executable in your
 runner's `PATH`.
 
+### Merge Request pipelines
+
+In merge request pipelines GitLab sets `CI_MERGE_REQUEST_REF_PATH` (for example
+`refs/merge-requests/15/head` or `refs/merge-requests/15/merge`). GitVersion
+reads this variable through the `GitLabCi` build agent when it is present,
+following the same pass-through pattern as Azure Pipelines (`BUILD_SOURCEBRANCH`)
+and GitHub Actions (`GITHUB_REF`).
+
+Branch resolution order in `GitLabCi`:
+
+1. `CI_COMMIT_TAG` set — treat as a tag pipeline (`GetCurrentBranch` returns `null`)
+2. `CI_MERGE_REQUEST_REF_PATH` set — use the merge request ref
+3. otherwise — `CI_COMMIT_REF_NAME` (branch name)
+
+After repository normalisation the friendly branch name becomes
+`merge-requests/<iid>/head` or `merge-requests/<iid>/merge`. Extend the
+`pull-request` branch configuration in `GitVersion.yml` so the regex matches
+GitLab's namespace (the default `pull-requests|pull|pr` pattern does not):
+
+```yaml
+workflow: GitFlow/v1
+branches:
+  pull-request:
+    regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+    label: PullRequest{Number}
+```
+
+`CI_COMMIT_REF_NAME` still contains the source branch name (for example
+`feature/foo`) in MR pipelines; it is ignored when `CI_MERGE_REQUEST_REF_PATH`
+is set.
+
 A working example of integrating GitVersion with GitLab is maintained in the project [Utterly Automated Versioning][utterly-automated-versioning]
 
 Here is a summary of what it demonstrated (many more details in the [Readme][readme])

--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -22,6 +22,12 @@ public class PullRequestInBuildAgentTest
         "refs/remotes/pull-requests/5/merge"
     ];
 
+    private static readonly string[] GitLabMergeRequestRefs =
+    [
+        "refs/merge-requests/5/head",
+        "refs/merge-requests/5/merge"
+    ];
+
     [TestCaseSource(nameof(PrMergeRefs))]
     public async Task VerifyAzurePipelinesPullRequest(string pullRequestRef)
     {
@@ -75,15 +81,16 @@ public class PullRequestInBuildAgentTest
         await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
     }
 
-    [TestCaseSource(nameof(PrMergeRefs))]
-    public async Task VerifyGitLabCIPullRequest(string pullRequestRef)
+    [TestCaseSource(nameof(GitLabMergeRequestRefs))]
+    public async Task VerifyGitLabCIPullRequest(string mergeRequestRef)
     {
         var env = new Dictionary<string, string>
         {
             { GitLabCi.EnvironmentVariableName, "true" },
-            { "CI_COMMIT_REF_NAME", PullRequestBranchName }
+            { GitLabCi.MergeRequestRefPathEnvironmentVariableName, mergeRequestRef },
+            { GitLabCi.CommitRefNameEnvironmentVariableName, "FeatureBranch" }
         };
-        await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
+        await VerifyGitLabMergeRequestVersionIsCalculatedProperly(mergeRequestRef, env);
     }
 
     [TestCaseSource(nameof(PrMergeRefs))]
@@ -142,9 +149,29 @@ public class PullRequestInBuildAgentTest
         await VerifyPullRequestVersionIsCalculatedProperly(pullRequestRef, env);
     }
 
+    private const string GitLabMergeRequestPullRequestConfig = """
+        workflow: GitFlow/v1
+        branches:
+          pull-request:
+            regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+        """;
+
+    private static async Task VerifyGitLabMergeRequestVersionIsCalculatedProperly(string mergeRequestRef, Dictionary<string, string> env)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var configPath = FileSystemHelper.Path.Combine(fixture.RepositoryPath, "GitVersion.yml");
+        await File.WriteAllTextAsync(configPath, GitLabMergeRequestPullRequestConfig);
+        await VerifyPullRequestVersionIsCalculatedProperly(fixture, mergeRequestRef, env);
+    }
+
     private static async Task VerifyPullRequestVersionIsCalculatedProperly(string pullRequestRef, Dictionary<string, string> env)
     {
         using var fixture = new EmptyRepositoryFixture();
+        await VerifyPullRequestVersionIsCalculatedProperly(fixture, pullRequestRef, env);
+    }
+
+    private static async Task VerifyPullRequestVersionIsCalculatedProperly(EmptyRepositoryFixture fixture, string pullRequestRef, Dictionary<string, string> env)
+    {
         var remoteRepositoryPath = FileSystemHelper.Path.GetRepositoryTempPath();
         RepositoryFixtureBase.Init(remoteRepositoryPath);
         using var remoteRepository = new Repository(remoteRepositoryPath);

--- a/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
+++ b/src/GitVersion.BuildAgents.Tests/Agents/GitLabCiTests.cs
@@ -27,7 +27,13 @@ public class GitLabCiTests : TestBase
     }
 
     [TearDown]
-    public void TearDown() => this.environment.SetEnvironmentVariable(GitLabCi.EnvironmentVariableName, null);
+    public void TearDown()
+    {
+        this.environment.SetEnvironmentVariable(GitLabCi.EnvironmentVariableName, null);
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, null);
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitTagEnvironmentVariableName, null);
+        this.environment.SetEnvironmentVariable(GitLabCi.MergeRequestRefPathEnvironmentVariableName, null);
+    }
 
     [Test]
     public void ShouldSetBuildNumber()
@@ -51,7 +57,7 @@ public class GitLabCiTests : TestBase
     [TestCase("#3-change_projectname", "#3-change_projectname")]
     public void GetCurrentBranchShouldHandleBranches(string branchName, string expectedResult)
     {
-        this.environment.SetEnvironmentVariable("CI_COMMIT_REF_NAME", branchName);
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, branchName);
 
         var result = this.buildServer.GetCurrentBranch(false);
 
@@ -64,8 +70,8 @@ public class GitLabCiTests : TestBase
     [TestCase("v1.2.1", "v1.2.1", null)]
     public void GetCurrentBranchShouldHandleTags(string branchName, string commitTag, string? expectedResult)
     {
-        this.environment.SetEnvironmentVariable("CI_COMMIT_REF_NAME", branchName);
-        this.environment.SetEnvironmentVariable("CI_COMMIT_TAG", commitTag); // only set in pipelines for tags
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, branchName);
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitTagEnvironmentVariableName, commitTag); // only set in pipelines for tags
 
         var result = this.buildServer.GetCurrentBranch(false);
 
@@ -79,18 +85,33 @@ public class GitLabCiTests : TestBase
         }
     }
 
-    [TestCase("main", "main")]
-    [TestCase("dev", "dev")]
-    [TestCase("development", "development")]
-    [TestCase("my_cool_feature", "my_cool_feature")]
-    [TestCase("#3-change_projectname", "#3-change_projectname")]
-    public void GetCurrentBranchShouldHandlePullRequests(string branchName, string expectedResult)
+    [TestCase("refs/merge-requests/1/head", "refs/merge-requests/1/head")]
+    [TestCase("refs/merge-requests/42/merge", "refs/merge-requests/42/merge")]
+    public void GetCurrentBranchShouldHandleMergeRequestRefPaths(string refPath, string expected)
     {
-        this.environment.SetEnvironmentVariable("CI_COMMIT_REF_NAME", branchName);
+        this.environment.SetEnvironmentVariable(GitLabCi.MergeRequestRefPathEnvironmentVariableName, refPath);
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, "developer");
 
-        var result = this.buildServer.GetCurrentBranch(false);
+        this.buildServer.GetCurrentBranch(false).ShouldBe(expected);
+    }
 
-        result.ShouldBe(expectedResult);
+    [Test]
+    public void GetCurrentBranchShouldPreferTagOverMergeRequestRefPath()
+    {
+        this.environment.SetEnvironmentVariable(GitLabCi.MergeRequestRefPathEnvironmentVariableName, "refs/merge-requests/1/head");
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, "v1.0.0");
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitTagEnvironmentVariableName, "v1.0.0");
+
+        this.buildServer.GetCurrentBranch(false).ShouldBeNull();
+    }
+
+    [Test]
+    public void GetCurrentBranchShouldFallBackToRefNameWhenMergeRequestRefPathIsEmpty()
+    {
+        this.environment.SetEnvironmentVariable(GitLabCi.MergeRequestRefPathEnvironmentVariableName, "");
+        this.environment.SetEnvironmentVariable(GitLabCi.CommitRefNameEnvironmentVariableName, "developer");
+
+        this.buildServer.GetCurrentBranch(false).ShouldBe("developer");
     }
 
     [Test]

--- a/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitLabCi.cs
@@ -7,6 +7,9 @@ namespace GitVersion.Agents;
 internal class GitLabCi : BuildAgentBase
 {
     public const string EnvironmentVariableName = "GITLAB_CI";
+    public const string CommitRefNameEnvironmentVariableName = "CI_COMMIT_REF_NAME";
+    public const string CommitTagEnvironmentVariableName = "CI_COMMIT_TAG";
+    public const string MergeRequestRefPathEnvironmentVariableName = "CI_MERGE_REQUEST_REF_PATH";
     private string? file;
 
     public GitLabCi(IEnvironment environment, ILog log, IFileSystem fileSystem) : base(environment, log, fileSystem) => WithPropertyFile("gitversion.properties");
@@ -22,14 +25,24 @@ internal class GitLabCi : BuildAgentBase
         $"GitVersion_{name}={value}"
     ];
 
+    // CI_MERGE_REQUEST_REF_PATH is only available in merge request pipelines,
     // CI_COMMIT_REF_NAME can contain either the branch or the tag
     // See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
     // CI_COMMIT_TAG is only available in tag pipelines,
     // so we can exit if CI_COMMIT_REF_NAME would return the tag
-    public override string? GetCurrentBranch(bool usingDynamicRepos) =>
-        string.IsNullOrEmpty(this.environment.GetEnvironmentVariable("CI_COMMIT_TAG"))
-            ? this.environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME")
-            : null;
+    public override string? GetCurrentBranch(bool usingDynamicRepos)
+    {
+        if (!string.IsNullOrEmpty(this.environment.GetEnvironmentVariable(CommitTagEnvironmentVariableName)))
+        {
+            return null;
+        }
+        var mergeRequestRefPath = this.environment.GetEnvironmentVariable(MergeRequestRefPathEnvironmentVariableName);
+        if (!string.IsNullOrEmpty(mergeRequestRefPath))
+        {
+            return mergeRequestRefPath;
+        }
+        return this.environment.GetEnvironmentVariable(CommitRefNameEnvironmentVariableName);
+    }
 
     public override bool PreventFetch() => true;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for GitLab CI Merge Request pipelines by reading `CI_MERGE_REQUEST_REF_PATH` in the `GitLabCi` build agent.

In MR pipelines, GitLab sets `CI_MERGE_REQUEST_REF_PATH` (for example `refs/merge-requests/15/head` or `refs/merge-requests/15/merge`). Previously, GitVersion used only `CI_COMMIT_REF_NAME`, which contains the **source branch name** (for example `developer` or `feature/foo`). Version calculation therefore followed `feature`/`develop` configuration instead of `pull-request`.

The change is limited to `GitVersion.BuildAgents`. In `GetCurrentBranch()`, precedence is now:

1. `CI_COMMIT_TAG` → `null` (tag pipeline)
2. `CI_MERGE_REQUEST_REF_PATH` → merge request ref (pass-through, unchanged)
3. `CI_COMMIT_REF_NAME` → branch name

This follows the same pass-through pattern as Azure Pipelines (`BUILD_SOURCEBRANCH`) and GitHub Actions (`GITHUB_REF`). **No changes to Core.**

After repository normalisation, the friendly branch name becomes `merge-requests/<iid>/head` or `merge-requests/<iid>/merge`. Users must extend the `pull-request` regex in `GitVersion.yml` for GitLab's namespace, because the default `pull-requests|pull|pr` pattern does not match:

```yaml
workflow: GitFlow/v1
branches:
  pull-request:
    regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
    label: PullRequest{Number}
```

**Affected areas:** `GitVersion.BuildAgents`, `GitVersion.BuildAgents.Tests`, `GitVersion.App.Tests`, `docs/input/docs/reference/build-servers/gitlab.md`.

**Backward compatibility:** Other build agents are unchanged. GitLab branch and tag pipelines behave as before. GitLab MR pipelines gain correct branch detection; they require the regex extension above to apply `pull-request` configuration.

## Related Issue

<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

Resolves #5007

## Motivation and Context

In GitLab Merge Request pipelines, the runner checks out a detached HEAD at `refs/merge-requests/<iid>/head`, while `CI_COMMIT_REF_NAME` still points at the source branch. Without reading `CI_MERGE_REQUEST_REF_PATH`, GitVersion normalised the repository against the wrong branch and calculated the wrong semantic version (for example `0.1.0-alpha.5` on `developer` instead of a `PullRequest` pre-release label).

An earlier contribution added GitLab-specific ref handling in Core; review feedback requested keeping CI/vendor logic in `GitVersion.BuildAgents` only. This revision addresses that feedback: detection stays in `GitLabCi`, with documentation and tests for the MR workflow.

## How Has This Been Tested?

- **Unit tests** (`GitLabCiTests`): branch resolution precedence (`CI_COMMIT_TAG` → `CI_MERGE_REQUEST_REF_PATH` → `CI_COMMIT_REF_NAME`); MR refs `refs/merge-requests/<iid>/head` and `/merge`; tag overrides MR; fallback when `CI_MERGE_REQUEST_REF_PATH` is empty.
- **Integration tests** (`PullRequestInBuildAgentTest.VerifyGitLabCIPullRequest`): end-to-end run with `GITLAB_CI` and `CI_MERGE_REQUEST_REF_PATH` set and `CI_COMMIT_REF_NAME=FeatureBranch` (ignored); asserts `FullSemVer` `1.0.4-PullRequest5.3` for both `head` and `merge` refs using a `GitVersion.yml` with the GitLab `pull-request` regex.
- **Local:** `dotnet test` on `GitVersion.BuildAgents.Tests` (`GitLabCiTests`) and `GitVersion.App.Tests` (`VerifyGitLabCIPullRequest`), `net10.0`.
- **Manual:** GitLab CI MR pipeline with diagnostic logging (`/verbosity Diagnostic /l console`); reproduced the pre-change behaviour (`Branch from build environment: developer` on `gittools/gitversion:6.6.1` when `CI_MERGE_REQUEST_REF_PATH` was set).

## Screenshots (if appropriate):

N/A

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

<!-- gk-ai-analysis-start:70b2161581ba29e91c70e4567d4465abac49d01c -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBzdXBwb3J0IGZvciBHaXRMYWIgQ0kgTWVyZ2UgUmVxdWVzdCBwaXBlbGluZXMgYnkgcmVhZGluZyBDSV9NRVJHRV9SRVFVRVNUX1JFRl9QQVRIIHRvIGNvcnJlY3RseSBkZXRlcm1pbmUgYnJhbmNoIG5hbWVzLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6Ik1lcmdlIHJlcXVlc3QgcmVmIHBhdGggdmFyaWFibGUgcHJlY2VkZW5jZSIsImRlc2NyaXB0aW9uIjoiSW4gYEdldEN1cnJlbnRCcmFuY2hgLCBwcmVjZWRlbmNlIGlzIHVwZGF0ZWQgdG8gZmlyc3QgY2hlY2sgZm9yIGBDSV9DT01NSVRfVEFHYCwgdGhlbiBgQ0lfTUVSR0VfUkVRVUVTVF9SRUZfUEFUSGAsIGFuZCBmaW5hbGx5IGZhbGxzIGJhY2sgdG8gYENJX0NPTU1JVF9SRUZfTkFNRWAuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6InNyYy9HaXRWZXJzaW9uLkJ1aWxkQWdlbnRzL0FnZW50cy9HaXRMYWJDaS5jcyIsImxpbmVTdGFydCI6MjgsImxpbmVFbmQiOjM5fSx7InRpdGxlIjoiRW52aXJvbm1lbnQgdmFyaWFibGVzIHJlZmFjdG9yZWQgYXMgY29uc3RhbnRzIiwiZGVzY3JpcHRpb24iOiJIYXJkY29kZWQgZW52aXJvbm1lbnQgdmFyaWFibGVzIHdlcmUgbW92ZWQgaW50byBjb25zdGFudHMgbGlrZSBgQ29tbWl0UmVmTmFtZUVudmlyb25tZW50VmFyaWFibGVOYW1lYCBmb3IgYmV0dGVyIG1haW50YWluYWJpbGl0eSBhbmQgcmV1c2FiaWxpdHkgYWNyb3NzIHRlc3RzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJzcmMvR2l0VmVyc2lvbi5CdWlsZEFnZW50cy9BZ2VudHMvR2l0TGFiQ2kuY3MiLCJsaW5lU3RhcnQiOjksImxpbmVFbmQiOjEyfSx7InRpdGxlIjoiRG9jdW1lbnRhdGlvbiB1cGRhdGVkIGZvciBHaXRMYWIgTVJzIiwiZGVzY3JpcHRpb24iOiJBZGRlZCBkZXRhaWxlZCBkb2N1bWVudGF0aW9uIGV4cGxhaW5pbmcgaG93IEdpdExhYiBDSSBzZXRzIGBDSV9NRVJHRV9SRVFVRVNUX1JFRl9QQVRIYCBhbmQgdGhlIHJlcXVpcmVtZW50IHRvIGV4dGVuZCBgR2l0VmVyc2lvbi55bWxgIHdpdGggYSBjdXN0b20gcmVnZXggdG8gc3VwcG9ydCBgcHVsbC1yZXF1ZXN0YCB0cmFja2luZy4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiZG9jcy9pbnB1dC9kb2NzL3JlZmVyZW5jZS9idWlsZC1zZXJ2ZXJzL2dpdGxhYi5tZCIsImxpbmVTdGFydCI6MTIsImxpbmVFbmQiOjM4fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:70b2161581ba29e91c70e4567d4465abac49d01c -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/GitTools/GitVersion/pull/5008?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->