### PR TITLE
feat(git): managed revision walk with libgit2-parity ordering and merge-base (Phase B.3)

### DIFF
--- a/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
@@ -1,0 +1,362 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitRevisionWalker"/> ordering and merge-base results against libgit2
+/// (via LibGit2Sharp) on the same fixture repositories — the parity GitVersion's version
+/// calculation depends on.
+/// </summary>
+[TestFixture]
+public class GitRevisionWalkerTests
+{
+    private static readonly string[] SortCombinations =
+    [
+        "None",
+        "Time",
+        "Topological",
+        "Topological, Time",
+        "Topological, Reverse",
+        "Time, Reverse",
+        "Topological, Time, Reverse"
+    ];
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void LinearHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateLinearRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void MergedHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateMergedRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void MergedHistoryWithExcludesMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateMergedRepository();
+        var excluded = repository.RevParse("v0");
+
+        var options = new GitRevisionWalkOptions { Sort = sort };
+        options.Include.Add(repository.ResolveId("HEAD"));
+        options.Exclude.Add(GitObjectId.Parse(excluded));
+
+        AssertWalkParity(repository, options, head: false, excludeSha: excluded);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void EqualCommitterTimestampsMatchLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateEqualTimestampRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void CrissCrossHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateCrissCrossRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void OctopusMergeMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        using var repository = CreateOctopusRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void FirstParentWalksMatchLibGit2(bool withExclude)
+    {
+        using var repository = CreateMergedRepository();
+
+        var options = new GitRevisionWalkOptions { FirstParentOnly = true };
+        options.Include.Add(repository.ResolveId("HEAD"));
+        string? excluded = null;
+
+        if (withExclude)
+        {
+            excluded = repository.RevParse("v0");
+            options.Exclude.Add(GitObjectId.Parse(excluded));
+        }
+
+        AssertWalkParity(repository, options, head: false, excludeSha: excluded);
+    }
+
+    [Test]
+    public void MultipleIncludesMatchLibGit2()
+    {
+        using var repository = CreateMergedRepository();
+        // Include two historic points rather than the merged tip.
+        var first = repository.RevParse("HEAD^1^");
+        var second = repository.RevParse("HEAD^2");
+
+        var options = new GitRevisionWalkOptions { Sort = GitRevisionSort.Topological | GitRevisionSort.Time };
+        options.Include.Add(GitObjectId.Parse(first));
+        options.Include.Add(GitObjectId.Parse(second));
+
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).Walk(options).Select(commit => commit.Sha.ToString()).ToList();
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var filter = new global::LibGit2Sharp.CommitFilter
+        {
+            IncludeReachableFrom = new[] { first, second },
+            SortBy = global::LibGit2Sharp.CommitSortStrategies.Topological | global::LibGit2Sharp.CommitSortStrategies.Time
+        };
+        var expected = libgit2.Commits.QueryBy(filter).Select(commit => commit.Sha).ToList();
+
+        actual.ShouldBe(expected);
+    }
+
+    [Test]
+    public void FindsTheMergeBaseOfDivergedBranches()
+    {
+        using var repository = CreateMergedRepository();
+
+        AssertMergeBaseParity(repository, repository.RevParse("main"), repository.RevParse("feature"));
+    }
+
+    [Test]
+    public void FindsTheMergeBaseOfCrissCrossBranches()
+    {
+        using var repository = CreateCrissCrossRepository();
+
+        AssertMergeBaseParity(repository, repository.RevParse("main"), repository.RevParse("dev"));
+        AssertMergeBaseParity(repository, repository.RevParse("dev"), repository.RevParse("main"));
+    }
+
+    [Test]
+    public void TheMergeBaseOfACommitAndItsAncestorIsTheAncestor()
+    {
+        using var repository = CreateLinearRepository();
+        var ancestor = repository.RevParse("HEAD~3");
+        var tip = repository.RevParse("HEAD");
+
+        using var store = repository.OpenObjectStore();
+        var walker = new GitRevisionWalker(store);
+
+        walker.FindMergeBase(GitObjectId.Parse(tip), GitObjectId.Parse(ancestor)).ShouldBe(GitObjectId.Parse(ancestor));
+        walker.FindMergeBase(GitObjectId.Parse(ancestor), GitObjectId.Parse(tip)).ShouldBe(GitObjectId.Parse(ancestor));
+        walker.FindMergeBase(GitObjectId.Parse(tip), GitObjectId.Parse(tip)).ShouldBe(GitObjectId.Parse(tip));
+    }
+
+    [Test]
+    public void UnrelatedHistoriesHaveNoMergeBase()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        var main = repository.Commit("on main");
+        repository.Run("checkout", "-q", "--orphan", "detached-root");
+        repository.WriteFile("b.txt", "b\n");
+        var orphan = repository.Commit("orphan root");
+
+        using var store = repository.OpenObjectStore();
+        new GitRevisionWalker(store)
+            .FindMergeBase(GitObjectId.Parse(main), GitObjectId.Parse(orphan))
+            .ShouldBeNull();
+    }
+
+    [Test]
+    public void WalksUpToTheShallowBoundary()
+    {
+        using var repository = CreateLinearRepository();
+        using var clone = new TempDirectory();
+        repository.Run("clone", "-q", "--depth", "2", "file://" + repository.RepositoryPath, clone.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(clone.FullPath);
+        using var store = layout.CreateObjectStore();
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(layout.CreateReferenceStore().ResolveToObjectId("HEAD")!.Value);
+
+        // The walk stops at the shallow boundary instead of failing on the missing parent.
+        new GitRevisionWalker(store).Walk(options).Count.ShouldBe(2);
+    }
+
+    private static void AssertWalkParity(GitTestRepository repository, GitRevisionWalkOptions options, bool head, string? excludeSha = null)
+    {
+        if (head)
+        {
+            options.Include.Add(repository.ResolveId("HEAD"));
+        }
+
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).Walk(options).Select(commit => commit.Sha.ToString()).ToList();
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var filter = new global::LibGit2Sharp.CommitFilter
+        {
+            IncludeReachableFrom = options.Include[0].ToString(),
+            SortBy = ToLibGit2Sort(options.Sort),
+            FirstParentOnly = options.FirstParentOnly
+        };
+
+        if (excludeSha is not null)
+        {
+            filter.ExcludeReachableFrom = excludeSha;
+        }
+
+        var expected = libgit2.Commits.QueryBy(filter).Select(commit => commit.Sha).ToList();
+
+        actual.ShouldBe(expected, $"sort: {options.Sort}, firstParent: {options.FirstParentOnly}, exclude: {excludeSha}");
+        actual.ShouldNotBeEmpty();
+    }
+
+    private static void AssertMergeBaseParity(GitTestRepository repository, string first, string second)
+    {
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).FindMergeBase(GitObjectId.Parse(first), GitObjectId.Parse(second));
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var expected = libgit2.ObjectDatabase.FindMergeBase(libgit2.Lookup<Commit>(first), libgit2.Lookup<Commit>(second));
+
+        expected.ShouldNotBeNull();
+        actual.ShouldNotBeNull();
+        actual.Value.ToString().ShouldBe(expected.Sha);
+    }
+
+    private static global::LibGit2Sharp.CommitSortStrategies ToLibGit2Sort(GitRevisionSort sort)
+    {
+        var result = global::LibGit2Sharp.CommitSortStrategies.None;
+
+        if (sort.HasFlag(GitRevisionSort.Topological))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Topological;
+        }
+
+        if (sort.HasFlag(GitRevisionSort.Time))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Time;
+        }
+
+        if (sort.HasFlag(GitRevisionSort.Reverse))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Reverse;
+        }
+
+        return result;
+    }
+
+    private static GitTestRepository CreateLinearRepository()
+    {
+        var repository = new GitTestRepository();
+
+        for (var i = 0; i < 6; i++)
+        {
+            repository.WriteFile("file.txt", $"content {i}\n");
+            repository.Commit($"commit {i}");
+
+            if (i == 0)
+            {
+                repository.Run("tag", "v0");
+            }
+        }
+
+        return repository;
+    }
+
+    private static GitTestRepository CreateMergedRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+        repository.Run("tag", "v0");
+
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1");
+        repository.WriteFile("feature.txt", "2\n");
+        repository.Commit("feature 2");
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.WriteFile("main.txt", "2\n");
+        repository.Commit("main 2");
+
+        repository.Merge("feature");
+        return repository;
+    }
+
+    private static GitTestRepository CreateEqualTimestampRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1", advanceClock: false);
+        repository.WriteFile("feature.txt", "2\n");
+        repository.Commit("feature 2", advanceClock: false);
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1", advanceClock: false);
+        repository.WriteFile("main.txt", "2\n");
+        repository.Commit("main 2", advanceClock: false);
+
+        repository.Merge("feature", advanceClock: false);
+        return repository;
+    }
+
+    private static GitTestRepository CreateCrissCrossRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("root");
+
+        repository.Run("checkout", "-q", "-b", "dev");
+        repository.WriteFile("dev.txt", "1\n");
+        var devCommit = repository.Commit("dev 1");
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        var mainCommit = repository.Commit("main 1");
+
+        // Merge in both directions to create a criss-cross: two best common ancestors.
+        repository.Merge(devCommit);
+        repository.Run("checkout", "-q", "dev");
+        repository.Merge(mainCommit);
+
+        return repository;
+    }
+
+    private static GitTestRepository CreateOctopusRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("root");
+
+        foreach (var branch in new[] { "b1", "b2" })
+        {
+            repository.Run("checkout", "-q", "-b", branch, "main");
+            repository.WriteFile($"{branch}.txt", "1\n");
+            repository.Commit($"{branch} 1");
+        }
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.Merge("b1", "b2");
+
+        return repository;
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
@@ -24,7 +24,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void LinearHistoryMatchesLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateLinearRepository();
 
         AssertWalkParity(repository, new() { Sort = sort }, head: true);
