### PR TITLE
feat(ci): sync GitVersion schema to SchemaStore on new schema releases

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -61,7 +61,6 @@ jobs:
           brew bump-formula-pr gitversion \
             --url "$url" \
             --sha256 "$sha256" \
-            --fork-org gittools
             --no-audit \
             --no-browse \
             --message "For additional details see https://github.com/GitTools/GitVersion/releases/tag/${version}"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,0 +1,88 @@
+name: Update SchemaStore
+
+on:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - schemas/**
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'GitVersion schema version to publish (e.g. 6.7)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-schemastore:
+    name: Open PR to SchemaStore
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: gh-pages
+          fetch-depth: 2
+
+      - name: Detect schema version
+        id: detect
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="$(git diff --name-only --diff-filter=A "${{ github.event.before }}" "${{ github.event.after }}" -- 'schemas/*/GitVersion.configuration.json' \
+              | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Load GitHub release token
+        id: github-creds
+        if: steps.detect.outputs.version != ''
+        uses: gittools/cicd/github-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
+        with:
+          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: '[Update SchemaStore]'
+        if: steps.detect.outputs.version != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.github-creds.outputs.github_release_token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          git config --global user.name "GitTools Bot"
+          git config --global user.email "gittoolsbot@outlook.com"
+
+          gh repo sync GitTools/schemastore --source SchemaStore/schemastore --branch master
+
+          workdir="$(mktemp -d)"
+          gh repo clone GitTools/schemastore "$workdir" -- --branch master
+          cd "$workdir"
+
+          branch="gitversion-schema-${VERSION}"
+          git checkout -b "$branch"
+
+          url="https://gitversion.net/schemas/${VERSION}/GitVersion.configuration.json"
+          catalog="src/api/json/catalog.json"
+          schemaRef="src/schemas/json/gitversion.json"
+
+          jq --arg url "$url" --arg version "$VERSION" \
+            '(.schemas[] | select(.name == "GitVersion")) |= (.url = $url | .versions[$version] = $url)' \
+            "$catalog" > "$catalog.tmp" && mv "$catalog.tmp" "$catalog"
+          jq --arg ref "$url" '."$ref" = $ref' "$schemaRef" > "$schemaRef.tmp" && mv "$schemaRef.tmp" "$schemaRef"
+
+          git commit -am "update gitversion schema to ${VERSION}" || { echo "Nothing to update, skipping PR."; exit 0; }
+          git push origin "$branch"
+
+          gh pr create --repo SchemaStore/schemastore --head "GitTools:${branch}" --base master \
+            --title "update gitversion schema to ${VERSION}" \
+            --body "Automated update of the GitVersion configuration schema for the ${VERSION} release."

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,11 +1,9 @@
 name: Update SchemaStore
 
 on:
-  push:
-    branches:
-      - gh-pages
-    paths:
-      - schemas/**
+  workflow_run:
+    workflows: [ 'Verify & Publish Docs' ]
+    types: [ completed ]
   workflow_dispatch:
     inputs:
       version:
@@ -17,6 +15,7 @@ permissions:
 
 jobs:
   update-schemastore:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Open PR to SchemaStore
     runs-on: ubuntu-24.04
     steps:
@@ -37,13 +36,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
-          BEFORE_SHA: ${{ github.event.before }}
-          AFTER_SHA: ${{ github.event.after }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             version="$INPUT_VERSION"
           else
-            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
+            # docs.yml pushes a single commit to gh-pages per run, so the newly
+            # added schema folder (if any) is in the diff of the last commit.
+            version="$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,9 +1,11 @@
 name: Update SchemaStore
 
 on:
-  workflow_run:
-    workflows: [ 'Verify & Publish Docs' ]
-    types: [ completed ]
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - schemas/**
   workflow_dispatch:
     inputs:
       version:
@@ -15,7 +17,6 @@ permissions:
 
 jobs:
   update-schemastore:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Open PR to SchemaStore
     runs-on: ubuntu-24.04
     steps:
@@ -28,7 +29,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: gh-pages
-          fetch-depth: 2
+          # Full history so the before/after SHAs from the push event are always
+          # available locally, regardless of how many commits the push contained.
+          fetch-depth: 0
 
       - name: Detect schema version
         id: detect
@@ -36,13 +39,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             version="$INPUT_VERSION"
           else
-            # docs.yml pushes a single commit to gh-pages per run, so the newly
-            # added schema folder (if any) is in the diff of the last commit.
-            version="$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'schemas/*/GitVersion.configuration.json' \
+            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -34,11 +34,16 @@ jobs:
       - name: Detect schema version
         id: detect
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="$INPUT_VERSION"
           else
