### PR TITLE
fix: allow incorrect labels if placeholders are missing

### DIFF
--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -127,21 +127,39 @@ public class ConfigurationExtensionsTests : TestBase
     }
 
     [Test]
-    public void EnsureGetBranchSpecificLabelThrowsWhenEnvVarMissing()
+    public void EnsureGetBranchSpecificLabelReturnsLabelTemplateWhenEnvVarMissing()
     {
         var environment = new TestEnvironment();
         // Do not set MISSING_VAR
+        var expectedLabel = "pr-{env:MISSING_VAR}";
 
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
             .WithBranch(BranchName, builder => builder
-                .WithLabel("pr-{env:MISSING_VAR}")
+                .WithLabel(expectedLabel)
                 .WithRegularExpression(@"^pull[/-]"))
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
-        Should.Throw<ArgumentException>(() =>
-            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
+        actual.ShouldBe(expectedLabel);
+    }
+
+    [Test]
+    public void EnsureGetBranchSpecificLabelReturnsLabelTemplateWhenPropertyMissing()
+    {
+        var expectedLabel = "{BranchName}";
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithoutBranches()
+            .WithBranch("feature/test", builder => builder
+                .WithLabel("{BranchName}")
+                .WithRegularExpression(@"^features?[\/-]"))
+            .Build();
+
+        var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, new TestEnvironment());
+        actual.ShouldBe(expectedLabel);
     }
 
     [TestCase("case-00/my-branch", "case-00-my-branch")]

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -133,8 +133,15 @@ internal static class ConfigurationExtensions
             var effectiveBranchName = branchNameOverride ?? branchName;
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
 
-            return label.FormatWith(labelPlaceholders, environment)
-                .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");
+            try
+            {
+                return label.FormatWith(labelPlaceholders, environment)
+                    .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");
+            }
+            catch (Exception e) when (e is ArgumentException or FormatException)
+            {
+                return label;
+            }
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Avoids throwing when label placeholders are not found. This fixes a 6.x regression.

See https://github.com/GitTools/GitVersion/discussions/5021

## Related Issue

<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

Resolves #5026 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Users reported that their existing config worked in 6.7 but threw exceptions in 6.8. The cause was bad config, but we should still support this behavior at least for 6.x. We can enforce good config from 7.x onwards.

## How Has This Been Tested?

<!-- 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Please describe in detail how you tested your changes.

-->
Added unit tests to validate old behavior.

## Screenshots (if appropriate):

<!-- Drag and drop screenshots here -->

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* \[x] My code follows the code style of this project.
* \[ ] My change requires a change to the documentation.
* \[ ] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