@@ -33,7 +33,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void MergedHistoryMatchesLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateMergedRepository();
 
         AssertWalkParity(repository, new() { Sort = sort }, head: true);
@@ -42,7 +42,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void MergedHistoryWithExcludesMatchesLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateMergedRepository();
         var excluded = repository.RevParse("v0");
 
@@ -56,7 +56,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void EqualCommitterTimestampsMatchLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateEqualTimestampRepository();
 
         AssertWalkParity(repository, new() { Sort = sort }, head: true);
@@ -65,7 +65,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void CrissCrossHistoryMatchesLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateCrissCrossRepository();
 
         AssertWalkParity(repository, new() { Sort = sort }, head: true);
@@ -74,7 +74,7 @@ public class GitRevisionWalkerTests
     [TestCaseSource(nameof(SortCombinations))]
     public void OctopusMergeMatchesLibGit2(string sortName)
     {
-        var sort = Enum.Parse<GitRevisionSort>(sortName);
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
         using var repository = CreateOctopusRepository();
 
         AssertWalkParity(repository, new() { Sort = sort }, head: true);
@@ -107,7 +107,7 @@ public class GitRevisionWalkerTests
         var first = repository.RevParse("HEAD^1^");
         var second = repository.RevParse("HEAD^2");
 
-        var options = new GitRevisionWalkOptions { Sort = GitRevisionSort.Topological | GitRevisionSort.Time };
+        var options = new GitRevisionWalkOptions { Sort = GitRevisionSortStrategies.Topological | GitRevisionSortStrategies.Time };
         options.Include.Add(GitObjectId.Parse(first));
         options.Include.Add(GitObjectId.Parse(second));
 
@@ -232,21 +232,21 @@ public class GitRevisionWalkerTests
         actual.Value.ToString().ShouldBe(expected.Sha);
     }
 
