### PR TITLE
feat: git CLI backend for mutating/network operations behind GITVERSION_GIT_BACKEND switch

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   unit_test:
-    name: ${{ matrix.os }} - net${{ matrix.dotnet_version }}
+    name: ${{ matrix.os }} - net${{ matrix.dotnet_version }} - ${{ matrix.git_backend }}
     permissions:
       id-token: write
     strategy:
@@ -24,6 +24,9 @@ jobs:
       matrix:
         os: [ windows-2025-vs2026, ubuntu-24.04, macos-26 ]
         dotnet_version: ${{ fromJson(inputs.dotnet_versions) }}
+        # Run the suite against both Git backends until libgit2 is removed,
+        # see https://github.com/GitTools/GitVersion/issues/5031
+        git_backend: [ libgit2, managed ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,6 +44,8 @@ jobs:
 
       - name: '[Unit Test]'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          GITVERSION_GIT_BACKEND: ${{ matrix.git_backend }}
         with:
           shell: pwsh
           timeout_minutes: 30
@@ -50,13 +55,13 @@ jobs:
 
       - name: Test Summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
-        if: always() && matrix.dotnet_version == '10.0'
+        if: always() && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
         with:
           paths: artifacts/test-results/**/results.xml
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0'
+        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
         with:
           files: artifacts/test-results/**/results.xml
           report_type: 'test_results'
@@ -64,7 +69,7 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0'
+        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
         with:
           directory: artifacts/test-results
           report_type: 'coverage'

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,25 @@
 ## Unreleased
 
+### Selectable Git backend (libgit2 vs. managed)
+
+GitVersion is migrating away from LibGit2Sharp and its native libgit2 binaries towards a managed implementation combined with the `git` CLI ([#5031](https://github.com/GitTools/GitVersion/issues/5031)). A single environment variable selects the backend:
+
+| Release | Default backend | Switch |
+| ------- | --------------- | ------ |
+| v7.0    | `libgit2`       | `GITVERSION_GIT_BACKEND=managed` to opt in to the new backend |
+| v7.1    | `managed`       | `GITVERSION_GIT_BACKEND=libgit2` to fall back |
+| later   | `managed`       | libgit2 backend removed |
+
+Behavioral notes when using the `managed` backend:
+
+* Mutating and network operations (repository normalization on CI build agents, dynamic repositories via `--url`, checkout, fetch) are performed by invoking the `git` executable, which must be available on the `PATH`. Plain version calculation on an already-prepared checkout does not require it.
+* v7.0 behavior is unchanged unless you opt in. Please test the `managed` backend and report issues — the libgit2 backend will be removed once the new backend has proven itself over several releases.
+
+### Git abstraction API changes (`GitVersion.Core`)
+
+* `CommitFilter.IncludeReachableFrom` and `CommitFilter.ExcludeReachableFrom` are now typed as the new `ICommitish` marker interface (implemented by `ICommit` and `IBranch`) instead of `object?`. Code that assigned other types to these properties no longer compiles; code passing `ICommit`/`IBranch` instances is unaffected.
+* The `GitVersion.LibGit2SharpExtensions` class (the `IRepository.ToGitRepository()` extension) has been removed from the public API of `GitVersion.LibGit2Sharp`.
+
 ### Invalid label formatting is not ignored
 Previously bad label formatting config would be silently accepted. For example `{Branhc}` (when BranchName is misspelled) or even `{BranchName` (missing a closing brace). This is not ignored now and exceptions will be thrown if formatting problems exist in the label config. This brings it into line with how assembly string formatting is treated.
 

--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -153,10 +153,28 @@ CLI executor hygiene:
 
 ## 5. Phased migration (every phase shippable)
 
+### Release strategy: one switch, two backends, a public testing window
+
+A single public environment variable — **`GITVERSION_GIT_BACKEND=libgit2|managed`** — selects the entire
+backend. `managed` opts into the new implementation stack as far as it exists at each release (first the
+CLI mutator, later also the managed reader). The version-to-default mapping is explicit:
+
+| Release | Default backend | Opt-in / opt-out |
+|---|---|---|
+| **v7.0** | `libgit2` | `GITVERSION_GIT_BACKEND=managed` to test the new backend |
+| **v7.1** | `managed` | `GITVERSION_GIT_BACKEND=libgit2` to fall back |
+| v7.x (later) | `managed` | libgit2 removed (Phase E) once the fallback has gone several releases unused/regression-free |
+
+Both backends ship side by side throughout the v7.0–v7.x window so users can validate `managed` against
+their real repositories and report issues before libgit2 is dropped. For that whole window, the CI
+unit-test matrix runs the full suite against both backends (`git_backend` dimension in `_unit_tests.yml`) —
+both legs must stay green.
+
 ### Phase A — CLI mutator first (reads stay on libgit2) · ~2–3 weeks
 Replace `GitRepository.mutating.cs` + mutating collection members with `GitVersion.Git.CommandLine`.
-Reads keep using libgit2; the wrapper invalidates its lazy `Repository` handle after each mutation so libgit2
-sees external ref changes. Escape hatch: `GITVERSION_GIT_BACKEND_MUTATOR=cli|libgit2` for one release.
+Reads keep using libgit2; the wrapper drops its cached collection wrappers after each CLI mutation so
+external ref changes become visible (the libgit2 handle itself must not be disposed — wrappers already
+handed out reference its native memory). Selected via `GITVERSION_GIT_BACKEND=managed`.
 This immediately retires the most fragile native code paths (network, SSL, credentials).
 
 ### Phase B-pre — interface cleanups · ~3–5 days
@@ -175,8 +193,10 @@ Backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2
 - **Real-world corpus script**: `gitversion /nocache /output json` diffed across backends on this repo,
   GitReleaseManager, dotnet/runtime, a shallow CI-style clone, and a worktree checkout
 
-### Phase C — default flip · ~1 week + one release soak
-Default `managed`; `libgit2` remains an env-var escape hatch for one minor release. Dual CI matrix stays green.
+### Phase C — default flip in v7.1 · ~1 week + multi-release soak
+**v7.0 ships with default `libgit2`** (managed opt-in); **v7.1 flips the default to `managed`** with
+`GITVERSION_GIT_BACKEND=libgit2` as the fallback while users validate the new backend. The dual-backend
+CI matrix stays green throughout the window.
 
 ### Phase D — fixture migration (parallel with B) · ~2–3 weeks
 `GitVersion.Testing` moves to pure git-CLI writes via the existing `ExecuteGitCmd` pattern:

--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -1,0 +1,237 @@
+# Replacing LibGit2Sharp with a managed Git implementation
+
+Research and migration plan for [#236](https://github.com/arturcic/GitVersion/issues/236) — researched 2026-07, based on a full survey of the `next/v7` tree.
+
+## 1. Motivation
+
+LibGit2Sharp wraps the native `libgit2` library and has been a recurring source of pain for GitVersion for close to a decade:
+
+- **Native binary load failures** on end-user machines and CI images — GitTools/GitVersion
+  [#1097](https://github.com/GitTools/GitVersion/issues/1097),
+  [#1203](https://github.com/GitTools/GitVersion/issues/1203),
+  [#1744](https://github.com/GitTools/GitVersion/issues/1744),
+  [#1852](https://github.com/GitTools/GitVersion/issues/1852),
+  [#2615](https://github.com/GitTools/GitVersion/issues/2615),
+  [#2884](https://github.com/GitTools/GitVersion/issues/2884). The failure mode is always the same class:
+  the RID-specific `libgit2-*.so/.dylib/.dll` doesn't match the runtime OS/arch/libc (musl vs glibc,
+  new Ubuntu OpenSSL versions, ARM variants) or cannot be located by the MSBuild task's assembly-load context.
+- **Packaging weight**: `LibGit2Sharp.NativeBinaries` unpacks ~12 native binaries
+  (linux x64/arm/arm64/musl/ppc64le, osx x64/arm64, win x64/x86/arm64) into `runtimes/<rid>/native/`
+  of every published artifact — and `GitVersion.MsBuild` ships that payload **per TFM** (net8.0/net9.0/net10.0).
+- **Platform lag**: new RIDs, libcs and OS versions require waiting on libgit2 + LibGit2Sharp + NativeBinaries releases
+  (GitVersion is currently pinned to LibGit2Sharp 0.31.0).
+- **Feature lag**: libgit2 trails git itself (SHA-256 repos, reftable, partial clone), and its global native state
+  complicates concurrent use inside MSBuild.
+
+Precedent: Nerdbank.GitVersioning faced the same problem and built a managed read-only engine
+([dotnet/Nerdbank.GitVersioning#505](https://github.com/dotnet/Nerdbank.GitVersioning/issues/505),
+[#521](https://github.com/dotnet/Nerdbank.GitVersioning/pull/521)). It became their default backend and delivered
+**>10x throughput on history walks** compared to libgit2. NBGV kept libgit2 for write paths; the plan below goes one
+step further and removes the native dependency entirely.
+
+## 2. Landscape: managed Git options in .NET (2026)
+
+| Candidate | Reads | Writes | Fetch/clone | Maintained | Assessment |
+|---|---|---|---|---|---|
+| [NBGV ManagedGit](https://github.com/dotnet/Nerdbank.GitVersioning/tree/main/src/NerdBank.GitVersioning/ManagedGit) | objects, packs (incl. deltas), refs; tuned for version calculation | No | No | Active, but internal to NBGV (MIT) | **Primary porting source** — proven pack/idx/delta code, the source of the >10x speedup |
+| [GitReader](https://github.com/kekyo/GitReader) (kekyo) | full traversal: branches/tags/commits, packfiles, worktrees, index, .gitignore | No | No | Active (v1.18, .NET 10 TFMs, zero deps) | Porting inspiration for worktree handling and commit-graph; viable external dependency if vendoring were rejected |
+| [ManagedGitLib](https://github.com/GlebChili/ManagedGitLib) | standalone extraction of NBGV ManagedGit | No | No | Stale (~2022) | Proof that vendoring/extracting NBGV's code works; not a dependency to take |
+| DotGit, GitRead.Net, GitSharp, NGit | partial readers / ancient ports | No | No | Dead | Skip |
+| `git` CLI shell-out (MinVer-style) | yes | yes | yes, with system credential helpers | n/a | **Chosen for writes + network** — requires `git` on PATH, which every CI normalization scenario already implies |
+
+**The decisive fact:** no maintained managed .NET library implements git *write* operations or the smart-HTTP/SSH
+*transport* (fetch/clone). Every managed option is read-only. Any replacement strategy must therefore pair a managed
+reader with something else for the write/network surface — and that something is the `git` CLI, which is guaranteed
+present in exactly the scenarios (CI normalization, dynamic repositories) that need it.
+
+### Decisions
+
+1. **Hybrid backend**: vendored fully-managed reader for all read/history operations; `git` CLI shell-out for
+   writes and network. Zero native binaries ship with GitVersion afterwards.
+2. **Vendored, not an external package**: the managed reader lives in this repo (ported from NBGV ManagedGit, MIT,
+   with attribution), giving full control over revwalk semantics — which version output depends on.
+3. **`src/` (stable) tree first**; `new-cli` follows by source-linking the read-only subset, exactly as it
+   source-links the LibGit2Sharp adapter today.
+
+## 3. Current LibGit2Sharp surface (survey results)
+
+### 3.1 The seam is clean
+
+`GitVersion.Core` has **no LibGit2Sharp reference**. It consumes only its own abstraction in
+`src/GitVersion.Core/Git/` (~20 interfaces: `IGitRepository`, `IMutatingGitRepository`, `IGitRepositoryInfo`,
+`ICommit`, `IBranch`, `ITag`, `IReference`, `IRemote`, `IRefSpec`, `IObjectId`, their collections, and support types
+`CommitFilter`, `AuthenticationInfo`, `ReferenceName`). Only three projects reference LibGit2Sharp:
+
+1. `src/GitVersion.LibGit2Sharp` — the production adapter
+2. `src/GitVersion.Testing` — test fixtures
+3. `new-cli/GitVersion.Core.Libgit2Sharp` — source-links the adapter's files, read-only subset
+   (excludes `GitRepository.mutating.cs` and `GitRepositoryInfo.cs`)
+
+### 3.2 Read surface (the bulk — must be reimplemented)
+
+- Repository discovery and open: walk-up discovery, `.git` file indirection (worktrees/submodules),
+  commondir split, bare detection, shallow detection (`repo.Info.IsShallow`)
+- HEAD, branch/tag/reference/remote enumeration (incl. glob queries via `Refs.FromGlob`)
+- Commit metadata: id, parents, committer `When`, message
+- **Revwalk**: `CommitCollection.QueryBy(CommitFilter)` → libgit2 `IncludeReachableFrom` /
+  `ExcludeReachableFrom` / `FirstParentOnly` / `SortBy` (Topological, Time). Ordering is
+  version-output-affecting.
+- **Merge-base**: `repo.ObjectDatabase.FindMergeBase(c1, c2)`
+- **Tree diff**: `ICommit.DiffPaths` via `repo.Diff.Compare<TreeChanges>(tree, parentTree)` (changed paths only)
+- **Status**: `UncommittedChangesCount()` via `Diff.Compare<TreeChanges>(Head.Tip.Tree, DiffTargets.Index | DiffTargets.WorkingDirectory)` with `RetrieveStatus()` fallback
+
+### 3.3 Write + network surface (small, one consumer)
+
+Everything mutating funnels through **`src/GitVersion.Core/Core/GitPreparer.cs`** (CI normalization and dynamic
+repositories), implemented in `src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs` and the collection wrappers:
+
+- `Clone(url, workdir, auth)` — no-checkout clone with username/password credentials
+- `Fetch(remote, refSpecs, auth, log)` — authenticated HTTPS (username/password only; no SSH path exists today)
+- `Checkout(spec)`; `CreateBranchForPullRequestBranch(auth)` (uses network `ls-remote` under the hood)
+- `References.Add/UpdateTarget`, `Branches.UpdateTrackedBranch/Remove`, `Remotes.Update(refspec)/Remove`
+- Error mapping is already string-based (parses "401"/"404" out of exception messages);
+  `LockedFileException` is retried via Polly (`RepositoryExtensions.RunSafe`)
+
+### 3.4 Known abstraction leaks (to fix during migration)
+
+- Public `LibGit2SharpExtensions.ToGitRepository(IRepository)` exposes a LibGit2Sharp type
+- `CommitFilter.SortBy` is numerically cast to `LibGit2Sharp.CommitSortStrategies`
+- `CommitFilter.IncludeReachableFrom`/`ExcludeReachableFrom` are typed `object?`
+
+### 3.5 Test fixtures
+
+`src/GitVersion.Testing` (~300 LoC of real LibGit2Sharp usage in `Fixtures/RepositoryFixtureBase.cs` +
+`Extensions/GitTestExtensions.cs`) is *write-heavy*: stage/commit/tag/branch/merge-no-ff/checkout/clone/fetch/config.
+It already shells out to real `git` for `init -b`, shallow `pull --depth 1` and `gc` — so a pure git-CLI fixture
+backend is a natural completion of an existing pattern. Six test files additionally use LibGit2Sharp directly
+(mostly `ToGitRepository()` and `Signature`).
+
+## 4. Target architecture
+
+```
+src/
+  GitVersion.Git.Managed/          vendored managed reader (no GitVersion.Core dependency)
+    Objects/    GitObjectId (hash-agnostic), pack + .idx v2 readers, delta streams,
+                pack cache, loose-object reader, multi-pack-index reader
+    Parsing/    commit parser (author/committer/when/message/encoding), tree parser,
+                annotated-tag parser
+    Refs/       loose refs, packed-refs, symbolic refs, HEAD, glob enumeration
+    Repository/ discovery (walk-up, .git file, commondir), worktree resolver, shallow info
+    History/    revwalk (topo/time, first-parent, exclusions — libgit2-parity),
+                merge-base (paint-down-to-common), commit-graph reader (later, optional)
+    Diff/       recursive tree-vs-tree changed-paths diff (no rename detection)
+    Status/     .git/index v2–v4 reader, workdir/index status for UncommittedChangesCount
+  GitVersion.Git.CommandLine/      git CLI executor (writes + network only)
+  GitVersion.Git/                  thin adapter implementing IGitRepository (managed reader)
+                                   + IMutatingGitRepository (CLI mutator); mirrors the
+                                   current adapter file layout so DI is unchanged
+```
+
+Port-vs-fresh decisions:
+
+| Component | Decision |
+|---|---|
+| Pack/idx/delta reading, pack cache, loose objects, object id | **Port from NBGV ManagedGit** (MIT, attribution in headers + NOTICE) |
+| Commit/tree parsing | Port + extend (NBGV skips author/message — GitVersion needs them) |
+| Annotated tags, multi-pack-index, discovery/worktrees, shallow | Fresh (small, well-specified formats) |
+| **Revwalk**, **merge-base**, tree diff, index/status | **Fresh** — highest-parity-risk pieces, written against libgit2's documented algorithms |
+| SHA-256 repos | Hash-agnostic `GitObjectId` from day one; detect `extensions.objectformat=sha256` and fail with a clear message initially (parity: libgit2 can't read them either) |
+| Reftable (`extensions.refstorage=reftable`) | Detect and fail with a clear message; reader in backlog |
+
+CLI executor hygiene:
+
+- Arguments via `ProcessStartInfo.ArgumentList` (no shell, no quoting bugs); `LC_ALL=C`, `GIT_TERMINAL_PROMPT=0`,
+  `-c core.quotepath=false`
+- **Plumbing-only parsing** (`rev-parse`, `ls-remote`, `update-ref`, `symbolic-ref`, `for-each-ref --format`,
+  `config`); porcelain commands (`clone`, `fetch`, `checkout`, `branch`) invoked for side effects only
+- Auth: per-invocation `-c http.<url>.extraHeader=Authorization: Basic <b64>` — never URL userinfo,
+  never persisted to config
+- stderr classification mapped to today's exceptions: `.lock` failures → `LockedFileException`
+  (keeps the Polly retry untouched), 401/403/404 → the same messages `GitPreparer` expects
+- One-time `git version` probe; require ≥ 2.30, actionable error if git is absent when a mutating
+  operation is requested
+
+## 5. Phased migration (every phase shippable)
+
+### Phase A — CLI mutator first (reads stay on libgit2) · ~2–3 weeks
+Replace `GitRepository.mutating.cs` + mutating collection members with `GitVersion.Git.CommandLine`.
+Reads keep using libgit2; the wrapper invalidates its lazy `Repository` handle after each mutation so libgit2
+sees external ref changes. Escape hatch: `GITVERSION_GIT_BACKEND_MUTATOR=cli|libgit2` for one release.
+This immediately retires the most fragile native code paths (network, SSL, credentials).
+
+### Phase B-pre — interface cleanups · ~3–5 days
+Core-owned `CommitSortStrategies` enum (explicit mapping in the libgit2 adapter instead of a numeric cast),
+typed `CommitFilter` reachable-from members, remove/internalize `ToGitRepository`.
+
+### Phase B — managed reader behind a flag · ~8–12 weeks
+Build `GitVersion.Git.Managed` bottom-up with per-layer unit tests against git-CLI-generated fixture repos
+(loose/packed/mixed objects, packed-refs, worktrees, shallow, multi-pack-index, index v4).
+Backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2`). Validation:
+- **CI matrix**: full integration suites (`GitVersion.Core.Tests`, `GitVersion.App.Tests`) run on both backends,
+  three OSes — the suites assert exact SemVer strings over complex histories and are the strongest parity oracle
+- **DualBackendParityTests**: open the same fixture with both backends; deep-equality on ref enumeration,
+  order-sensitive `QueryBy` sequences, `FindMergeBase` over all commit pairs (incl. criss-cross and
+  equal-timestamp fixtures), `DiffPaths`, `UncommittedChangesCount`
+- **Real-world corpus script**: `gitversion /nocache /output json` diffed across backends on this repo,
+  GitReleaseManager, dotnet/runtime, a shallow CI-style clone, and a worktree checkout
+
+### Phase C — default flip · ~1 week + one release soak
+Default `managed`; `libgit2` remains an env-var escape hatch for one minor release. Dual CI matrix stays green.
+
+### Phase D — fixture migration (parallel with B) · ~2–3 weeks
+`GitVersion.Testing` moves to pure git-CLI writes via the existing `ExecuteGitCmd` pattern:
+deterministic `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env (several tests advance commit time explicitly),
+`git commit --allow-empty`, `-c commit.gpgsign=false -c gc.auto=0`. Migrate the six direct-usage test files.
+If suite time regresses from process spawns, batch history creation with `git fast-import`.
+
+### Phase E — remove LibGit2Sharp · ~1–2 weeks
+Delete `src/GitVersion.LibGit2Sharp` and `new-cli/GitVersion.Core.Libgit2Sharp`; drop the package from
+`Directory.Packages.props`; re-point new-cli source-linking at `GitVersion.Git` + `GitVersion.Git.Managed`
+(read-only subset). Add a packaging assertion test: **zero `runtimes/**/native/*` entries** in the
+`GitVersion.MsBuild` and `GitVersion.Tool` nupkgs. Document the new runtime requirement: `git` on PATH is needed
+**only** for dynamic-repo/CI-normalization scenarios — pure version calculation on a prepared checkout needs no
+git binary at all (a strict improvement for MSBuild-task users).
+
+### Phase F (optional) — performance accelerators · ~2–3 weeks
+Commit-graph reader (generation numbers for topo sort and merge-base), benchmark-driven pack cache tuning.
+
+## 6. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Revwalk ordering divergence → wrong versions** | Port libgit2's `revwalk.c` algorithm precisely (time-queue with insertion-order tiebreak, Kahn-style topo over it, mark-uninteresting propagation); order-sensitive dual-backend sequence tests; corpus diffing as the Phase C gate |
+| Merge-base candidate choice on criss-cross merges (libgit2 returns one of several) | Replicate libgit2's paint-down selection; assert *version output* on criss-cross fixtures plus one SHA-level canary test to detect drift |
+| Shallow clones (the CI default) | `.git/shallow` boundaries treated as parentless in the walker; existing `MakeShallow` fixture covers it |
+| Worktrees / `.git`-file / commondir | Dedicated `WorktreeResolver`; existing worktree tests + new fixtures |
+| Rename detection assumed in `DiffPaths` | Verify adapter options at Phase B kickoff — libgit2's default `Compare<TreeChanges>` doesn't do rename detection, so a plain recursive tree diff is expected to be exact parity |
+| Performance regressions | Port NBGV's pack cache; BenchmarkDotNet suite (end-to-end + revwalk/merge-base/status micro); Phase C gate: no scenario >20% slower — expectation is large wins per NBGV precedent |
+| git CLI availability/version drift | Only the mutator needs git; version probe (≥2.30) with actionable error; CI leg on a container with the oldest supported git |
+| CLI output stability | Plumbing + `--format` parsing only; stderr matching limited to error classification with conservative fallback (unknown → generic error carrying stderr, as today) |
+| Locale/encoding | `LC_ALL=C`; honor the commit `encoding` header with Latin-1 fallback (matching git); `core.quotepath=false` |
+| Concurrency (parallel MSBuild tasks) | Managed reader is read-only and lock-free; per-instance or thread-safe pack cache; removes libgit2's native global state entirely |
+| SHA-256 / reftable repos | Detect and fail with clear messages (no regression — libgit2 can't read them either); hash-agnostic design keeps the door open |
+| License/attribution of vendored code | MIT headers + NOTICE entries for NBGV ManagedGit (and GitReader if any code is taken) |
+
+## 7. Verification strategy
+
+1. Full integration suite × backend × OS matrix green through Phases B–D
+2. `DualBackendParityTests` structural deep-equality on adversarial fixtures (equal timestamps, criss-cross,
+   octopus merges, packed+loose refs, annotated+lightweight tags on one commit, shallow, worktree,
+   multi-pack-index, index v4)
+3. Real-world corpus JSON diffing recorded before the Phase C flip
+4. Benchmark gate (≥ parity everywhere, expected wins on history walks)
+5. Packaging assertion: no native binaries in shipped nupkgs (Phase E)
+
+## 8. Effort summary
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| A | git-CLI mutator + auth/error/lock mapping | 2–3 weeks |
+| B-pre | interface cleanups | 3–5 days |
+| B | managed reader + adapter + parity harness | 8–12 weeks |
+| C | default flip + soak | 1 week + 1 release |
+| D | fixture migration (parallel with B) | 2–3 weeks |
+| E | LibGit2Sharp removal, new-cli re-link, packaging tests | 1–2 weeks |
+| F | commit-graph accelerator (optional) | 2–3 weeks |
+
+**Total to a LibGit2Sharp-free GitVersion: ~4–5 months elapsed including soak cycles.**

--- a/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
@@ -1,0 +1,91 @@
+using GitVersion.Git;
+using GitVersion.Helpers;
+using GitVersion.Testing.Extensions;
+using LibGit2Sharp;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+public class GitCliMutatorTests : TestBase
+{
+    private static GitCliMutator CreateMutator() =>
+        new(NullLogger<GitCliMutator>.Instance, new GitCliExecutor(NullLogger<GitCliExecutor>.Instance));
+
+    [Test]
+    public void CheckoutSwitchesToTheGivenBranch()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.Repository.CreateBranch("feature/cli");
+
+        CreateMutator().Checkout(fixture.RepositoryPath, "feature/cli");
+
+        fixture.Repository.Head.FriendlyName.ShouldBe("feature/cli");
+    }
+
+    [Test]
+    public void CheckoutOfUnknownSpecThrows()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+
+        Should.Throw<InvalidOperationException>(() => CreateMutator().Checkout(fixture.RepositoryPath, "does-not-exist"));
+    }
+
+    [Test]
+    public void FetchBringsNewRemoteCommitsIntoTheLocalRepository()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        var newCommit = fixture.Repository.MakeACommit();
+        var localRepository = fixture.LocalRepositoryFixture.Repository;
+        localRepository.Lookup(newCommit.Sha).ShouldBeNull();
+
+        CreateMutator().Fetch(fixture.LocalRepositoryFixture.RepositoryPath, "origin", [], new AuthenticationInfo());
+
+        localRepository.Lookup(newCommit.Sha).ShouldNotBeNull();
+    }
+
+    [Test]
+    public void CloneCreatesRepositoryWithoutCheckingOutTheWorkingDirectory()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        try
+        {
+            CreateMutator().Clone(fixture.RepositoryPath, targetPath, new AuthenticationInfo());
+
+            using var clonedRepository = new Repository(targetPath);
+            clonedRepository.Head.Tip.ShouldNotBeNull();
+            Directory.EnumerateFileSystemEntries(targetPath)
+                .Where(entry => FileSystemHelper.Path.GetFileName(entry) != ".git")
+                .ShouldBeEmpty();
+        }
+        finally
+        {
+            FileSystemHelper.Directory.DeleteDirectory(targetPath);
+        }
+    }
+
+    [Test]
+    public void CloneOfMissingRepositoryThrows()
+    {
+        var missingSource = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPathLegacy(), "gitversion-does-not-exist");
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        Should.Throw<InvalidOperationException>(() => CreateMutator().Clone(missingSource, targetPath, new AuthenticationInfo()));
+    }
+
+    [Test]
+    public void ListRemoteReferencesReturnsBranchTips()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        var remoteTipSha = fixture.Repository.Head.Tip.Sha;
+
+        var references = CreateMutator().ListRemoteReferences(fixture.LocalRepositoryFixture.RepositoryPath, "origin", new AuthenticationInfo());
+
+        references.Single(r => r.CanonicalName == "refs/heads/main").TargetSha.ShouldBe(remoteTipSha);
+        references.ShouldNotContain(r => r.CanonicalName == "HEAD");
+    }
+}

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -78,7 +78,7 @@ public static class GitRepositoryTestingExtensions
             => DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
     }
 
-    extension(RemoteCollection remotes)
+    extension(LibGit2Sharp.RemoteCollection remotes)
     {
         public void RenameRemote(string oldName, string newName)
         {

--- a/src/GitVersion.Core/Git/CommitFilter.cs
+++ b/src/GitVersion.Core/Git/CommitFilter.cs
@@ -6,11 +6,11 @@ public record CommitFilter
     /// <summary>Gets a value indicating whether only the first-parent chain should be traversed.</summary>
     public bool FirstParentOnly { get; init; }
 
-    /// <summary>Gets the commit, branch, or tag from which reachable commits are included.</summary>
-    public object? IncludeReachableFrom { get; init; }
+    /// <summary>Gets the commit or branch from which reachable commits are included.</summary>
+    public ICommitish? IncludeReachableFrom { get; init; }
 
-    /// <summary>Gets the commit, branch, or tag whose reachable commits are excluded from the result.</summary>
-    public object? ExcludeReachableFrom { get; init; }
+    /// <summary>Gets the commit or branch whose reachable commits are excluded from the result.</summary>
+    public ICommitish? ExcludeReachableFrom { get; init; }
 
     /// <summary>Gets the ordering strategy applied to the resulting commits.</summary>
     public CommitSortStrategies SortBy { get; init; }

--- a/src/GitVersion.Core/Git/IBranch.cs
+++ b/src/GitVersion.Core/Git/IBranch.cs
@@ -1,7 +1,7 @@
 namespace GitVersion.Git;
 
 /// <summary>Represents a Git branch, exposing its tip commit and tracking information.</summary>
-public interface IBranch : IEquatable<IBranch?>, IComparable<IBranch>, INamedReference
+public interface IBranch : IEquatable<IBranch?>, IComparable<IBranch>, INamedReference, ICommitish
 {
     /// <summary>Gets the most recent commit on this branch, or <see langword="null"/> for an empty branch.</summary>
     ICommit? Tip { get; }

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -1,7 +1,7 @@
 namespace GitVersion.Git;
 
 /// <summary>Represents a single Git commit.</summary>
-public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>
+public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, ICommitish
 {
     /// <summary>Gets the direct parent commits of this commit.</summary>
     IReadOnlyList<ICommit> Parents { get; }

--- a/src/GitVersion.Core/Git/ICommitish.cs
+++ b/src/GitVersion.Core/Git/ICommitish.cs
@@ -1,0 +1,4 @@
+namespace GitVersion.Git;
+
+/// <summary>Marker for objects that can serve as the starting point of a commit graph traversal (a commit or a branch tip).</summary>
+public interface ICommitish;

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -200,11 +200,11 @@ GitVersion.Git.BranchCommit.Equals(GitVersion.Git.BranchCommit? other) -> bool
 GitVersion.Git.CommitFilter
 GitVersion.Git.CommitFilter.CommitFilter() -> void
 GitVersion.Git.CommitFilter.CommitFilter(GitVersion.Git.CommitFilter! original) -> void
-GitVersion.Git.CommitFilter.ExcludeReachableFrom.get -> object?
+GitVersion.Git.CommitFilter.ExcludeReachableFrom.get -> GitVersion.Git.ICommitish?
 GitVersion.Git.CommitFilter.ExcludeReachableFrom.init -> void
 GitVersion.Git.CommitFilter.FirstParentOnly.get -> bool
 GitVersion.Git.CommitFilter.FirstParentOnly.init -> void
-GitVersion.Git.CommitFilter.IncludeReachableFrom.get -> object?
+GitVersion.Git.CommitFilter.IncludeReachableFrom.get -> GitVersion.Git.ICommitish?
 GitVersion.Git.CommitFilter.IncludeReachableFrom.init -> void
 GitVersion.Git.CommitFilter.SortBy.get -> GitVersion.Git.CommitSortStrategies
 GitVersion.Git.CommitFilter.SortBy.init -> void
@@ -234,6 +234,7 @@ GitVersion.Git.ICommit.When.get -> System.DateTimeOffset
 GitVersion.Git.ICommitCollection
 GitVersion.Git.ICommitCollection.GetCommitsPriorTo(System.DateTimeOffset olderThan) -> System.Collections.Generic.IEnumerable<GitVersion.Git.ICommit!>!
 GitVersion.Git.ICommitCollection.QueryBy(GitVersion.Git.CommitFilter! commitFilter) -> System.Collections.Generic.IEnumerable<GitVersion.Git.ICommit!>!
+GitVersion.Git.ICommitish
 GitVersion.Git.IGitRepository
 GitVersion.Git.IGitRepository.Branches.get -> GitVersion.Git.IBranchCollection!
 GitVersion.Git.IGitRepository.Commits.get -> GitVersion.Git.ICommitCollection!

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -40,8 +40,13 @@ internal class GitVersionCacheKeyFactory(
     {
         var dotGitDirectory = this.repositoryInfo.DotGitDirectory;
 
-        // traverse the directory and get a list of files, use that for GetHash
-        var contents = CalculateDirectoryContents(FileSystemHelper.Path.Combine(dotGitDirectory, "refs"));
+        // traverse the directory and get a list of files, use that for GetHash.
+        // The refs directory may not exist when all refs are packed (e.g. a fresh
+        // clone by recent versions of git writes refs to packed-refs only).
+        var refsPath = FileSystemHelper.Path.Combine(dotGitDirectory, "refs");
+        var contents = this.fileSystem.Directory.Exists(refsPath)
+            ? CalculateDirectoryContents(refsPath)
+            : [];
 
         return GetHash(contents);
     }

--- a/src/GitVersion.Git.CommandLine/GitCliExecutor.cs
+++ b/src/GitVersion.Git.CommandLine/GitCliExecutor.cs
@@ -1,0 +1,92 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+/// <summary>Executes the <c>git</c> command-line executable and captures its output.</summary>
+internal interface IGitCliExecutor
+{
+    /// <summary>Runs <c>git</c> with the given arguments and returns the completed result without throwing on failure.</summary>
+    GitCliResult Execute(string? workingDirectory, IReadOnlyList<string> arguments);
+}
+
+/// <summary>The outcome of a single <c>git</c> invocation.</summary>
+internal sealed record GitCliResult(int ExitCode, string StandardOutput, string StandardError)
+{
+    public bool IsSuccess => ExitCode == 0;
+}
+
+internal sealed class GitCliExecutor(ILogger<GitCliExecutor> logger) : IGitCliExecutor
+{
+    private readonly ILogger<GitCliExecutor> logger = logger.NotNull();
+
+    public GitCliResult Execute(string? workingDirectory, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        if (workingDirectory != null)
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        // Deterministic, non-interactive invocations: never prompt for credentials
+        // and keep any parsed output locale-independent.
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+        startInfo.Environment["LC_ALL"] = "C";
+
+        this.logger.LogDebug("Executing 'git {Arguments}' in '{WorkingDirectory}'", string.Join(' ', arguments), workingDirectory);
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+
+        var standardOutput = new StringBuilder();
+        var standardError = new StringBuilder();
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                standardOutput.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                standardError.AppendLine(e.Data);
+            }
+        };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or PlatformNotSupportedException)
+        {
+            throw new InvalidOperationException(
+                "The 'git' executable could not be started. Ensure Git is installed and available on the PATH.", ex);
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        var result = new GitCliResult(process.ExitCode, standardOutput.ToString(), standardError.ToString());
+        if (!result.IsSuccess)
+        {
+            this.logger.LogDebug("'git {Arguments}' exited with code {ExitCode}: {StandardError}", string.Join(' ', arguments), result.ExitCode, result.StandardError);
+        }
+
+        return result;
+    }
+}

--- a/src/GitVersion.Git.CommandLine/GitCliMutator.cs
+++ b/src/GitVersion.Git.CommandLine/GitCliMutator.cs
@@ -1,0 +1,145 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+/// <summary>A remote reference as reported by <c>git ls-remote</c>.</summary>
+internal sealed record GitRemoteReference(string CanonicalName, string TargetSha);
+
+/// <summary>
+/// Performs the mutating and network Git operations GitVersion needs (repository normalization)
+/// by invoking the <c>git</c> command-line executable instead of libgit2.
+/// </summary>
+internal interface IGitCliMutator
+{
+    void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth);
+    void Fetch(string workingDirectory, string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth);
+    void Checkout(string workingDirectory, string commitOrBranchSpec);
+    IReadOnlyList<GitRemoteReference> ListRemoteReferences(string workingDirectory, string remoteName, AuthenticationInfo auth);
+}
+
+internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecutor executor) : IGitCliMutator
+{
+    private readonly ILogger<GitCliMutator> logger = logger.NotNull();
+    private readonly IGitCliExecutor executor = executor.NotNull();
+
+    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth)
+    {
+        ArgumentNullException.ThrowIfNull(sourceUrl);
+        ArgumentNullException.ThrowIfNull(workdirPath);
+
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl, auth);
+        arguments.AddRange(["clone", "--no-checkout", sourceUrl, workdirPath]);
+
+        var result = this.executor.Execute(null, arguments);
+        ThrowOnFailure(result);
+        this.logger.LogInformation("Cloned repository '{SourceUrl}' into '{WorkdirPath}'", sourceUrl, workdirPath);
+    }
+
+    public void Fetch(string workingDirectory, string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth)
+    {
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl: null, auth);
+        arguments.AddRange(["fetch", remote]);
+        arguments.AddRange(refSpecs);
+
+        var result = this.executor.Execute(workingDirectory, arguments);
+        ThrowOnFailure(result);
+    }
+
+    public void Checkout(string workingDirectory, string commitOrBranchSpec)
+    {
+        // libgit2's Commands.Checkout attaches HEAD when given a canonical local branch name,
+        // while `git checkout refs/heads/x` would detach — use the branch shortname instead.
+        // `--no-guess` suppresses git's remote-branch DWIM, which libgit2 does not have.
+        const string localBranchPrefix = "refs/heads/";
+        var spec = commitOrBranchSpec.StartsWith(localBranchPrefix, StringComparison.Ordinal)
+            ? commitOrBranchSpec[localBranchPrefix.Length..]
+            : commitOrBranchSpec;
+
+        var result = this.executor.Execute(workingDirectory, ["checkout", "--no-guess", spec]);
+        ThrowOnFailure(result);
+    }
+
+    public IReadOnlyList<GitRemoteReference> ListRemoteReferences(string workingDirectory, string remoteName, AuthenticationInfo auth)
+    {
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl: null, auth);
+        arguments.AddRange(["ls-remote", "--quiet", remoteName]);
+
+        var result = this.executor.Execute(workingDirectory, arguments);
+        ThrowOnFailure(result);
+
+        var references = new List<GitRemoteReference>();
+        foreach (var line in result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = line.IndexOf('\t');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var sha = line[..separator];
+            var name = line[(separator + 1)..];
+
+            // Skip peeled entries ("<ref>^{}") and the symbolic HEAD advertisement: neither is
+            // part of libgit2's ListReferences result that this replaces, and HEAD would show up
+            // as a duplicate of the branch it points at.
+            if (name.EndsWith("^{}", StringComparison.Ordinal) || !name.StartsWith("refs/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            references.Add(new(name, sha));
+        }
+
+        return references;
+    }
+
+    private static void AddAuthentication(List<string> arguments, string? sourceUrl, AuthenticationInfo auth)
+    {
+        if (auth.Username.IsNullOrWhiteSpace())
+        {
+            return;
+        }
+
+        // Same credential semantics as the libgit2 UsernamePasswordCredentials provider: basic auth
+        // over HTTPS. Passed per invocation via configuration so it is never persisted and never
+        // appears in the remote URL. ArgumentList passes it without shell interpolation, and the
+        // value is not echoed by git in error output.
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{auth.Username}:{auth.Password ?? string.Empty}"));
+        var scope = sourceUrl == null ? "http" : $"http.{sourceUrl}";
+        arguments.AddRange(["-c", $"{scope}.extraHeader=Authorization: Basic {credentials}"]);
+    }
+
+    private static void ThrowOnFailure(GitCliResult result)
+    {
+        if (result.IsSuccess)
+        {
+            return;
+        }
+
+        var message = result.StandardError;
+        if (message.Contains(".lock", StringComparison.Ordinal) && message.Contains("Unable to create", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new LockedFileException(message);
+        }
+
+        if (message.Contains("401") || message.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Unauthorized: Incorrect username/password");
+        }
+
+        if (message.Contains("403"))
+        {
+            throw new InvalidOperationException("Forbidden: Possibly Incorrect username/password");
+        }
+
+        if (message.Contains("404") || message.Contains("Repository not found", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Not found: The repository was not found");
+        }
+
+        throw new InvalidOperationException($"Git command failed with exit code {result.ExitCode}: {message}");
+    }
+}

--- a/src/GitVersion.Git.CommandLine/GitVersion.Git.CommandLine.csproj
+++ b/src/GitVersion.Git.CommandLine/GitVersion.Git.CommandLine.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="GitVersion.LibGit2Sharp" />
+        <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+    </ItemGroup>
+
+</Project>

--- a/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
@@ -34,17 +34,38 @@ internal sealed class CommitCollection : ICommitCollection
             IncludeReachableFrom = includeReachableFrom,
             ExcludeReachableFrom = excludeReachableFrom,
             FirstParentOnly = commitFilter.FirstParentOnly,
-            SortBy = (LibGit2Sharp.CommitSortStrategies)commitFilter.SortBy
+            SortBy = GetSortStrategies(commitFilter.SortBy)
         };
         var commitLog = ((IQueryableCommitLog)this.innerCollection).QueryBy(filter);
         return new CommitCollection(commitLog, this.diff, this.repositoryCache);
 
-        static object? GetReacheableFrom(object? item) =>
+        static object? GetReacheableFrom(ICommitish? item) =>
             item switch
             {
                 Commit c => (LibGit2Sharp.Commit)c,
                 Branch b => (LibGit2Sharp.Branch)b,
                 _ => null
             };
+
+        static LibGit2Sharp.CommitSortStrategies GetSortStrategies(CommitSortStrategies sortBy)
+        {
+            var result = LibGit2Sharp.CommitSortStrategies.None;
+            if (sortBy.HasFlag(CommitSortStrategies.Topological))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Topological;
+            }
+
+            if (sortBy.HasFlag(CommitSortStrategies.Time))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Time;
+            }
+
+            if (sortBy.HasFlag(CommitSortStrategies.Reverse))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Reverse;
+            }
+
+            return result;
+        }
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -46,6 +46,20 @@ internal sealed partial class GitRepository
         this.repositoryLazy = new(() => new Repository(gitDirectory));
     }
 
+    /// <summary>
+    /// Drops the cached collection wrappers so that changes made outside this instance
+    /// (e.g. by the git CLI) become visible. The libgit2 repository itself re-reads refs
+    /// and objects from disk on demand, so it must not be disposed here — wrapper objects
+    /// already handed out still reference its native memory.
+    /// </summary>
+    internal void ResetCachedCollections()
+    {
+        this.tags = null;
+        this.commits = null;
+        this.remotes = null;
+        this.references = null;
+    }
+
     public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)
     {
         commit = commit.NotNull();

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
@@ -5,12 +5,29 @@ using LibGit2Sharp.Handlers;
 
 namespace GitVersion.Git;
 
-internal partial class GitRepository(ILogger<GitRepository> logger) : IMutatingGitRepository
+internal partial class GitRepository(ILogger<GitRepository> logger, IGitCliMutator? cliMutator = null) : IMutatingGitRepository
 {
     private readonly ILogger<GitRepository> logger = logger.NotNull();
+    private readonly IGitCliMutator? cliMutator = cliMutator;
+
+    /// <summary>
+    /// Opt-in switch for performing mutating and network operations through the git CLI
+    /// instead of libgit2. See https://github.com/GitTools/GitVersion/issues/5031.
+    /// </summary>
+    private bool UseCliBackend =>
+        this.cliMutator is not null
+        && string.Equals(SysEnv.GetEnvironmentVariable("GITVERSION_GIT_BACKEND_MUTATOR"), "cli", StringComparison.OrdinalIgnoreCase);
+
+    private string CliWorkingDirectory => RepositoryInstance.Info.WorkingDirectory ?? RepositoryInstance.Info.Path;
 
     public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth)
     {
+        if (UseCliBackend)
+        {
+            this.cliMutator!.Clone(sourceUrl, workdirPath, auth);
+            return;
+        }
+
         try
         {
             var path = Repository.Clone(sourceUrl, workdirPath, GetCloneOptions(auth));
@@ -41,12 +58,30 @@ internal partial class GitRepository(ILogger<GitRepository> logger) : IMutatingG
             throw new InvalidOperationException("There was an unknown problem with the Git repository you provided", ex);
         }
     }
-    public void Checkout(string commitOrBranchSpec) =>
+    public void Checkout(string commitOrBranchSpec)
+    {
+        if (UseCliBackend)
+        {
+            RepositoryExtensions.RunSafe(() => this.cliMutator!.Checkout(CliWorkingDirectory, commitOrBranchSpec));
+            ResetCachedCollections();
+            return;
+        }
+
         RepositoryExtensions.RunSafe(() =>
             Commands.Checkout(RepositoryInstance, commitOrBranchSpec));
-    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage) =>
+    }
+    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage)
+    {
+        if (UseCliBackend)
+        {
+            RepositoryExtensions.RunSafe(() => this.cliMutator!.Fetch(CliWorkingDirectory, remote, refSpecs, auth));
+            ResetCachedCollections();
+            return;
+        }
+
         RepositoryExtensions.RunSafe(() =>
             Commands.Fetch((Repository)RepositoryInstance, remote, refSpecs, GetFetchOptions(auth), logMessage));
+    }
     public void CreateBranchForPullRequestBranch(AuthenticationInfo auth) => RepositoryExtensions.RunSafe(() =>
     {
         this.logger.LogInformation("Fetching remote refs to see if there is a pull request ref");
@@ -59,15 +94,14 @@ internal partial class GitRepository(ILogger<GitRepository> logger) : IMutatingG
 
         var headTipSha = Head.Tip.Sha;
         var remote = RepositoryInstance.Network.Remotes.Single();
-        var reference = GetPullRequestReference(auth, remote, headTipSha);
-        var canonicalName = reference.CanonicalName;
-        var referenceName = ReferenceName.Parse(reference.CanonicalName);
+        var (canonicalName, targetSha) = GetPullRequestReference(auth, remote, headTipSha);
+        var referenceName = ReferenceName.Parse(canonicalName);
         this.logger.LogInformation("Found remote tip '{CanonicalName}' pointing at the commit '{HeadTipSha}'.", canonicalName, headTipSha);
 
         if (referenceName.IsTag)
         {
             this.logger.LogInformation("Checking out tag '{CanonicalName}'", canonicalName);
-            Checkout(reference.Target.Sha);
+            Checkout(targetSha);
         }
         else if (referenceName.IsPullRequest)
         {
@@ -85,21 +119,16 @@ internal partial class GitRepository(ILogger<GitRepository> logger) : IMutatingG
             throw new WarningException(message);
         }
     });
-    private DirectReference GetPullRequestReference(AuthenticationInfo auth, LibGit2Sharp.Remote remote, string headTipSha)
+    private (string CanonicalName, string TargetSha) GetPullRequestReference(AuthenticationInfo auth, LibGit2Sharp.Remote remote, string headTipSha)
     {
-        var network = RepositoryInstance.Network;
-        var credentialsProvider = GetCredentialsProvider(auth);
-        var remoteTips = (credentialsProvider != null
-                ? network.ListReferences(remote, credentialsProvider)
-                : network.ListReferences(remote))
-            .Select(r => r.ResolveToDirectReference()).ToList();
+        var remoteTips = ListRemoteReferences(auth, remote);
 
         var remoteRefsList = string.Join(FileSystemHelper.Path.NewLine, remoteTips.Select(r => r.CanonicalName));
         this.logger.LogInformation("""
                                    Remote Refs:
                                    {RemoteRefsList}
                                    """, remoteRefsList);
-        var refs = remoteTips.Where(r => r.TargetIdentifier == headTipSha).ToList();
+        var refs = remoteTips.Where(r => r.TargetSha == headTipSha).ToList();
 
         switch (refs.Count)
         {
@@ -116,7 +145,21 @@ internal partial class GitRepository(ILogger<GitRepository> logger) : IMutatingG
                 }
         }
 
-        return refs[0];
+        return (refs[0].CanonicalName, refs[0].TargetSha);
+    }
+    private List<GitRemoteReference> ListRemoteReferences(AuthenticationInfo auth, LibGit2Sharp.Remote remote)
+    {
+        if (UseCliBackend)
+        {
+            return [.. this.cliMutator!.ListRemoteReferences(CliWorkingDirectory, remote.Name, auth)];
+        }
+
+        var network = RepositoryInstance.Network;
+        var credentialsProvider = GetCredentialsProvider(auth);
+        var references = credentialsProvider != null
+            ? network.ListReferences(remote, credentialsProvider)
+            : network.ListReferences(remote);
+        return [.. references.Select(r => r.ResolveToDirectReference()).Select(r => new GitRemoteReference(r.CanonicalName, r.TargetIdentifier))];
     }
     private static FetchOptions GetFetchOptions(AuthenticationInfo auth) =>
         new() { CredentialsProvider = GetCredentialsProvider(auth) };

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
@@ -159,10 +159,10 @@ internal partial class GitRepository(ILogger<GitRepository> logger, IGitCliMutat
 
         var network = RepositoryInstance.Network;
         var credentialsProvider = GetCredentialsProvider(auth);
-        var references = credentialsProvider != null
+        var remoteReferences = credentialsProvider != null
             ? network.ListReferences(remote, credentialsProvider)
             : network.ListReferences(remote);
-        return [.. references.Select(r => r.ResolveToDirectReference()).Select(r => new GitRemoteReference(r.CanonicalName, r.TargetIdentifier))];
+        return [.. remoteReferences.Select(r => r.ResolveToDirectReference()).Select(r => new GitRemoteReference(r.CanonicalName, r.TargetIdentifier))];
     }
     private static FetchOptions GetFetchOptions(AuthenticationInfo auth) =>
         new() { CredentialsProvider = GetCredentialsProvider(auth) };

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs
@@ -11,12 +11,15 @@ internal partial class GitRepository(ILogger<GitRepository> logger, IGitCliMutat
     private readonly IGitCliMutator? cliMutator = cliMutator;
 
     /// <summary>
-    /// Opt-in switch for performing mutating and network operations through the git CLI
-    /// instead of libgit2. See https://github.com/GitTools/GitVersion/issues/5031.
+    /// Selects the Git backend implementation. 'managed' opts into the new implementation stack
+    /// as far as it exists — currently mutating and network operations through the git CLI, with
+    /// the managed reader to follow. The default is 'libgit2' in v7.0 and flips to 'managed' in
+    /// v7.1 (with 'libgit2' as the fallback); both backends ship side by side until libgit2 is
+    /// removed. See https://github.com/GitTools/GitVersion/issues/5031.
     /// </summary>
     private bool UseCliBackend =>
         this.cliMutator is not null
-        && string.Equals(SysEnv.GetEnvironmentVariable("GITVERSION_GIT_BACKEND_MUTATOR"), "cli", StringComparison.OrdinalIgnoreCase);
+        && string.Equals(SysEnv.GetEnvironmentVariable("GITVERSION_GIT_BACKEND"), "managed", StringComparison.OrdinalIgnoreCase);
 
     private string CliWorkingDirectory => RepositoryInstance.Info.WorkingDirectory ?? RepositoryInstance.Info.Path;
 

--- a/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
+++ b/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
+        <ProjectReference Include="..\GitVersion.Git.CommandLine\GitVersion.Git.CommandLine.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
+++ b/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
@@ -8,4 +8,10 @@
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+        <InternalsVisibleTo Include="GitVersion.MsBuild.Tests" />
+        <InternalsVisibleTo Include="GitVersion.Output.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
+++ b/src/GitVersion.LibGit2Sharp/GitVersionLibGit2SharpModule.cs
@@ -6,6 +6,8 @@ public class GitVersionLibGit2SharpModule : IGitVersionModule
 {
     public void RegisterTypes(IServiceCollection services)
     {
+        services.AddSingleton<IGitCliExecutor, GitCliExecutor>();
+        services.AddSingleton<IGitCliMutator, GitCliMutator>();
         services.AddSingleton<IGitRepository, GitRepository>();
         services.AddSingleton<IMutatingGitRepository>(sp => (IMutatingGitRepository)sp.GetRequiredService<IGitRepository>());
         services.AddSingleton<IGitRepositoryInfo, GitRepositoryInfo>();

--- a/src/GitVersion.LibGit2Sharp/LibGit2SharpExtensions.cs
+++ b/src/GitVersion.LibGit2Sharp/LibGit2SharpExtensions.cs
@@ -3,7 +3,7 @@ using LibGit2Sharp;
 
 namespace GitVersion;
 
-public static class LibGit2SharpExtensions
+internal static class LibGit2SharpExtensions
 {
     extension(IRepository repository)
     {

--- a/src/GitVersion.LibGit2Sharp/PublicAPI.Shipped.txt
+++ b/src/GitVersion.LibGit2Sharp/PublicAPI.Shipped.txt
@@ -8,7 +8,3 @@ GitVersion.Git.GitRepositoryInfo.ProjectRootDirectory.get -> string?
 GitVersion.GitVersionLibGit2SharpModule
 GitVersion.GitVersionLibGit2SharpModule.GitVersionLibGit2SharpModule() -> void
 GitVersion.GitVersionLibGit2SharpModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
-GitVersion.LibGit2SharpExtensions
-GitVersion.LibGit2SharpExtensions.extension(LibGit2Sharp.IRepository!)
-GitVersion.LibGit2SharpExtensions.extension(LibGit2Sharp.IRepository!).ToGitRepository() -> GitVersion.Git.IGitRepository!
-static GitVersion.LibGit2SharpExtensions.ToGitRepository(this LibGit2Sharp.IRepository! repository) -> GitVersion.Git.IGitRepository!

--- a/src/GitVersion.slnx
+++ b/src/GitVersion.slnx
@@ -8,6 +8,7 @@
     <Project Path="GitVersion.BuildAgents/GitVersion.BuildAgents.csproj" />
     <Project Path="GitVersion.Configuration.Tests/GitVersion.Configuration.Tests.csproj" />
     <Project Path="GitVersion.Configuration/GitVersion.Configuration.csproj" />
+    <Project Path="GitVersion.Git.CommandLine/GitVersion.Git.CommandLine.csproj" />
     <Project Path="GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj" />
     <Project Path="GitVersion.Output.Tests/GitVersion.Output.Tests.csproj" />
     <Project Path="GitVersion.Output/GitVersion.Output.csproj" />


### PR DESCRIPTION
## Description

First step of the LibGit2Sharp replacement (#5031): a git CLI backend for all mutating and network operations, selectable via a single environment variable, with the design document and the interface cleanups that later phases build on.

Closes #5032

### What's included

- **Design document** (`docs/design/managed-git-migration.md`): motivation, library landscape research, LibGit2Sharp surface analysis, target architecture, phases A–F with the explicit release mapping (v7.0 default `libgit2`, v7.1 default `managed`, removal later), risks and verification strategy.
- **Interface cleanups (Phase B-pre)**: `CommitFilter.IncludeReachableFrom`/`ExcludeReachableFrom` typed via new `ICommitish` marker (implemented by `ICommit`/`IBranch`) instead of `object?`; `CommitSortStrategies` mapped explicitly to LibGit2Sharp instead of a numeric cast; public `IRepository.ToGitRepository()` extension internalized.
- **Phase A — `GitVersion.Git.CommandLine`**: Process-based `GitCliExecutor` (argument lists, `LC_ALL=C`, `GIT_TERMINAL_PROMPT=0`) and `GitCliMutator` implementing clone (`--no-checkout`), fetch, checkout and `ls-remote`, with per-invocation basic auth via `http.extraHeader` and stderr mapped onto the existing `LockedFileException`/401/403/404 handling.
- **Single backend switch**: `GITVERSION_GIT_BACKEND=libgit2|managed`; `GitRepository` routes its `IMutatingGitRepository` operations through the CLI when `managed` is selected. Default remains `libgit2` for v7.0.
- **Dual-backend CI**: the unit-test workflow matrix gains a `git_backend` dimension — the full suite runs against both backends on every OS until libgit2 is removed.
- **Breaking-changes entries** for the backend selection table and the abstraction API changes.
- **Cache-key fix**: `GitVersionCacheKeyFactory` no longer throws when `.git/refs` is absent (fresh clones by recent git versions keep all refs packed).

### Parity notes (managed backend vs libgit2)

- Checkout strips the `refs/heads/` prefix (git would detach where libgit2 attaches) and passes `--no-guess` (libgit2 has no remote-branch DWIM).
- `ls-remote` parsing drops peeled `^{}` and symbolic `HEAD` entries to match `ListReferences`.
- After CLI mutations only the cached collection wrappers are dropped; the libgit2 handle is not disposed (handed-out wrappers reference its native memory).

### Verification

- Full `GitVersion.Core.Tests` (36k) and `GitVersion.App.Tests` (345) pass with both `GITVERSION_GIT_BACKEND=libgit2` and `=managed`; CI matrix green on all OS × .NET × backend legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
