### PR TITLE
chore(deps): consolidate Dependabot config and enable devcontainer feature updates

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,34 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
+    "ghcr.io/devcontainers/features/git": {
+      "version": "1.3.7",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a",
+      "integrity": "sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a"
+    },
+    "ghcr.io/devcontainers/features/github-cli": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/powershell": {
+      "version": "2.0.2",
+      "resolved": "ghcr.io/devcontainers/features/powershell@sha256:82ea3880c5706ac3963f1b5e940a7f5871835393a5472f80008148b995d58d61",
+      "integrity": "sha256:82ea3880c5706ac3963f1b5e940a7f5871835393a5472f80008148b995d58d61"
+    },
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes": {
+      "version": "2.1.1",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd",
+      "integrity": "sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,27 +7,27 @@
         "context": "."
     },
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2": {
+        "ghcr.io/devcontainers/features/common-utils": {
             "installZsh": "true",
             "username": "vscode",
             "userUid": "1000",
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/git:1": {
+        "ghcr.io/devcontainers/features/git": {
             "version": "os-provided",
             "ppa": "false"
         },
-        "ghcr.io/devcontainers/features/powershell:1": {
+        "ghcr.io/devcontainers/features/powershell": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/github-cli:1": {
+        "ghcr.io/devcontainers/features/github-cli": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "ghcr.io/devcontainers/features/docker-in-docker": {
             "version": "latest"
         },
-        "ghcr.io/eitsupi/devcontainer-features/jq-likes:2.1.1": {
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes": {
             "jqVersion": "latest",
             "yqVersion": "latest",
             "xqVersion": "none"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,18 @@ updates:
       actions:
         patterns:
           - "actions/*"
+      docker:
+        patterns:
+          - "docker/*"
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
+      reviewdog:
+        patterns:
+          - "reviewdog/*"
+      gittools:
+        patterns:
+          - "gittools/*"
     directories:
       - /.github/workflows
       - /.github/actions
@@ -89,11 +101,29 @@ updates:
       cronjob: "0 12 1,15 * *"
 
   - package-ecosystem: docker
-    directory: /.devcontainer
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "(docker deps)"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    directories:
+      - /.devcontainer
+      - /build/docker
     schedule:
       interval: daily
 
-  - package-ecosystem: docker
-    directory: /build/docker
+  - package-ecosystem: devcontainers
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "(devcontainer deps)"
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
+    directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
## What

Consolidates the Dependabot configuration and wires up automated updates for devcontainer features.

### `.github/dependabot.yml`
- **Merge the two `docker` ecosystem entries** into one using a `directories:` list (`/.devcontainer`, `/build/docker`) — they had identical daily schedules. Also added the `labels`/`commit-message` prefix the other ecosystems already carry.
- **Add a `devcontainers` ecosystem** so the `features:` in `devcontainer.json` (`ghcr.io/devcontainers/features/*`, `eitsupi/...`) get updated. The existing `docker` entry only bumped the `FROM` in the Dockerfile.
- **Group more github-actions vendors** — beyond `actions/*`, now also `docker/*`, `github/codeql-action/*`, `reviewdog/*`, and `gittools/*`, based on the actions actually used across the workflows. Single-use actions (harden-runner, scorecard, codecov, etc.) are left ungrouped intentionally so they stay easy to review.

### `.devcontainer/`
- Add `devcontainer-lock.json` with resolved versions + digests and unpin the feature tags — required for the `devcontainers` Dependabot ecosystem to track and bump features.

## Note
The unpinned feature tags rely on `devcontainer-lock.json` for version resolution. Worth rebuilding the devcontainer once to confirm features still resolve as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)