-    private static global::LibGit2Sharp.CommitSortStrategies ToLibGit2Sort(GitRevisionSort sort)
+    private static global::LibGit2Sharp.CommitSortStrategies ToLibGit2Sort(GitRevisionSortStrategies sort)
     {
         var result = global::LibGit2Sharp.CommitSortStrategies.None;
 
-        if (sort.HasFlag(GitRevisionSort.Topological))
+        if (sort.HasFlag(GitRevisionSortStrategies.Topological))
         {
             result |= global::LibGit2Sharp.CommitSortStrategies.Topological;
         }
 
-        if (sort.HasFlag(GitRevisionSort.Time))
+        if (sort.HasFlag(GitRevisionSortStrategies.Time))
         {
             result |= global::LibGit2Sharp.CommitSortStrategies.Time;
         }
 
-        if (sort.HasFlag(GitRevisionSort.Reverse))
+        if (sort.HasFlag(GitRevisionSortStrategies.Reverse))
         {
             result |= global::LibGit2Sharp.CommitSortStrategies.Reverse;
         }

--- a/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
@@ -96,13 +96,22 @@ internal sealed class GitTestRepository : IDisposable
     }
 
     /// <summary>
-    /// Stages all changes and creates a commit with a deterministic, unique date. Returns the commit sha.
+    /// Stages all changes and creates a commit with a deterministic date. Returns the commit sha.
     /// </summary>
-    public string Commit(string message)
+    /// <param name="message">The commit message.</param>
+    /// <param name="advanceClock">
+    /// Whether to advance the deterministic clock before committing. Pass <see langword="false"/>
+    /// to create commits sharing the same committer timestamp.
+    /// </param>
+    public string Commit(string message, bool advanceClock = true)
     {
-        this.ticks++;
+        if (advanceClock)
+        {
+            this.ticks++;
+        }
+
         Run("add", "--all");
-        Run("commit", "-q", "--no-verify", "-m", message);
+        Run("commit", "-q", "--no-verify", "--allow-empty", "-m", message);
         return RevParse("HEAD");
     }
 
@@ -132,6 +141,27 @@ internal sealed class GitTestRepository : IDisposable
         {
             File.Delete(messageFile);
         }
+    }
+
+    /// <summary>
+    /// Merges the given commits or branches into the current branch with a deterministic date.
+    /// </summary>
+    public string Merge(string firstBranch, string? secondBranch = null, bool advanceClock = true)
+    {
+        if (advanceClock)
+        {
+            this.ticks++;
+        }
+
+        List<string> arguments = ["merge", "-q", "--no-ff", "--no-edit", firstBranch];
+
+        if (secondBranch is not null)
+        {
+            arguments.Add(secondBranch);
+        }
+
+        Run([.. arguments]);
+        return RevParse("HEAD");
     }
 
     public string RevParse(string reference) => Run("rev-parse", reference);

--- a/src/GitVersion.Git.Managed/History/GitRevisionSort.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionSort.cs
@@ -1,0 +1,30 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The sort orders supported by <see cref="GitRevisionWalker"/>, mirroring the strategies
+/// GitVersion uses when querying commit history.
+/// </summary>
+[Flags]
+internal enum GitRevisionSort
+{
+    /// <summary>
+    /// Git's default ordering: reverse chronological by committer date.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Topological ordering: a commit is only emitted after all of the emitted
+    /// commits which list it as a parent.
+    /// </summary>
+    Topological = 1,
+
+    /// <summary>
+    /// Reverse chronological ordering by committer date.
+    /// </summary>
+    Time = 2,
+
+    /// <summary>
+    /// Reverses the selected ordering.
+    /// </summary>
+    Reverse = 4
+}

--- a/src/GitVersion.Git.Managed/History/GitRevisionSortStrategies.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionSortStrategies.cs
@@ -5,7 +5,7 @@ namespace GitVersion.Git;
 /// GitVersion uses when querying commit history.
 /// </summary>
 [Flags]
