### PR TITLE
feat(git): managed Git refs and repository discovery (Phase B.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
       - main
       - 'support/*'
       - 'next/*'
+      # gate managed-git phase PRs with the full test matrix pre-merge (#5031)
+      - 'feature/managed-git'
     paths:
       - '**'
       - '!docs/**'

--- a/src/GitVersion.Git.Managed.Tests/GitReferenceStoreTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitReferenceStoreTests.cs
@@ -1,0 +1,200 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitReferenceStoreTests
+{
+    [Test]
+    public void ResolvesALooseBranchToItsCommit()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+        var reference = store.GetReference("refs/heads/main");
+
+        reference.ShouldNotBeNull();
+        reference.IsSymbolic.ShouldBeFalse();
+        reference.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void EnumerationMatchesGitForEachRef()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("first");
+        repository.Run("branch", "feature/a");
+        repository.Run("tag", "lightweight");
+        repository.Run("tag", "-a", "v1.0.0", "-m", "annotated");
+        repository.WriteFile("file.txt", "more content\n");
+        repository.Commit("second");
+
+        var store = repository.OpenReferenceStore();
+        var actual = store.EnumerateReferences()
+            .Select(reference => $"{reference.CanonicalName} {reference.ObjectId}")
+            .ToList();
+
+        var expected = repository
+            .Run("for-each-ref", "--format=%(refname) %(objectname)")
+            .Split('\n');
+
+        actual.ShouldBe(expected);
+    }
+
+    [Test]
+    public void ReadsPackedRefsIncludingPeeledTargets()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v1.0.0", "-m", "annotated");
+        var tagSha = repository.RevParse("v1.0.0");
+
+        repository.Run("pack-refs", "--all", "--prune");
+        File.Exists(Path.Combine(repository.GitDirectory, "refs", "heads", "main")).ShouldBeFalse();
+
+        var store = repository.OpenReferenceStore();
+
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(commitSha));
+
+        var tag = store.GetReference("refs/tags/v1.0.0");
+        tag.ShouldNotBeNull();
+        tag.ObjectId.ShouldBe(GitObjectId.Parse(tagSha));
+        tag.PeeledObjectId.ShouldBe(GitObjectId.Parse(repository.RevParse("v1.0.0^{}")));
+    }
+
+    [Test]
+    public void LooseReferencesWinOverPackedReferences()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("first");
+        repository.Run("pack-refs", "--all", "--prune");
+
+        repository.WriteFile("file.txt", "more content\n");
+        var newSha = repository.Commit("second");
+
+        var store = repository.OpenReferenceStore();
+
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(newSha));
+        store.EnumerateReferences("refs/heads/")
+            .ShouldHaveSingleItem()
+            .ObjectId.ShouldBe(GitObjectId.Parse(newSha));
+    }
+
+    [Test]
+    public void HeadIsSymbolicWhenABranchIsCheckedOut()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+        var head = store.GetHead();
+
+        head.ShouldNotBeNull();
+        head.IsSymbolic.ShouldBeTrue();
+        head.SymbolicTargetName.ShouldBe("refs/heads/main");
+
+        var resolved = store.Resolve("HEAD");
+        resolved.ShouldNotBeNull();
+        resolved.CanonicalName.ShouldBe("refs/heads/main");
+        resolved.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void HeadIsDirectWhenDetached()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+        repository.Run("checkout", "-q", "--detach");
+
+        var head = repository.OpenReferenceStore().GetHead();
+
+        head.ShouldNotBeNull();
+        head.IsSymbolic.ShouldBeFalse();
+        head.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void HeadOfAnUnbornBranchResolvesToNull()
+    {
+        using var repository = new GitTestRepository();
+
+        var store = repository.OpenReferenceStore();
+
+        store.GetHead().ShouldNotBeNull().IsSymbolic.ShouldBeTrue();
+        store.Resolve("HEAD").ShouldBeNull();
+        store.ResolveToObjectId("HEAD").ShouldBeNull();
+    }
+
+    [Test]
+    public void FollowsChainsOfSymbolicReferences()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+        repository.Run("symbolic-ref", "refs/sym/one", "refs/heads/main");
+        repository.Run("symbolic-ref", "refs/sym/two", "refs/sym/one");
+
+        var store = repository.OpenReferenceStore();
+        var resolved = store.Resolve("refs/sym/two");
+
+        resolved.ShouldNotBeNull();
+        resolved.CanonicalName.ShouldBe("refs/heads/main");
+        resolved.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void ReturnsNullForAMissingReference()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+
+        store.GetReference("refs/heads/does-not-exist").ShouldBeNull();
+        store.Resolve("refs/heads/does-not-exist").ShouldBeNull();
+    }
+
+    [Test]
+    public void EnumerationCanBeFilteredByPrefix()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("branch", "feature/a");
+        repository.Run("tag", "v1.0.0");
+        repository.Run("tag", "v2.0.0");
+
+        var store = repository.OpenReferenceStore();
+
+        store.EnumerateReferences("refs/tags/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/tags/v1.0.0", "refs/tags/v2.0.0"]);
+
+        store.EnumerateReferences("refs/heads/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/heads/feature/a", "refs/heads/main"]);
+    }
+
+    [Test]
+    public void ResolvedHeadCanBeReadFromTheObjectStore()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("readable through refs");
+
+        var store = repository.OpenReferenceStore();
+        var headId = store.ResolveToObjectId("HEAD");
+
+        headId.ShouldNotBeNull();
+
+        using var objectStore = repository.OpenObjectStore();
+        objectStore.GetCommit(headId.Value).Message.ShouldBe("readable through refs\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
@@ -1,0 +1,128 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitRepositoryLayoutTests
+{
+    [Test]
+    public void DiscoversARepositoryFromItsRootAndFromANestedDirectory()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("sub/dir/file.txt", "content\n");
+        repository.Commit("a commit");
+
+        foreach (var startPath in new[] { repository.RepositoryPath, Path.Combine(repository.RepositoryPath, "sub", "dir") })
+        {
+            var layout = GitRepositoryLayout.Discover(startPath);
+
+            layout.GitDirectory.ShouldBe(Path.GetFullPath(repository.GitDirectory));
+            layout.CommonDirectory.ShouldBe(layout.GitDirectory);
+            layout.WorkingDirectory.ShouldBe(Path.GetFullPath(repository.RepositoryPath));
+            layout.ObjectsDirectory.ShouldBe(Path.GetFullPath(repository.ObjectsDirectory));
+            layout.IsShallow.ShouldBeFalse();
+        }
+    }
+
+    [Test]
+    public void ReturnsNullOutsideOfARepository()
+    {
+        using var directory = new TempDirectory();
+        Directory.CreateDirectory(directory.FullPath);
+
+        GitRepositoryLayout.TryDiscover(directory.FullPath).ShouldBeNull();
+        Should.Throw<GitObjectStoreException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+    }
+
+    [Test]
+    public void ResolvesLinkedWorktrees()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var worktree = new TempDirectory();
+        repository.Run("worktree", "add", "-q", "-b", "wt-branch", worktree.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(worktree.FullPath);
+
+        layout.WorkingDirectory.ShouldBe(Path.GetFullPath(worktree.FullPath));
+        layout.GitDirectory.ShouldContain(Path.Combine(".git", "worktrees"));
+        layout.CommonDirectory.ShouldBe(Path.GetFullPath(repository.GitDirectory));
+
+        // HEAD is per-worktree; the refs are shared with the main repository.
+        var store = layout.CreateReferenceStore();
+        var head = store.GetHead();
+        head.ShouldNotBeNull();
+        head.SymbolicTargetName.ShouldBe("refs/heads/wt-branch");
+        store.ResolveToObjectId("HEAD").ShouldBe(GitObjectId.Parse(sha));
+        store.EnumerateReferences("refs/heads/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/heads/main", "refs/heads/wt-branch"]);
+
+        using var objectStore = layout.CreateObjectStore();
+        objectStore.GetCommit(GitObjectId.Parse(sha)).Message.ShouldBe("a commit\n");
+    }
+
+    [Test]
+    public void DetectsShallowClones()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "one\n");
+        repository.Commit("first");
+        repository.WriteFile("file.txt", "two\n");
+        var tipSha = repository.Commit("second");
+
+        using var clone = new TempDirectory();
+        repository.Run("clone", "-q", "--depth", "1", "file://" + repository.RepositoryPath, clone.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(clone.FullPath);
+
+        layout.IsShallow.ShouldBeTrue();
+        var shallowCommits = layout.ReadShallowCommits();
+        shallowCommits.ShouldHaveSingleItem().ShouldBe(GitObjectId.Parse(tipSha));
+
+        // The boundary commit object still records its parent (the shallow file, not the
+        // object, cuts the history), but the parent object is absent from the clone.
+        using var objectStore = layout.CreateObjectStore();
+        var boundary = objectStore.GetCommit(shallowCommits[0]);
+        boundary.Parents.ShouldHaveSingleItem();
+        objectStore.TryGetObject(boundary.Parents[0], "commit", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public void DiscoversABareRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var bare = new TempDirectory();
+        repository.Run("clone", "-q", "--bare", "file://" + repository.RepositoryPath, bare.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(bare.FullPath);
+
+        layout.WorkingDirectory.ShouldBeNull();
+        layout.GitDirectory.ShouldBe(Path.GetFullPath(bare.FullPath));
+        layout.CommonDirectory.ShouldBe(layout.GitDirectory);
+
+        layout.CreateReferenceStore().ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void ThrowsForReftableRepositories()
+    {
+        using var directory = new TempDirectory();
+
+        using var repository = new GitTestRepository();
+
+        try
+        {
+            repository.Run("init", "-q", "--ref-format=reftable", "-b", "main", directory.FullPath);
+        }
+        catch (InvalidOperationException)
+        {
+            Assert.Ignore("The installed git version does not support the reftable ref format.");
+        }
+
+        Should.Throw<NotSupportedException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
@@ -20,11 +20,17 @@ internal sealed class GitTestRepository : IDisposable
         RepositoryPath = Path.Combine(Path.GetTempPath(), "managed-git-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(RepositoryPath);
         Run("init", "-q", "-b", "main");
+
+        // Use the path exactly as git sees it (symlinks resolved, e.g. /var -> /private/var on
+        // macOS), so paths git writes into gitdir/commondir files compare equal to ours.
+        RepositoryPath = Path.GetFullPath(Run("rev-parse", "--show-toplevel"));
     }
 
     public string RepositoryPath { get; }
 
-    public string ObjectsDirectory => Path.Combine(RepositoryPath, ".git", "objects");
+    public string GitDirectory => Path.Combine(RepositoryPath, ".git");
+
+    public string ObjectsDirectory => Path.Combine(GitDirectory, "objects");
 
     /// <summary>
     /// Gets the date used for the author and the committer of the most recent commit or tag.
@@ -133,6 +139,8 @@ internal sealed class GitTestRepository : IDisposable
     public GitObjectId ResolveId(string reference) => GitObjectId.Parse(RevParse(reference));
 
     public GitObjectStore OpenObjectStore() => new(ObjectsDirectory);
+
+    public GitReferenceStore OpenReferenceStore() => new(GitDirectory);
 
     public void Dispose()
     {

--- a/src/GitVersion.Git.Managed.Tests/TempDirectory.cs
+++ b/src/GitVersion.Git.Managed.Tests/TempDirectory.cs
@@ -1,0 +1,29 @@
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Reserves a unique temporary directory path (without creating it, so it can be used as
+/// a target for <c>git clone</c> or <c>git worktree add</c>) and deletes it on dispose.
+/// </summary>
+internal sealed class TempDirectory : IDisposable
+{
+    public string FullPath { get; } = Path.Combine(Path.GetTempPath(), "managed-git-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(FullPath))
+            {
+                Directory.Delete(FullPath, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/RandomAccessStream.cs
+++ b/src/GitVersion.Git.Managed/RandomAccessStream.cs
@@ -13,7 +13,6 @@ internal sealed class RandomAccessStream : Stream
 {
     private readonly SafeFileHandle handle;
     private readonly long length;
-    private long position;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomAccessStream"/> class.
@@ -39,11 +38,7 @@ internal sealed class RandomAccessStream : Stream
     public override long Length => this.length;
 
     /// <inheritdoc/>
-    public override long Position
-    {
-        get => this.position;
-        set => this.position = value;
-    }
+    public override long Position { get; set; }
 
     /// <inheritdoc/>
     public override void Flush()
@@ -56,14 +51,14 @@ internal sealed class RandomAccessStream : Stream
     /// <inheritdoc/>
     public override int Read(Span<byte> buffer)
     {
-        var toRead = (int)Math.Min(buffer.Length, this.length - this.position);
+        var toRead = (int)Math.Min(buffer.Length, this.length - Position);
         if (toRead <= 0)
         {
             return 0;
         }
 
-        var read = RandomAccess.Read(this.handle, buffer[..toRead], this.position);
-        this.position += read;
+        var read = RandomAccess.Read(this.handle, buffer[..toRead], Position);
+        Position += read;
         return read;
     }
 
@@ -73,7 +68,7 @@ internal sealed class RandomAccessStream : Stream
         var newPosition = origin switch
         {
             SeekOrigin.Begin => offset,
-            SeekOrigin.Current => this.position + offset,
+            SeekOrigin.Current => Position + offset,
             _ => throw new NotSupportedException()
         };
 
@@ -87,8 +82,8 @@ internal sealed class RandomAccessStream : Stream
             throw new IOException("Attempted to seek before the start or beyond the end of the stream.");
         }
 
-        this.position = newPosition;
-        return this.position;
+        Position = newPosition;
+        return Position;
     }
 
     /// <inheritdoc/>

--- a/src/GitVersion.Git.Managed/Refs/GitReference.cs
+++ b/src/GitVersion.Git.Managed/Refs/GitReference.cs
@@ -1,0 +1,40 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git reference: either a direct reference pointing at an object,
+/// or a symbolic reference pointing at another reference.
+/// </summary>
+internal sealed class GitReference
+{
+    /// <summary>
+    /// Gets the canonical name of the reference, e.g. <c>refs/heads/main</c> or <c>HEAD</c>.
+    /// </summary>
+    public required string CanonicalName { get; init; }
+
+    /// <summary>
+    /// Gets the object id the reference points at, for direct references.
+    /// </summary>
+    public GitObjectId? ObjectId { get; init; }
+
+    /// <summary>
+    /// Gets the canonical name of the reference this reference points at, for symbolic references.
+    /// </summary>
+    public string? SymbolicTargetName { get; init; }
+
+    /// <summary>
+    /// Gets the fully peeled target of the reference (the commit an annotated tag ultimately
+    /// points at), when known from the <c>packed-refs</c> file; otherwise <see langword="null"/>.
+    /// </summary>
+    public GitObjectId? PeeledObjectId { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a symbolic reference.
+    /// </summary>
+    public bool IsSymbolic => SymbolicTargetName is not null;
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        IsSymbolic
+            ? $"{CanonicalName} -> {SymbolicTargetName}"
+            : $"{CanonicalName} -> {ObjectId}";
+}

--- a/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
+++ b/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
@@ -1,0 +1,235 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only access to the references of a Git repository: loose refs under
+/// <c>refs/</c>, the <c>packed-refs</c> file (including peeled targets), and per-worktree
+/// refs such as <c>HEAD</c>.
+/// </summary>
+/// <remarks>
+/// Loose references take precedence over entries in <c>packed-refs</c>, matching git.
+/// </remarks>
+internal sealed class GitReferenceStore
+{
+    private const string RefsPrefix = "refs/";
+
+    // Matches git's limit on the depth of nested symbolic references (MAXDEPTH in refs.c).
+    private const int MaxSymbolicReferenceDepth = 5;
+
+    private readonly string gitDirectory;
+    private readonly string commonDirectory;
+    private readonly Lazy<Dictionary<string, GitReference>> packedReferences;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitReferenceStore"/> class.
+    /// </summary>
+    /// <param name="gitDirectory">The (per-worktree) git directory, which contains <c>HEAD</c>.</param>
+    /// <param name="commonDirectory">
+    /// The common git directory, which contains <c>refs/</c> and <c>packed-refs</c>.
+    /// Defaults to <paramref name="gitDirectory"/>.
+    /// </param>
+    public GitReferenceStore(string gitDirectory, string? commonDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(gitDirectory);
+
+        this.gitDirectory = Path.GetFullPath(gitDirectory);
+        this.commonDirectory = commonDirectory is null ? this.gitDirectory : Path.GetFullPath(commonDirectory);
+        this.packedReferences = new(ReadPackedReferences);
+    }
+
+    /// <summary>
+    /// Reads a single reference by its canonical name, without following symbolic references.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>refs/heads/main</c> or <c>HEAD</c>.</param>
+    /// <returns>The reference, or <see langword="null"/> if it does not exist.</returns>
+    public GitReference? GetReference(string canonicalName)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalName);
+
+        return ReadLooseReference(canonicalName)
+            ?? (this.packedReferences.Value.TryGetValue(canonicalName, out var packed) ? packed : null);
+    }
+
+    /// <summary>
+    /// Reads the <c>HEAD</c> reference of the (worktree's) repository.
+    /// </summary>
+    /// <returns>The <c>HEAD</c> reference, or <see langword="null"/> if it does not exist.</returns>
+    public GitReference? GetHead() => GetReference("HEAD");
+
+    /// <summary>
+    /// Resolves a reference to a direct reference, following symbolic references.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>HEAD</c> or <c>refs/heads/main</c>.</param>
+    /// <returns>
+    /// The direct reference at the end of the symbolic chain, or <see langword="null"/> when the
+    /// reference does not exist (e.g. <c>HEAD</c> pointing at an unborn branch).
+    /// </returns>
+    public GitReference? Resolve(string canonicalName)
+    {
+        var current = GetReference(canonicalName);
+
+        for (var depth = 0; current is { IsSymbolic: true }; depth++)
+        {
+            if (depth >= MaxSymbolicReferenceDepth)
+            {
+                throw new GitObjectStoreException($"The symbolic reference '{canonicalName}' is nested more than {MaxSymbolicReferenceDepth} levels deep.");
+            }
+
+            current = GetReference(current.SymbolicTargetName!);
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Resolves a reference to the object id it (ultimately) points at.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>HEAD</c> or <c>refs/tags/v1.0.0</c>.</param>
+    /// <returns>The object id, or <see langword="null"/> when the reference does not exist.</returns>
+    public GitObjectId? ResolveToObjectId(string canonicalName) => Resolve(canonicalName)?.ObjectId;
+
+    /// <summary>
+    /// Enumerates the references whose canonical name starts with the given prefix,
+    /// in ordinal name order. Loose references shadow packed references of the same name.
+    /// </summary>
+    /// <param name="prefix">The prefix to filter by, e.g. <c>refs/</c>, <c>refs/heads/</c> or <c>refs/tags/</c>.</param>
+    /// <returns>The matching references.</returns>
+    public IEnumerable<GitReference> EnumerateReferences(string prefix = RefsPrefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var references = new SortedDictionary<string, GitReference>(StringComparer.Ordinal);
+
+        foreach (var packed in this.packedReferences.Value.Values)
+        {
+            if (packed.CanonicalName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                references[packed.CanonicalName] = packed;
+            }
+        }
+
+        var refsRoot = Path.Combine(this.commonDirectory, "refs");
+
+        if (Directory.Exists(refsRoot))
+        {
+            foreach (var file in Directory.EnumerateFiles(refsRoot, "*", SearchOption.AllDirectories))
+            {
+                var canonicalName = RefsPrefix + Path.GetRelativePath(refsRoot, file).Replace(Path.DirectorySeparatorChar, '/');
+
+                if (!canonicalName.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (ReadLooseReference(canonicalName) is { } reference)
+                {
+                    references[canonicalName] = reference;
+                }
+            }
+        }
+
+        return references.Values;
+    }
+
+    private GitReference? ReadLooseReference(string canonicalName)
+    {
+        // HEAD and other pseudo-refs (ORIG_HEAD, FETCH_HEAD, ...) are per-worktree and live in
+        // the git directory; everything under refs/ is shared and lives in the common directory.
+        var directory = canonicalName.StartsWith(RefsPrefix, StringComparison.Ordinal)
+            ? this.commonDirectory
+            : this.gitDirectory;
+
+        var path = Path.Combine(directory, canonicalName.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        string? line;
+
+        using (var reader = new StreamReader(path, Encoding.UTF8))
+        {
+            line = reader.ReadLine();
+        }
+
+        line = line?.Trim();
+
+        if (string.IsNullOrEmpty(line))
+        {
+            return null;
+        }
+
+        if (line.StartsWith("ref: ", StringComparison.Ordinal))
+        {
+            return new()
+            {
+                CanonicalName = canonicalName,
+                SymbolicTargetName = line["ref: ".Length..].Trim()
+            };
+        }
+
+        return new()
+        {
+            CanonicalName = canonicalName,
+            ObjectId = GitObjectId.Parse(line)
+        };
+    }
+
+    private Dictionary<string, GitReference> ReadPackedReferences()
+    {
+        var references = new Dictionary<string, GitReference>(StringComparer.Ordinal);
+        var packedRefsPath = Path.Combine(this.commonDirectory, "packed-refs");
+
+        if (!File.Exists(packedRefsPath))
+        {
+            return references;
+        }
+
+        string? previousName = null;
+
+        foreach (var rawLine in File.ReadLines(packedRefsPath, Encoding.UTF8))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0 || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('^'))
+            {
+                // A peeled line holds the fully-peeled target of the preceding annotated tag.
+                if (previousName is null)
+                {
+                    throw new GitObjectStoreException("The packed-refs file is malformed: a peeled line has no preceding reference.");
+                }
+
+                var peeled = references[previousName];
+                references[previousName] = new()
+                {
+                    CanonicalName = peeled.CanonicalName,
+                    ObjectId = peeled.ObjectId,
+                    PeeledObjectId = GitObjectId.Parse(line[1..])
+                };
+                continue;
+            }
+
+            var separator = line.IndexOf(' ');
+
+            if (separator <= 0 || separator == line.Length - 1)
+            {
+                throw new GitObjectStoreException("The packed-refs file is malformed: a line does not contain an object id and a reference name.");
+            }
+
+            var name = line[(separator + 1)..];
+            references[name] = new()
+            {
+                CanonicalName = name,
+                ObjectId = GitObjectId.Parse(line[..separator])
+            };
+            previousName = name;
+        }
+
+        return references;
+    }
+}

--- a/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
+++ b/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
@@ -66,10 +66,11 @@ internal sealed class GitReferenceStore
     public GitReference? Resolve(string canonicalName)
     {
         var current = GetReference(canonicalName);
+        var depth = 0;
 
-        for (var depth = 0; current is { IsSymbolic: true }; depth++)
+        while (current is { IsSymbolic: true })
         {
-            if (depth >= MaxSymbolicReferenceDepth)
+            if (++depth > MaxSymbolicReferenceDepth)
             {
                 throw new GitObjectStoreException($"The symbolic reference '{canonicalName}' is nested more than {MaxSymbolicReferenceDepth} levels deep.");
             }
@@ -99,12 +100,10 @@ internal sealed class GitReferenceStore
 
         var references = new SortedDictionary<string, GitReference>(StringComparer.Ordinal);
 
-        foreach (var packed in this.packedReferences.Value.Values)
+        foreach (var packed in this.packedReferences.Value.Values
+                     .Where(reference => reference.CanonicalName.StartsWith(prefix, StringComparison.Ordinal)))
         {
-            if (packed.CanonicalName.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                references[packed.CanonicalName] = packed;
-            }
+            references[packed.CanonicalName] = packed;
         }
 
         var refsRoot = Path.Combine(this.commonDirectory, "refs");

--- a/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
@@ -1,0 +1,178 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Describes the on-disk layout of a Git repository: where its git directory, common
+/// directory and working directory are, and how to open its object and reference stores.
+/// Handles regular repositories, bare repositories, linked worktrees (<c>.git</c> files
+/// and <c>commondir</c> indirection) and shallow clones.
+/// </summary>
+internal sealed class GitRepositoryLayout
+{
+    private const string GitDirectoryOrFileName = ".git";
+    private const string GitDirFilePrefix = "gitdir:";
+
+    /// <summary>
+    /// Gets the (per-worktree) git directory, which contains <c>HEAD</c>.
+    /// </summary>
+    public required string GitDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the common git directory, which contains <c>objects/</c>, <c>refs/</c> and
+    /// <c>packed-refs</c>. Equal to <see cref="GitDirectory"/> except for linked worktrees.
+    /// </summary>
+    public required string CommonDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the root of the working directory, or <see langword="null"/> for bare repositories.
+    /// </summary>
+    public string? WorkingDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the path to the object database of the repository.
+    /// </summary>
+    public string ObjectsDirectory => Path.Combine(CommonDirectory, "objects");
+
+    /// <summary>
+    /// Gets a value indicating whether the repository is a shallow clone.
+    /// </summary>
+    public bool IsShallow => File.Exists(ShallowFilePath);
+
+    private string ShallowFilePath => Path.Combine(CommonDirectory, "shallow");
+
+    /// <summary>
+    /// Discovers the repository containing <paramref name="startPath"/> by walking up the
+    /// directory hierarchy, resolving <c>.git</c> files (linked worktrees, submodules) and
+    /// the <c>commondir</c> indirection.
+    /// </summary>
+    /// <param name="startPath">The path at which to start the discovery.</param>
+    /// <returns>The layout of the discovered repository.</returns>
+    /// <exception cref="GitObjectStoreException">No repository was found.</exception>
+    public static GitRepositoryLayout Discover(string startPath) =>
+        TryDiscover(startPath)
+            ?? throw new GitObjectStoreException($"No git repository was found at or above '{startPath}'.");
+
+    /// <summary>
+    /// Discovers the repository containing <paramref name="startPath"/> by walking up the
+    /// directory hierarchy, resolving <c>.git</c> files (linked worktrees, submodules) and
+    /// the <c>commondir</c> indirection.
+    /// </summary>
+    /// <param name="startPath">The path at which to start the discovery.</param>
+    /// <returns>The layout of the discovered repository, or <see langword="null"/> if none was found.</returns>
+    public static GitRepositoryLayout? TryDiscover(string startPath)
+    {
+        ArgumentNullException.ThrowIfNull(startPath);
+
+        for (var current = Path.GetFullPath(startPath); current is not null; current = Path.GetDirectoryName(current))
+        {
+            var dotGit = Path.Combine(current, GitDirectoryOrFileName);
+
+            if (Directory.Exists(dotGit))
+            {
+                return FromGitDirectory(dotGit, current);
+            }
+
+            if (File.Exists(dotGit))
+            {
+                return FromGitDirectory(ResolveGitDirFile(dotGit), current);
+            }
+
+            if (IsGitDirectory(current))
+            {
+                // A bare repository, or the .git directory itself.
+                return FromGitDirectory(current, workingDirectory: null);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates the layout for a known git directory, resolving the <c>commondir</c> indirection
+    /// used by linked worktrees.
+    /// </summary>
+    /// <param name="gitDirectory">The git directory.</param>
+    /// <param name="workingDirectory">The root of the working directory, or <see langword="null"/> for bare repositories.</param>
+    /// <returns>The layout of the repository.</returns>
+    public static GitRepositoryLayout FromGitDirectory(string gitDirectory, string? workingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(gitDirectory);
+
+        gitDirectory = Path.GetFullPath(gitDirectory);
+        var commonDirectory = gitDirectory;
+
+        // Linked worktrees store the path of the main repository's git directory in a 'commondir' file.
+        var commonDirFile = Path.Combine(gitDirectory, "commondir");
+
+        if (File.Exists(commonDirFile))
+        {
+            var target = File.ReadAllText(commonDirFile).Trim();
+
+            commonDirectory = Path.IsPathRooted(target)
+                ? Path.GetFullPath(target)
+                : Path.GetFullPath(Path.Combine(gitDirectory, target));
+        }
+
+        if (Directory.Exists(Path.Combine(commonDirectory, "reftable")))
+        {
+            throw new NotSupportedException("Repositories using the reftable reference storage format are not supported yet.");
+        }
+
+        return new()
+        {
+            GitDirectory = gitDirectory,
+            CommonDirectory = commonDirectory,
+            WorkingDirectory = workingDirectory
+        };
+    }
+
+    /// <summary>
+    /// Opens the object store of the repository.
+    /// </summary>
+    /// <returns>A new <see cref="GitObjectStore"/> over the repository's object database.</returns>
+    public GitObjectStore CreateObjectStore() => new(ObjectsDirectory);
+
+    /// <summary>
+    /// Opens the reference store of the repository.
+    /// </summary>
+    /// <returns>A new <see cref="GitReferenceStore"/> over the repository's references.</returns>
+    public GitReferenceStore CreateReferenceStore() => new(GitDirectory, CommonDirectory);
+
+    /// <summary>
+    /// Reads the commit ids at the boundary of a shallow clone from the <c>shallow</c> file.
+    /// </summary>
+    /// <returns>The shallow boundary commits, or an empty list when the repository is not shallow.</returns>
+    public IReadOnlyList<GitObjectId> ReadShallowCommits()
+    {
+        if (!IsShallow)
+        {
+            return [];
+        }
+
+        return [.. File.ReadLines(ShallowFilePath, Encoding.UTF8)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .Select(GitObjectId.Parse)];
+    }
+
+    private static bool IsGitDirectory(string path) =>
+        File.Exists(Path.Combine(path, "HEAD"))
+        && Directory.Exists(Path.Combine(path, "objects"))
+        && Directory.Exists(Path.Combine(path, "refs"));
+
+    private static string ResolveGitDirFile(string dotGitFile)
+    {
+        // Format: "gitdir: <path>", where the path may be relative to the file's directory.
+        var content = File.ReadAllText(dotGitFile).Trim();
+
+        if (!content.StartsWith(GitDirFilePrefix, StringComparison.Ordinal))
+        {
+            throw new GitObjectStoreException($"The .git file '{dotGitFile}' is malformed: it does not start with '{GitDirFilePrefix}'.");
+        }
+
+        var target = content[GitDirFilePrefix.Length..].Trim();
+
+        return Path.IsPathRooted(target)
+            ? Path.GetFullPath(target)
+            : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(dotGitFile)!, target));
+    }
+}


### PR DESCRIPTION
Closes #5034. Part of #5031 — see `docs/design/managed-git-migration.md`. Builds on #5043 (Phase B.1).

## What

Second layer of the vendored managed reader in `src/GitVersion.Git.Managed` (still no GitVersion.Core dependency, all types `internal`):

- **`GitReferenceStore`** (`Refs/`) — loose refs under `refs/`, `packed-refs` parsing including peeled (`^`) lines, loose-over-packed precedence (matching git), symbolic reference resolution (`HEAD` attached/detached/unborn, `symbolic-ref` chains with git's depth limit), prefix-filtered enumeration in deterministic ordinal order
- **`GitRepositoryLayout`** (`Repository/`) — walk-up discovery, `.git` file (`gitdir:`) resolution for linked worktrees, `commondir` indirection, bare repository detection, shallow-clone detection + `shallow` file parsing, and factory methods wiring the B.1 `GitObjectStore` / new `GitReferenceStore` to the discovered paths
- **Reftable** — detected and rejected with a clear `NotSupportedException`, per the design doc
- Also fixes the Sonar `S2292` leftover from #5043 (`RandomAccessStream.Position` is now an auto-property)

## Tests

17 new tests (66 total, all green) against real-git-CLI fixture repos:

- reference enumeration byte-identical to `git for-each-ref`
- `pack-refs --all --prune` (peeled annotated tags, loose files gone), loose-shadows-packed after a new commit
- HEAD: attached (symbolic), detached (direct), unborn branch (resolves to null)
- `symbolic-ref` chains resolve through multiple hops
- worktrees: `.git` file + `commondir` resolution, shared refs, per-worktree HEAD, object store reachable through the layout
- shallow clone (`--depth 1`): `shallow` file parsed; boundary commit still records its parent while the parent object is absent (parent trimming is the B.3 revwalk's job)
- bare clone discovery; reftable repository rejection

## Checks

- `dotnet build ./src/GitVersion.slnx` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)