### PR TITLE
feat: throw when label is invalid or missing placeholders

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Invalid label formatting is not ignored
+Previously bad label formatting config would be silently accepted. For example `{Branhc}` (when BranchName is misspelled) or even `{BranchName` (missing a closing brace). This is not ignored now and exceptions will be thrown if formatting problems exist in the label config. This brings it into line with how assembly string formatting is treated.
+
 ### CLI Arguments — POSIX-style Syntax
 
 The command-line interface has been migrated from Windows-style (`/switch` and single-dash `-switch`) arguments to POSIX-style `--long-name` arguments using [System.CommandLine](https://github.com/dotnet/command-line-api).

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -127,29 +127,26 @@ public class ConfigurationExtensionsTests : TestBase
     }
 
     [Test]
-    public void EnsureGetBranchSpecificLabelReturnsLabelTemplateWhenEnvVarMissing()
+    public void EnsureGetBranchSpecificLabelThrowsWhenEnvVarMissing()
     {
         var environment = new TestEnvironment();
         // Do not set MISSING_VAR
-        var expectedLabel = "pr-{env:MISSING_VAR}";
 
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
             .WithBranch(BranchName, builder => builder
-                .WithLabel(expectedLabel)
+                .WithLabel("pr-{env:MISSING_VAR}")
                 .WithRegularExpression(@"^pull[/-]"))
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
-        actual.ShouldBe(expectedLabel);
+        Should.Throw<ArgumentException>(() =>
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment));
     }
 
     [Test]
-    public void EnsureGetBranchSpecificLabelReturnsLabelTemplateWhenPropertyMissing()
+    public void EnsureGetBranchSpecificLabelThrowsWhenBranchNamePropertyMissing()
     {
-        var expectedLabel = "{BranchName}";
-
         var configuration = GitFlowConfigurationBuilder.New
             .WithoutBranches()
             .WithBranch("feature/test", builder => builder
@@ -158,8 +155,8 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, new TestEnvironment());
-        actual.ShouldBe(expectedLabel);
+        Should.Throw<ArgumentException>(() =>
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, new TestEnvironment()));
     }
 
     [TestCase("case-00/my-branch", "case-00-my-branch")]

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -133,15 +133,8 @@ internal static class ConfigurationExtensions
             var effectiveBranchName = branchNameOverride ?? branchName;
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
 
-            try
-            {
-                return label.FormatWith(labelPlaceholders, environment)
-                    .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");
-            }
-            catch (Exception e) when (e is ArgumentException or FormatException)
-            {
-                return label;
-            }
+            return label.FormatWith(labelPlaceholders, environment)
+                .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");
         }
 
         public TaggedSemanticVersions GetTaggedSemanticVersion()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Follow-up change to make invalid labels or labels missing placeholders throw instead of silently accepting them.

## Related Issue

<!--

This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
Please replace "XYZ" below with the issue number that is being resolved by this
pull request.

-->

Resolves #5026 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
As discussed in linked issue, the breaking behavior we want for v7 is to throw when labels are invalid or missing placeholders, which is how assembly formatting is treated. This is to align formatting expectations across the config.

## How Has This Been Tested?

<!-- 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
Please describe in detail how you tested your changes.

-->
Existing tests modified to exhibit new behavior.

## Screenshots (if appropriate):

<!-- Drag and drop screenshots here -->

## Checklist:

<!--

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!

-->

* \[x] My code follows the code style of this project.
* \[x] My change requires a change to the documentation.
* \[x] I have updated the documentation accordingly.
* \[x] I have added tests to cover my changes.
* \[x] All new and existing tests passed.