-internal enum GitRevisionSort
+internal enum GitRevisionSortStrategies
 {
     /// <summary>
     /// Git's default ordering: reverse chronological by committer date.

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
@@ -19,7 +19,7 @@ internal sealed class GitRevisionWalkOptions
     /// <summary>
     /// Gets the sort order of the walk.
     /// </summary>
-    public GitRevisionSort Sort { get; init; } = GitRevisionSort.None;
+    public GitRevisionSortStrategies Sort { get; init; } = GitRevisionSortStrategies.None;
 
     /// <summary>
     /// Gets a value indicating whether only the first parent of each commit is followed.

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Describes a revision walk: which commits to start from, which histories to exclude,
+/// the sort order, and whether to follow only first parents.
+/// </summary>
+internal sealed class GitRevisionWalkOptions
+{
+    /// <summary>
+    /// Gets the commits whose histories are included in the walk.
+    /// </summary>
+    public IList<GitObjectId> Include { get; } = [];
+
+    /// <summary>
+    /// Gets the commits whose histories (including the commits themselves) are excluded from the walk.
+    /// </summary>
+    public IList<GitObjectId> Exclude { get; } = [];
+
+    /// <summary>
+    /// Gets the sort order of the walk.
+    /// </summary>
+    public GitRevisionSort Sort { get; init; } = GitRevisionSort.None;
+
+    /// <summary>
+    /// Gets a value indicating whether only the first parent of each commit is followed.
+    /// </summary>
+    public bool FirstParentOnly { get; init; }
+}

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -414,7 +414,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             }
         }
 
-        private void MarkParentsUninteresting(WalkNode node)
+        private static void MarkParentsUninteresting(WalkNode node)
         {
             // Mark all (currently parsed) ancestors uninteresting, chasing first-parent
             // chains and stopping at commits which have not been parsed yet — the limiting

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -33,7 +33,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
         var walk = new WalkState(this, options);
         var result = walk.Run();
 
-        if (options.Sort.HasFlag(GitRevisionSort.Reverse))
+        if (options.Sort.HasFlag(GitRevisionSortStrategies.Reverse))
         {
             result.Reverse();
         }
@@ -227,12 +227,12 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
                 seeds = LimitList(seeds);
             }
 
-            if (options.Sort.HasFlag(GitRevisionSort.Topological))
+            if (options.Sort.HasFlag(GitRevisionSortStrategies.Topological))
             {
-                return SortInTopologicalOrder(seeds, byTime: options.Sort.HasFlag(GitRevisionSort.Time));
+                return SortInTopologicalOrder(seeds, byTime: options.Sort.HasFlag(GitRevisionSortStrategies.Time));
             }
 
-            if (options.Sort.HasFlag(GitRevisionSort.Time))
+            if (options.Sort.HasFlag(GitRevisionSortStrategies.Time))
             {
                 return EmitByTime(seeds);
             }
@@ -242,7 +242,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
 
         private (List<WalkNode> Seeds, bool Limited) PrepareSeeds()
         {
-            var limited = options.Sort != GitRevisionSort.None;
+            var limited = options.Sort != GitRevisionSortStrategies.None;
 
             // Pushes prepend to the input list; includes are pushed before hides,
             // and a hide overrides an earlier push of the same commit.
@@ -454,7 +454,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             }
         }
 
-        private List<WalkNode> EmitByTime(List<WalkNode> seeds)
+        private static List<WalkNode> EmitByTime(List<WalkNode> seeds)
         {
             var queue = new BinaryHeap(byTime: true);
 
@@ -498,53 +498,20 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             return result;
         }
 
