### PR TITLE
feat: managed Git object store — loose objects, packfiles, multi-pack-index (Phase B.1)

### DIFF
--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -110,7 +110,9 @@ backend is a natural completion of an existing pattern. Six test files additiona
 
 ```
 src/
-  GitVersion.Git.Managed/          vendored managed reader (no GitVersion.Core dependency)
+  GitVersion.Git.Managed/          vendored managed reader; the raw git-format layers below
+                                   are Core-free, Core is referenced only once the interface
+                                   implementations land (final Phase B step)
     Objects/    GitObjectId (hash-agnostic), pack + .idx v2 readers, delta streams,
                 pack cache, loose-object reader, multi-pack-index reader
     Parsing/    commit parser (author/committer/when/message/encoding), tree parser,
@@ -122,10 +124,12 @@ src/
     Diff/       recursive tree-vs-tree changed-paths diff (no rename detection)
     Status/     .git/index v2–v4 reader, workdir/index status for UncommittedChangesCount
   GitVersion.Git.CommandLine/      git CLI executor (writes + network only)
-  GitVersion.Git/                  thin adapter implementing IGitRepository (managed reader)
-                                   + IMutatingGitRepository (CLI mutator); mirrors the
-                                   current adapter file layout so DI is unchanged
 ```
+
+No separate adapter project: `GitVersion.Git.Managed` implements `IGitRepository` (managed reader)
+and `IMutatingGitRepository` (delegating to the CLI mutator) **directly**, mirroring how
+`GitVersion.LibGit2Sharp` implements the same interfaces over libgit2 today — same file layout,
+so the DI surface is unchanged.
 
 Port-vs-fresh decisions:
 
