### PR TITLE
fix(ci): fix schemastore.yml git push auth and catalog.json diff bloat

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -61,7 +61,6 @@ jobs:
           brew bump-formula-pr gitversion \
             --url "$url" \
             --sha256 "$sha256" \
-            --fork-org gittools
             --no-audit \
             --no-browse \
             --message "For additional details see https://github.com/GitTools/GitVersion/releases/tag/${version}"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -68,6 +68,7 @@ jobs:
 
           git config --global user.name "GitTools Bot"
           git config --global user.email "gittoolsbot@outlook.com"
+          gh auth setup-git
 
           gh repo sync GitTools/schemastore --source SchemaStore/schemastore --branch master
 
@@ -82,9 +83,37 @@ jobs:
           catalog="src/api/json/catalog.json"
           schemaRef="src/schemas/json/gitversion.json"
 
-          jq --arg url "$url" --arg version "$VERSION" \
-            '(.schemas[] | select(.name == "GitVersion")) |= (.url = $url | .versions[$version] = $url)' \
-            "$catalog" > "$catalog.tmp" && mv "$catalog.tmp" "$catalog"
+          # catalog.json mixes compact and multi-line JSON arrays throughout its
+          # ~10k lines, so re-serializing the whole document (e.g. via jq) reformats
+          # every entry and produces a huge, unreviewable diff. Patch only the text
+          # of the GitVersion schema object instead, leaving the rest untouched.
+          python3 - "$catalog" "$VERSION" "$url" <<'PYEOF'
+          import re
+          import sys
+
+          path, version, url = sys.argv[1], sys.argv[2], sys.argv[3]
+
+          with open(path, encoding="utf-8") as f:
+              text = f.read()
+
+          start = text.index('"name": "GitVersion"')
+          end = text.index('"name":', start + 1)
+          block = text[start:end]
+
+          old_url = re.search(r'"url": "([^"]+)"', block).group(1)
+          new_block = block.replace(f'"url": "{old_url}"', f'"url": "{url}"', 1)
+
+          last_version_entry = re.search(r'(\n(\s*)"[^"]+": "[^"]+")(\n\s*\}\s*\n)', new_block)
+          indent = last_version_entry.group(2)
+          insert_at = last_version_entry.end(1)
+          new_block = f"{new_block[:insert_at]},\n{indent}\"{version}\": \"{url}\"{new_block[insert_at:]}"
+
+          text = text[:start] + new_block + text[end:]
+
+          with open(path, "w", encoding="utf-8") as f:
+              f.write(text)
+          PYEOF
+
           jq --arg ref "$url" '."$ref" = $ref' "$schemaRef" > "$schemaRef.tmp" && mv "$schemaRef.tmp" "$schemaRef"
 
           git commit -am "update gitversion schema to ${VERSION}" || { echo "Nothing to update, skipping PR."; exit 0; }

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,0 +1,88 @@
+name: Update SchemaStore
+
+on:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - schemas/**
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'GitVersion schema version to publish (e.g. 6.7)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-schemastore:
+    name: Open PR to SchemaStore
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: gh-pages
+          fetch-depth: 2
+
+      - name: Detect schema version
+        id: detect
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="$(git diff --name-only --diff-filter=A "${{ github.event.before }}" "${{ github.event.after }}" -- 'schemas/*/GitVersion.configuration.json' \
+              | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Load GitHub release token
+        id: github-creds
+        if: steps.detect.outputs.version != ''
+        uses: gittools/cicd/github-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
+        with:
+          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: '[Update SchemaStore]'
+        if: steps.detect.outputs.version != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.github-creds.outputs.github_release_token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          git config --global user.name "GitTools Bot"
+          git config --global user.email "gittoolsbot@outlook.com"
+
+          gh repo sync GitTools/schemastore --source SchemaStore/schemastore --branch master
+
+          workdir="$(mktemp -d)"
+          gh repo clone GitTools/schemastore "$workdir" -- --branch master
+          cd "$workdir"
+
+          branch="gitversion-schema-${VERSION}"
+          git checkout -b "$branch"
+
+          url="https://gitversion.net/schemas/${VERSION}/GitVersion.configuration.json"
+          catalog="src/api/json/catalog.json"
+          schemaRef="src/schemas/json/gitversion.json"
+
+          jq --arg url "$url" --arg version "$VERSION" \
+            '(.schemas[] | select(.name == "GitVersion")) |= (.url = $url | .versions[$version] = $url)' \
+            "$catalog" > "$catalog.tmp" && mv "$catalog.tmp" "$catalog"
+          jq --arg ref "$url" '."$ref" = $ref' "$schemaRef" > "$schemaRef.tmp" && mv "$schemaRef.tmp" "$schemaRef"
+
+          git commit -am "update gitversion schema to ${VERSION}" || { echo "Nothing to update, skipping PR."; exit 0; }
+          git push origin "$branch"
+
+          gh pr create --repo SchemaStore/schemastore --head "GitTools:${branch}" --base master \
+            --title "update gitversion schema to ${VERSION}" \
+            --body "Automated update of the GitVersion configuration schema for the ${VERSION} release."

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,11 +1,9 @@
 name: Update SchemaStore
 
 on:
