### PR TITLE
fix: sanitize labels correctly when using enviornment variables

### DIFF
--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -143,4 +143,24 @@ public class ConfigurationExtensionsTests : TestBase
         Should.Throw<ArgumentException>(() =>
             effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment));
     }
+
+    [TestCase("case-00/my-branch", "case-00-my-branch")]
+    [TestCase("my-branch", "my-branch")]
+    [TestCase("my_branch/valid", "my-branch-valid")]
+    public void EnsureGetBranchSpecificLabelReturnsValidLabelForEnvironmentVariables(string variable, string expectedLabel)
+    {
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable("GITHUB_HEAD_REF", variable);
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("feature/test-feature", builder => builder
+                .WithLabel("{env:GITHUB_HEAD_REF}")
+                .WithRegularExpression(@"^features?[\/-](?<BranchName>.+)"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test-feature"));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-feature"), null, environment);
+        actual.ShouldBe(expectedLabel);
+    }
 }

--- a/src/GitVersion.Core/Core/RegexPatterns.cs
+++ b/src/GitVersion.Core/Core/RegexPatterns.cs
@@ -34,6 +34,9 @@ internal static partial class RegexPatterns
     [StringSyntax(StringSyntaxAttribute.Regex, Options)]
     internal const string SanitizeNameRegexPattern = "[^a-zA-Z0-9-]";
 
+    [StringSyntax(StringSyntaxAttribute.Regex, Options)]
+    internal const string SanitizeLabelRegexPattern = "[^a-zA-Z0-9-.]";
+
 #if NET9_0_OR_GREATER
     [GeneratedRegex(SwitchArgumentRegexPattern, Options)]
     public static partial Regex SwitchArgumentRegex { get; }

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -133,7 +133,8 @@ internal static class ConfigurationExtensions
             var effectiveBranchName = branchNameOverride ?? branchName;
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
 
-            return label.FormatWith(labelPlaceholders, environment);
+            return label.FormatWith(labelPlaceholders, environment)
+                .RegexReplace(RegexPatterns.SanitizeNameRegexPattern, "-");
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -134,7 +134,7 @@ internal static class ConfigurationExtensions
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
 
             return label.FormatWith(labelPlaceholders, environment)
-                .RegexReplace(RegexPatterns.SanitizeNameRegexPattern, "-");
+                .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Using `{BranchName}` formatting for labels correctly removes slashes and other non-compliant characters, but environment variables do not have the same sanitization applied. This fixes this to apply to environment variables as well.

## Related Issue

<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

Resolves #5009 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!-- 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Please describe in detail how you tested your changes.

-->

## Screenshots (if appropriate):

<!-- Drag and drop screenshots here -->

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