-        private List<WalkNode> SortInTopologicalOrder(List<WalkNode> list, bool byTime)
+        private static List<WalkNode> SortInTopologicalOrder(List<WalkNode> list, bool byTime)
         {
             // A commit may only be emitted after all commits in the list which have it as a
             // parent. Ready commits are emitted chronologically when time-sorting, otherwise
             // in the order the limiting pass produced them.
-            foreach (var node in list)
-            {
-                node.InDegree = 1;
-            }
+            ComputeChildCounts(list);
 
-            foreach (var node in list)
-            {
-                foreach (var parent in node.Parents)
-                {
-                    if (parent.InDegree > 0)
-                    {
-                        parent.InDegree++;
-                    }
-                }
-            }
-
-            var queue = new BinaryHeap(byTime);
-
-            foreach (var node in list)
-            {
-                if (node.InDegree == 1)
-                {
-                    queue.Insert(node);
-                }
-            }
-
-            if (!byTime)
-            {
-                queue.Reverse();
-            }
-
+            var queue = CreateReadyQueue(list, byTime);
             var result = new List<WalkNode>();
 
             while (queue.Pop() is { } next)
             {
-                foreach (var parent in next.Parents)
+                foreach (var parent in next.Parents.Where(parent => parent.InDegree > 0))
                 {
-                    if (parent.InDegree == 0)
-                    {
-                        continue;
-                    }
-
                     if (--parent.InDegree == 1)
                     {
                         queue.Insert(parent);
@@ -562,7 +529,39 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             return result;
         }
 
-        private IEnumerable<WalkNode> ParsedParents(WalkNode node)
+        private static void ComputeChildCounts(List<WalkNode> list)
+        {
+            foreach (var node in list)
+            {
+                node.InDegree = 1;
+            }
+
+            foreach (var parent in list.SelectMany(node => node.Parents).Where(parent => parent.InDegree > 0))
+            {
+                parent.InDegree++;
+            }
+        }
+
+        private static BinaryHeap CreateReadyQueue(List<WalkNode> list, bool byTime)
+        {
+            var queue = new BinaryHeap(byTime);
+
+            foreach (var node in list.Where(node => node.InDegree == 1))
+            {
+                queue.Insert(node);
+            }
+
+            // The tips must come out in traversal order; without time-sorting the plain
+            // vector pops from the end, so reverse it to preserve the insertion order.
+            if (!byTime)
+            {
+                queue.Reverse();
+            }
+
+            return queue;
+        }
+
+        private static IEnumerable<WalkNode> ParsedParents(WalkNode node)
         {
             if (!node.Parsed)
             {

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -1,0 +1,732 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Walks commit history in the orders GitVersion depends on (chronological, topological,
+/// reversed, first-parent-only, with include/exclude reachability sets) and computes merge
+/// bases. The walk replicates libgit2's revision-walk behavior — including its date-directed
+/// limiting pass and its tie-breaking on equal committer timestamps — because GitVersion's
+/// version output depends on the exact commit ordering. Parity is validated against libgit2
+/// by the test suite.
+/// </summary>
+/// <remarks>
+/// Missing parent objects (e.g. beyond a shallow-clone boundary) terminate traversal at
+/// that point instead of failing the walk.
+/// </remarks>
+internal sealed class GitRevisionWalker(GitObjectStore objectStore)
+{
+    // The number of uninteresting commits to look at after running out of interesting ones,
+    // matching git's slop heuristic for clock-skewed histories.
+    private const int Slop = 5;
+
+    private readonly GitObjectStore objectStore = objectStore ?? throw new ArgumentNullException(nameof(objectStore));
+    private readonly Dictionary<GitObjectId, GitCommit?> commitCache = [];
+
+    /// <summary>
+    /// Walks the commits described by <paramref name="options"/> and returns them in order.
+    /// </summary>
+    /// <param name="options">The walk description.</param>
+    /// <returns>The commits, in the requested order.</returns>
+    public IReadOnlyList<GitCommit> Walk(GitRevisionWalkOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var walk = new WalkState(this, options);
+        var result = walk.Run();
+
+        if (options.Sort.HasFlag(GitRevisionSort.Reverse))
+        {
+            result.Reverse();
+        }
+
+        return [.. result.Select(node => node.Commit)];
+    }
+
+    /// <summary>
+    /// Finds the best common ancestor of two commits, the way <c>git merge-base</c> does:
+    /// paint-down-to-common followed by elimination of redundant candidates.
+    /// </summary>
+    /// <param name="first">The first commit.</param>
+    /// <param name="second">The second commit.</param>
+    /// <returns>The merge base, or <see langword="null"/> when the histories are unrelated.</returns>
+    public GitObjectId? FindMergeBase(GitObjectId first, GitObjectId second)
+    {
+        if (first == second)
+        {
+            return TryLoad(first) is null ? null : first;
+        }
+
+        var candidates = PaintDownToCommon(first, second);
+
+        return candidates.Count switch
+        {
+            0 => null,
+            1 => candidates[0],
+            _ => RemoveRedundantCandidates(candidates)
+        };
+    }
+
+    private HashSet<GitObjectId> CollectReachable(IEnumerable<GitObjectId> roots, bool firstParentOnly)
+    {
+        var reachable = new HashSet<GitObjectId>();
+        var stack = new Stack<GitObjectId>();
+
+        foreach (var root in roots)
+        {
+            stack.Push(root);
+        }
+
+        while (stack.Count > 0)
+        {
+            var id = stack.Pop();
+
+            if (!reachable.Add(id) || TryLoad(id) is not { } commit)
+            {
+                continue;
+            }
+
+            foreach (var parentId in firstParentOnly ? commit.Parents.Take(1) : commit.Parents)
+            {
+                stack.Push(parentId);
+            }
+        }
+
+        return reachable;
+    }
+
+    private List<GitObjectId> PaintDownToCommon(GitObjectId first, GitObjectId second)
+    {
+        const int flagFirst = 1;
+        const int flagSecond = 2;
+        const int flagStale = 4;
+        const int flagBoth = flagFirst | flagSecond;
+
+        var flags = new Dictionary<GitObjectId, int>();
+        var candidates = new List<GitObjectId>();
+        var queue = new PriorityQueue<GitCommit, (long Time, long Sequence)>(TimeDescendingComparer.Instance);
+        var sequence = 0L;
+
+        void Enqueue(GitObjectId id, int newFlags)
+        {
+            var current = flags.GetValueOrDefault(id);
+
+            if ((current | newFlags) == current)
+            {
+                return;
+            }
+
+            flags[id] = current | newFlags;
+
+            if (TryLoad(id) is { } commit)
+            {
+                queue.Enqueue(commit, (commit.Committer.When.ToUnixTimeSeconds(), sequence++));
+            }
+        }
+
+        Enqueue(first, flagFirst);
+        Enqueue(second, flagSecond);
+
+        while (queue.UnorderedItems.Any(entry => (flags[entry.Element.Sha] & flagStale) == 0))
+        {
+            var commit = queue.Dequeue();
+            var commitFlags = flags[commit.Sha];
+            var paint = commitFlags & flagBoth;
+
+            if (paint == flagBoth)
+            {
+                if ((commitFlags & flagStale) == 0)
+                {
+                    candidates.Add(commit.Sha);
+                    flags[commit.Sha] = commitFlags | flagStale;
+                }
+
+                // Everything below a common commit is stale: it cannot be a better candidate.
+                paint |= flagStale;
+            }
+
+            foreach (var parentId in commit.Parents)
+            {
+                Enqueue(parentId, paint);
+            }
+        }
+
+        return candidates;
+    }
+
+    private GitObjectId? RemoveRedundantCandidates(List<GitObjectId> candidates)
+    {
+        // A candidate which is an ancestor of another candidate is redundant. Candidates are
+        // in discovery order (most recent first), so return the first independent one.
+        foreach (var candidate in candidates)
+        {
+            var others = candidates.Where(other => other != candidate).ToList();
+
+            if (!IsAncestorOfAny(candidate, others))
+            {
+                return candidate;
+            }
+        }
+
+        return candidates[0];
+    }
+
+    private bool IsAncestorOfAny(GitObjectId candidate, List<GitObjectId> others)
+    {
+        foreach (var other in others)
+        {
+            if (TryLoad(other) is not { } commit)
+            {
+                continue;
+            }
+
+            if (CollectReachable(commit.Parents, firstParentOnly: false).Contains(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private GitCommit? TryLoad(GitObjectId id)
+    {
+        if (this.commitCache.TryGetValue(id, out var cached))
+        {
+            return cached;
+        }
+
+        GitCommit? commit = null;
+
+        if (this.objectStore.TryGetObject(id, GitObjectTypes.Commit, out var stream))
+        {
+            using (stream)
+            {
+                commit = GitCommitReader.Read(stream, id);
+            }
+        }
+
+        this.commitCache[id] = commit;
+        return commit;
+    }
+
+    /// <summary>
+    /// The per-walk engine. Mirrors libgit2's revwalk phases: seed preparation, the
+    /// date-directed limiting pass, and the per-sort emission disciplines.
+    /// </summary>
+    private sealed class WalkState(GitRevisionWalker walker, GitRevisionWalkOptions options)
+    {
+        private readonly Dictionary<GitObjectId, WalkNode> nodes = [];
+
+        private bool FirstParentOnly => options.FirstParentOnly;
+
+        public List<WalkNode> Run()
+        {
+            var (seeds, limited) = PrepareSeeds();
+
+            if (limited)
+            {
+                seeds = LimitList(seeds);
+            }
+
+            if (options.Sort.HasFlag(GitRevisionSort.Topological))
+            {
+                return SortInTopologicalOrder(seeds, byTime: options.Sort.HasFlag(GitRevisionSort.Time));
+            }
+
+            if (options.Sort.HasFlag(GitRevisionSort.Time))
+            {
+                return EmitByTime(seeds);
+            }
+
+            return limited ? [.. seeds.Where(node => !node.Uninteresting)] : EmitUnsorted(seeds);
+        }
+
+        private (List<WalkNode> Seeds, bool Limited) PrepareSeeds()
+        {
+            var limited = options.Sort != GitRevisionSort.None;
+
+            // Pushes prepend to the input list; includes are pushed before hides,
+            // and a hide overrides an earlier push of the same commit.
+            var userInput = new List<WalkNode>();
+
+            foreach (var (id, uninteresting) in
+                     options.Include.Select(id => (id, false)).Concat(options.Exclude.Select(id => (id, true))))
+            {
+                var node = LookupNode(id);
+
+                if (node.Uninteresting && !uninteresting)
+                {
+                    continue;
+                }
+
+                node.Uninteresting = uninteresting;
+                limited |= uninteresting;
+                userInput.Insert(0, node);
+            }
+
+            var seeds = new List<WalkNode>();
+
+            foreach (var node in userInput)
+            {
+                Parse(node);
+
+                if (node.Uninteresting)
+                {
+                    MarkParentsUninteresting(node);
+                }
+
+                if (!node.Seen)
+                {
+                    node.Seen = true;
+                    seeds.Add(node);
+                }
+            }
+
+            return (seeds, limited);
+        }
+
+        /// <summary>
+        /// The date-directed limiting pass: traverses from the seeds in descending date order,
+        /// propagating "uninteresting" and stopping a few commits (the slop) after only
+        /// uninteresting commits remain. Returns the interesting commits in traversal order.
+        /// </summary>
+        private List<WalkNode> LimitList(List<WalkNode> seeds)
+        {
+            var list = new LinkedList<WalkNode>(seeds);
+            var newList = new List<WalkNode>();
+            var slop = Slop;
+            var time = long.MaxValue;
+
+            while (list.First is { } head)
+            {
+                list.RemoveFirst();
+                var commit = head.Value;
+
+                AddParentsToList(commit, list);
+
+                if (commit.Uninteresting)
+                {
+                    MarkParentsUninteresting(commit);
+
+                    slop = StillInteresting(list, time, slop);
+
+                    if (slop > 0)
+                    {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                time = commit.Time;
+                newList.Add(commit);
+            }
+
+            return newList;
+        }
+
+        private void AddParentsToList(WalkNode commit, LinkedList<WalkNode> list)
+        {
+            if (commit.Added)
+            {
+                return;
+            }
+
+            commit.Added = true;
+
+            if (commit.Uninteresting)
+            {
+                // Hidden histories ignore first-parent simplification: hide as much as possible.
+                foreach (var parent in ParsedParents(commit))
+                {
+                    parent.Uninteresting = true;
+                    Parse(parent);
+
+                    if (parent.Parents.Count > 0)
+                    {
+                        MarkParentsUninteresting(parent);
+                    }
+
+                    parent.Seen = true;
+                    InsertByDate(list, parent);
+                }
+
+                return;
+            }
+
+            foreach (var parent in ParsedParents(commit))
+            {
+                Parse(parent);
+
+                if (parent.Parsed && !parent.Seen)
+                {
+                    parent.Seen = true;
+                    InsertByDate(list, parent);
+                }
+
+                if (FirstParentOnly)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static int StillInteresting(LinkedList<WalkNode> list, long time, int slop)
+        {
+            if (list.Count == 0)
+            {
+                return 0;
+            }
+
+            // A destination commit later than our current date means we are not done.
+            if (time <= list.First!.Value.Time)
+            {
+                return Slop;
+            }
+
+            foreach (var item in list)
+            {
+                if (!item.Uninteresting || item.Time > time)
+                {
+                    return Slop;
+                }
+            }
+
+            return slop - 1;
+        }
+
+        private static void InsertByDate(LinkedList<WalkNode> list, WalkNode item)
+        {
+            // Keep the list in descending date order; equal dates go after existing entries.
+            var current = list.First;
+
+            while (current is not null && current.Value.Time >= item.Time)
+            {
+                current = current.Next;
+            }
+
+            if (current is null)
+            {
+                list.AddLast(item);
+            }
+            else
+            {
+                list.AddBefore(current, item);
+            }
+        }
+
+        private void MarkParentsUninteresting(WalkNode node)
+        {
+            // Mark all (currently parsed) ancestors uninteresting, chasing first-parent
+            // chains and stopping at commits which have not been parsed yet — the limiting
+            // pass will pick those up as it reaches them.
+            var pending = new Stack<WalkNode>();
+
+            foreach (var parent in ParsedParents(node))
+            {
+                pending.Push(parent);
+            }
+
+            while (pending.Count > 0)
+            {
+                var commit = pending.Pop();
+
+                while (true)
+                {
+                    if (commit.Uninteresting)
+                    {
+                        break;
+                    }
+
+                    commit.Uninteresting = true;
+
+                    if (!commit.Parsed || commit.Parents.Count == 0)
+                    {
+                        break;
+                    }
+
+                    foreach (var parent in commit.Parents)
+                    {
+                        pending.Push(parent);
+                    }
+
+                    commit = commit.Parents[0];
+                }
+            }
+        }
+
+        private List<WalkNode> EmitByTime(List<WalkNode> seeds)
+        {
+            var queue = new BinaryHeap(byTime: true);
+
+            foreach (var node in seeds)
+            {
+                queue.Insert(node);
+            }
+
+            var result = new List<WalkNode>();
+
+            while (queue.Pop() is { } next)
+            {
+                if (!next.Uninteresting)
+                {
+                    result.Add(next);
+                }
+            }
+
+            return result;
+        }
+
+        private List<WalkNode> EmitUnsorted(List<WalkNode> seeds)
+        {
+            // The default walk: pop the head of a date-sorted list, lazily inserting parents.
+            var list = new LinkedList<WalkNode>(seeds);
+            var result = new List<WalkNode>();
+
+            while (list.First is { } head)
+            {
+                list.RemoveFirst();
+                var commit = head.Value;
+
+                AddParentsToList(commit, list);
+
+                if (!commit.Uninteresting)
+                {
+                    result.Add(commit);
+                }
+            }
+
+            return result;
+        }
+
+        private List<WalkNode> SortInTopologicalOrder(List<WalkNode> list, bool byTime)
+        {
+            // A commit may only be emitted after all commits in the list which have it as a
+            // parent. Ready commits are emitted chronologically when time-sorting, otherwise
+            // in the order the limiting pass produced them.
+            foreach (var node in list)
+            {
+                node.InDegree = 1;
+            }
+
+            foreach (var node in list)
+            {
+                foreach (var parent in node.Parents)
+                {
+                    if (parent.InDegree > 0)
+                    {
+                        parent.InDegree++;
+                    }
+                }
+            }
+
+            var queue = new BinaryHeap(byTime);
+
+            foreach (var node in list)
+            {
+                if (node.InDegree == 1)
+                {
+                    queue.Insert(node);
+                }
+            }
+
+            if (!byTime)
+            {
+                queue.Reverse();
+            }
+
+            var result = new List<WalkNode>();
+
+            while (queue.Pop() is { } next)
+            {
+                foreach (var parent in next.Parents)
+                {
+                    if (parent.InDegree == 0)
+                    {
+                        continue;
+                    }
+
+                    if (--parent.InDegree == 1)
+                    {
+                        queue.Insert(parent);
+                    }
+                }
+
+                next.InDegree = 0;
+
+                if (!next.Uninteresting)
+                {
+                    result.Add(next);
+                }
+            }
+
+            return result;
+        }
+
+        private IEnumerable<WalkNode> ParsedParents(WalkNode node)
+        {
+            if (!node.Parsed)
+            {
+                yield break;
+            }
+
+            foreach (var parent in node.Parents)
+            {
+                yield return parent;
+            }
+        }
+
+        private WalkNode LookupNode(GitObjectId id)
+        {
+            if (!this.nodes.TryGetValue(id, out var node))
+            {
+                node = new(id);
+                this.nodes.Add(id, node);
+            }
+
+            return node;
+        }
+
+        private void Parse(WalkNode node)
+        {
+            if (node.Parsed || walker.TryLoad(node.Id) is not { } commit)
+            {
+                return;
+            }
+
+            node.Commit = commit;
+            node.Time = commit.Committer.When.ToUnixTimeSeconds();
+            node.Parents.AddRange(commit.Parents.Select(LookupNode));
+            node.Parsed = true;
+        }
+    }
+
+    private sealed class WalkNode(GitObjectId id)
+    {
+        public GitObjectId Id { get; } = id;
+        public GitCommit Commit { get; set; } = null!;
+        public long Time { get; set; }
+        public List<WalkNode> Parents { get; } = [];
+        public bool Parsed { get; set; }
+        public bool Seen { get; set; }
+        public bool Uninteresting { get; set; }
+        public bool Added { get; set; }
+        public int InDegree { get; set; }
+    }
+
+    /// <summary>
+    /// A binary min-heap over descending commit time, replicating the classic array-heap
+    /// mechanics (append + sift-up on insert; move-last-to-root + sift-down on pop, with
+    /// strict comparisons) so that the emission order of equal-timestamp commits matches
+    /// libgit2's. Without time ordering it degrades to a plain vector popped from the end.
+    /// </summary>
+    private sealed class BinaryHeap(bool byTime)
+    {
+        private readonly List<WalkNode> items = [];
+
+        public void Insert(WalkNode item)
+        {
+            this.items.Add(item);
+
+            if (byTime)
+            {
+                SiftUp(this.items.Count - 1);
+            }
+        }
+
+        public void Reverse() => this.items.Reverse();
+
+        public WalkNode? Pop()
+        {
+            if (this.items.Count == 0)
+            {
+                return null;
+            }
+
+            if (!byTime)
+            {
+                var last = this.items[^1];
+                this.items.RemoveAt(this.items.Count - 1);
+                return last;
+            }
+
+            var result = this.items[0];
+
+            if (this.items.Count > 1)
+            {
+                this.items[0] = this.items[^1];
+                this.items.RemoveAt(this.items.Count - 1);
+                SiftDown(0);
+            }
+            else
+            {
+                this.items.RemoveAt(0);
+            }
+
+            return result;
+        }
+
+        private static int Compare(WalkNode left, WalkNode right) => right.Time.CompareTo(left.Time);
+
+        private void SiftUp(int index)
+        {
+            var item = this.items[index];
+
+            while (index > 0)
+            {
+                var parentIndex = (index - 1) >> 1;
+                var parent = this.items[parentIndex];
+
+                if (Compare(parent, item) <= 0)
+                {
+                    break;
+                }
+
+                this.items[index] = parent;
+                index = parentIndex;
+            }
+
+            this.items[index] = item;
+        }
+
+        private void SiftDown(int index)
+        {
+            var item = this.items[index];
+
+            while (true)
+            {
+                var childIndex = (index << 1) + 1;
+
+                if (childIndex >= this.items.Count)
+                {
+                    break;
+                }
+
+                if (childIndex + 1 < this.items.Count && Compare(this.items[childIndex], this.items[childIndex + 1]) > 0)
+                {
+                    childIndex++;
+                }
+
+                if (Compare(item, this.items[childIndex]) <= 0)
+                {
+                    break;
+                }
+
+                this.items[index] = this.items[childIndex];
+                index = childIndex;
+            }
+
+            this.items[index] = item;
+        }
+    }
+
+    private sealed class TimeDescendingComparer : IComparer<(long Time, long Sequence)>
+    {
+        public static TimeDescendingComparer Instance { get; } = new();
+
+        public int Compare((long Time, long Sequence) x, (long Time, long Sequence) y)
+        {
+            var byTime = y.Time.CompareTo(x.Time);
+            return byTime != 0 ? byTime : x.Sequence.CompareTo(y.Sequence);
+        }
+    }
+}


### PR DESCRIPTION
Closes #5035. Part of #5031 — see `docs/design/managed-git-migration.md`. Builds on #5043 (B.1) and #5045 (B.2).

## What

Third layer of the vendored managed reader in `src/GitVersion.Git.Managed` (still no GitVersion.Core dependency, all types `internal`) — the **highest-risk parity phase** per the design doc's risk register, since GitVersion's version output depends on exact commit ordering:

- **`GitRevisionWalker.Walk`** (`History/`) — covers exactly the query surface `RepositoryStore` uses: include/exclude reachability sets, sorts `None`, `Time`, `Topological`, `Topological|Time`, `Topological|Reverse` (+ all `Reverse` combos), and `FirstParentOnly`. The walk replicates libgit2's revwalk phases:
  - the **date-directed limiting pass** (with git's slop heuristic) that runs for any non-default sort or exclusion
  - lazy **date-ordered parent insertion** where equal committer dates keep insertion order
  - **binary-heap emission** for time sorting — the heap mechanics (move-last-to-root + strict-compare sift) are what determine libgit2's tie order for equal-timestamp commits, which GitVersion fixtures produce routinely
  - the **reversed insertion vector** for plain topological sorting (tips FIFO, then DFS-like lineage grouping)
- **`GitRevisionWalker.FindMergeBase`** — paint-down-to-common with redundant-candidate elimination, matching `git_merge_base` including criss-cross histories (validated in both argument orders)
- **Shallow tolerance** — missing parent objects terminate traversal at the boundary instead of failing

## Licensing note

libgit2 is GPLv2 (+ linking exception), **not** MIT — no code was ported. These are fresh implementations; libgit2's source was consulted only as the behavioral specification, and parity is enforced by tests.

## Tests

50 new tests (116 total, all green). The parity suite runs **the same queries through LibGit2Sharp on the same git-CLI-generated fixtures** and requires byte-identical commit sequences:

- 7 sort combinations × 6 repository shapes: linear, branched+merged, criss-cross, **all-equal committer timestamps**, octopus (3-parent), merged-with-excludes
- first-parent walks (with and without excludes), multiple includes
- merge-base: diverged branches, criss-cross (both directions), ancestor/self cases, unrelated histories (orphan root) → null
- shallow clone: walk stops at the boundary

## Checks

- `dotnet build ./src/GitVersion.slnx` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)