-  push:
-    branches:
-      - gh-pages
-    paths:
-      - schemas/**
+  workflow_run:
+    workflows: [ 'Verify & Publish Docs' ]
+    types: [ completed ]
   workflow_dispatch:
     inputs:
       version:
@@ -17,6 +15,7 @@ permissions:
 
 jobs:
   update-schemastore:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Open PR to SchemaStore
     runs-on: ubuntu-24.04
     steps:
@@ -37,13 +36,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
-          BEFORE_SHA: ${{ github.event.before }}
-          AFTER_SHA: ${{ github.event.after }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             version="$INPUT_VERSION"
           else
-            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
+            # docs.yml pushes a single commit to gh-pages per run, so the newly
+            # added schema folder (if any) is in the diff of the last commit.
+            version="$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -1,9 +1,11 @@
 name: Update SchemaStore
 
 on:
-  workflow_run:
-    workflows: [ 'Verify & Publish Docs' ]
-    types: [ completed ]
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - schemas/**
   workflow_dispatch:
     inputs:
       version:
@@ -15,7 +17,6 @@ permissions:
 
 jobs:
   update-schemastore:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Open PR to SchemaStore
     runs-on: ubuntu-24.04
     steps:
@@ -28,7 +29,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: gh-pages
-          fetch-depth: 2
+          # Full history so the before/after SHAs from the push event are always
+          # available locally, regardless of how many commits the push contained.
+          fetch-depth: 0
 
       - name: Detect schema version
         id: detect
@@ -36,13 +39,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             version="$INPUT_VERSION"
           else
-            # docs.yml pushes a single commit to gh-pages per run, so the newly
-            # added schema folder (if any) is in the diff of the last commit.
-            version="$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'schemas/*/GitVersion.configuration.json' \
+            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schemastore.yml
+++ b/.github/workflows/schemastore.yml
@@ -34,11 +34,16 @@ jobs:
       - name: Detect schema version
         id: detect
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="$INPUT_VERSION"
           else
-            version="$(git diff --name-only --diff-filter=A "${{ github.event.before }}" "${{ github.event.after }}" -- 'schemas/*/GitVersion.configuration.json' \
+            version="$(git diff --name-only --diff-filter=A "$BEFORE_SHA" "$AFTER_SHA" -- 'schemas/*/GitVersion.configuration.json' \
               | sed -E 's#schemas/([^/]+)/.*#\1#' | sort -V | tail -1)"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/build/docs/Tasks/PublishDocs.cs
+++ b/build/docs/Tasks/PublishDocs.cs
@@ -88,6 +88,15 @@ public sealed class PublishDocsInternal : FrostingTask<BuildContext>
         context.EnsureDirectoryExists(schemaTargetDir);
         context.CopyDirectory(Paths.Schemas, schemaTargetDir);
 
+        // gh-pages needs its own copy of this workflow so that a push to gh-pages
+        // can trigger it directly (GitHub resolves push-triggered workflows using
+        // the file as it exists on the pushed branch, not on the default branch).
+        var workflowsTargetDir = publishFolder.Combine(".github").Combine("workflows");
+        context.EnsureDirectoryExists(workflowsTargetDir);
+        context.CopyFile(
+            Paths.Root.CombineWithFilePath(".github/workflows/schemastore.yml"),
+            workflowsTargetDir.CombineWithFilePath("schemastore.yml"));
+
         if (!context.GitHasUncommitedChanges(publishFolder))
         {
             return;


### PR DESCRIPTION
## Summary

Follow-up to #5018, fixing two real failures found in the first live run of `.github/workflows/schemastore.yml` (a `workflow_dispatch` run for `6.8`: https://github.com/GitTools/GitVersion/actions/runs/28647172956/job/84956436257).

## What was broken

1. **Push auth failure**: `gh repo clone`/`gh repo sync` authenticate through the `gh` CLI's own token handling, but the subsequent plain `git push origin "$branch"` doesn't pick that up — it failed with `fatal: could not read Username for 'https://github.com': No such device or address`. Fixed by running `gh auth setup-git` up front, which configures git's credential helper to use `GH_TOKEN`.
2. **Massive, unreviewable diff on `catalog.json`**: piping the whole ~10k-line file through `jq` to bump the GitVersion entry produced a diff of ~4000 lines instead of the expected handful. `catalog.json` mixes compact single-line and multi-line JSON arrays throughout, so `jq`'s pretty-printer reformats every entry in the file, not just the one being changed. Replaced the `jq` edit for `catalog.json` with a small inline Python script that only rewrites the text of the GitVersion schema object, leaving the rest of the file byte-for-byte untouched. Verified locally against the real `SchemaStore/schemastore` catalog.json that this reproduces the same 3-line diff as the real merged reference PR ([SchemaStore/schemastore#5485](https://github.com/SchemaStore/schemastore/pull/5485)). `gitversion.json` is tiny (5 lines) so it's left on `jq`.

## Test plan

- [x] `actionlint` passes locally.
- [x] Extracted the workflow's `run:` script via YAML parsing and ran it against a real downloaded copy of `SchemaStore/schemastore`'s `catalog.json` — confirmed a minimal 3-line diff and valid JSON output.
- [ ] Re-run `workflow_dispatch` with a real version once merged to confirm the push/PR creation now succeeds end-to-end.