-            version="$(git diff --name-only --diff-filter=A "${{ github.event.before }}" "${{ github.event.after }}" -- 'schemas/*/GitVersion.configuration.json' \
+            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/build/docs/Tasks/PublishDocs.cs
+++ b/build/docs/Tasks/PublishDocs.cs
@@ -88,6 +88,15 @@ public sealed class PublishDocsInternal : FrostingTask<BuildContext>
         context.EnsureDirectoryExists(schemaTargetDir);
         context.CopyDirectory(Paths.Schemas, schemaTargetDir);
 
+        // gh-pages needs its own copy of this workflow so that a push to gh-pages
+        // can trigger it directly (GitHub resolves push-triggered workflows using
+        // the file as it exists on the pushed branch, not on the default branch).
+        var workflowsTargetDir = publishFolder.Combine(".github").Combine("workflows");
+        context.EnsureDirectoryExists(workflowsTargetDir);
+        context.CopyFile(
+            Paths.Root.CombineWithFilePath(".github/workflows/schemastore.yml"),
+            workflowsTargetDir.CombineWithFilePath("schemastore.yml"));
+
         if (!context.GitHasUncommitedChanges(publishFolder))
         {
             return;


### PR DESCRIPTION
## Summary

Adds `.github/workflows/schemastore.yml`, which automates opening a PR against [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore) whenever a new GitVersion schema version is published, per #5017.

## How it works

- **Trigger**: pushes to `gh-pages` that touch `schemas/**` (i.e. right after `docs.yml` publishes docs and the generated schema for the release), or `workflow_dispatch` with a `version` input for manual re-runs.
- **Detection**: on the automatic trigger, diffs `before`/`after` on `gh-pages` for newly *added* `schemas/*/GitVersion.configuration.json` files and derives the version from the folder name. If nothing new was added (e.g. a patch release with no new schema), the job no-ops. On manual trigger, the provided `version` input is used directly instead.
- **Auth**: uses a single token from `gittools/cicd/github-creds` (same mechanism as `homebrew.yml` uses for opening PRs against `homebrew-core`) for both pushing to the [GitTools/schemastore](https://github.com/GitTools/schemastore) fork and opening the PR against the upstream repo. A GitHub App token was considered (as used in `gittools-actions.yml`), but App installation tokens are scoped to repos the app is installed on and can't open a PR against `SchemaStore/schemastore`, which GitTools doesn't control — so a single PAT-based identity (like homebrew.yml) is the correct fit here.
- **Update logic**:
  1. `gh repo sync` brings the `GitTools/schemastore` fork's `master` up to date with upstream.
  2. Clones the fork, branches as `gitversion-schema-<version>`.
  3. Uses `jq` to bump the GitVersion entry's `url`, add the new `versions` map entry in `src/api/json/catalog.json`, and update the `$ref` in `src/schemas/json/gitversion.json` — matching [SchemaStore/schemastore#5485](https://github.com/SchemaStore/schemastore/pull/5485).
  4. Commits, pushes, and opens the PR via `gh pr create --repo SchemaStore/schemastore`.

## Test plan

- [ ] `actionlint` passes on the new workflow (verified locally).
- [ ] Manually trigger via `workflow_dispatch` with a real historical version (e.g. `6.7`) against a test fork to confirm the `jq` edits and PR creation work end-to-end, since this can't be exercised from a local sandbox (needs `OP_SERVICE_ACCOUNT_TOKEN` and push access to `GitTools/schemastore`).
- [ ] Confirm the automatic trigger correctly detects a newly-added schema folder on the next real release that ships a new schema version.