@@ -206,7 +210,7 @@ If suite time regresses from process spawns, batch history creation with `git fa
 
 ### Phase E — remove LibGit2Sharp · ~1–2 weeks
 Delete `src/GitVersion.LibGit2Sharp` and `new-cli/GitVersion.Core.Libgit2Sharp`; drop the package from
-`Directory.Packages.props`; re-point new-cli source-linking at `GitVersion.Git` + `GitVersion.Git.Managed`
+`Directory.Packages.props`; re-point new-cli source-linking at `GitVersion.Git.Managed`
 (read-only subset). Add a packaging assertion test: **zero `runtimes/**/native/*` entries** in the
 `GitVersion.MsBuild` and `GitVersion.Tool` nupkgs. Document the new runtime requirement: `git` on PATH is needed
 **only** for dynamic-repo/CI-normalization scenarios — pure version calculation on a prepared checkout needs no
@@ -248,7 +252,7 @@ Commit-graph reader (generation numbers for topo sort and merge-base), benchmark
 |---|---|---|
 | A | git-CLI mutator + auth/error/lock mapping | 2–3 weeks |
 | B-pre | interface cleanups | 3–5 days |
-| B | managed reader + adapter + parity harness | 8–12 weeks |
+| B | managed reader + direct interface implementations + parity harness | 8–12 weeks |
 | C | default flip + soak | 1 week + 1 release |
 | D | fixture migration (parallel with B) | 2–3 weeks |
 | E | LibGit2Sharp removal, new-cli re-link, packaging tests | 1–2 weeks |

--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -123,13 +123,22 @@ src/
                 merge-base (paint-down-to-common), commit-graph reader (later, optional)
     Diff/       recursive tree-vs-tree changed-paths diff (no rename detection)
     Status/     .git/index v2–v4 reader, workdir/index status for UncommittedChangesCount
-  GitVersion.Git.CommandLine/      git CLI executor (writes + network only)
+    CommandLine/ git CLI executor + mutator (writes + network only) — absorbed from the
+                 interim GitVersion.Git.CommandLine project at the final Phase B step
 ```
 
 No separate adapter project: `GitVersion.Git.Managed` implements `IGitRepository` (managed reader)
 and `IMutatingGitRepository` (delegating to the CLI mutator) **directly**, mirroring how
 `GitVersion.LibGit2Sharp` implements the same interfaces over libgit2 today — same file layout,
 so the DI surface is unchanged.
+
+One-library end state: all git interaction (managed reads + CLI writes) lives in
+`GitVersion.Git.Managed`, just as `GitVersion.LibGit2Sharp` is the single libgit2 library today.
+`GitVersion.Git.CommandLine` exists only as an interim project (created in Phase A so the CLI
+mutator could ship while reads stayed on libgit2); when it folds into `GitVersion.Git.Managed`
+at the final Phase B step, `GitVersion.LibGit2Sharp` re-points its mutator `ProjectReference`
+to `GitVersion.Git.Managed` for the dual-backend window and that reference disappears with the
+project's deletion in Phase E.
 
 Port-vs-fresh decisions:
 
@@ -175,7 +184,8 @@ unit-test matrix runs the full suite against both backends (`git_backend` dimens
 both legs must stay green.
 
 ### Phase A — CLI mutator first (reads stay on libgit2) · ~2–3 weeks
-Replace `GitRepository.mutating.cs` + mutating collection members with `GitVersion.Git.CommandLine`.
+Replace `GitRepository.mutating.cs` + mutating collection members with `GitVersion.Git.CommandLine`
+(an interim project — it merges into `GitVersion.Git.Managed` at the final Phase B step, see §4).
 Reads keep using libgit2; the wrapper drops its cached collection wrappers after each CLI mutation so
 external ref changes become visible (the libgit2 handle itself must not be disposed — wrappers already
 handed out reference its native memory). Selected via `GITVERSION_GIT_BACKEND=managed`.
@@ -188,7 +198,9 @@ typed `CommitFilter` reachable-from members, remove/internalize `ToGitRepository
 ### Phase B — managed reader behind a flag · ~8–12 weeks
 Build `GitVersion.Git.Managed` bottom-up with per-layer unit tests against git-CLI-generated fixture repos
 (loose/packed/mixed objects, packed-refs, worktrees, shallow, multi-pack-index, index v4).
-Backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2`). Validation:
+The final B step takes the `GitVersion.Core` reference, lands the direct `IGitRepository`/
+`IMutatingGitRepository` implementations, absorbs `GitVersion.Git.CommandLine` (see §4), and wires
+backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2`). Validation:
 - **CI matrix**: full integration suites (`GitVersion.Core.Tests`, `GitVersion.App.Tests`) run on both backends,
   three OSes — the suites assert exact SemVer strings over complex histories and are the strongest parity oracle
 - **DualBackendParityTests**: open the same fixture with both backends; deep-equality on ref enumeration,

--- a/src/GitVersion.Git.Managed.Tests/AssemblyParallelizable.cs
+++ b/src/GitVersion.Git.Managed.Tests/AssemblyParallelizable.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/src/GitVersion.Git.Managed.Tests/GitObjectIdTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitObjectIdTests.cs
@@ -1,0 +1,160 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitObjectIdTests
+{
+    private const string Sha1Hex = "4e912736c27e40b389904d046dc63dc9f578117f";
+    private const string Sha256Hex = "9c5e01e5827b7a2e0f9b2ecabf5ee89f4fd8b7c153bf8dd9b1f38f9b7d6f2a3c";
+
+    [Test]
+    public void ParsesA40CharacterSha1HexString()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha1Size);
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesUpperCaseHexAndNormalizesToLowerCase()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex.ToUpperInvariant().AsSpan());
+
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesA64CharacterSha256HexString()
+    {
+        var objectId = GitObjectId.Parse(Sha256Hex);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha256Size);
+        objectId.ToString().ShouldBe(Sha256Hex);
+    }
+
+    [Test]
+    public void ParsesRawBytes()
+    {
+        var bytes = Convert.FromHexString(Sha1Hex);
+
+        var objectId = GitObjectId.Parse(bytes);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha1Size);
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesAsciiEncodedHex()
+    {
+        var asciiHex = Encoding.ASCII.GetBytes(Sha1Hex);
+
+        var objectId = GitObjectId.ParseHex(asciiHex);
+
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [TestCase(0)]
+    [TestCase(19)]
+    [TestCase(39)]
+    [TestCase(41)]
+    public void ParseRejectsInvalidHexLengths(int length) =>
+        Should.Throw<ArgumentException>(() => GitObjectId.Parse(new string('a', length)));
+
+    [Test]
+    public void ParseRejectsInvalidRawByteLengths() =>
+        Should.Throw<ArgumentException>(() => GitObjectId.Parse(new byte[21]));
+
+    [Test]
+    public void ParseRejectsNonHexCharacters() =>
+        Should.Throw<FormatException>(() => GitObjectId.Parse("zz12736c27e40b389904d046dc63dc9f578117f4"));
+
+    [Test]
+    public void EqualObjectIdsAreEqualAndHaveTheSameHashCode()
+    {
+        var left = GitObjectId.Parse(Sha1Hex);
+        var right = GitObjectId.ParseHex(Encoding.ASCII.GetBytes(Sha1Hex));
+
+        left.ShouldBe(right);
+        (left == right).ShouldBeTrue();
+        (left != right).ShouldBeFalse();
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+        left.Equals((object)right).ShouldBeTrue();
+    }
+
+    [Test]
+    public void DifferentObjectIdsAreNotEqual()
+    {
+        var left = GitObjectId.Parse(Sha1Hex);
+        var right = GitObjectId.Parse("4e912736c27e40b389904d046dc63dc9f5781180");
+
+        left.ShouldNotBe(right);
+        (left == right).ShouldBeFalse();
+        (left != right).ShouldBeTrue();
+    }
+
+    [Test]
+    public void ASha1IdIsNotEqualToASha256IdWithTheSamePrefix()
+    {
+        var sha1 = GitObjectId.Parse(Sha1Hex);
+        var sha256 = GitObjectId.Parse(Sha1Hex + new string('0', 24));
+
+        sha1.ShouldNotBe(sha256);
+    }
+
+    [Test]
+    public void CanBeUsedAsADictionaryKey()
+    {
+        var dictionary = new Dictionary<GitObjectId, string>
+        {
+            [GitObjectId.Parse(Sha1Hex)] = "value"
+        };
+
+        dictionary[GitObjectId.ParseHex(Encoding.ASCII.GetBytes(Sha1Hex))].ShouldBe("value");
+    }
+
+    [TestCase(0, "")]
+    [TestCase(1, "4")]
+    [TestCase(7, "4e91273")]
+    [TestCase(40, Sha1Hex)]
+    public void ToStringWithLengthReturnsAHexPrefix(int length, string expected)
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.ToString(length).ShouldBe(expected);
+    }
+
+    [Test]
+    public void ToStringWithInvalidLengthThrows()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        Should.Throw<ArgumentOutOfRangeException>(() => objectId.ToString(41));
+        Should.Throw<ArgumentOutOfRangeException>(() => objectId.ToString(-1));
+    }
+
+    [Test]
+    public void CopyToCopiesTheRawBytes()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+        var buffer = new byte[GitObjectId.Sha1Size];
+
+        objectId.CopyTo(buffer);
+
+        buffer.ShouldBe(Convert.FromHexString(Sha1Hex));
+    }
+
+    [Test]
+    public void AsUInt16ReturnsTheFirstTwoBytes()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.AsUInt16().ShouldBe((ushort)0x4e91);
+    }
+
+    [Test]
+    public void EmptyHasAZeroHashLength()
+    {
+        GitObjectId.Empty.HashLength.ShouldBe(0);
+        GitObjectId.Empty.ShouldBe(default(GitObjectId));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
@@ -1,0 +1,152 @@
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Creates a real Git repository in a temporary directory by invoking the <c>git</c>
+/// command-line executable, with deterministic author/committer identities and dates.
+/// </summary>
+internal sealed class GitTestRepository : IDisposable
+{
+    public const string AuthorName = "Test Author";
+    public const string AuthorEmail = "author@example.com";
+    public const string CommitterName = "Test Committer";
+    public const string CommitterEmail = "committer@example.com";
+
+    private static readonly DateTimeOffset BaseDate = new(2023, 6, 1, 10, 0, 0, TimeSpan.FromHours(2));
+
+    private int ticks;
+
+    public GitTestRepository()
+    {
+        RepositoryPath = Path.Combine(Path.GetTempPath(), "managed-git-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(RepositoryPath);
+        Run("init", "-q", "-b", "main");
+    }
+
+    public string RepositoryPath { get; }
+
+    public string ObjectsDirectory => Path.Combine(RepositoryPath, ".git", "objects");
+
+    /// <summary>
+    /// Gets the date used for the author and the committer of the most recent commit or tag.
+    /// </summary>
+    public DateTimeOffset CurrentDate => BaseDate.AddMinutes(this.ticks);
+
+    /// <summary>
+    /// Runs <c>git</c> with the given arguments in the repository and returns its standard output.
+    /// </summary>
+    public string Run(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = RepositoryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        var date = $"{CurrentDate.ToUnixTimeSeconds()} +0200";
+        startInfo.Environment["GIT_AUTHOR_NAME"] = AuthorName;
+        startInfo.Environment["GIT_AUTHOR_EMAIL"] = AuthorEmail;
+        startInfo.Environment["GIT_AUTHOR_DATE"] = date;
+        startInfo.Environment["GIT_COMMITTER_NAME"] = CommitterName;
+        startInfo.Environment["GIT_COMMITTER_EMAIL"] = CommitterEmail;
+        startInfo.Environment["GIT_COMMITTER_DATE"] = date;
+        startInfo.Environment["GIT_CONFIG_GLOBAL"] = Path.Combine(RepositoryPath, "no-global-config");
+        startInfo.Environment["GIT_CONFIG_NOSYSTEM"] = "1";
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+        process.Start();
+
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"'git {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}: {standardError}");
+        }
+
+        return standardOutput.TrimEnd('\n');
+    }
+
+    /// <summary>
+    /// Writes a file (relative to the repository root), creating parent directories as needed.
+    /// </summary>
+    public void WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(RepositoryPath, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+    }
+
+    /// <summary>
+    /// Stages all changes and creates a commit with a deterministic, unique date. Returns the commit sha.
+    /// </summary>
+    public string Commit(string message)
+    {
+        this.ticks++;
+        Run("add", "--all");
+        Run("commit", "-q", "--no-verify", "-m", message);
+        return RevParse("HEAD");
+    }
+
+    /// <summary>
+    /// Creates a commit whose message is taken verbatim from the given bytes.
+    /// </summary>
+    public string CommitWithMessageBytes(byte[] messageBytes, string? commitEncoding = null)
+    {
+        this.ticks++;
+        var messageFile = Path.Combine(RepositoryPath, "..", $"message-{Guid.NewGuid():N}.txt");
+        File.WriteAllBytes(messageFile, messageBytes);
+
+        try
+        {
+            Run("add", "--all");
+            var arguments = new List<string>();
+            if (commitEncoding is not null)
+            {
+                arguments.AddRange(["-c", $"i18n.commitEncoding={commitEncoding}"]);
+            }
+
+            arguments.AddRange(["commit", "-q", "--no-verify", "--allow-empty", "-F", messageFile]);
+            Run([.. arguments]);
+            return RevParse("HEAD");
+        }
+        finally
+        {
+            File.Delete(messageFile);
+        }
+    }
+
+    public string RevParse(string reference) => Run("rev-parse", reference);
+
+    public GitObjectId ResolveId(string reference) => GitObjectId.Parse(RevParse(reference));
+
+    public GitObjectStore OpenObjectStore() => new(ObjectsDirectory);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(RepositoryPath, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
+++ b/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <ProjectReference Include="..\GitVersion.Git.Managed\GitVersion.Git.Managed.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="GitVersion.Git" />
+    </ItemGroup>
+
+</Project>

--- a/src/GitVersion.Git.Managed.Tests/LooseObjectTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/LooseObjectTests.cs
@@ -1,0 +1,190 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class LooseObjectTests
+{
+    [Test]
+    public void ReadsACommitFromLooseObjects()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var firstSha = repository.Commit("first commit");
+        repository.WriteFile("file.txt", "hello world\n");
+        var secondSha = repository.Commit("second commit");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(secondSha));
+
+        commit.Sha.ToString().ShouldBe(secondSha);
+        commit.Tree.ToString().ShouldBe(repository.RevParse("HEAD^{tree}"));
+        commit.Parents.Count.ShouldBe(1);
+        commit.Parents[0].ToString().ShouldBe(firstSha);
+        commit.Message.ShouldBe("second commit\n");
+
+        commit.Author.Name.ShouldBe(GitTestRepository.AuthorName);
+        commit.Author.Email.ShouldBe(GitTestRepository.AuthorEmail);
+        commit.Committer.Name.ShouldBe(GitTestRepository.CommitterName);
+        commit.Committer.Email.ShouldBe(GitTestRepository.CommitterEmail);
+    }
+
+    [Test]
+    public void ReadsARootCommitWithoutParents()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var sha = repository.Commit("initial");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Parents.ShouldBeEmpty();
+        commit.Message.ShouldBe("initial\n");
+    }
+
+    [Test]
+    public void CommitMatchesGitLogOutput()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("subject line\n\nbody line one\nbody line two");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        var expected = repository
+            .Run("log", "-1", "--format=%an%n%ae%n%at%n%cn%n%ce%n%ct", sha)
+            .Split('\n');
+
+        commit.Author.Name.ShouldBe(expected[0]);
+        commit.Author.Email.ShouldBe(expected[1]);
+        commit.Author.When.ToUnixTimeSeconds().ShouldBe(long.Parse(expected[2]));
+        commit.Committer.Name.ShouldBe(expected[3]);
+        commit.Committer.Email.ShouldBe(expected[4]);
+        commit.Committer.When.ToUnixTimeSeconds().ShouldBe(long.Parse(expected[5]));
+
+        commit.Author.When.Offset.ShouldBe(TimeSpan.FromHours(2));
+        commit.Author.When.ShouldBe(repository.CurrentDate);
+        commit.Message.ShouldBe("subject line\n\nbody line one\nbody line two\n");
+    }
+
+    [Test]
+    public void CommitMessageMatchesGitCatFileOutput()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a message with special characters: äöü — ✓");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        var raw = repository.Run("cat-file", "commit", sha);
+        var expectedMessage = raw[(raw.IndexOf("\n\n", StringComparison.Ordinal) + 2)..];
+
+        commit.Message.TrimEnd('\n').ShouldBe(expectedMessage);
+    }
+
+    [Test]
+    public void ReadsACommitMessageHonoringTheEncodingHeader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var messageBytes = Encoding.Latin1.GetBytes("café à la crème\n");
+        var sha = repository.CommitWithMessageBytes(messageBytes, "ISO-8859-1");
+
+        repository.Run("cat-file", "commit", sha).ShouldContain("encoding ISO-8859-1");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("café à la crème\n");
+    }
+
+    [Test]
+    public void FallsBackToLatin1ForInvalidUtf8WithoutAnEncodingHeader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var messageBytes = Encoding.Latin1.GetBytes("café\n");
+        var sha = repository.CommitWithMessageBytes(messageBytes);
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("café\n");
+    }
+
+    [Test]
+    public void ReadsABlobFromLooseObjects()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "blob content\n");
+        repository.Commit("add file");
+
+        using var store = repository.OpenObjectStore();
+        using var blob = store.GetBlob(repository.ResolveId("HEAD:file.txt"));
+        using var reader = new StreamReader(blob);
+
+        reader.ReadToEnd().ShouldBe("blob content\n");
+    }
+
+    [Test]
+    public void ReportsTheObjectTypeWhenItIsNotKnownUpFront()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(GitObjectId.Parse(sha), out var stream, out var objectType).ShouldBeTrue();
+
+        using (stream)
+        {
+            objectType.ShouldBe("commit");
+        }
+    }
+
+    [Test]
+    public void DoesNotFindAMissingObject()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var missing = GitObjectId.Parse("0123456789abcdef0123456789abcdef01234567");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(missing, "commit", out _).ShouldBeFalse();
+
+        var exception = Should.Throw<GitObjectStoreException>(() => store.GetCommit(missing));
+        exception.ObjectNotFound.ShouldBeTrue();
+    }
+
+    [Test]
+    public void DoesNotFindAnObjectWhenRequestedWithTheWrongType()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(GitObjectId.Parse(sha), "blob", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsObjectsFromAnAlternateObjectDatabase()
+    {
+        using var upstream = new GitTestRepository();
+        upstream.WriteFile("file.txt", "shared content\n");
+        var sha = upstream.Commit("shared commit");
+
+        using var dependent = new GitTestRepository();
+        var infoDirectory = Path.Combine(dependent.ObjectsDirectory, "info");
+        Directory.CreateDirectory(infoDirectory);
+        File.WriteAllText(Path.Combine(infoDirectory, "alternates"), upstream.ObjectsDirectory + "\n");
+
+        using var store = dependent.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("shared commit\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/MultiPackIndexTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/MultiPackIndexTests.cs
@@ -1,0 +1,82 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class MultiPackIndexTests
+{
+    [Test]
+    public void ReadsObjectsFromMultiplePacksThroughTheMultiPackIndex()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        var firstSha = repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+
+        repository.WriteFile("file.txt", "second\n");
+        var secondSha = repository.Commit("second commit");
+        repository.Run("repack", "-d", "-q");
+
+        repository.Run("multi-pack-index", "write");
+
+        var packDirectory = Path.Combine(repository.ObjectsDirectory, "pack");
+        File.Exists(Path.Combine(packDirectory, "multi-pack-index")).ShouldBeTrue();
+        Directory.GetFiles(packDirectory, "*.pack").Length.ShouldBe(2);
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(firstSha)).Message.ShouldBe("first commit\n");
+
+        var second = store.GetCommit(GitObjectId.Parse(secondSha));
+        second.Message.ShouldBe("second commit\n");
+        second.Parents[0].ToString().ShouldBe(firstSha);
+    }
+
+    [Test]
+    public void TheMultiPackIndexReaderLooksUpObjectsAcrossPacks()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        var firstSha = repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+
+        repository.WriteFile("file.txt", "second\n");
+        var secondSha = repository.Commit("second commit");
+        repository.Run("repack", "-d", "-q");
+
+        repository.Run("multi-pack-index", "write");
+
+        using var stream = File.OpenRead(Path.Combine(repository.ObjectsDirectory, "pack", "multi-pack-index"));
+        using var reader = new GitMultiPackIndexReader(stream);
+
+        reader.PackNames.Count.ShouldBe(2);
+        reader.PackNames.ShouldAllBe(name => name.StartsWith("pack-"));
+
+        var first = reader.GetOffset(GitObjectId.Parse(firstSha));
+        var second = reader.GetOffset(GitObjectId.Parse(secondSha));
+
+        first.ShouldNotBeNull();
+        second.ShouldNotBeNull();
+        first.Value.PackIndex.ShouldNotBe(second.Value.PackIndex, "the two commits live in different packs");
+        first.Value.Offset.ShouldBeGreaterThan(0);
+        second.Value.Offset.ShouldBeGreaterThan(0);
+
+        reader.GetOffset(GitObjectId.Parse("0123456789abcdef0123456789abcdef01234567")).ShouldBeNull();
+    }
+
+    [Test]
+    public void ReadsLooseObjectsWhenAMultiPackIndexIsPresent()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+        repository.Run("multi-pack-index", "write");
+
+        repository.WriteFile("file.txt", "second\n");
+        var looseSha = repository.Commit("loose commit");
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(looseSha)).Message.ShouldBe("loose commit\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/PackedObjectTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/PackedObjectTests.cs
@@ -1,0 +1,139 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class PackedObjectTests
+{
+    [Test]
+    public void ReadsCommitsFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var firstSha = repository.Commit("first commit");
+        repository.WriteFile("file.txt", "hello world\n");
+        var secondSha = repository.Commit("second commit");
+
+        repository.Run("gc", "-q");
+        AssertHasNoLooseObjects(repository);
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(secondSha));
+
+        commit.Tree.ToString().ShouldBe(repository.RevParse("HEAD^{tree}"));
+        commit.Parents[0].ToString().ShouldBe(firstSha);
+        commit.Message.ShouldBe("second commit\n");
+        commit.Author.Name.ShouldBe(GitTestRepository.AuthorName);
+        commit.Committer.When.ShouldBe(repository.CurrentDate);
+    }
+
+    [Test]
+    public void ReadsDeltifiedObjectsFromAPackWithDeepDeltaChains()
+    {
+        using var repository = new GitTestRepository();
+        var commits = CreateDeltaFriendlyHistory(repository);
+
+        repository.Run("repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+        AssertHasNoLooseObjects(repository);
+
+        AssertWholeHistoryIsReadable(repository, commits);
+    }
+
+    [Test]
+    public void ReadsRefDeltaObjectsFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        var commits = CreateDeltaFriendlyHistory(repository);
+
+        repository.Run("-c", "repack.useDeltaBaseOffset=false", "repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+        AssertHasNoLooseObjects(repository);
+
+        AssertWholeHistoryIsReadable(repository, commits);
+    }
+
+    [Test]
+    public void ReadsBlobsAndTreesFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        var expectedContent = new StringBuilder();
+        for (var i = 0; i < 20; i++)
+        {
+            expectedContent.AppendLine($"line {i} of a delta friendly file with some repeating content");
+            repository.WriteFile("file.txt", expectedContent.ToString());
+            repository.Commit($"commit {i}");
+        }
+
+        repository.Run("repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+
+        using var store = repository.OpenObjectStore();
+        using var blob = store.GetBlob(repository.ResolveId("HEAD:file.txt"));
+        using var reader = new StreamReader(blob);
+        reader.ReadToEnd().ShouldBe(expectedContent.ToString());
+
+        var tree = store.GetTree(repository.ResolveId("HEAD^{tree}"));
+        tree.Entries.Count.ShouldBe(1);
+        tree.Entries[0].Name.ShouldBe("file.txt");
+    }
+
+    [Test]
+    public void ReadsLooseObjectsCreatedAfterThePack()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var packedSha = repository.Commit("packed commit");
+        repository.Run("gc", "-q");
+
+        repository.WriteFile("file.txt", "hello again\n");
+        var looseSha = repository.Commit("loose commit");
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(packedSha)).Message.ShouldBe("packed commit\n");
+        store.GetCommit(GitObjectId.Parse(looseSha)).Message.ShouldBe("loose commit\n");
+    }
+
+    private static List<(string Sha, string Message)> CreateDeltaFriendlyHistory(GitTestRepository repository)
+    {
+        List<(string Sha, string Message)> commits = [];
+        var content = new StringBuilder();
+
+        for (var i = 0; i < 30; i++)
+        {
+            content.AppendLine($"line {i} of a delta friendly file with some repeating content");
+            repository.WriteFile("file.txt", content.ToString());
+            var message = $"commit {i}";
+            commits.Add((repository.Commit(message), message));
+        }
+
+        return commits;
+    }
+
+    private static void AssertWholeHistoryIsReadable(GitTestRepository repository, List<(string Sha, string Message)> commits)
+    {
+        using var store = repository.OpenObjectStore();
+
+        for (var i = 0; i < commits.Count; i++)
+        {
+            var commit = store.GetCommit(GitObjectId.Parse(commits[i].Sha));
+
+            commit.Message.ShouldBe(commits[i].Message + "\n");
+            commit.Parents.Count.ShouldBe(i == 0 ? 0 : 1);
+            if (i > 0)
+            {
+                commit.Parents[0].ToString().ShouldBe(commits[i - 1].Sha);
+            }
+
+            using var blob = store.GetBlob(repository.ResolveId($"{commits[i].Sha}:file.txt"));
+            using var reader = new StreamReader(blob);
+            var lines = reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            lines.Length.ShouldBe(i + 1);
+        }
+    }
+
+    private static void AssertHasNoLooseObjects(GitTestRepository repository)
+    {
+        var looseObjects = Directory
+            .EnumerateDirectories(repository.ObjectsDirectory)
+            .Where(directory => Path.GetFileName(directory) is { Length: 2 })
+            .SelectMany(Directory.EnumerateFiles);
+
+        looseObjects.ShouldBeEmpty();
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/TagTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/TagTests.cs
@@ -1,0 +1,80 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class TagTests
+{
+    [Test]
+    public void ReadsAnAnnotatedTag()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v1.2.3", "-m", "release 1.2.3");
+
+        var tagSha = repository.RevParse("v1.2.3");
+        tagSha.ShouldNotBe(commitSha, "an annotated tag should be its own object");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(GitObjectId.Parse(tagSha));
+
+        tag.Sha.ToString().ShouldBe(tagSha);
+        tag.Name.ShouldBe("v1.2.3");
+        tag.TargetType.ShouldBe("commit");
+        tag.Target.ToString().ShouldBe(commitSha);
+        tag.Message.ShouldBe("release 1.2.3\n");
+
+        tag.Tagger.ShouldNotBeNull();
+        tag.Tagger.Value.Name.ShouldBe(GitTestRepository.CommitterName);
+        tag.Tagger.Value.Email.ShouldBe(GitTestRepository.CommitterEmail);
+        tag.Tagger.Value.When.ShouldBe(repository.CurrentDate);
+    }
+
+    [Test]
+    public void ReadsAnAnnotatedTagWithAMultiLineMessage()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("tag", "-a", "v2.0.0", "-m", "subject\n\nbody with details");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(repository.ResolveId("v2.0.0"));
+
+        tag.Message.ShouldBe("subject\n\nbody with details\n");
+    }
+
+    [Test]
+    public void ReadsANestedAnnotatedTag()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("tag", "-a", "inner", "-m", "inner tag");
+        repository.Run("tag", "-a", "outer", "-m", "outer tag", "inner");
+
+        using var store = repository.OpenObjectStore();
+        var outer = store.GetTag(repository.ResolveId("outer"));
+
+        outer.TargetType.ShouldBe("tag");
+        outer.Target.ToString().ShouldBe(repository.RevParse("inner"));
+    }
+
+    [Test]
+    public void ReadsAnAnnotatedTagFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v3.0.0", "-m", "packed tag");
+        var tagSha = repository.RevParse("v3.0.0");
+
+        repository.Run("gc", "-q");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(GitObjectId.Parse(tagSha));
+
+        tag.Name.ShouldBe("v3.0.0");
+        tag.Target.ToString().ShouldBe(commitSha);
+        tag.Message.ShouldBe("packed tag\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/TreeTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/TreeTests.cs
@@ -1,0 +1,90 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class TreeTests
+{
+    [Test]
+    public void ReadsTheRootTreeEntriesMatchingGitLsTree()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        repository.WriteFile("b.txt", "b\n");
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add files");
+
+        using var store = repository.OpenObjectStore();
+        var treeId = repository.ResolveId("HEAD^{tree}");
+        var tree = store.GetTree(treeId);
+
+        tree.Sha.ShouldBe(treeId);
+
+        // git ls-tree prints: <mode> SP <type> SP <sha> TAB <name>
+        var expectedEntries = repository
+            .Run("ls-tree", treeId.ToString())
+            .Split('\n')
+            .Select(line =>
+            {
+                var parts = line.Split('\t');
+                var meta = parts[0].Split(' ');
+                return (Mode: meta[0], Type: meta[1], Sha: meta[2], Name: parts[1]);
+            })
+            .ToList();
+
+        tree.Entries.Count.ShouldBe(expectedEntries.Count);
+
+        for (var i = 0; i < expectedEntries.Count; i++)
+        {
+            var entry = tree.Entries[i];
+            var expected = expectedEntries[i];
+
+            entry.Name.ShouldBe(expected.Name);
+            entry.Mode.PadLeft(6, '0').ShouldBe(expected.Mode);
+            entry.Sha.ToString().ShouldBe(expected.Sha);
+            entry.IsTree.ShouldBe(expected.Type == "tree");
+        }
+    }
+
+    [Test]
+    public void ReadsANestedTree()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add nested file");
+
+        using var store = repository.OpenObjectStore();
+        var rootTree = store.GetTree(repository.ResolveId("HEAD^{tree}"));
+
+        var subEntry = rootTree.FindEntry("sub");
+        subEntry.ShouldNotBeNull();
+        subEntry.IsTree.ShouldBeTrue();
+
+        var subTree = store.GetTree(subEntry.Sha);
+        subTree.Entries.Count.ShouldBe(1);
+        subTree.Entries[0].Name.ShouldBe("c.txt");
+        subTree.Entries[0].IsTree.ShouldBeFalse();
+        subTree.Entries[0].Sha.ToString().ShouldBe(repository.RevParse("HEAD:sub/c.txt"));
+    }
+
+    [Test]
+    public void FindsANodeUsingTheStreamingReader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add files");
+
+        using var store = repository.OpenObjectStore();
+        var treeId = repository.ResolveId("HEAD^{tree}");
+
+        using (var treeStream = store.GetObject(treeId, "tree"))
+        {
+            var node = GitTreeStreamingReader.FindNode(treeStream, "sub"u8);
+            node.ToString().ShouldBe(repository.RevParse("HEAD:sub"));
+        }
+
+        using (var treeStream = store.GetObject(treeId, "tree"))
+        {
+            GitTreeStreamingReader.FindNode(treeStream, "missing"u8).ShouldBe(GitObjectId.Empty);
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/DeltaInstruction.cs
+++ b/src/GitVersion.Git.Managed/DeltaInstruction.cs
@@ -1,0 +1,43 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Enumerates the instruction types which can be found in a deltified stream.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal enum DeltaInstructionType
+{
+    /// <summary>
+    /// Instructs the caller to insert a new byte range into the object.
+    /// </summary>
+    Insert = 0,
+
+    /// <summary>
+    /// Instructs the caller to copy a byte range from the source object.
+    /// </summary>
+    Copy = 1
+}
+
+/// <summary>
+/// Represents an instruction in a deltified stream.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal struct DeltaInstruction
+{
+    /// <summary>
+    /// The type of the current instruction.
+    /// </summary>
+    public DeltaInstructionType InstructionType;
+
+    /// <summary>
+    /// If the <see cref="InstructionType"/> is <see cref="DeltaInstructionType.Copy"/>,
+    /// the offset of the base stream to start copying from.
+    /// </summary>
+    public int Offset;
+
+    /// <summary>
+    /// The number of bytes to copy or insert.
+    /// </summary>
+    public int Size;
+}

--- a/src/GitVersion.Git.Managed/DeltaStreamReader.cs
+++ b/src/GitVersion.Git.Managed/DeltaStreamReader.cs
@@ -36,48 +36,53 @@ internal static class DeltaStreamReader
         }
         else
         {
-            if ((instruction & 0b0000_0001) != 0)
-            {
-                value.Offset |= (byte)stream.ReadByte();
-            }
-
-            if ((instruction & 0b0000_0010) != 0)
-            {
-                value.Offset |= (byte)stream.ReadByte() << 8;
-            }
-
-            if ((instruction & 0b0000_0100) != 0)
-            {
-                value.Offset |= (byte)stream.ReadByte() << 16;
-            }
-
-            if ((instruction & 0b0000_1000) != 0)
-            {
-                value.Offset |= (byte)stream.ReadByte() << 24;
-            }
-
-            if ((instruction & 0b0001_0000) != 0)
-            {
-                value.Size = (byte)stream.ReadByte();
-            }
-
-            if ((instruction & 0b0010_0000) != 0)
-            {
-                value.Size |= (byte)stream.ReadByte() << 8;
-            }
-
-            if ((instruction & 0b0100_0000) != 0)
-            {
-                value.Size |= (byte)stream.ReadByte() << 16;
-            }
-
-            // Size zero is automatically converted to 0x10000.
-            if (value.Size == 0)
-            {
-                value.Size = 0x10000;
-            }
+            ReadCopyInstruction(stream, instruction, ref value);
         }
 
         return value;
+    }
+
+    private static void ReadCopyInstruction(Stream stream, byte instruction, ref DeltaInstruction value)
+    {
+        if ((instruction & 0b0000_0001) != 0)
+        {
+            value.Offset |= (byte)stream.ReadByte();
+        }
+
+        if ((instruction & 0b0000_0010) != 0)
+        {
+            value.Offset |= (byte)stream.ReadByte() << 8;
+        }
+
+        if ((instruction & 0b0000_0100) != 0)
+        {
+            value.Offset |= (byte)stream.ReadByte() << 16;
+        }
+
+        if ((instruction & 0b0000_1000) != 0)
+        {
+            value.Offset |= (byte)stream.ReadByte() << 24;
+        }
+
+        if ((instruction & 0b0001_0000) != 0)
+        {
+            value.Size = (byte)stream.ReadByte();
+        }
+
+        if ((instruction & 0b0010_0000) != 0)
+        {
+            value.Size |= (byte)stream.ReadByte() << 8;
+        }
+
+        if ((instruction & 0b0100_0000) != 0)
+        {
+            value.Size |= (byte)stream.ReadByte() << 16;
+        }
+
+        // Size zero is automatically converted to 0x10000.
+        if (value.Size == 0)
+        {
+            value.Size = 0x10000;
+        }
     }
 }

--- a/src/GitVersion.Git.Managed/DeltaStreamReader.cs
+++ b/src/GitVersion.Git.Managed/DeltaStreamReader.cs
@@ -1,0 +1,83 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads delta instructions from a <see cref="Stream"/>.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal static class DeltaStreamReader
+{
+    /// <summary>
+    /// Reads the next instruction from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">The stream from which to read the instruction.</param>
+    /// <returns>The next instruction if found; otherwise, <see langword="null"/>.</returns>
+    public static DeltaInstruction? Read(Stream stream)
+    {
+        var next = stream.ReadByte();
+
+        if (next == -1)
+        {
+            return null;
+        }
+
+        var instruction = (byte)next;
+
+        DeltaInstruction value;
+        value.Offset = 0;
+        value.Size = 0;
+
+        value.InstructionType = (DeltaInstructionType)((instruction & 0b1000_0000) >> 7);
+
+        if (value.InstructionType == DeltaInstructionType.Insert)
+        {
+            value.Size = instruction & 0b0111_1111;
+        }
+        else
+        {
+            if ((instruction & 0b0000_0001) != 0)
+            {
+                value.Offset |= (byte)stream.ReadByte();
+            }
+
+            if ((instruction & 0b0000_0010) != 0)
+            {
+                value.Offset |= (byte)stream.ReadByte() << 8;
+            }
+
+            if ((instruction & 0b0000_0100) != 0)
+            {
+                value.Offset |= (byte)stream.ReadByte() << 16;
+            }
+
+            if ((instruction & 0b0000_1000) != 0)
+            {
+                value.Offset |= (byte)stream.ReadByte() << 24;
+            }
+
+            if ((instruction & 0b0001_0000) != 0)
+            {
+                value.Size = (byte)stream.ReadByte();
+            }
+
+            if ((instruction & 0b0010_0000) != 0)
+            {
+                value.Size |= (byte)stream.ReadByte() << 8;
+            }
+
+            if ((instruction & 0b0100_0000) != 0)
+            {
+                value.Size |= (byte)stream.ReadByte() << 16;
+            }
+
+            // Size zero is automatically converted to 0x10000.
+            if (value.Size == 0)
+            {
+                value.Size = 0x10000;
+            }
+        }
+
+        return value;
+    }
+}

--- a/src/GitVersion.Git.Managed/FileHelpers.cs
+++ b/src/GitVersion.Git.Managed/FileHelpers.cs
@@ -1,0 +1,34 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+internal static class FileHelpers
+{
+    /// <summary>
+    /// Opens the file with a given path for reading, if it exists.
+    /// </summary>
+    /// <param name="path">The path to the file.</param>
+    /// <param name="stream">The stream opened over the file, if the file exists.</param>
+    /// <returns><see langword="true"/> if the file exists; otherwise <see langword="false"/>.</returns>
+    public static bool TryOpen(string path, [NotNullWhen(true)] out FileStream? stream)
+    {
+        if (!File.Exists(path))
+        {
+            stream = null;
+            return false;
+        }
+
+        try
+        {
+            stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return true;
+        }
+        catch (IOException)
+        {
+            stream = null;
+            return false;
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitCommit.cs
+++ b/src/GitVersion.Git.Managed/GitCommit.cs
@@ -1,0 +1,42 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git commit, as stored in the Git object database.
+/// </summary>
+internal sealed class GitCommit
+{
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> which uniquely identifies this commit.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of the root tree of this commit.
+    /// </summary>
+    public required GitObjectId Tree { get; init; }
+
+    /// <summary>
+    /// Gets the parents of this commit, in order.
+    /// </summary>
+    public required IReadOnlyList<GitObjectId> Parents { get; init; }
+
+    /// <summary>
+    /// Gets the author of this commit.
+    /// </summary>
+    public required GitSignature Author { get; init; }
+
+    /// <summary>
+    /// Gets the committer of this commit.
+    /// </summary>
+    public required GitSignature Committer { get; init; }
+
+    /// <summary>
+    /// Gets the full commit message, decoded honoring the commit's <c>encoding</c> header.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git Commit: {Sha}";
+}

--- a/src/GitVersion.Git.Managed/GitCommitReader.cs
+++ b/src/GitVersion.Git.Managed/GitCommitReader.cs
@@ -1,0 +1,117 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitCommit"/> object.
+/// </summary>
+internal static class GitCommitReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitCommit"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the commit in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public static GitCommit Read(Stream stream, GitObjectId sha)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var span = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(span);
+
+            return Read(span, sha);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitCommit"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="commit">A <see cref="ReadOnlySpan{T}"/> which contains the commit in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public static GitCommit Read(ReadOnlySpan<byte> commit, GitObjectId sha)
+    {
+        GitObjectId? tree = null;
+        List<GitObjectId> parents = [];
+        ReadOnlySpan<byte> authorLine = default;
+        ReadOnlySpan<byte> committerLine = default;
+        var hasAuthor = false;
+        var hasCommitter = false;
+        string? encodingName = null;
+
+        var buffer = commit;
+
+        while (!buffer.IsEmpty)
+        {
+            var lineEnd = buffer.IndexOf((byte)'\n');
+            if (lineEnd < 0)
+            {
+                lineEnd = buffer.Length;
+            }
+
+            var line = buffer[..lineEnd];
+            buffer = buffer[Math.Min(lineEnd + 1, buffer.Length)..];
+
+            if (line.IsEmpty)
+            {
+                // An empty line separates the headers from the commit message.
+                break;
+            }
+
+            if (line[0] == ' ')
+            {
+                // A continuation of the previous (multi-line) header, such as gpgsig; skip.
+                continue;
+            }
+
+            if (line.StartsWith("tree "u8))
+            {
+                tree = GitObjectId.ParseHex(line["tree "u8.Length..]);
+            }
+            else if (line.StartsWith("parent "u8))
+            {
+                parents.Add(GitObjectId.ParseHex(line["parent "u8.Length..]));
+            }
+            else if (line.StartsWith("author "u8))
+            {
+                authorLine = line["author "u8.Length..];
+                hasAuthor = true;
+            }
+            else if (line.StartsWith("committer "u8))
+            {
+                committerLine = line["committer "u8.Length..];
+                hasCommitter = true;
+            }
+            else if (line.StartsWith("encoding "u8))
+            {
+                encodingName = GitTextDecoder.Decode(line["encoding "u8.Length..]);
+            }
+        }
+
+        if (tree is null || !hasAuthor || !hasCommitter)
+        {
+            throw new GitObjectStoreException($"The commit {sha} is malformed: a tree, author or committer header is missing.");
+        }
+
+        return new()
+        {
+            Sha = sha,
+            Tree = tree.Value,
+            Parents = parents,
+            Author = GitSignature.Parse(authorLine, encodingName),
+            Committer = GitSignature.Parse(committerLine, encodingName),
+            Message = GitTextDecoder.Decode(buffer, encodingName)
+        };
+    }
+}

--- a/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
@@ -1,0 +1,218 @@
+using System.Buffers.Binary;
+using System.IO.MemoryMappedFiles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a Git <c>multi-pack-index</c> file (format version 1), which indexes the objects
+/// of multiple pack files in a single file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitformat-pack#_multi_pack_index_midx_files_have_the_following_format"/>
+internal sealed unsafe class GitMultiPackIndexReader : IDisposable
+{
+    private const uint PackNamesChunkId = 0x504E414D;     // "PNAM"
+    private const uint OidFanoutChunkId = 0x4F494446;     // "OIDF"
+    private const uint OidLookupChunkId = 0x4F49444C;     // "OIDL"
+    private const uint ObjectOffsetsChunkId = 0x4F4F4646; // "OOFF"
+    private const uint LargeOffsetsChunkId = 0x4C4F4646;  // "LOFF"
+
+    private const int HeaderLength = 12;
+    private const int ChunkTableEntryLength = 12;
+
+    private readonly MemoryMappedFile file;
+    private readonly MemoryMappedViewAccessor accessor;
+    private readonly int oidLength;
+    private readonly int[] fanoutTable = new int[256];
+    private readonly Dictionary<uint, long> chunkOffsets = [];
+    private byte* ptr;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitMultiPackIndexReader"/> class.
+    /// </summary>
+    /// <param name="stream">A <see cref="FileStream"/> which points to the multi-pack-index file.</param>
+    public GitMultiPackIndexReader(FileStream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        this.file = MemoryMappedFile.CreateFromFile(stream, mapName: null, capacity: 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+        this.accessor = this.file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
+
+        try
+        {
+            var header = GetSpan(0, HeaderLength);
+
+            if (!header[..4].SequenceEqual("MIDX"u8))
+            {
+                throw new GitObjectStoreException("The multi-pack-index file has an invalid signature.");
+            }
+
+            var version = header[4];
+            if (version != 1)
+            {
+                throw new GitObjectStoreException($"Multi-pack-index version {version} is not supported; only version 1 is supported.");
+            }
+
+            this.oidLength = header[5] switch
+            {
+                1 => GitObjectId.Sha1Size,
+                2 => GitObjectId.Sha256Size,
+                _ => throw new GitObjectStoreException($"The multi-pack-index object id version {header[5]} is not supported.")
+            };
+
+            var chunkCount = header[6];
+            var baseFileCount = header[7];
+            var packCount = BinaryPrimitives.ReadUInt32BigEndian(header[8..12]);
+
+            if (baseFileCount != 0)
+            {
+                throw new NotSupportedException("Incremental multi-pack-index chains are not supported.");
+            }
+
+            var chunkTable = GetSpan(HeaderLength, (chunkCount + 1) * ChunkTableEntryLength);
+
+            for (var i = 0; i < chunkCount; i++)
+            {
+                var entry = chunkTable.Slice(i * ChunkTableEntryLength, ChunkTableEntryLength);
+                var chunkId = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
+                var chunkOffset = BinaryPrimitives.ReadInt64BigEndian(entry[4..12]);
+                this.chunkOffsets[chunkId] = chunkOffset;
+            }
+
+            var fanout = GetSpan(GetChunkOffset(OidFanoutChunkId), 256 * 4);
+
+            for (var i = 0; i < 256; i++)
+            {
+                this.fanoutTable[i] = BinaryPrimitives.ReadInt32BigEndian(fanout.Slice(4 * i, 4));
+            }
+
+            PackNames = ReadPackNames((int)packCount);
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets the names of the pack files indexed by this multi-pack-index, without their
+    /// file extension, in the order used by <see cref="GetOffset(GitObjectId)"/>.
+    /// </summary>
+    public IReadOnlyList<string> PackNames { get; } = [];
+
+    /// <summary>
+    /// Looks up an object in the multi-pack-index.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to look up.</param>
+    /// <returns>
+    /// If found, the index (into <see cref="PackNames"/>) of the pack which contains the object,
+    /// and the offset of the object within that pack; otherwise, <see langword="null"/>.
+    /// </returns>
+    public (int PackIndex, long Offset)? GetOffset(GitObjectId objectId)
+    {
+        if (objectId.HashLength != this.oidLength)
+        {
+            return null;
+        }
+
+        Span<byte> objectName = stackalloc byte[this.oidLength];
+        objectId.CopyTo(objectName);
+
+        var start = objectName[0] == 0 ? 0 : this.fanoutTable[objectName[0] - 1];
+        var end = this.fanoutTable[objectName[0]] - 1;
+
+        if (end < start)
+        {
+            return null;
+        }
+
+        var oidLookupOffset = GetChunkOffset(OidLookupChunkId);
+        var table = GetSpan(oidLookupOffset + ((long)this.oidLength * start), this.oidLength * (end - start + 1));
+
+        var order = -1;
+        var i = 0;
+
+        var low = 0;
+        var high = end - start;
+
+        while (low <= high)
+        {
+            i = (low + high) / 2;
+
+            order = table.Slice(this.oidLength * i, this.oidLength).SequenceCompareTo(objectName);
+
+            if (order < 0)
+            {
+                low = i + 1;
+            }
+            else if (order > 0)
+            {
+                high = i - 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (order != 0)
+        {
+            return null;
+        }
+
+        var objectIndex = start + i;
+        var entry = GetSpan(GetChunkOffset(ObjectOffsetsChunkId) + (8L * objectIndex), 8);
+        var packIndex = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
+        var offset = BinaryPrimitives.ReadUInt32BigEndian(entry[4..8]);
+
+        if ((offset & 0x8000_0000) != 0)
+        {
+            throw new NotSupportedException("Multi-pack-index files with large (>= 2 GiB) object offsets are not supported.");
+        }
+
+        return ((int)packIndex, offset);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.ptr is not null)
+        {
+            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            this.ptr = null;
+        }
+
+        this.accessor.Dispose();
+        this.file.Dispose();
+    }
+
+    private long GetChunkOffset(uint chunkId) =>
+        this.chunkOffsets.TryGetValue(chunkId, out var offset)
+            ? offset
+            : throw new GitObjectStoreException($"The multi-pack-index file is missing the required 0x{chunkId:X8} chunk.");
+
+    private string[] ReadPackNames(int packCount)
+    {
+        var names = new string[packCount];
+        var offset = GetChunkOffset(PackNamesChunkId);
+
+        for (var i = 0; i < packCount; i++)
+        {
+            var length = 0;
+
+            while (GetSpan(offset + length, 1)[0] != 0)
+            {
+                length++;
+            }
+
+            var name = Encoding.UTF8.GetString(GetSpan(offset, length));
+            names[i] = Path.GetFileNameWithoutExtension(name);
+            offset += length + 1;
+        }
+
+        return names;
+    }
+
+    private ReadOnlySpan<byte> GetSpan(long offset, int length) => new(this.ptr + offset, length);
+}

--- a/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
@@ -1,5 +1,4 @@
 using System.Buffers.Binary;
-using System.IO.MemoryMappedFiles;
 
 namespace GitVersion.Git;
 
@@ -8,39 +7,33 @@ namespace GitVersion.Git;
 /// of multiple pack files in a single file.
 /// </summary>
 /// <seealso href="https://git-scm.com/docs/gitformat-pack#_multi_pack_index_midx_files_have_the_following_format"/>
-internal sealed unsafe class GitMultiPackIndexReader : IDisposable
+internal sealed class GitMultiPackIndexReader : IDisposable
 {
     private const uint PackNamesChunkId = 0x504E414D;     // "PNAM"
     private const uint OidFanoutChunkId = 0x4F494446;     // "OIDF"
     private const uint OidLookupChunkId = 0x4F49444C;     // "OIDL"
     private const uint ObjectOffsetsChunkId = 0x4F4F4646; // "OOFF"
-    private const uint LargeOffsetsChunkId = 0x4C4F4646;  // "LOFF"
 
     private const int HeaderLength = 12;
     private const int ChunkTableEntryLength = 12;
 
-    private readonly MemoryMappedFile file;
-    private readonly MemoryMappedViewAccessor accessor;
+    private readonly FileStream stream;
     private readonly int oidLength;
     private readonly int[] fanoutTable = new int[256];
-    private readonly Dictionary<uint, long> chunkOffsets = [];
-    private byte* ptr;
+    private readonly Dictionary<uint, (long Offset, long Length)> chunks = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GitMultiPackIndexReader"/> class.
     /// </summary>
-    /// <param name="stream">A <see cref="FileStream"/> which points to the multi-pack-index file.</param>
+    /// <param name="stream">A <see cref="FileStream"/> which points to the multi-pack-index file. Ownership is transferred to the reader.</param>
     public GitMultiPackIndexReader(FileStream stream)
     {
-        ArgumentNullException.ThrowIfNull(stream);
-
-        this.file = MemoryMappedFile.CreateFromFile(stream, mapName: null, capacity: 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
-        this.accessor = this.file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
-        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
         try
         {
-            var header = GetSpan(0, HeaderLength);
+            Span<byte> header = stackalloc byte[HeaderLength];
+            stream.SafeFileHandle.ReadExactlyAt(0, header);
 
             if (!header[..4].SequenceEqual("MIDX"u8))
             {
@@ -69,28 +62,13 @@ internal sealed unsafe class GitMultiPackIndexReader : IDisposable
                 throw new NotSupportedException("Incremental multi-pack-index chains are not supported.");
             }
 
-            var chunkTable = GetSpan(HeaderLength, (chunkCount + 1) * ChunkTableEntryLength);
-
-            for (var i = 0; i < chunkCount; i++)
-            {
-                var entry = chunkTable.Slice(i * ChunkTableEntryLength, ChunkTableEntryLength);
-                var chunkId = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
-                var chunkOffset = BinaryPrimitives.ReadInt64BigEndian(entry[4..12]);
-                this.chunkOffsets[chunkId] = chunkOffset;
-            }
-
-            var fanout = GetSpan(GetChunkOffset(OidFanoutChunkId), 256 * 4);
-
-            for (var i = 0; i < 256; i++)
-            {
-                this.fanoutTable[i] = BinaryPrimitives.ReadInt32BigEndian(fanout.Slice(4 * i, 4));
-            }
-
+            ReadChunkTable(chunkCount);
+            ReadFanoutTable();
             PackNames = ReadPackNames((int)packCount);
         }
         catch
         {
-            Dispose();
+            this.stream.Dispose();
             throw;
         }
     }
@@ -99,7 +77,7 @@ internal sealed unsafe class GitMultiPackIndexReader : IDisposable
     /// Gets the names of the pack files indexed by this multi-pack-index, without their
     /// file extension, in the order used by <see cref="GetOffset(GitObjectId)"/>.
     /// </summary>
-    public IReadOnlyList<string> PackNames { get; } = [];
+    public IReadOnlyList<string> PackNames { get; }
 
     /// <summary>
     /// Looks up an object in the multi-pack-index.
@@ -119,28 +97,21 @@ internal sealed unsafe class GitMultiPackIndexReader : IDisposable
         Span<byte> objectName = stackalloc byte[this.oidLength];
         objectId.CopyTo(objectName);
 
-        var start = objectName[0] == 0 ? 0 : this.fanoutTable[objectName[0] - 1];
-        var end = this.fanoutTable[objectName[0]] - 1;
+        var low = objectName[0] == 0 ? 0 : this.fanoutTable[objectName[0] - 1];
+        var high = this.fanoutTable[objectName[0]] - 1;
 
-        if (end < start)
-        {
-            return null;
-        }
+        var oidLookupOffset = GetChunk(OidLookupChunkId).Offset;
 
-        var oidLookupOffset = GetChunkOffset(OidLookupChunkId);
-        var table = GetSpan(oidLookupOffset + ((long)this.oidLength * start), this.oidLength * (end - start + 1));
-
+        Span<byte> current = stackalloc byte[this.oidLength];
         var order = -1;
         var i = 0;
-
-        var low = 0;
-        var high = end - start;
 
         while (low <= high)
         {
             i = (low + high) / 2;
 
-            order = table.Slice(this.oidLength * i, this.oidLength).SequenceCompareTo(objectName);
+            this.stream.SafeFileHandle.ReadExactlyAt(oidLookupOffset + ((long)this.oidLength * i), current);
+            order = current.SequenceCompareTo(objectName);
 
             if (order < 0)
             {
@@ -161,8 +132,9 @@ internal sealed unsafe class GitMultiPackIndexReader : IDisposable
             return null;
         }
 
-        var objectIndex = start + i;
-        var entry = GetSpan(GetChunkOffset(ObjectOffsetsChunkId) + (8L * objectIndex), 8);
+        Span<byte> entry = stackalloc byte[8];
+        this.stream.SafeFileHandle.ReadExactlyAt(GetChunk(ObjectOffsetsChunkId).Offset + (8L * i), entry);
+
         var packIndex = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
         var offset = BinaryPrimitives.ReadUInt32BigEndian(entry[4..8]);
 
@@ -175,44 +147,63 @@ internal sealed unsafe class GitMultiPackIndexReader : IDisposable
     }
 
     /// <inheritdoc/>
-    public void Dispose()
-    {
-        if (this.ptr is not null)
-        {
-            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            this.ptr = null;
-        }
+    public void Dispose() => this.stream.Dispose();
 
-        this.accessor.Dispose();
-        this.file.Dispose();
+    private (long Offset, long Length) GetChunk(uint chunkId) =>
+        this.chunks.TryGetValue(chunkId, out var chunk)
+            ? chunk
+            : throw new GitObjectStoreException($"The multi-pack-index file is missing the required 0x{chunkId:X8} chunk.");
+
+    private void ReadChunkTable(int chunkCount)
+    {
+        // The chunk table has chunkCount + 1 entries; the terminating entry (id 0) records
+        // the offset at which the chunks end, which yields each chunk's length.
+        var table = new byte[(chunkCount + 1) * ChunkTableEntryLength];
+        this.stream.SafeFileHandle.ReadExactlyAt(HeaderLength, table);
+
+        for (var i = 0; i < chunkCount; i++)
+        {
+            var entry = table.AsSpan(i * ChunkTableEntryLength, ChunkTableEntryLength);
+            var chunkId = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
+            var chunkOffset = BinaryPrimitives.ReadInt64BigEndian(entry[4..12]);
+            var nextChunkOffset = BinaryPrimitives.ReadInt64BigEndian(table.AsSpan(((i + 1) * ChunkTableEntryLength) + 4, 8));
+            this.chunks[chunkId] = (chunkOffset, nextChunkOffset - chunkOffset);
+        }
     }
 
-    private long GetChunkOffset(uint chunkId) =>
-        this.chunkOffsets.TryGetValue(chunkId, out var offset)
-            ? offset
-            : throw new GitObjectStoreException($"The multi-pack-index file is missing the required 0x{chunkId:X8} chunk.");
+    private void ReadFanoutTable()
+    {
+        Span<byte> fanout = stackalloc byte[256 * 4];
+        this.stream.SafeFileHandle.ReadExactlyAt(GetChunk(OidFanoutChunkId).Offset, fanout);
+
+        for (var i = 0; i < 256; i++)
+        {
+            this.fanoutTable[i] = BinaryPrimitives.ReadInt32BigEndian(fanout.Slice(4 * i, 4));
+        }
+    }
 
     private string[] ReadPackNames(int packCount)
     {
+        var (chunkOffset, chunkLength) = GetChunk(PackNamesChunkId);
+
+        var contents = new byte[chunkLength];
+        this.stream.SafeFileHandle.ReadExactlyAt(chunkOffset, contents);
+
         var names = new string[packCount];
-        var offset = GetChunkOffset(PackNamesChunkId);
+        var span = contents.AsSpan();
 
         for (var i = 0; i < packCount; i++)
         {
-            var length = 0;
-
-            while (GetSpan(offset + length, 1)[0] != 0)
+            var nameEnd = span.IndexOf((byte)0);
+            if (nameEnd < 0)
             {
-                length++;
+                throw new GitObjectStoreException("The multi-pack-index pack name chunk is malformed.");
             }
 
-            var name = Encoding.UTF8.GetString(GetSpan(offset, length));
-            names[i] = Path.GetFileNameWithoutExtension(name);
-            offset += length + 1;
+            names[i] = Path.GetFileNameWithoutExtension(Encoding.UTF8.GetString(span[..nameEnd]));
+            span = span[(nameEnd + 1)..];
         }
 
         return names;
     }
-
-    private ReadOnlySpan<byte> GetSpan(long offset, int length) => new(this.ptr + offset, length);
 }

--- a/src/GitVersion.Git.Managed/GitObjectId.cs
+++ b/src/GitVersion.Git.Managed/GitObjectId.cs
@@ -1,0 +1,228 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Identifies an object stored in the Git object database. The id of an object is the hash
+/// of its contents. This type is hash-agnostic: it stores up to 32 bytes together with the
+/// hash length, supporting both SHA-1 (20 bytes) and SHA-256 (32 bytes) repositories.
+/// </summary>
+/// <seealso href="https://git-scm.com/book/en/v2/Git-Internals-Git-Objects"/>
+internal struct GitObjectId : IEquatable<GitObjectId>
+{
+    /// <summary>The length, in bytes, of a SHA-1 object id.</summary>
+    public const int Sha1Size = 20;
+
+    /// <summary>The length, in bytes, of a SHA-256 object id.</summary>
+    public const int Sha256Size = 32;
+
+    private const string HexDigits = "0123456789abcdef";
+    private static readonly byte[] ReverseHexDigits = BuildReverseHexDigits();
+
+    private HashBuffer value;
+    private byte length;
+    private string? sha;
+
+    [InlineArray(Sha256Size)]
+    private struct HashBuffer
+    {
+        private byte element;
+    }
+
+    /// <summary>
+    /// Gets a <see cref="GitObjectId"/> which represents an empty <see cref="GitObjectId"/>.
+    /// </summary>
+    public static GitObjectId Empty => default;
+
+    /// <summary>
+    /// Gets the length, in bytes, of the hash represented by this object id. Zero for <see cref="Empty"/>.
+    /// </summary>
+    public readonly int HashLength => this.length;
+
+    public static bool operator ==(GitObjectId left, GitObjectId right) => left.Equals(right);
+
+    public static bool operator !=(GitObjectId left, GitObjectId right) => !left.Equals(right);
+
+    /// <summary>
+    /// Parses a sequence of byte values as a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The raw hash bytes. Must be exactly 20 (SHA-1) or 32 (SHA-256) bytes in length.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(ReadOnlySpan<byte> value)
+    {
+        if (value.Length is not (Sha1Size or Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {Sha1Size} or {Sha256Size} bytes, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+        value.CopyTo(bytes);
+        objectId.length = (byte)value.Length;
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation. Must be 40 (SHA-1) or 64 (SHA-256) characters long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(ReadOnlySpan<char> value)
+    {
+        if (value.Length is not (2 * Sha1Size or 2 * Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {2 * Sha1Size} or {2 * Sha256Size} characters, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c1 = GetHexValue(value[i++]) << 4;
+            var c2 = GetHexValue(value[i]);
+
+            bytes[i >> 1] = (byte)(c1 + c2);
+        }
+
+        objectId.length = (byte)(value.Length / 2);
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation. Must be 40 (SHA-1) or 64 (SHA-256) characters long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(string value)
+    {
+        var objectId = Parse(value.AsSpan());
+        objectId.sha = value.ToLowerInvariant();
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the ASCII-encoded hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation, encoded in ASCII. Must be 40 (SHA-1) or 64 (SHA-256) bytes long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId ParseHex(ReadOnlySpan<byte> value)
+    {
+        if (value.Length is not (2 * Sha1Size or 2 * Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {2 * Sha1Size} or {2 * Sha256Size} characters, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c1 = GetHexValue((char)value[i++]) << 4;
+            var c2 = GetHexValue((char)value[i]);
+
+            bytes[i >> 1] = (byte)(c1 + c2);
+        }
+
+        objectId.length = (byte)(value.Length / 2);
+        return objectId;
+    }
+
+    /// <inheritdoc/>
+    public override readonly bool Equals(object? obj) => obj is GitObjectId other && Equals(other);
+
+    /// <inheritdoc/>
+    public readonly bool Equals(GitObjectId other)
+    {
+        ReadOnlySpan<byte> mine = this.value;
+        ReadOnlySpan<byte> theirs = other.value;
+        return this.length == other.length && mine.SequenceEqual(theirs);
+    }
+
+    /// <inheritdoc/>
+    public override readonly int GetHashCode()
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        return BinaryPrimitives.ReadInt32LittleEndian(bytes);
+    }
+
+    /// <summary>
+    /// Gets a <see cref="ushort"/> which represents the first two bytes of this <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <returns>The first two bytes of this <see cref="GitObjectId"/>, in big-endian order.</returns>
+    public readonly ushort AsUInt16()
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        return BinaryPrimitives.ReadUInt16BigEndian(bytes);
+    }
+
+    /// <summary>
+    /// Copies the byte representation of this <see cref="GitObjectId"/> to a <see cref="Span{T}"/>.
+    /// </summary>
+    /// <param name="destination">The memory to which to copy this <see cref="GitObjectId"/>. Must be at least <see cref="HashLength"/> bytes long.</param>
+    public readonly void CopyTo(Span<byte> destination)
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        bytes[..this.length].CopyTo(destination);
+    }
+
+    /// <summary>
+    /// Returns the hexadecimal representation of this object id.
+    /// </summary>
+    /// <inheritdoc/>
+    public override string ToString() => this.sha ??= ToString(this.length * 2);
+
+    /// <summary>
+    /// Returns the first <paramref name="length"/> hexadecimal characters of this object id.
+    /// </summary>
+    /// <param name="length">The number of hexadecimal characters to return.</param>
+    /// <returns>A hexadecimal prefix of this object id.</returns>
+    public readonly string ToString(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, this.length * 2);
+
+        Span<char> chars = stackalloc char[length];
+        ReadOnlySpan<byte> bytes = this.value;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var b = bytes[i >> 1];
+            chars[i] = HexDigits[(i & 1) == 0 ? b >> 4 : b & 0x0F];
+        }
+
+        return new string(chars);
+    }
+
+    private static int GetHexValue(char c)
+    {
+        var index = c - '0';
+        if (index < 0 || index >= ReverseHexDigits.Length || (index != 0 && ReverseHexDigits[index] == 0 && c != '0'))
+        {
+            throw new FormatException($"The character '{c}' is not a valid hexadecimal digit.");
+        }
+
+        return ReverseHexDigits[index];
+    }
+
+    private static byte[] BuildReverseHexDigits()
+    {
+        var bytes = new byte['f' - '0' + 1];
+
+        for (var i = 0; i < 10; i++)
+        {
+            bytes[i] = (byte)i;
+        }
+
+        for (var i = 10; i < 16; i++)
+        {
+            bytes[i + 'a' - '0' - 0x0a] = (byte)i;
+            bytes[i + 'A' - '0' - 0x0a] = (byte)i;
+        }
+
+        return bytes;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectId.cs
+++ b/src/GitVersion.Git.Managed/GitObjectId.cs
@@ -1,6 +1,7 @@
 // Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
 
 using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace GitVersion.Git;
@@ -22,6 +23,7 @@ internal struct GitObjectId : IEquatable<GitObjectId>
     private const string HexDigits = "0123456789abcdef";
     private static readonly byte[] ReverseHexDigits = BuildReverseHexDigits();
 
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "The inline array is written through its span conversion.")]
     private HashBuffer value;
     private byte length;
     private string? sha;
@@ -79,16 +81,17 @@ internal struct GitObjectId : IEquatable<GitObjectId>
 
         var objectId = default(GitObjectId);
         Span<byte> bytes = objectId.value;
+        var byteCount = value.Length / 2;
 
-        for (var i = 0; i < value.Length; i++)
+        for (var i = 0; i < byteCount; i++)
         {
-            var c1 = GetHexValue(value[i++]) << 4;
-            var c2 = GetHexValue(value[i]);
+            var high = GetHexValue(value[2 * i]);
+            var low = GetHexValue(value[(2 * i) + 1]);
 
-            bytes[i >> 1] = (byte)(c1 + c2);
+            bytes[i] = (byte)((high << 4) + low);
         }
 
-        objectId.length = (byte)(value.Length / 2);
+        objectId.length = (byte)byteCount;
         return objectId;
     }
 
@@ -118,16 +121,17 @@ internal struct GitObjectId : IEquatable<GitObjectId>
 
         var objectId = default(GitObjectId);
         Span<byte> bytes = objectId.value;
+        var byteCount = value.Length / 2;
 
-        for (var i = 0; i < value.Length; i++)
+        for (var i = 0; i < byteCount; i++)
         {
-            var c1 = GetHexValue((char)value[i++]) << 4;
-            var c2 = GetHexValue((char)value[i]);
+            var high = GetHexValue((char)value[2 * i]);
+            var low = GetHexValue((char)value[(2 * i) + 1]);
 
-            bytes[i >> 1] = (byte)(c1 + c2);
+            bytes[i] = (byte)((high << 4) + low);
         }
 
-        objectId.length = (byte)(value.Length / 2);
+        objectId.length = (byte)byteCount;
         return objectId;
     }
 

--- a/src/GitVersion.Git.Managed/GitObjectStore.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStore.cs
@@ -1,0 +1,284 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only access to the objects stored in a Git object database
+/// (a <c>.git/objects</c> directory), without relying on native libraries or
+/// the <c>git</c> executable.
+/// </summary>
+/// <remarks>
+/// Objects are looked up in the <c>multi-pack-index</c> (when present), in the
+/// individual pack files, among the loose objects, and finally in the alternate
+/// object databases listed in <c>objects/info/alternates</c> (one level deep).
+/// </remarks>
+internal sealed class GitObjectStore : IDisposable
+{
+    private readonly List<GitObjectStore> alternates = [];
+    private readonly Dictionary<string, GitPack> packsByName = new(StringComparer.Ordinal);
+    private readonly Lazy<string[]> packNames;
+    private readonly Lazy<GitMultiPackIndexReader?> multiPackIndex;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitObjectStore"/> class.
+    /// </summary>
+    /// <param name="objectDirectory">The path to the Git object directory (usually <c>.git/objects</c>).</param>
+    public GitObjectStore(string objectDirectory) : this(objectDirectory, followAlternates: true)
+    {
+    }
+
+    private GitObjectStore(string objectDirectory, bool followAlternates)
+    {
+        ArgumentNullException.ThrowIfNull(objectDirectory);
+
+        ObjectDirectory = Path.GetFullPath(objectDirectory);
+        this.packNames = new(LoadPackNames);
+        this.multiPackIndex = new(LoadMultiPackIndex);
+
+        if (followAlternates)
+        {
+            LoadAlternates();
+        }
+    }
+
+    /// <summary>
+    /// Gets the full path to the Git object directory.
+    /// </summary>
+    public string ObjectDirectory { get; }
+
+    /// <summary>
+    /// Reads the commit with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public GitCommit GetCommit(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Commit);
+        return GitCommitReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Reads the tree with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public GitTree GetTree(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Tree);
+        return GitTreeReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Reads the annotated tag with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the annotated tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public GitTag GetTag(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Tag);
+        return GitTagReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Opens a stream over the contents of the blob with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the blob.</param>
+    /// <returns>A <see cref="Stream"/> over the blob contents.</returns>
+    public Stream GetBlob(GitObjectId objectId) => GetObject(objectId, GitObjectTypes.Blob);
+
+    /// <summary>
+    /// Opens a stream over the contents of the object with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <returns>A <see cref="Stream"/> over the object contents.</returns>
+    /// <exception cref="GitObjectStoreException">The object could not be found.</exception>
+    public Stream GetObject(GitObjectId objectId, string objectType) =>
+        TryGetObjectCore(objectId, objectType)?.Stream
+            ?? throw new GitObjectStoreException($"An object of type '{objectType}' with id '{objectId}' could not be found.") { ObjectNotFound = true };
+
+    /// <summary>
+    /// Attempts to open a stream over the contents of the object with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> over the object contents.</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, string objectType, [NotNullWhen(true)] out Stream? stream)
+    {
+        stream = TryGetObjectCore(objectId, objectType)?.Stream;
+        return stream is not null;
+    }
+
+    /// <summary>
+    /// Attempts to open a stream over the contents of the object with the given object id,
+    /// without knowing its object type up front.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> over the object contents.</param>
+    /// <param name="objectType">If found, receives the object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType)
+    {
+        (stream, objectType) = TryGetObjectCore(objectId, objectType: null) is { } result
+            ? (result.Stream, result.ObjectType)
+            : (null, null);
+        return stream is not null;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        foreach (var pack in this.packsByName.Values)
+        {
+            pack.Dispose();
+        }
+
+        this.packsByName.Clear();
+
+        if (this.multiPackIndex.IsValueCreated)
+        {
+            this.multiPackIndex.Value?.Dispose();
+        }
+
+        foreach (var alternate in this.alternates)
+        {
+            alternate.Dispose();
+        }
+    }
+
+    private (Stream Stream, string ObjectType)? TryGetObjectCore(GitObjectId objectId, string? objectType)
+    {
+        // Prefer the multi-pack-index when present.
+        if (this.multiPackIndex.Value is { } midx && midx.GetOffset(objectId) is { } location)
+        {
+            var pack = GetPack(midx.PackNames[location.PackIndex]);
+
+            try
+            {
+                return pack.GetObject(location.Offset, objectType);
+            }
+            catch (GitObjectStoreException exception) when (exception.ObjectNotFound)
+            {
+                // The object exists, but with a different type than requested.
+                return null;
+            }
+        }
+
+        // Fall back to the per-pack .idx files (also covers packs newer than the multi-pack-index).
+        foreach (var packName in this.packNames.Value)
+        {
+            if (GetPack(packName).TryGetObject(objectId, objectType, out var stream, out var actualType))
+            {
+                return (stream, actualType);
+            }
+        }
+
+        if (TryGetLooseObject(objectId, objectType) is { } looseObject)
+        {
+            return looseObject;
+        }
+
+        foreach (var alternate in this.alternates)
+        {
+            if (alternate.TryGetObjectCore(objectId, objectType) is { } fromAlternate)
+            {
+                return fromAlternate;
+            }
+        }
+
+        return null;
+    }
+
+    private (Stream Stream, string ObjectType)? TryGetLooseObject(GitObjectId objectId, string? objectType)
+    {
+        var sha = objectId.ToString();
+        var path = Path.Combine(ObjectDirectory, sha[..2], sha[2..]);
+
+        if (!FileHelpers.TryOpen(path, out var fileStream))
+        {
+            return null;
+        }
+
+        var objectStream = new GitObjectStream(fileStream);
+
+        if (objectType is not null && objectStream.ObjectType != objectType)
+        {
+            objectStream.Dispose();
+            return null;
+        }
+
+        return (objectStream, objectStream.ObjectType);
+    }
+
+    private GitPack GetPack(string packName)
+    {
+        if (!this.packsByName.TryGetValue(packName, out var pack))
+        {
+            var packDirectory = Path.Combine(ObjectDirectory, "pack");
+            pack = new(
+                (id, type) => TryGetObjectCore(id, type),
+                Path.Combine(packDirectory, packName + ".idx"),
+                Path.Combine(packDirectory, packName + ".pack"));
+            this.packsByName.Add(packName, pack);
+        }
+
+        return pack;
+    }
+
+    private string[] LoadPackNames()
+    {
+        var packDirectory = Path.Combine(ObjectDirectory, "pack");
+
+        if (!Directory.Exists(packDirectory))
+        {
+            return [];
+        }
+
+        return [.. Directory.GetFiles(packDirectory, "*.idx")
+            .Where(indexPath => File.Exists(Path.ChangeExtension(indexPath, ".pack")))
+            .Select(Path.GetFileNameWithoutExtension)
+            .OfType<string>()
+            .Order(StringComparer.Ordinal)];
+    }
+
+    private GitMultiPackIndexReader? LoadMultiPackIndex()
+    {
+        var multiPackIndexPath = Path.Combine(ObjectDirectory, "pack", "multi-pack-index");
+
+        return FileHelpers.TryOpen(multiPackIndexPath, out var stream)
+            ? new GitMultiPackIndexReader(stream)
+            : null;
+    }
+
+    private void LoadAlternates()
+    {
+        var alternatesPath = Path.Combine(ObjectDirectory, "info", "alternates");
+
+        if (!File.Exists(alternatesPath))
+        {
+            return;
+        }
+
+        foreach (var line in File.ReadLines(alternatesPath))
+        {
+            var alternatePath = line.Trim();
+
+            if (alternatePath.Length == 0 || alternatePath.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (!Path.IsPathRooted(alternatePath))
+            {
+                alternatePath = Path.Combine(ObjectDirectory, alternatePath);
+            }
+
+            if (Directory.Exists(alternatePath))
+            {
+                // Alternates are followed one level deep only.
+                this.alternates.Add(new(alternatePath, followAlternates: false));
+            }
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectStoreException.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStoreException.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace GitVersion.Git;
 
 /// <summary>
 /// The exception thrown by the managed Git object store when the object database
 /// is malformed or a requested object cannot be found.
 /// </summary>
+[SuppressMessage("Critical Code Smell", "S3871:Exception types should be \"public\"", Justification = "Every type in this vendored library is internal by design (Phase B.1); the exception never crosses the assembly boundary.")]
 internal sealed class GitObjectStoreException : Exception
 {
     public GitObjectStoreException()

--- a/src/GitVersion.Git.Managed/GitObjectStoreException.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStoreException.cs
@@ -1,0 +1,26 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The exception thrown by the managed Git object store when the object database
+/// is malformed or a requested object cannot be found.
+/// </summary>
+internal sealed class GitObjectStoreException : Exception
+{
+    public GitObjectStoreException()
+    {
+    }
+
+    public GitObjectStoreException(string message) : base(message)
+    {
+    }
+
+    public GitObjectStoreException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this exception represents a missing object
+    /// (as opposed to a malformed object database).
+    /// </summary>
+    public bool ObjectNotFound { get; init; }
+}

--- a/src/GitVersion.Git.Managed/GitObjectStream.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStream.cs
@@ -1,0 +1,75 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A <see cref="Stream"/> which reads data stored as a loose object in the Git object store.
+/// The data is stored as a zlib-compressed stream prefixed with the object type and data length.
+/// </summary>
+internal sealed class GitObjectStream : GitZLibStream
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitObjectStream"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> from which to read data.</param>
+    public GitObjectStream(Stream stream)
+        : base(stream) => ObjectType = ReadObjectTypeAndLength();
+
+    /// <summary>
+    /// Gets the object type of this Git object, such as <c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>.
+    /// </summary>
+    public string ObjectType { get; }
+
+    private string ReadObjectTypeAndLength()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var typeLength = 0;
+
+        while (true)
+        {
+            var read = ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (read == ' ')
+            {
+                break;
+            }
+
+            if (typeLength >= buffer.Length)
+            {
+                throw new GitObjectStoreException("Invalid loose object header: the object type is too long.");
+            }
+
+            buffer[typeLength++] = (byte)read;
+        }
+
+        long length = 0;
+
+        while (true)
+        {
+            var read = ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (read == 0)
+            {
+                break;
+            }
+
+            if (read is < '0' or > '9')
+            {
+                throw new GitObjectStoreException("Invalid loose object header: the object length is malformed.");
+            }
+
+            length = (10 * length) + (read - '0');
+        }
+
+        Initialize(length);
+        return GitObjectTypes.Canonicalize(buffer[..typeLength]);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectTypes.cs
+++ b/src/GitVersion.Git.Managed/GitObjectTypes.cs
@@ -1,0 +1,42 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Well-known Git object type names.
+/// </summary>
+internal static class GitObjectTypes
+{
+    public const string Commit = "commit";
+    public const string Tree = "tree";
+    public const string Blob = "blob";
+    public const string Tag = "tag";
+
+    /// <summary>
+    /// Returns the canonical (interned) object type name for the given UTF-8 encoded type.
+    /// </summary>
+    /// <param name="type">The UTF-8 encoded object type name.</param>
+    /// <returns>The canonical object type name.</returns>
+    public static string Canonicalize(ReadOnlySpan<byte> type)
+    {
+        if (type.SequenceEqual("commit"u8))
+        {
+            return Commit;
+        }
+
+        if (type.SequenceEqual("tree"u8))
+        {
+            return Tree;
+        }
+
+        if (type.SequenceEqual("blob"u8))
+        {
+            return Blob;
+        }
+
+        if (type.SequenceEqual("tag"u8))
+        {
+            return Tag;
+        }
+
+        throw new GitObjectStoreException($"Unknown git object type '{Encoding.UTF8.GetString(type)}'.");
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPack.cs
+++ b/src/GitVersion.Git.Managed/GitPack.cs
@@ -1,7 +1,6 @@
 // Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
 
 using System.Diagnostics.CodeAnalysis;
-using System.IO.MemoryMappedFiles;
 
 namespace GitVersion.Git;
 
@@ -21,10 +20,8 @@ internal delegate (Stream Stream, string ObjectType)? ResolveGitObject(GitObject
 internal sealed class GitPack : IDisposable
 {
     private readonly ResolveGitObject resolveGitObject;
-    private readonly Func<FileStream> packStream;
-    private readonly Lazy<FileStream> indexStream;
+    private readonly Lazy<FileStream> packStream;
     private readonly GitPackCache cache;
-    private readonly Lazy<(MemoryMappedFile File, MemoryMappedViewAccessor Accessor)?> packFile;
 
     // Maps GitObjectIds to offsets in the git pack.
     private readonly Dictionary<GitObjectId, long> offsets = [];
@@ -41,24 +38,9 @@ internal sealed class GitPack : IDisposable
     public GitPack(ResolveGitObject resolveGitObject, string indexPath, string packPath, GitPackCache? cache = null)
     {
         this.resolveGitObject = resolveGitObject ?? throw new ArgumentNullException(nameof(resolveGitObject));
-        this.indexStream = new(() => File.OpenRead(indexPath));
-        this.packStream = () => File.OpenRead(packPath);
-        this.indexReader = new(() => new GitPackIndexReader(this.indexStream.Value));
+        this.indexReader = new(() => new GitPackIndexReader(File.OpenRead(indexPath)));
+        this.packStream = new(() => File.OpenRead(packPath));
         this.cache = cache ?? new GitPackMemoryCache();
-
-        this.packFile = new(() =>
-        {
-            // On 64-bit processes, we can use memory mapped streams (the address space
-            // will be large enough to map the entire pack file). On 32-bit processes,
-            // we directly access the underlying stream.
-            if (IntPtr.Size <= 4)
-            {
-                return null;
-            }
-
-            var file = MemoryMappedFile.CreateFromFile(this.packStream(), mapName: null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
-            return (file, file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read));
-        });
     }
 
     /// <summary>
@@ -122,17 +104,17 @@ internal sealed class GitPack : IDisposable
             return (cachedStream, cachedType);
         }
 
-        var packStream = GetPackStream();
+        var packDataStream = GetPackStream();
         Stream objectStream;
         string actualType;
 
         try
         {
-            (objectStream, actualType) = GitPackReader.GetObject(this, packStream, offset, objectType);
+            (objectStream, actualType) = GitPackReader.GetObject(this, packDataStream, offset, objectType);
         }
         catch
         {
-            packStream.Dispose();
+            packDataStream.Dispose();
             throw;
         }
 
@@ -147,10 +129,9 @@ internal sealed class GitPack : IDisposable
             this.indexReader.Value.Dispose();
         }
 
-        if (this.packFile.IsValueCreated && this.packFile.Value is { } mapped)
+        if (this.packStream.IsValueCreated)
         {
-            mapped.Accessor.Dispose();
-            mapped.File.Dispose();
+            this.packStream.Value.Dispose();
         }
 
         this.cache.Dispose();
@@ -173,8 +154,9 @@ internal sealed class GitPack : IDisposable
         return offset;
     }
 
-    private Stream GetPackStream() =>
-        this.packFile.Value is { } mapped
-            ? new MemoryMappedStream(mapped.Accessor)
-            : this.packStream();
+    private Stream GetPackStream()
+    {
+        var file = this.packStream.Value;
+        return new RandomAccessStream(file.SafeFileHandle, file.Length);
+    }
 }

--- a/src/GitVersion.Git.Managed/GitPack.cs
+++ b/src/GitVersion.Git.Managed/GitPack.cs
@@ -1,0 +1,180 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.MemoryMappedFiles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A delegate which resolves a Git object across the whole object store (used to resolve
+/// the base object of <c>ref-delta</c> deltified objects, which may live outside the pack).
+/// </summary>
+/// <param name="objectId">The Git object id of the object to fetch.</param>
+/// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+/// <returns>A stream over the object data and its actual object type, or <see langword="null"/> if not found.</returns>
+internal delegate (Stream Stream, string ObjectType)? ResolveGitObject(GitObjectId objectId, string? objectType);
+
+/// <summary>
+/// Supports retrieving objects from a Git pack file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal sealed class GitPack : IDisposable
+{
+    private readonly ResolveGitObject resolveGitObject;
+    private readonly Func<FileStream> packStream;
+    private readonly Lazy<FileStream> indexStream;
+    private readonly GitPackCache cache;
+    private readonly Lazy<(MemoryMappedFile File, MemoryMappedViewAccessor Accessor)?> packFile;
+
+    // Maps GitObjectIds to offsets in the git pack.
+    private readonly Dictionary<GitObjectId, long> offsets = [];
+
+    private readonly Lazy<GitPackIndexReader> indexReader;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPack"/> class.
+    /// </summary>
+    /// <param name="resolveGitObject">A delegate which fetches objects from the Git object store.</param>
+    /// <param name="indexPath">The full path to the index (<c>.idx</c>) file.</param>
+    /// <param name="packPath">The full path to the pack file.</param>
+    /// <param name="cache">A <see cref="GitPackCache"/> which is used to cache <see cref="Stream"/> objects which operate on the pack file.</param>
+    public GitPack(ResolveGitObject resolveGitObject, string indexPath, string packPath, GitPackCache? cache = null)
+    {
+        this.resolveGitObject = resolveGitObject ?? throw new ArgumentNullException(nameof(resolveGitObject));
+        this.indexStream = new(() => File.OpenRead(indexPath));
+        this.packStream = () => File.OpenRead(packPath);
+        this.indexReader = new(() => new GitPackIndexReader(this.indexStream.Value));
+        this.cache = cache ?? new GitPackMemoryCache();
+
+        this.packFile = new(() =>
+        {
+            // On 64-bit processes, we can use memory mapped streams (the address space
+            // will be large enough to map the entire pack file). On 32-bit processes,
+            // we directly access the underlying stream.
+            if (IntPtr.Size <= 4)
+            {
+                return null;
+            }
+
+            var file = MemoryMappedFile.CreateFromFile(this.packStream(), mapName: null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+            return (file, file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read));
+        });
+    }
+
+    /// <summary>
+    /// Resolves a Git object across the whole object store. Used to resolve the base
+    /// object of <c>ref-delta</c> deltified objects.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to fetch.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A stream over the object data and its actual object type, or <see langword="null"/> if not found.</returns>
+    public (Stream Stream, string ObjectType)? ResolveBaseObject(GitObjectId objectId, string? objectType) =>
+        this.resolveGitObject(objectId, objectType);
+
+    /// <summary>
+    /// Attempts to retrieve a Git object from this Git pack.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> which represents the object.</param>
+    /// <param name="actualType">If found, receives the actual object type.</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, string? objectType, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? actualType)
+    {
+        var offset = GetOffset(objectId);
+
+        if (offset is null)
+        {
+            stream = null;
+            actualType = null;
+            return false;
+        }
+
+        try
+        {
+            (stream, actualType) = GetObject(offset.Value, objectType);
+            return true;
+        }
+        catch (GitObjectStoreException exception) when (exception.ObjectNotFound)
+        {
+            stream = null;
+            actualType = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets a Git object at a specific offset.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object, relative to the pack file.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A <see cref="Stream"/> which represents the object, and the actual object type.</returns>
+    public (Stream Stream, string ObjectType) GetObject(long offset, string? objectType)
+    {
+        if (this.cache.TryOpen(offset, out var cachedStream, out var cachedType))
+        {
+            if (objectType is not null && cachedType != objectType)
+            {
+                cachedStream.Dispose();
+                throw new GitObjectStoreException($"An object of type {objectType} could not be located at offset {offset}.") { ObjectNotFound = true };
+            }
+
+            return (cachedStream, cachedType);
+        }
+
+        var packStream = GetPackStream();
+        Stream objectStream;
+        string actualType;
+
+        try
+        {
+            (objectStream, actualType) = GitPackReader.GetObject(this, packStream, offset, objectType);
+        }
+        catch
+        {
+            packStream.Dispose();
+            throw;
+        }
+
+        return (this.cache.Add(offset, objectStream, actualType), actualType);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.indexReader.IsValueCreated)
+        {
+            this.indexReader.Value.Dispose();
+        }
+
+        if (this.packFile.IsValueCreated && this.packFile.Value is { } mapped)
+        {
+            mapped.Accessor.Dispose();
+            mapped.File.Dispose();
+        }
+
+        this.cache.Dispose();
+    }
+
+    private long? GetOffset(GitObjectId objectId)
+    {
+        if (this.offsets.TryGetValue(objectId, out var cachedOffset))
+        {
+            return cachedOffset;
+        }
+
+        var offset = this.indexReader.Value.GetOffset(objectId);
+
+        if (offset is not null)
+        {
+            this.offsets.Add(objectId, offset.Value);
+        }
+
+        return offset;
+    }
+
+    private Stream GetPackStream() =>
+        this.packFile.Value is { } mapped
+            ? new MemoryMappedStream(mapped.Accessor)
+            : this.packStream();
+}

--- a/src/GitVersion.Git.Managed/GitPackCache.cs
+++ b/src/GitVersion.Git.Managed/GitPackCache.cs
@@ -1,0 +1,46 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a cache in which objects retrieved from a <see cref="GitPack"/> are cached.
+/// Caching these objects can be of interest, because retrieving data from a <see cref="GitPack"/>
+/// can be potentially expensive: the data is compressed and can be deltified.
+/// </summary>
+internal abstract class GitPackCache : IDisposable
+{
+    /// <summary>
+    /// Attempts to retrieve a Git object from cache.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object in the Git pack.</param>
+    /// <param name="stream">A <see cref="Stream"/> which will be set to the cached data, if found.</param>
+    /// <param name="objectType">The object type of the cached object, if found.</param>
+    /// <returns><see langword="true"/> if the object was found in cache; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType);
+
+    /// <summary>
+    /// Adds a Git object to this cache.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object in the Git pack.</param>
+    /// <param name="stream">A <see cref="Stream"/> which represents the object to add.</param>
+    /// <param name="objectType">The object type of the object to add to the cache.</param>
+    /// <returns>A <see cref="Stream"/> which represents the cached entry.</returns>
+    public abstract Stream Add(long offset, Stream stream, string objectType);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes of native and managed resources associated by this object.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> to dispose managed and native resources; <see langword="false"/> to only dispose of native resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackDeltafiedStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackDeltafiedStream.cs
@@ -1,0 +1,159 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads data from a deltified object.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal sealed class GitPackDeltafiedStream : Stream
+{
+    private readonly long length;
+
+    private readonly Stream baseStream;
+    private readonly Stream deltaStream;
+
+    private long position;
+    private DeltaInstruction? current;
+    private int offset;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPackDeltafiedStream"/> class.
+    /// </summary>
+    /// <param name="baseStream">The base stream to which the deltas are applied.</param>
+    /// <param name="deltaStream">A <see cref="Stream"/> which contains a sequence of <see cref="DeltaInstruction"/>s.</param>
+    public GitPackDeltafiedStream(Stream baseStream, Stream deltaStream)
+    {
+        this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+        this.deltaStream = deltaStream ?? throw new ArgumentNullException(nameof(deltaStream));
+
+        _ = this.deltaStream.ReadMbsInt(); // base object length
+        this.length = this.deltaStream.ReadMbsInt();
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => false;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        var read = 0;
+
+        while (read < buffer.Length && TryGetInstruction(out var instruction))
+        {
+            var source = instruction.InstructionType == DeltaInstructionType.Copy ? this.baseStream : this.deltaStream;
+
+            var canRead = Math.Min(buffer.Length - read, instruction.Size - this.offset);
+            var didRead = source.Read(buffer.Slice(read, canRead));
+
+            if (didRead == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            read += didRead;
+            this.offset += didRead;
+        }
+
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin == SeekOrigin.Begin && offset == this.position)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Current && offset == 0)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Begin && offset > this.position)
+        {
+            this.ReadBytes(checked((int)(offset - this.position)));
+            return this.position;
+        }
+
+        throw new NotSupportedException("Only forward seeks are supported.");
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.deltaStream.Dispose();
+            this.baseStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private bool TryGetInstruction(out DeltaInstruction instruction)
+    {
+        if (this.current is not null && this.offset < this.current.Value.Size)
+        {
+            instruction = this.current.Value;
+            return true;
+        }
+
+        this.current = DeltaStreamReader.Read(this.deltaStream);
+
+        if (this.current is null)
+        {
+            instruction = default;
+            return false;
+        }
+
+        instruction = this.current.Value;
+
+        switch (instruction.InstructionType)
+        {
+            case DeltaInstructionType.Copy:
+                this.baseStream.Seek(instruction.Offset, SeekOrigin.Begin);
+                this.offset = 0;
+                break;
+
+            case DeltaInstructionType.Insert:
+                this.offset = 0;
+                break;
+
+            default:
+                throw new GitObjectStoreException($"Invalid delta instruction type '{instruction.InstructionType}'.");
+        }
+
+        return true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackIndexReader.cs
@@ -1,41 +1,34 @@
 // Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
 
 using System.Buffers.Binary;
-using System.IO.MemoryMappedFiles;
 
 namespace GitVersion.Git;
 
 /// <summary>
-/// Reads a Git pack index (<c>.idx</c>) file, version 2, using a memory-mapped file.
+/// Reads a Git pack index (<c>.idx</c>) file, version 2.
 /// </summary>
 /// <seealso href="https://git-scm.com/docs/pack-format"/>
-internal sealed unsafe class GitPackIndexReader : IDisposable
+internal sealed class GitPackIndexReader : IDisposable
 {
     private static readonly byte[] Header = [0xff, 0x74, 0x4f, 0x63];
 
-    private readonly MemoryMappedFile file;
-    private readonly MemoryMappedViewAccessor accessor;
+    // The object name table starts at: 4 (header) + 4 (version) + 256 * 4 (fanout table).
+    private const int NameTableStart = 4 + 4 + (256 * 4);
+
+    private readonly FileStream stream;
 
     // The fanout table consists of 256 4-byte network byte order integers.
     // The N-th entry of this table records the number of objects in the corresponding pack,
     // the first byte of whose object name is less than or equal to N.
     private readonly int[] fanoutTable = new int[257];
-    private byte* ptr;
 
     private bool initialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GitPackIndexReader"/> class.
     /// </summary>
-    /// <param name="stream">A <see cref="FileStream"/> which points to the index file.</param>
-    public GitPackIndexReader(FileStream stream)
-    {
-        ArgumentNullException.ThrowIfNull(stream);
-
-        this.file = MemoryMappedFile.CreateFromFile(stream, mapName: null, capacity: 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
-        this.accessor = this.file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
-        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
-    }
+    /// <param name="stream">A <see cref="FileStream"/> which points to the index file. Ownership is transferred to the reader.</param>
+    public GitPackIndexReader(FileStream stream) => this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
     /// <summary>
     /// Gets the offset of a Git object in the pack file.
@@ -51,42 +44,30 @@ internal sealed unsafe class GitPackIndexReader : IDisposable
         Span<byte> objectName = stackalloc byte[hashLength];
         objectId.CopyTo(objectName);
 
-        var packStart = this.fanoutTable[objectName[0]];
-        var packEnd = this.fanoutTable[objectName[0] + 1] - 1;
         var objectCount = this.fanoutTable[256];
 
         // The fanout table is followed by a table of sorted 20-byte SHA-1 object names.
-        // These are packed together without offset values to reduce the cache footprint
-        // of the binary search for a specific object name.
-        // The object names start at: 4 (header) + 4 (version) + 256 * 4 (fanout table).
-        var tableSize = hashLength * (packEnd - packStart + 1);
-        if (tableSize <= 0)
-        {
-            return null;
-        }
+        var low = this.fanoutTable[objectName[0]];
+        var high = this.fanoutTable[objectName[0] + 1] - 1;
 
-        var table = GetSpan(4 + 4 + (256 * 4) + (hashLength * packStart), tableSize);
-
-        var originalPackStart = packStart;
-        packEnd -= originalPackStart;
-        packStart = 0;
-
-        var i = 0;
+        Span<byte> current = stackalloc byte[hashLength];
         var order = -1;
+        var i = 0;
 
-        while (packStart <= packEnd)
+        while (low <= high)
         {
-            i = (packStart + packEnd) / 2;
+            i = (low + high) / 2;
 
-            order = table.Slice(hashLength * i, hashLength).SequenceCompareTo(objectName);
+            this.stream.SafeFileHandle.ReadExactlyAt(NameTableStart + ((long)hashLength * i), current);
+            order = current.SequenceCompareTo(objectName);
 
             if (order < 0)
             {
-                packStart = i + 1;
+                low = i + 1;
             }
             else if (order > 0)
             {
-                packEnd = i - 1;
+                high = i - 1;
             }
             else
             {
@@ -101,11 +82,13 @@ internal sealed unsafe class GitPackIndexReader : IDisposable
 
         // Get the offset value. It's located at:
         // 4 (header) + 4 (version) + 256 * 4 (fanout table) + 20 * objectCount (name table) + 4 * objectCount (CRC32) + 4 * i (offset values)
-        var offsetTableStart = 4 + 4 + (256 * 4) + (hashLength * objectCount) + (4 * objectCount);
-        var offsetBuffer = GetSpan(offsetTableStart + (4 * (i + originalPackStart)), 4);
-        var offset = BinaryPrimitives.ReadUInt32BigEndian(offsetBuffer);
+        var offsetTableStart = NameTableStart + (hashLength * objectCount) + (4 * objectCount);
+        Span<byte> offsetBuffer = stackalloc byte[8];
 
-        if (offsetBuffer[0] < 128)
+        this.stream.SafeFileHandle.ReadExactlyAt(offsetTableStart + (4L * i), offsetBuffer[..4]);
+        var offset = BinaryPrimitives.ReadUInt32BigEndian(offsetBuffer[..4]);
+
+        if ((offset & 0x8000_0000) == 0)
         {
             return offset;
         }
@@ -115,24 +98,12 @@ internal sealed unsafe class GitPackIndexReader : IDisposable
         // "large offsets are encoded as an index into the next table with the msbit set."
         offset &= 0x7FFFFFFF;
 
-        offsetBuffer = GetSpan(offsetTableStart + (4 * objectCount) + (8 * (int)offset), 8);
+        this.stream.SafeFileHandle.ReadExactlyAt(offsetTableStart + (4L * objectCount) + (8L * offset), offsetBuffer);
         return BinaryPrimitives.ReadInt64BigEndian(offsetBuffer);
     }
 
     /// <inheritdoc/>
-    public void Dispose()
-    {
-        if (this.ptr is not null)
-        {
-            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            this.ptr = null;
-        }
-
-        this.accessor.Dispose();
-        this.file.Dispose();
-    }
-
-    private ReadOnlySpan<byte> GetSpan(long offset, int length) => new(this.ptr + offset, length);
+    public void Dispose() => this.stream.Dispose();
 
     private void Initialize()
     {
@@ -142,7 +113,8 @@ internal sealed unsafe class GitPackIndexReader : IDisposable
         }
 
         const int fanoutTableLength = 256;
-        var value = GetSpan(0, 4 + (4 * fanoutTableLength) + 4);
+        Span<byte> value = stackalloc byte[4 + 4 + (4 * fanoutTableLength)];
+        this.stream.SafeFileHandle.ReadExactlyAt(0, value);
 
         var header = value[..4];
         var version = BinaryPrimitives.ReadInt32BigEndian(value.Slice(4, 4));

--- a/src/GitVersion.Git.Managed/GitPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackIndexReader.cs
@@ -1,0 +1,167 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Binary;
+using System.IO.MemoryMappedFiles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a Git pack index (<c>.idx</c>) file, version 2, using a memory-mapped file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal sealed unsafe class GitPackIndexReader : IDisposable
+{
+    private static readonly byte[] Header = [0xff, 0x74, 0x4f, 0x63];
+
+    private readonly MemoryMappedFile file;
+    private readonly MemoryMappedViewAccessor accessor;
+
+    // The fanout table consists of 256 4-byte network byte order integers.
+    // The N-th entry of this table records the number of objects in the corresponding pack,
+    // the first byte of whose object name is less than or equal to N.
+    private readonly int[] fanoutTable = new int[257];
+    private byte* ptr;
+
+    private bool initialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPackIndexReader"/> class.
+    /// </summary>
+    /// <param name="stream">A <see cref="FileStream"/> which points to the index file.</param>
+    public GitPackIndexReader(FileStream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        this.file = MemoryMappedFile.CreateFromFile(stream, mapName: null, capacity: 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+        this.accessor = this.file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
+    }
+
+    /// <summary>
+    /// Gets the offset of a Git object in the pack file.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the Git object for which to get the offset.</param>
+    /// <returns>If found, the offset of the Git object in the pack file; otherwise, <see langword="null"/>.</returns>
+    public long? GetOffset(GitObjectId objectId)
+    {
+        const int hashLength = GitObjectId.Sha1Size;
+
+        Initialize();
+
+        Span<byte> objectName = stackalloc byte[hashLength];
+        objectId.CopyTo(objectName);
+
+        var packStart = this.fanoutTable[objectName[0]];
+        var packEnd = this.fanoutTable[objectName[0] + 1] - 1;
+        var objectCount = this.fanoutTable[256];
+
+        // The fanout table is followed by a table of sorted 20-byte SHA-1 object names.
+        // These are packed together without offset values to reduce the cache footprint
+        // of the binary search for a specific object name.
+        // The object names start at: 4 (header) + 4 (version) + 256 * 4 (fanout table).
+        var tableSize = hashLength * (packEnd - packStart + 1);
+        if (tableSize <= 0)
+        {
+            return null;
+        }
+
+        var table = GetSpan(4 + 4 + (256 * 4) + (hashLength * packStart), tableSize);
+
+        var originalPackStart = packStart;
+        packEnd -= originalPackStart;
+        packStart = 0;
+
+        var i = 0;
+        var order = -1;
+
+        while (packStart <= packEnd)
+        {
+            i = (packStart + packEnd) / 2;
+
+            order = table.Slice(hashLength * i, hashLength).SequenceCompareTo(objectName);
+
+            if (order < 0)
+            {
+                packStart = i + 1;
+            }
+            else if (order > 0)
+            {
+                packEnd = i - 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (order != 0)
+        {
+            return null;
+        }
+
+        // Get the offset value. It's located at:
+        // 4 (header) + 4 (version) + 256 * 4 (fanout table) + 20 * objectCount (name table) + 4 * objectCount (CRC32) + 4 * i (offset values)
+        var offsetTableStart = 4 + 4 + (256 * 4) + (hashLength * objectCount) + (4 * objectCount);
+        var offsetBuffer = GetSpan(offsetTableStart + (4 * (i + originalPackStart)), 4);
+        var offset = BinaryPrimitives.ReadUInt32BigEndian(offsetBuffer);
+
+        if (offsetBuffer[0] < 128)
+        {
+            return offset;
+        }
+
+        // If the first bit of the offset address is set, the offset is stored as a 64-bit value in the table
+        // of 8-byte offset entries, which follows the table of 4-byte offset entries:
+        // "large offsets are encoded as an index into the next table with the msbit set."
+        offset &= 0x7FFFFFFF;
+
+        offsetBuffer = GetSpan(offsetTableStart + (4 * objectCount) + (8 * (int)offset), 8);
+        return BinaryPrimitives.ReadInt64BigEndian(offsetBuffer);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.ptr is not null)
+        {
+            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            this.ptr = null;
+        }
+
+        this.accessor.Dispose();
+        this.file.Dispose();
+    }
+
+    private ReadOnlySpan<byte> GetSpan(long offset, int length) => new(this.ptr + offset, length);
+
+    private void Initialize()
+    {
+        if (this.initialized)
+        {
+            return;
+        }
+
+        const int fanoutTableLength = 256;
+        var value = GetSpan(0, 4 + (4 * fanoutTableLength) + 4);
+
+        var header = value[..4];
+        var version = BinaryPrimitives.ReadInt32BigEndian(value.Slice(4, 4));
+
+        if (!header.SequenceEqual(Header))
+        {
+            throw new GitObjectStoreException("The pack index file has an invalid header.");
+        }
+
+        if (version != 2)
+        {
+            throw new GitObjectStoreException($"Pack index version {version} is not supported; only version 2 is supported.");
+        }
+
+        for (var i = 1; i <= fanoutTableLength; i++)
+        {
+            this.fanoutTable[i] = BinaryPrimitives.ReadInt32BigEndian(value.Slice(4 + (4 * i), 4));
+        }
+
+        this.initialized = true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
@@ -1,0 +1,61 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// <para>
+/// When a <see cref="Stream"/> is added to the <see cref="GitPackMemoryCache"/>, it is wrapped
+/// in a <see cref="GitPackMemoryCacheStream"/>. This stream allows for just-in-time, random,
+/// read-only access to the underlying data (which may be deltified and/or compressed).
+/// </para>
+/// <para>
+/// Whenever data is read from a <see cref="GitPackMemoryCacheStream"/>, the call is forwarded to the
+/// underlying <see cref="Stream"/> and cached in a <see cref="MemoryStream"/>. If the same data is read
+/// twice, it is read from the <see cref="MemoryStream"/>, rather than the underlying <see cref="Stream"/>.
+/// </para>
+/// </summary>
+internal sealed class GitPackMemoryCache : GitPackCache
+{
+    private readonly Dictionary<long, (GitPackMemoryCacheStream Stream, string ObjectType)> cache = [];
+
+    /// <inheritdoc/>
+    public override Stream Add(long offset, Stream stream, string objectType)
+    {
+        var cacheStream = new GitPackMemoryCacheStream(stream);
+        this.cache.Add(offset, (cacheStream, objectType));
+        return new GitPackMemoryCacheViewStream(cacheStream);
+    }
+
+    /// <inheritdoc/>
+    public override bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType)
+    {
+        if (this.cache.TryGetValue(offset, out var entry))
+        {
+            stream = new GitPackMemoryCacheViewStream(entry.Stream);
+            objectType = entry.ObjectType;
+            return true;
+        }
+
+        stream = null;
+        objectType = null;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var (stream, _) in this.cache.Values)
+            {
+                stream.Dispose();
+            }
+
+            this.cache.Clear();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
@@ -1,0 +1,109 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A stream which caches the data read from an underlying (non-seekable) stream in memory,
+/// providing random read-only access to that data.
+/// </summary>
+internal sealed class GitPackMemoryCacheStream : Stream
+{
+    private readonly Stream stream;
+    private readonly MemoryStream cacheStream = new();
+    private readonly long length;
+
+    public GitPackMemoryCacheStream(Stream stream)
+    {
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        this.length = this.stream.Length;
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.cacheStream.Position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        if (this.cacheStream.Length < this.length
+            && this.cacheStream.Position + buffer.Length > this.cacheStream.Length)
+        {
+            var currentPosition = this.cacheStream.Position;
+            var toRead = (int)(buffer.Length - this.cacheStream.Length + this.cacheStream.Position);
+            var actualRead = this.stream.Read(buffer[..toRead]);
+            this.cacheStream.Seek(0, SeekOrigin.End);
+            this.cacheStream.Write(buffer[..actualRead]);
+            this.cacheStream.Seek(currentPosition, SeekOrigin.Begin);
+            DisposeStreamIfRead();
+        }
+
+        return this.cacheStream.Read(buffer);
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Begin)
+        {
+            throw new NotSupportedException();
+        }
+
+        if (offset > this.cacheStream.Length)
+        {
+            this.cacheStream.Seek(0, SeekOrigin.End);
+            var toRead = (int)(offset - this.cacheStream.Length);
+            this.stream.ReadBytes(toRead, this.cacheStream);
+            DisposeStreamIfRead();
+            return this.cacheStream.Position;
+        }
+
+        return this.cacheStream.Seek(offset, origin);
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.stream.Dispose();
+            this.cacheStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void DisposeStreamIfRead()
+    {
+        if (this.cacheStream.Length == this.stream.Length)
+        {
+            this.stream.Dispose();
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
@@ -18,6 +18,12 @@ internal sealed class GitPackMemoryCacheStream : Stream
         this.length = this.stream.Length;
     }
 
+    /// <summary>
+    /// Gets the object on which <see cref="GitPackMemoryCacheViewStream"/> instances synchronize
+    /// their access to this shared stream.
+    /// </summary>
+    public object SyncRoot { get; } = new();
+
     /// <inheritdoc/>
     public override bool CanRead => true;
 

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
@@ -1,0 +1,79 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A read-only view over a shared <see cref="GitPackMemoryCacheStream"/> which maintains
+/// its own position, so multiple readers can independently consume the same cached object.
+/// </summary>
+internal sealed class GitPackMemoryCacheViewStream : Stream
+{
+    private readonly GitPackMemoryCacheStream baseStream;
+
+    private long position;
+
+    public GitPackMemoryCacheViewStream(GitPackMemoryCacheStream baseStream) =>
+        this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.baseStream.Length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        int read;
+
+        lock (this.baseStream)
+        {
+            if (this.baseStream.Position != this.position)
+            {
+                this.baseStream.Seek(this.position, SeekOrigin.Begin);
+            }
+
+            read = this.baseStream.Read(buffer);
+        }
+
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Begin)
+        {
+            throw new NotSupportedException();
+        }
+
+        this.position = Math.Min(offset, Length);
+        return this.position;
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
@@ -45,7 +45,7 @@ internal sealed class GitPackMemoryCacheViewStream : Stream
     {
         int read;
 
-        lock (this.baseStream)
+        lock (this.baseStream.SyncRoot)
         {
             if (this.baseStream.Position != this.position)
             {

--- a/src/GitVersion.Git.Managed/GitPackObjectType.cs
+++ b/src/GitVersion.Git.Managed/GitPackObjectType.cs
@@ -1,0 +1,31 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Enumerates the object types which can be stored in a Git pack file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal enum GitPackObjectType
+{
+    /// <summary>Invalid.</summary>
+    Invalid = 0,
+
+    /// <summary>A commit.</summary>
+    Commit = 1,
+
+    /// <summary>A tree.</summary>
+    Tree = 2,
+
+    /// <summary>A blob.</summary>
+    Blob = 3,
+
+    /// <summary>A tag.</summary>
+    Tag = 4,
+
+    /// <summary>A deltified object whose base object is referenced by a relative offset in the same pack.</summary>
+    OfsDelta = 6,
+
+    /// <summary>A deltified object whose base object is referenced by object id.</summary>
+    RefDelta = 7
+}

--- a/src/GitVersion.Git.Managed/GitPackReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackReader.cs
@@ -1,0 +1,125 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+internal static class GitPackReader
+{
+    /// <summary>
+    /// Reads a Git object which is stored at a given offset in a Git pack file.
+    /// </summary>
+    /// <param name="pack">The pack from which to read the object.</param>
+    /// <param name="stream">A (seekable) stream over the pack file. Ownership is transferred to the returned stream.</param>
+    /// <param name="offset">The offset of the object in the pack file.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A stream over the object data, and the actual object type.</returns>
+    public static (Stream Stream, string ObjectType) GetObject(GitPack pack, Stream stream, long offset, string? objectType)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        ArgumentNullException.ThrowIfNull(stream);
+
+        try
+        {
+            stream.Seek(offset, SeekOrigin.Begin);
+
+            var (type, decompressedSize) = ReadObjectHeader(stream);
+
+            switch (type)
+            {
+                case GitPackObjectType.OfsDelta:
+                    {
+                        var baseObjectRelativeOffset = ReadVariableLengthInteger(stream);
+                        var baseObjectOffset = offset - baseObjectRelativeOffset;
+
+                        var deltaStream = new GitZLibStream(stream, decompressedSize);
+                        var (baseStream, baseType) = pack.GetObject(baseObjectOffset, objectType);
+
+                        return (new GitPackDeltafiedStream(baseStream, deltaStream), baseType);
+                    }
+
+                case GitPackObjectType.RefDelta:
+                    {
+                        Span<byte> baseObjectId = stackalloc byte[GitObjectId.Sha1Size];
+                        stream.ReadExactly(baseObjectId);
+
+                        var baseObject = pack.ResolveBaseObject(GitObjectId.Parse(baseObjectId), objectType)
+                            ?? throw new GitObjectStoreException($"The base object of the deltified object at offset {offset} could not be found.") { ObjectNotFound = true };
+
+                        var seekableBaseObject = new GitPackMemoryCacheStream(baseObject.Stream);
+                        var deltaStream = new GitZLibStream(stream, decompressedSize);
+
+                        return (new GitPackDeltafiedStream(seekableBaseObject, deltaStream), baseObject.ObjectType);
+                    }
+
+                default:
+                    {
+                        var actualType = type switch
+                        {
+                            GitPackObjectType.Commit => GitObjectTypes.Commit,
+                            GitPackObjectType.Tree => GitObjectTypes.Tree,
+                            GitPackObjectType.Blob => GitObjectTypes.Blob,
+                            GitPackObjectType.Tag => GitObjectTypes.Tag,
+                            _ => throw new GitObjectStoreException($"The object at offset {offset} has an unsupported pack object type '{type}'.")
+                        };
+
+                        if (objectType is not null && actualType != objectType)
+                        {
+                            throw new GitObjectStoreException($"An object of type {objectType} could not be located at offset {offset}.") { ObjectNotFound = true };
+                        }
+
+                        return (new GitZLibStream(stream, decompressedSize), actualType);
+                    }
+            }
+        }
+        catch (EndOfStreamException eof)
+        {
+            throw new GitObjectStoreException($"An object could not be located at offset {offset}.", eof) { ObjectNotFound = true };
+        }
+    }
+
+    private static (GitPackObjectType ObjectType, long Length) ReadObjectHeader(Stream stream)
+    {
+        Span<byte> value = stackalloc byte[1];
+        stream.ReadExactly(value);
+
+        var type = (GitPackObjectType)((value[0] & 0b0111_0000) >> 4);
+        long length = value[0] & 0b_1111;
+
+        if ((value[0] & 0b1000_0000) == 0)
+        {
+            return (type, length);
+        }
+
+        var shift = 4;
+
+        do
+        {
+            stream.ReadExactly(value);
+            length |= (value[0] & 0b0111_1111L) << shift;
+            shift += 7;
+        }
+        while ((value[0] & 0b1000_0000) != 0);
+
+        return (type, length);
+    }
+
+    private static long ReadVariableLengthInteger(Stream stream)
+    {
+        long offset = -1;
+        int b;
+
+        do
+        {
+            offset++;
+            b = stream.ReadByte();
+            if (b == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            offset = (offset << 7) + (b & 127);
+        }
+        while ((b & 128) != 0);
+
+        return offset;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitSignature.cs
+++ b/src/GitVersion.Git.Managed/GitSignature.cs
@@ -1,0 +1,83 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Text;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents the signature of a Git committer, author or tagger.
+/// </summary>
+/// <param name="Name">The name of the person.</param>
+/// <param name="Email">The e-mail address of the person.</param>
+/// <param name="When">The date and time of the action, including the recorded UTC offset.</param>
+internal readonly record struct GitSignature(string Name, string Email, DateTimeOffset When)
+{
+    /// <summary>
+    /// Parses a signature line value in the format <c>Name &lt;email&gt; timestamp offset</c>,
+    /// for example <c>Jane Doe &lt;jane@example.com&gt; 1580753429 +0100</c>.
+    /// </summary>
+    /// <param name="value">The signature value (excluding the <c>author</c>/<c>committer</c>/<c>tagger</c> prefix).</param>
+    /// <param name="encodingName">The value of the containing object's <c>encoding</c> header, if present.</param>
+    /// <returns>The parsed <see cref="GitSignature"/>.</returns>
+    public static GitSignature Parse(ReadOnlySpan<byte> value, string? encodingName = null)
+    {
+        var emailStart = value.IndexOf((byte)'<');
+        var emailEnd = value.IndexOf((byte)'>');
+
+        if (emailStart < 0 || emailEnd < emailStart)
+        {
+            throw new GitObjectStoreException("A signature line is malformed: no e-mail address found.");
+        }
+
+        var name = value[..Math.Max(emailStart - 1, 0)];
+        var email = value[(emailStart + 1)..emailEnd];
+        var time = value[Math.Min(emailEnd + 2, value.Length)..];
+
+        var offsetStart = time.IndexOf((byte)' ');
+        if (offsetStart < 0)
+        {
+            offsetStart = time.Length;
+        }
+
+        if (!Utf8Parser.TryParse(time[..offsetStart], out long seconds, out _))
+        {
+            throw new GitObjectStoreException("A signature line is malformed: no timestamp found.");
+        }
+
+        var when = DateTimeOffset.FromUnixTimeSeconds(seconds);
+
+        if (TryParseOffset(time[Math.Min(offsetStart + 1, time.Length)..], out var offset))
+        {
+            when = when.ToOffset(offset);
+        }
+
+        return new(GitTextDecoder.Decode(name, encodingName), GitTextDecoder.Decode(email, encodingName), when);
+    }
+
+    private static bool TryParseOffset(ReadOnlySpan<byte> value, out TimeSpan offset)
+    {
+        offset = TimeSpan.Zero;
+
+        if (value.Length < 5 || (value[0] != '+' && value[0] != '-'))
+        {
+            return false;
+        }
+
+        var hours = ((value[1] - '0') * 10) + (value[2] - '0');
+        var minutes = ((value[3] - '0') * 10) + (value[4] - '0');
+
+        if (hours is < 0 or > 14 || minutes is < 0 or > 59)
+        {
+            return false;
+        }
+
+        offset = new TimeSpan(hours, minutes, 0);
+
+        if (value[0] == '-')
+        {
+            offset = offset.Negate();
+        }
+
+        return true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTag.cs
+++ b/src/GitVersion.Git.Managed/GitTag.cs
@@ -1,0 +1,42 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git annotated tag, as stored in the Git object database.
+/// </summary>
+internal sealed class GitTag
+{
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> which uniquely identifies this annotated tag.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of the object this tag points at.
+    /// </summary>
+    public required GitObjectId Target { get; init; }
+
+    /// <summary>
+    /// Gets the type of the object this tag points at, e.g. <c>commit</c> or, for nested tags, <c>tag</c>.
+    /// </summary>
+    public required string TargetType { get; init; }
+
+    /// <summary>
+    /// Gets the name of this tag.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the tagger of this tag, or <see langword="null"/> when the tag has no <c>tagger</c> header.
+    /// </summary>
+    public GitSignature? Tagger { get; init; }
+
+    /// <summary>
+    /// Gets the tag message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git Tag: {Name} with id {Sha}";
+}

--- a/src/GitVersion.Git.Managed/GitTagReader.cs
+++ b/src/GitVersion.Git.Managed/GitTagReader.cs
@@ -1,0 +1,116 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitTag"/> (annotated tag) object.
+/// </summary>
+internal static class GitTagReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitTag"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the tag in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public static GitTag Read(Stream stream, GitObjectId sha)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var span = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(span);
+
+            return Read(span, sha);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitTag"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="tag">A <see cref="ReadOnlySpan{T}"/> which contains the tag in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public static GitTag Read(ReadOnlySpan<byte> tag, GitObjectId sha)
+    {
+        GitObjectId? target = null;
+        string? targetType = null;
+        string? name = null;
+        GitSignature? tagger = null;
+        ReadOnlySpan<byte> taggerLine = default;
+        var hasTagger = false;
+
+        var buffer = tag;
+
+        while (!buffer.IsEmpty)
+        {
+            var lineEnd = buffer.IndexOf((byte)'\n');
+            if (lineEnd < 0)
+            {
+                lineEnd = buffer.Length;
+            }
+
+            var line = buffer[..lineEnd];
+            buffer = buffer[Math.Min(lineEnd + 1, buffer.Length)..];
+
+            if (line.IsEmpty)
+            {
+                // An empty line separates the headers from the tag message.
+                break;
+            }
+
+            if (line[0] == ' ')
+            {
+                // A continuation of the previous (multi-line) header; skip.
+                continue;
+            }
+
+            if (line.StartsWith("object "u8))
+            {
+                target = GitObjectId.ParseHex(line["object "u8.Length..]);
+            }
+            else if (line.StartsWith("type "u8))
+            {
+                targetType = GitObjectTypes.Canonicalize(line["type "u8.Length..]);
+            }
+            else if (line.StartsWith("tag "u8))
+            {
+                name = GitTextDecoder.Decode(line["tag "u8.Length..]);
+            }
+            else if (line.StartsWith("tagger "u8))
+            {
+                taggerLine = line["tagger "u8.Length..];
+                hasTagger = true;
+            }
+        }
+
+        if (target is null || targetType is null || name is null)
+        {
+            throw new GitObjectStoreException($"The tag {sha} is malformed: an object, type or tag header is missing.");
+        }
+
+        if (hasTagger)
+        {
+            tagger = GitSignature.Parse(taggerLine);
+        }
+
+        return new()
+        {
+            Sha = sha,
+            Target = target.Value,
+            TargetType = targetType,
+            Name = name,
+            Tagger = tagger,
+            Message = GitTextDecoder.Decode(buffer)
+        };
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTagReader.cs
+++ b/src/GitVersion.Git.Managed/GitTagReader.cs
@@ -46,8 +46,6 @@ internal static class GitTagReader
         string? targetType = null;
         string? name = null;
         GitSignature? tagger = null;
-        ReadOnlySpan<byte> taggerLine = default;
-        var hasTagger = false;
 
         var buffer = tag;
 
@@ -88,19 +86,13 @@ internal static class GitTagReader
             }
             else if (line.StartsWith("tagger "u8))
             {
-                taggerLine = line["tagger "u8.Length..];
-                hasTagger = true;
+                tagger = GitSignature.Parse(line["tagger "u8.Length..]);
             }
         }
 
         if (target is null || targetType is null || name is null)
         {
             throw new GitObjectStoreException($"The tag {sha} is malformed: an object, type or tag header is missing.");
-        }
-
-        if (hasTagger)
-        {
-            tagger = GitSignature.Parse(taggerLine);
         }
 
         return new()

--- a/src/GitVersion.Git.Managed/GitTextDecoder.cs
+++ b/src/GitVersion.Git.Managed/GitTextDecoder.cs
@@ -1,0 +1,52 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Decodes text stored in Git objects, matching git's behavior: content is assumed to be
+/// UTF-8 (or the encoding named by the commit's <c>encoding</c> header), falling back to
+/// Latin-1 when the bytes are not valid UTF-8.
+/// </summary>
+internal static class GitTextDecoder
+{
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// Decodes the given bytes as UTF-8, falling back to Latin-1 when the bytes are not valid UTF-8.
+    /// </summary>
+    /// <param name="bytes">The bytes to decode.</param>
+    /// <returns>The decoded string.</returns>
+    public static string Decode(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            return StrictUtf8.GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return Encoding.Latin1.GetString(bytes);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the given bytes using the named encoding when available, otherwise
+    /// falling back to <see cref="Decode(ReadOnlySpan{byte})"/>.
+    /// </summary>
+    /// <param name="bytes">The bytes to decode.</param>
+    /// <param name="encodingName">The value of the object's <c>encoding</c> header, if present.</param>
+    /// <returns>The decoded string.</returns>
+    public static string Decode(ReadOnlySpan<byte> bytes, string? encodingName)
+    {
+        if (encodingName is not null && !encodingName.Equals("UTF-8", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                return Encoding.GetEncoding(encodingName).GetString(bytes);
+            }
+            catch (ArgumentException)
+            {
+                // Unknown or unsupported encoding: fall back to git's default behavior.
+            }
+        }
+
+        return Decode(bytes);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTree.cs
+++ b/src/GitVersion.Git.Managed/GitTree.cs
@@ -1,0 +1,64 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git tree, as stored in the Git object database.
+/// </summary>
+internal sealed class GitTree
+{
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of this tree.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the entries in this tree, in the order in which they are stored.
+    /// </summary>
+    public required IReadOnlyList<GitTreeEntry> Entries { get; init; }
+
+    /// <summary>
+    /// Gets the entry with the given name, or <see langword="null"/> if no such entry exists.
+    /// </summary>
+    /// <param name="name">The name of the entry to find.</param>
+    /// <returns>The matching entry, if found.</returns>
+    public GitTreeEntry? FindEntry(string name) => Entries.FirstOrDefault(entry => entry.Name == name);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git tree: {Sha}";
+}
+
+/// <summary>
+/// Represents an individual entry in a Git tree.
+/// </summary>
+/// <param name="name">The name of the entry.</param>
+/// <param name="mode">The file mode of the entry, as stored in the tree object (octal, without leading zeros), e.g. <c>100644</c> or <c>40000</c>.</param>
+/// <param name="sha">The Git object id of the blob or tree of the entry.</param>
+internal sealed class GitTreeEntry(string name, string mode, GitObjectId sha)
+{
+    private const string TreeMode = "40000";
+
+    /// <summary>
+    /// Gets the name of the entry.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the file mode of the entry, as stored in the tree object (octal, without leading zeros),
+    /// e.g. <c>100644</c> for a regular file or <c>40000</c> for a directory.
+    /// </summary>
+    public string Mode { get; } = mode;
+
+    /// <summary>
+    /// Gets the Git object id of the blob or tree of the entry.
+    /// </summary>
+    public GitObjectId Sha { get; } = sha;
+
+    /// <summary>
+    /// Gets a value indicating whether this entry points to a tree (directory).
+    /// </summary>
+    public bool IsTree => Mode == TreeMode;
+
+    /// <inheritdoc/>
+    public override string ToString() => Name;
+}

--- a/src/GitVersion.Git.Managed/GitTreeReader.cs
+++ b/src/GitVersion.Git.Managed/GitTreeReader.cs
@@ -1,0 +1,82 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitTree"/> object.
+/// </summary>
+internal static class GitTreeReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitTree"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the tree in its binary representation.</param>
+    /// <param name="objectId">The <see cref="GitObjectId"/> of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public static GitTree Read(Stream stream, GitObjectId objectId)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var contents = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(contents);
+
+            return Read(contents, objectId);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitTree"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="tree">A <see cref="ReadOnlySpan{T}"/> which contains the tree in its binary representation.</param>
+    /// <param name="objectId">The <see cref="GitObjectId"/> of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public static GitTree Read(ReadOnlySpan<byte> tree, GitObjectId objectId)
+    {
+        List<GitTreeEntry> entries = [];
+
+        var contents = tree;
+
+        while (!contents.IsEmpty)
+        {
+            // Format: [mode] [file/folder name]\0[object id of the referenced blob or tree]
+            var (name, mode, sha, entryLength) = ReadEntry(contents);
+            entries.Add(new(name, mode, sha));
+            contents = contents[entryLength..];
+        }
+
+        return new()
+        {
+            Sha = objectId,
+            Entries = entries
+        };
+    }
+
+    internal static (string Name, string Mode, GitObjectId Sha, int EntryLength) ReadEntry(ReadOnlySpan<byte> contents)
+    {
+        const int hashLength = GitObjectId.Sha1Size;
+
+        var modeEnd = contents.IndexOf((byte)' ');
+        var nameEnd = contents.IndexOf((byte)0);
+
+        if (modeEnd < 0 || nameEnd < modeEnd || contents.Length < nameEnd + 1 + hashLength)
+        {
+            throw new GitObjectStoreException("The tree object is malformed.");
+        }
+
+        var mode = Encoding.UTF8.GetString(contents[..modeEnd]);
+        var name = GitTextDecoder.Decode(contents[(modeEnd + 1)..nameEnd]);
+        var sha = GitObjectId.Parse(contents.Slice(nameEnd + 1, hashLength));
+
+        return (name, mode, sha, nameEnd + 1 + hashLength);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTreeStreamingReader.cs
+++ b/src/GitVersion.Git.Managed/GitTreeStreamingReader.cs
@@ -1,0 +1,60 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Finds entries in Git tree objects without materializing the whole tree.
+/// </summary>
+internal static class GitTreeStreamingReader
+{
+    /// <summary>
+    /// Finds a specific node in a git tree.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which represents the git tree.</param>
+    /// <param name="name">The name of the node to find, in its UTF-8 representation.</param>
+    /// <returns>
+    /// The <see cref="GitObjectId"/> of the requested node, or <see cref="GitObjectId.Empty"/> if not found.
+    /// </returns>
+    public static GitObjectId FindNode(Stream stream, ReadOnlySpan<byte> name)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        const int hashLength = GitObjectId.Sha1Size;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var contents = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(contents);
+
+            while (!contents.IsEmpty)
+            {
+                var modeEnd = contents.IndexOf((byte)' ');
+                var nameEnd = contents.IndexOf((byte)0);
+
+                if (modeEnd < 0 || nameEnd < modeEnd || contents.Length < nameEnd + 1 + hashLength)
+                {
+                    throw new GitObjectStoreException("The tree object is malformed.");
+                }
+
+                var currentName = contents[(modeEnd + 1)..nameEnd];
+
+                if (currentName.SequenceEqual(name))
+                {
+                    return GitObjectId.Parse(contents.Slice(nameEnd + 1, hashLength));
+                }
+
+                contents = contents[(nameEnd + 1 + hashLength)..];
+            }
+
+            return GitObjectId.Empty;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
+++ b/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
     <ItemGroup Label="RemoveUnusedGlobalUsings">
         <Using Remove="Microsoft.Extensions.DependencyInjection" />
         <Using Remove="Microsoft.Extensions.DependencyInjection.Extensions" />

--- a/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
+++ b/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup Label="RemoveUnusedGlobalUsings">
+        <Using Remove="Microsoft.Extensions.DependencyInjection" />
+        <Using Remove="Microsoft.Extensions.DependencyInjection.Extensions" />
+        <Using Remove="Microsoft.Extensions.Logging" />
+        <Using Remove="Microsoft.Extensions.Logging.Abstractions" />
+        <Using Remove="Microsoft.Extensions.Options" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="GitVersion.Git.Managed.Tests" />
+    </ItemGroup>
+
+</Project>

--- a/src/GitVersion.Git.Managed/GitZLibStream.cs
+++ b/src/GitVersion.Git.Managed/GitZLibStream.cs
@@ -1,0 +1,146 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.IO.Compression;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A <see cref="Stream"/> which reads zlib-compressed data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This stream parses but ignores the two-byte zlib header at the start of the compressed
+/// stream. It keeps track of the current position and, if provided, the length, and supports
+/// forward-only seeking.
+/// </para>
+/// <para>
+/// This class wraps a <see cref="DeflateStream"/> rather than inheriting from it, because
+/// <see cref="DeflateStream"/> detects whether <c>Read(Span{byte})</c> is being overridden
+/// and behaves differently when it is.
+/// </para>
+/// </remarks>
+internal class GitZLibStream : Stream
+{
+    private readonly DeflateStream stream;
+    private long length;
+    private long position;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitZLibStream"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> from which to read data.</param>
+    /// <param name="length">The size of the uncompressed data.</param>
+    public GitZLibStream(Stream stream, long length = -1)
+    {
+        this.stream = new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: false);
+        this.length = length;
+
+        Span<byte> zlibHeader = stackalloc byte[2];
+        stream.ReadExactly(zlibHeader);
+
+        if (zlibHeader[0] != 0x78 || (zlibHeader[1] != 0x01 && zlibHeader[1] != 0x9C && zlibHeader[1] != 0x5E && zlibHeader[1] != 0xDA))
+        {
+            throw new GitObjectStoreException($"Invalid zlib header {zlibHeader[0]:X2} {zlibHeader[1]:X2}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var read = this.stream.Read(buffer, offset, count);
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        var read = this.stream.Read(buffer);
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int ReadByte()
+    {
+        var value = this.stream.ReadByte();
+
+        if (value != -1)
+        {
+            this.position += 1;
+        }
+
+        return value;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin == SeekOrigin.Begin && offset == this.position)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Current && offset == 0)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Begin && offset > this.position)
+        {
+            this.ReadBytes(checked((int)(offset - this.position)));
+            return this.position;
+        }
+
+        throw new NotSupportedException("Only forward seeks are supported.");
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.stream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Initializes the length and position properties.
+    /// </summary>
+    /// <param name="length">The length of the uncompressed data.</param>
+    protected void Initialize(long length)
+    {
+        this.position = 0;
+        this.length = length;
+    }
+}

--- a/src/GitVersion.Git.Managed/MemoryMappedStream.cs
+++ b/src/GitVersion.Git.Managed/MemoryMappedStream.cs
@@ -1,0 +1,122 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.IO.MemoryMappedFiles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only, seekable access to a <see cref="MemoryMappedFile"/>.
+/// </summary>
+internal sealed unsafe class MemoryMappedStream : Stream
+{
+    private readonly MemoryMappedViewAccessor accessor;
+    private readonly long length;
+    private readonly byte* ptr;
+    private long position;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemoryMappedStream"/> class.
+    /// </summary>
+    /// <param name="accessor">The accessor to the memory mapped stream.</param>
+    public MemoryMappedStream(MemoryMappedViewAccessor accessor)
+    {
+        this.accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
+        this.length = this.accessor.Capacity;
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => this.position = value;
+    }
+
+    /// <inheritdoc/>
+    public override void Flush()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+
+        var read = (int)Math.Min(buffer.Length, this.length - this.position);
+
+        new ReadOnlySpan<byte>(this.ptr + this.position, read).CopyTo(buffer);
+
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+
+        var newPosition = this.position;
+
+        switch (origin)
+        {
+            case SeekOrigin.Begin:
+                newPosition = offset;
+                break;
+
+            case SeekOrigin.Current:
+                newPosition += offset;
+                break;
+
+            case SeekOrigin.End:
+            default:
+                throw new NotSupportedException();
+        }
+
+        if (newPosition > this.length)
+        {
+            newPosition = this.length;
+        }
+
+        if (newPosition < 0)
+        {
+            throw new IOException("Attempted to seek before the start or beyond the end of the stream.");
+        }
+
+        this.position = newPosition;
+        return this.position;
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !this.disposed)
+        {
+            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            this.disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/GitVersion.Git.Managed/NOTICE.md
+++ b/src/GitVersion.Git.Managed/NOTICE.md
@@ -1,0 +1,35 @@
+# Third-party notices
+
+## Nerdbank.GitVersioning
+
+Portions of the code in this project (the managed Git object store reader) are derived from
+[Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning), specifically its
+`ManagedGit` implementation.
+
+Nerdbank.GitVersioning is licensed under the MIT License:
+
+```
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/src/GitVersion.Git.Managed/RandomAccessStream.cs
+++ b/src/GitVersion.Git.Managed/RandomAccessStream.cs
@@ -1,29 +1,29 @@
 // Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
 
-using System.IO.MemoryMappedFiles;
+using Microsoft.Win32.SafeHandles;
 
 namespace GitVersion.Git;
 
 /// <summary>
-/// Provides read-only, seekable access to a <see cref="MemoryMappedFile"/>.
+/// Provides read-only, seekable access to a file through a shared <see cref="SafeFileHandle"/>.
+/// Each instance maintains its own position, so multiple streams can read the same file
+/// concurrently without interfering with each other. The handle is not owned by this stream.
 /// </summary>
-internal sealed unsafe class MemoryMappedStream : Stream
+internal sealed class RandomAccessStream : Stream
 {
-    private readonly MemoryMappedViewAccessor accessor;
+    private readonly SafeFileHandle handle;
     private readonly long length;
-    private readonly byte* ptr;
     private long position;
-    private bool disposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MemoryMappedStream"/> class.
+    /// Initializes a new instance of the <see cref="RandomAccessStream"/> class.
     /// </summary>
-    /// <param name="accessor">The accessor to the memory mapped stream.</param>
-    public MemoryMappedStream(MemoryMappedViewAccessor accessor)
+    /// <param name="handle">The handle of the file to read. Remains owned by the caller.</param>
+    /// <param name="length">The length of the file.</param>
+    public RandomAccessStream(SafeFileHandle handle, long length)
     {
-        this.accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
-        this.accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref this.ptr);
-        this.length = this.accessor.Capacity;
+        this.handle = handle ?? throw new ArgumentNullException(nameof(handle));
+        this.length = length;
     }
 
     /// <inheritdoc/>
@@ -56,12 +56,13 @@ internal sealed unsafe class MemoryMappedStream : Stream
     /// <inheritdoc/>
     public override int Read(Span<byte> buffer)
     {
-        ObjectDisposedException.ThrowIf(this.disposed, this);
+        var toRead = (int)Math.Min(buffer.Length, this.length - this.position);
+        if (toRead <= 0)
+        {
+            return 0;
+        }
 
-        var read = (int)Math.Min(buffer.Length, this.length - this.position);
-
-        new ReadOnlySpan<byte>(this.ptr + this.position, read).CopyTo(buffer);
-
+        var read = RandomAccess.Read(this.handle, buffer[..toRead], this.position);
         this.position += read;
         return read;
     }
@@ -69,24 +70,12 @@ internal sealed unsafe class MemoryMappedStream : Stream
     /// <inheritdoc/>
     public override long Seek(long offset, SeekOrigin origin)
     {
-        ObjectDisposedException.ThrowIf(this.disposed, this);
-
-        var newPosition = this.position;
-
-        switch (origin)
+        var newPosition = origin switch
         {
-            case SeekOrigin.Begin:
-                newPosition = offset;
-                break;
-
-            case SeekOrigin.Current:
-                newPosition += offset;
-                break;
-
-            case SeekOrigin.End:
-            default:
-                throw new NotSupportedException();
-        }
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => this.position + offset,
+            _ => throw new NotSupportedException()
+        };
 
         if (newPosition > this.length)
         {
@@ -107,16 +96,4 @@ internal sealed unsafe class MemoryMappedStream : Stream
 
     /// <inheritdoc/>
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-    /// <inheritdoc/>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing && !this.disposed)
-        {
-            this.accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            this.disposed = true;
-        }
-
-        base.Dispose(disposing);
-    }
 }

--- a/src/GitVersion.Git.Managed/SafeFileHandleExtensions.cs
+++ b/src/GitVersion.Git.Managed/SafeFileHandleExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides extension methods for reading files through a <see cref="SafeFileHandle"/>.
+/// </summary>
+internal static class SafeFileHandleExtensions
+{
+    /// <summary>
+    /// Fills <paramref name="buffer"/> with the bytes stored at <paramref name="offset"/> in the file,
+    /// without affecting any stream position.
+    /// </summary>
+    /// <param name="handle">The handle of the file to read from.</param>
+    /// <param name="offset">The offset in the file at which to start reading.</param>
+    /// <param name="buffer">The buffer to fill.</param>
+    /// <exception cref="EndOfStreamException">Thrown when the file ends before <paramref name="buffer"/> could be filled.</exception>
+    public static void ReadExactlyAt(this SafeFileHandle handle, long offset, Span<byte> buffer)
+    {
+        var totalRead = 0;
+
+        while (totalRead < buffer.Length)
+        {
+            var read = RandomAccess.Read(handle, buffer[totalRead..], offset + totalRead);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += read;
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/StreamExtensions.cs
+++ b/src/GitVersion.Git.Managed/StreamExtensions.cs
@@ -1,0 +1,69 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides extension methods for the <see cref="Stream"/> class.
+/// </summary>
+internal static class StreamExtensions
+{
+    /// <summary>
+    /// Reads a variable-length integer off a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">The stream off which to read the variable-length integer.</param>
+    /// <returns>The requested value.</returns>
+    /// <exception cref="EndOfStreamException">Thrown when the stream runs out of data before the integer could be read.</exception>
+    public static int ReadMbsInt(this Stream stream)
+    {
+        var value = 0;
+        var currentBit = 0;
+
+        while (true)
+        {
+            var read = stream.ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            value |= (read & 0b_0111_1111) << currentBit;
+            currentBit += 7;
+
+            if (read < 128)
+            {
+                break;
+            }
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Reads the specified number of bytes from a stream, or until the end of the stream.
+    /// </summary>
+    /// <param name="readFrom">The stream to read from.</param>
+    /// <param name="length">The number of bytes to be read.</param>
+    /// <param name="copyTo">The stream to copy the read bytes to, if required.</param>
+    /// <returns>The number of bytes actually read. This will be less than <paramref name="length"/> only if the end of <paramref name="readFrom"/> is reached.</returns>
+    public static int ReadBytes(this Stream readFrom, int length, Stream? copyTo = null)
+    {
+        var bytesRemaining = length;
+        var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(50 * 1024, bytesRemaining));
+        while (bytesRemaining > 0)
+        {
+            var read = readFrom.Read(buffer, 0, Math.Min(buffer.Length, bytesRemaining));
+            if (read == 0)
+            {
+                break;
+            }
+
+            copyTo?.Write(buffer, 0, read);
+            bytesRemaining -= read;
+        }
+
+        ArrayPool<byte>.Shared.Return(buffer);
+        return length - bytesRemaining;
+    }
+}

--- a/src/GitVersion.slnx
+++ b/src/GitVersion.slnx
@@ -9,6 +9,8 @@
     <Project Path="GitVersion.Configuration.Tests/GitVersion.Configuration.Tests.csproj" />
     <Project Path="GitVersion.Configuration/GitVersion.Configuration.csproj" />
     <Project Path="GitVersion.Git.CommandLine/GitVersion.Git.CommandLine.csproj" />
+    <Project Path="GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj" />
+    <Project Path="GitVersion.Git.Managed/GitVersion.Git.Managed.csproj" />
     <Project Path="GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj" />
     <Project Path="GitVersion.Output.Tests/GitVersion.Output.Tests.csproj" />
     <Project Path="GitVersion.Output/GitVersion.Output.csproj" />


### PR DESCRIPTION
## Description

Phase B.1 of the LibGit2Sharp replacement (#5031): the managed Git **object store** — the first layer of the vendored managed reader.

Closes #5033

### What's included

`src/GitVersion.Git.Managed` (internal types, zero dependencies — no GitVersion.Core, no LibGit2Sharp, no packages):

- **`GitObjectId`** — hash-agnostic (`[InlineArray(32)]` + length byte): SHA-1 today, SHA-256-ready; parses 40/64-char hex and 20/32-byte raw, Span-based.
- **Object access** — loose objects (zlib), pack/.idx v2 (memory-mapped) with ofs-delta and ref-delta resolution and a pack memory cache; ported from [Nerdbank.GitVersioning ManagedGit](https://github.com/dotnet/Nerdbank.GitVersioning) (MIT — per-file attribution headers + `NOTICE.md`).
- **`GitMultiPackIndexReader`** — midx v1 (PNAM/OIDF/OIDL/OOFF chunks; LOFF and incremental chains rejected with clear errors).
- **`GitObjectStore`** facade — typed getters (commit/tree/tag/blob) with lookup order midx → per-pack .idx → loose → alternates (one level).
- **Parsers extended beyond NBGV** (which only read tree/parents/committer): author + committer with name/email/when *including timezone offset*, full commit message honoring the `encoding` header (strict UTF-8 with Latin-1 fallback, matching git), annotated tags with tagger/message, tree entries with raw octal modes.

### Tests

`src/GitVersion.Git.Managed.Tests` — 49 tests generating fixture repositories with the real `git` CLI (deterministic author/committer dates) and validating byte-for-byte against `git cat-file`/`git log`/`git ls-tree`:

- loose and packed round-trips, 30-commit delta chains via `repack --depth=50 --window=50` (both ofs-delta and ref-delta via `repack.useDeltaBaseOffset=false`)
- annotated/nested/packed tags, multi-line messages, ISO-8859-1 `encoding` header, invalid-UTF-8 fallback
- multi-pack-index with two packs (direct reader + store lookups), alternates, `GitObjectId` semantics

### Not ported from NBGV (and why)

- `GitRepository.cs` / `GitReferenceReader` — refs and discovery are Phase B.2 (#5034)
- `GitPackPooledStream` / `GitPackNullCache` — dead code paths upstream
- Win32 PInvoke file-open fast path — would add a CsWin32 dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
