### PR TITLE
feat(git): managed tree diff, index reader and status calculator (Phase B.4)

### DIFF
--- a/src/GitVersion.Git.Managed.Tests/GitIndexTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitIndexTests.cs
@@ -1,0 +1,96 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitIndexTests
+{
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    public void IndexEntriesMatchGitLsFiles(int indexVersion)
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.WriteFile("sub/deep/c.txt", "three\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--chmod=+x", "a.txt");
+
+        if (indexVersion == 3)
+        {
+            // Git only writes version 3 when an entry actually carries extended flags.
+            repository.Run("update-index", "--skip-worktree", "sub/b.txt");
+        }
+
+        repository.Run("update-index", $"--index-version={indexVersion}");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+
+        index.Version.ShouldBe(indexVersion);
+
+        // git ls-files --stage prints: <mode> SP <sha> SP <stage> TAB <path>
+        var expected = repository
+            .Run("ls-files", "--stage")
+            .Split('\n')
+            .Select(line =>
+            {
+                var parts = line.Split('\t');
+                var meta = parts[0].Split(' ');
+                return (Mode: Convert.ToUInt32(meta[0], 8), Sha: meta[1], Stage: int.Parse(meta[2]), Path: parts[1]);
+            })
+            .ToList();
+
+        index.Entries.Count.ShouldBe(expected.Count);
+
+        for (var i = 0; i < expected.Count; i++)
+        {
+            var entry = index.Entries[i];
+            entry.Path.ShouldBe(expected[i].Path);
+            entry.Mode.ShouldBe(expected[i].Mode);
+            entry.ObjectId.ToString().ShouldBe(expected[i].Sha);
+            entry.Stage.ShouldBe(expected[i].Stage);
+        }
+
+        index.Entries.Single(entry => entry.Path == "a.txt").IsExecutable.ShouldBeTrue();
+        index.Entries.Single(entry => entry.Path == "sub/b.txt").IsExecutable.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsStatDataUsedForCleanDetection()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "content\n");
+        repository.Commit("commit");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+        var entry = index.Entries.ShouldHaveSingleItem();
+
+        entry.Size.ShouldBe((uint)"content\n".Length);
+        entry.ModificationTimeSeconds.ShouldBeGreaterThan(0u);
+        entry.AssumeValid.ShouldBeFalse();
+        entry.SkipWorktree.ShouldBeFalse();
+        entry.IntentToAdd.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsSkipWorktreeExtendedFlags()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("b.txt", "two\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--skip-worktree", "a.txt");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+
+        index.Entries.Single(entry => entry.Path == "a.txt").SkipWorktree.ShouldBeTrue();
+        index.Entries.Single(entry => entry.Path == "b.txt").SkipWorktree.ShouldBeFalse();
+    }
+
+    [Test]
+    public void AMissingIndexFileYieldsAnEmptyIndex()
+    {
+        var index = GitIndex.Read(Path.Combine(Path.GetTempPath(), "does-not-exist", "index"));
+
+        index.Entries.ShouldBeEmpty();
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
@@ -1,0 +1,176 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitStatusCalculator"/> against the exact expression the
+/// LibGit2Sharp adapter uses for <c>IGitRepository.UncommittedChangesCount</c>.
+/// </summary>
+[TestFixture]
+public class GitStatusCalculatorTests
+{
+    [Test]
+    public void ACleanWorkingDirectoryHasNoChanges()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.Commit("commit");
+
+        AssertParity(repository, expectedCount: 0);
+    }
+
+    [Test]
+    public void CountsModifiedStagedDeletedAndUntrackedPathsOnce()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("modified.txt", "one\n");
+        repository.WriteFile("both.txt", "one\n");
+        repository.WriteFile("staged.txt", "one\n");
+        repository.WriteFile("deleted.txt", "one\n");
+        repository.WriteFile("removed.txt", "one\n");
+        repository.Commit("commit");
+
+        repository.WriteFile("modified.txt", "two\n");            // modified, unstaged
+        repository.WriteFile("staged.txt", "two\n");
+        repository.Run("add", "staged.txt");                       // modified, staged
+        repository.WriteFile("both.txt", "two\n");
+        repository.Run("add", "both.txt");
+        repository.WriteFile("both.txt", "three\n");               // staged and modified again
+        File.Delete(Path.Combine(repository.RepositoryPath, "deleted.txt")); // deleted, unstaged
+        repository.Run("rm", "-q", "removed.txt");                 // deleted, staged
+        repository.WriteFile("untracked.txt", "new\n");            // untracked
+        repository.WriteFile("sub/untracked.txt", "new\n");        // untracked in new directory
+
+        AssertParity(repository, expectedCount: 7);
+    }
+
+    [Test]
+    public void ContentRestoredToTheCommittedStateIsClean()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        // Touch the file (mtime changes, content identical): requires re-hashing to prove clean.
+        repository.WriteFile("a.txt", "one\n");
+
+        AssertParity(repository, expectedCount: 0);
+    }
+
+    [Test]
+    public void RespectsGitIgnoreRules()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "*.log\nbuild/\n!important.log\n/anchored.txt\n");
+        repository.WriteFile("sub/.gitignore", "local-*\n");
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        repository.WriteFile("noise.log", "ignored\n");            // ignored by *.log
+        repository.WriteFile("important.log", "kept\n");           // re-included by negation
+        repository.WriteFile("build/out.txt", "ignored\n");        // ignored directory
+        repository.WriteFile("anchored.txt", "ignored\n");         // anchored to root
+        repository.WriteFile("sub/anchored.txt", "not anchored\n");// same name below root is not ignored
+        repository.WriteFile("sub/local-cache", "ignored\n");      // nested .gitignore
+        repository.WriteFile("sub/tracked-new.txt", "new\n");      // untracked
+
+        AssertParity(repository, expectedCount: 3); // important.log, sub/anchored.txt, sub/tracked-new.txt
+    }
+
+    [Test]
+    public void RespectsInfoExclude()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        Directory.CreateDirectory(Path.Combine(repository.GitDirectory, "info"));
+        File.WriteAllText(Path.Combine(repository.GitDirectory, "info", "exclude"), "*.tmp\n");
+
+        repository.WriteFile("scratch.tmp", "ignored\n");
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void CountsExecutableBitChanges()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The executable bit does not exist on Windows.");
+            return;
+        }
+
+        using var repository = new GitTestRepository();
+        repository.WriteFile("script.sh", "#!/bin/sh\n");
+        repository.Commit("commit");
+
+        var scriptPath = Path.Combine(repository.RepositoryPath, "script.sh");
+        File.SetUnixFileMode(scriptPath, File.GetUnixFileMode(scriptPath) | UnixFileMode.UserExecute);
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void CountsUntrackedFilesInAnEmptyRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("untracked.txt", "new\n");
+        repository.WriteFile("also-untracked.txt", "new\n");
+
+        AssertParity(repository, expectedCount: 2);
+    }
+
+    [Test]
+    public void WorksAgainstAnIndexInVersion4Format()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--index-version=4");
+
+        repository.WriteFile("a.txt", "two\n");
+        repository.WriteFile("untracked.txt", "new\n");
+
+        AssertParity(repository, expectedCount: 2);
+    }
+
+    private static void AssertParity(GitTestRepository repository, int expectedCount)
+    {
+        var actual = ManagedCount(repository);
+        var expected = LibGit2Count(repository);
+
+        actual.ShouldBe(expected, "managed count should match the libgit2 adapter");
+        actual.ShouldBe(expectedCount, "scenario expectation");
+    }
+
+    private static int ManagedCount(GitTestRepository repository)
+    {
+        var layout = GitRepositoryLayout.Discover(repository.RepositoryPath);
+        using var store = layout.CreateObjectStore();
+        var calculator = new GitStatusCalculator(layout, store);
+
+        return layout.CreateReferenceStore().ResolveToObjectId("HEAD") is { } headId
+            ? calculator.CountUncommittedChanges(store.GetCommit(headId).Tree)
+            : calculator.CountChangesInEmptyRepository();
+    }
+
+    private static int LibGit2Count(GitTestRepository repository)
+    {
+        // The exact expression from GitVersion.LibGit2Sharp's GetUncommittedChangesCountInternal.
+        using var libgit2 = new Repository(repository.RepositoryPath);
+
+        if (libgit2.Head?.Tip == null)
+        {
+            var status = libgit2.RetrieveStatus();
+            return status.Untracked.Count() + status.Staged.Count();
+        }
+
+        return libgit2.Diff
+            .Compare<TreeChanges>(libgit2.Head.Tip.Tree, DiffTargets.Index | DiffTargets.WorkingDirectory)
+            .Count;
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitTreeDiffTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTreeDiffTests.cs
@@ -1,0 +1,134 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitTreeDiff"/> against libgit2's default <c>TreeChanges</c> path
+/// list, which is what GitVersion exposes as <c>ICommit.DiffPaths</c>.
+/// </summary>
+[TestFixture]
+public class GitTreeDiffTests
+{
+    [Test]
+    public void ChangedPathsMatchLibGit2ForEveryCommit()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "one\n");
+        repository.WriteFile("sub/deep/c.txt", "one\n");
+        repository.Commit("root commit");
+
+        repository.WriteFile("a.txt", "two\n");
+        repository.WriteFile("sub/new.txt", "new\n");
+        repository.Commit("modify and add");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "sub", "b.txt"));
+        repository.Commit("delete nested file");
+
+        repository.WriteFile("d.txt", "d\n");
+        repository.Run("update-index", "--chmod=+x", "a.txt");
+        repository.Commit("exec bit and new file");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void ChangedPathsMatchLibGit2WhenAFileBecomesADirectory()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("thing", "file\n");
+        repository.WriteFile("z.txt", "z\n");
+        repository.Commit("file");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing"));
+        repository.WriteFile("thing/inner.txt", "dir\n");
+        repository.WriteFile("thing/other.txt", "dir\n");
+        repository.Commit("becomes a directory");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing", "inner.txt"));
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing", "other.txt"));
+        Directory.Delete(Path.Combine(repository.RepositoryPath, "thing"));
+        repository.WriteFile("thing", "file again\n");
+        repository.Commit("becomes a file again");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void ChangedPathsOfMergeCommitsUseTheFirstParent()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1");
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.Merge("feature");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void IdenticalTreesProduceNoChangedPaths()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        using var store = repository.OpenObjectStore();
+        var tree = store.GetCommit(repository.ResolveId("HEAD")).Tree;
+
+        new GitTreeDiff(store).GetChangedPaths(tree, tree).ShouldBeEmpty();
+    }
+
+    [Test]
+    public void FlattenTreeListsAllBlobPaths()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "one\n");
+        repository.WriteFile("sub/deep/c.txt", "one\n");
+        repository.Commit("commit");
+
+        using var store = repository.OpenObjectStore();
+        var tree = store.GetCommit(repository.ResolveId("HEAD")).Tree;
+
+        var files = new GitTreeDiff(store).FlattenTree(tree);
+
+        files.Keys.Order(StringComparer.Ordinal).ShouldBe(["a.txt", "sub/b.txt", "sub/deep/c.txt"]);
+        files["a.txt"].Sha.ToString().ShouldBe(repository.RevParse("HEAD:a.txt"));
+    }
+
+    private static void AssertDiffPathsParityForAllCommits(GitTestRepository repository)
+    {
+        using var store = repository.OpenObjectStore();
+        var treeDiff = new GitTreeDiff(store);
+        var walker = new GitRevisionWalker(store);
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(repository.ResolveId("HEAD"));
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+
+        foreach (var commit in walker.Walk(options))
+        {
+            var parentTree = commit.Parents.Count > 0
+                ? store.GetCommit(commit.Parents[0]).Tree
+                : (GitObjectId?)null;
+
+            var actual = treeDiff.GetChangedPaths(parentTree, commit.Tree);
+
+            // The adapter's DiffPaths: Compare<TreeChanges>(commit.Tree, firstParent?.Tree).Paths
+            var libgit2Commit = libgit2.Lookup<Commit>(commit.Sha.ToString())!;
+            var expected = libgit2.Diff
+                .Compare<TreeChanges>(libgit2Commit.Tree, libgit2Commit.Parents.FirstOrDefault()?.Tree)
+                .Select(element => element.Path)
+                .ToList();
+
+            actual.ShouldBe(expected, $"commit: {commit.Message.TrimEnd()}");
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/Diff/GitTreeDiff.cs
+++ b/src/GitVersion.Git.Managed/Diff/GitTreeDiff.cs
@@ -1,0 +1,160 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Computes the paths changed between two trees: a recursive tree-vs-tree diff with no
+/// rename detection, matching libgit2's default <c>TreeChanges</c> path list (which is
+/// what GitVersion's <c>ICommit.DiffPaths</c> exposes). Identical subtrees are skipped
+/// by object id; entries align using git's canonical tree order, where directory names
+/// compare as if they had a trailing slash.
+/// </summary>
+internal sealed class GitTreeDiff(GitObjectStore objectStore)
+{
+    private readonly GitObjectStore objectStore = objectStore ?? throw new ArgumentNullException(nameof(objectStore));
+
+    /// <summary>
+    /// Returns the repository-relative paths which differ between the two trees,
+    /// in path order. Either side may be <see langword="null"/> to diff against the
+    /// empty tree (e.g. for root commits).
+    /// </summary>
+    /// <param name="oldTreeId">The object id of the old tree, or <see langword="null"/> for the empty tree.</param>
+    /// <param name="newTreeId">The object id of the new tree, or <see langword="null"/> for the empty tree.</param>
+    /// <returns>The changed paths.</returns>
+    public IReadOnlyList<string> GetChangedPaths(GitObjectId? oldTreeId, GitObjectId? newTreeId)
+    {
+        if (Nullable.Equals(oldTreeId, newTreeId))
+        {
+            return [];
+        }
+
+        var paths = new List<string>();
+        DiffTrees(LoadTree(oldTreeId), LoadTree(newTreeId), prefix: "", paths);
+        return paths;
+    }
+
+    /// <summary>
+    /// Flattens a tree into all of its blob paths and their entries.
+    /// </summary>
+    /// <param name="treeId">The object id of the tree, or <see langword="null"/> for the empty tree.</param>
+    /// <returns>A dictionary of repository-relative path to tree entry.</returns>
+    public Dictionary<string, GitTreeEntry> FlattenTree(GitObjectId? treeId)
+    {
+        var files = new Dictionary<string, GitTreeEntry>(StringComparer.Ordinal);
+
+        if (treeId is { } id)
+        {
+            Flatten(this.objectStore.GetTree(id), prefix: "", files);
+        }
+
+        return files;
+    }
+
+    private void Flatten(GitTree tree, string prefix, Dictionary<string, GitTreeEntry> files)
+    {
+        foreach (var entry in tree.Entries)
+        {
+            if (entry.IsTree)
+            {
+                Flatten(this.objectStore.GetTree(entry.Sha), prefix + entry.Name + "/", files);
+            }
+            else
+            {
+                files[prefix + entry.Name] = entry;
+            }
+        }
+    }
+
+    private GitTree? LoadTree(GitObjectId? treeId) => treeId is { } id ? this.objectStore.GetTree(id) : null;
+
+    private void DiffTrees(GitTree? oldTree, GitTree? newTree, string prefix, List<string> paths)
+    {
+        var oldEntries = oldTree?.Entries ?? [];
+        var newEntries = newTree?.Entries ?? [];
+        var oldIndex = 0;
+        var newIndex = 0;
+
+        while (oldIndex < oldEntries.Count || newIndex < newEntries.Count)
+        {
+            var comparison = (oldIndex < oldEntries.Count, newIndex < newEntries.Count) switch
+            {
+                (true, false) => -1,
+                (false, true) => 1,
+                _ => CompareTreeNames(oldEntries[oldIndex], newEntries[newIndex])
+            };
+
+            if (comparison < 0)
+            {
+                EmitAll(oldEntries[oldIndex++], prefix, paths);
+            }
+            else if (comparison > 0)
+            {
+                EmitAll(newEntries[newIndex++], prefix, paths);
+            }
+            else
+            {
+                DiffAlignedEntries(oldEntries[oldIndex++], newEntries[newIndex++], prefix, paths);
+            }
+        }
+    }
+
+    private void DiffAlignedEntries(GitTreeEntry oldEntry, GitTreeEntry newEntry, string prefix, List<string> paths)
+    {
+        if (oldEntry.Sha == newEntry.Sha && oldEntry.Mode == newEntry.Mode)
+        {
+            return;
+        }
+
+        if (oldEntry.IsTree && newEntry.IsTree)
+        {
+            if (oldEntry.Sha != newEntry.Sha)
+            {
+                DiffTrees(LoadTree(oldEntry.Sha), LoadTree(newEntry.Sha), prefix + oldEntry.Name + "/", paths);
+            }
+
+            return;
+        }
+
+        if (!oldEntry.IsTree && !newEntry.IsTree)
+        {
+            paths.Add(prefix + oldEntry.Name);
+            return;
+        }
+
+        // The name changed type between a file and a directory: the file path sorts
+        // before the paths inside the directory.
+        var (file, tree) = oldEntry.IsTree ? (newEntry, oldEntry) : (oldEntry, newEntry);
+        paths.Add(prefix + file.Name);
+        EmitAll(tree, prefix, paths);
+    }
+
+    private void EmitAll(GitTreeEntry entry, string prefix, List<string> paths)
+    {
+        if (!entry.IsTree)
+        {
+            paths.Add(prefix + entry.Name);
+            return;
+        }
+
+        var tree = this.objectStore.GetTree(entry.Sha);
+
+        foreach (var child in tree.Entries)
+        {
+            EmitAll(child, prefix + entry.Name + "/", paths);
+        }
+    }
+
+    private static int CompareTreeNames(GitTreeEntry left, GitTreeEntry right)
+    {
+        // Entries with the same name align even when their type differs, so a
+        // file-to-directory change on one name is detected as such.
+        if (left.Name == right.Name)
+        {
+            return 0;
+        }
+
+        // Git's canonical tree order: directory names sort as if they ended with '/'.
+        var leftName = left.IsTree ? left.Name + "/" : left.Name;
+        var rightName = right.IsTree ? right.Name + "/" : right.Name;
+
+        return string.CompareOrdinal(leftName, rightName);
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
@@ -94,8 +94,8 @@ internal sealed class GitIgnoreRules
             return null;
         }
 
-        // A pattern containing a slash is anchored to the ignore file's directory;
-        // otherwise it matches at any depth below it.
+        // Patterns containing a slash are anchored to the directory of the ignore file,
+        // while all other patterns match at any depth below it.
         if (!pattern.Contains('/'))
         {
             pattern = "**/" + pattern;
@@ -103,7 +103,12 @@ internal sealed class GitIgnoreRules
 
         pattern = pattern.TrimStart('/');
 
-        return (new Regex("^" + TranslateToRegex(pattern) + "$", RegexOptions.CultureInvariant), directoryOnly, negated);
+        var regex = new Regex(
+            "^" + TranslateToRegex(pattern) + "$",
+            RegexOptions.CultureInvariant,
+            TimeSpan.FromSeconds(1));
+
+        return (regex, directoryOnly, negated);
     }
 
     private static string TrimTrailingSpaces(string line)

--- a/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
@@ -1,0 +1,203 @@
+using System.Text.RegularExpressions;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// The parsed rules of a single ignore source (a <c>.gitignore</c> file or
+/// <c>.git/info/exclude</c>), matched against paths relative to the source's directory.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitignore"/>
+internal sealed class GitIgnoreRules
+{
+    private readonly List<(Regex Pattern, bool DirectoryOnly, bool Negated)> rules = [];
+
+    private GitIgnoreRules(IEnumerable<string> lines)
+    {
+        foreach (var line in lines)
+        {
+            if (ParseLine(line) is { } rule)
+            {
+                this.rules.Add(rule);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads the rules from an ignore file, or returns <see langword="null"/> when the file does not exist.
+    /// </summary>
+    /// <param name="path">The path of the ignore file.</param>
+    /// <returns>The parsed rules, if the file exists.</returns>
+    public static GitIgnoreRules? Load(string path) => File.Exists(path) ? new(File.ReadLines(path)) : null;
+
+    /// <summary>
+    /// Parses ignore rules from text lines.
+    /// </summary>
+    /// <param name="lines">The lines of an ignore file.</param>
+    /// <returns>The parsed rules.</returns>
+    public static GitIgnoreRules Parse(IEnumerable<string> lines) => new(lines);
+
+    /// <summary>
+    /// Determines whether this source decides the ignored state of the given path.
+    /// The last matching rule wins, per gitignore semantics.
+    /// </summary>
+    /// <param name="relativePath">The path, relative to this source's directory, using forward slashes.</param>
+    /// <param name="isDirectory">Whether the path refers to a directory.</param>
+    /// <returns>
+    /// <see langword="true"/> (ignored), <see langword="false"/> (explicitly re-included),
+    /// or <see langword="null"/> when no rule matches.
+    /// </returns>
+    public bool? IsIgnored(string relativePath, bool isDirectory)
+    {
+        for (var i = this.rules.Count - 1; i >= 0; i--)
+        {
+            var (pattern, directoryOnly, negated) = this.rules[i];
+
+            if (directoryOnly && !isDirectory)
+            {
+                continue;
+            }
+
+            if (pattern.IsMatch(relativePath))
+            {
+                return !negated;
+            }
+        }
+
+        return null;
+    }
+
+    private static (Regex Pattern, bool DirectoryOnly, bool Negated)? ParseLine(string line)
+    {
+        var pattern = TrimTrailingSpaces(line);
+
+        if (pattern.Length == 0 || pattern[0] == '#')
+        {
+            return null;
+        }
+
+        var negated = pattern[0] == '!';
+
+        if (negated)
+        {
+            pattern = pattern[1..];
+        }
+
+        var directoryOnly = pattern.EndsWith('/');
+
+        if (directoryOnly)
+        {
+            pattern = pattern[..^1];
+        }
+
+        if (pattern.Length == 0)
+        {
+            return null;
+        }
+
+        // A pattern containing a slash is anchored to the ignore file's directory;
+        // otherwise it matches at any depth below it.
+        if (!pattern.Contains('/'))
+        {
+            pattern = "**/" + pattern;
+        }
+
+        pattern = pattern.TrimStart('/');
+
+        return (new Regex("^" + TranslateToRegex(pattern) + "$", RegexOptions.CultureInvariant), directoryOnly, negated);
+    }
+
+    private static string TrimTrailingSpaces(string line)
+    {
+        var end = line.Length;
+
+        while (end > 0 && line[end - 1] == ' ' && (end < 2 || line[end - 2] != '\\'))
+        {
+            end--;
+        }
+
+        return line[..end];
+    }
+
+    private static string TranslateToRegex(string pattern)
+    {
+        var regex = new StringBuilder();
+        var i = 0;
+
+        while (i < pattern.Length)
+        {
+            var atSegmentStart = i == 0 || pattern[i - 1] == '/';
+
+            if (atSegmentStart && pattern.AsSpan(i).StartsWith("**/", StringComparison.Ordinal))
+            {
+                regex.Append("(?:[^/]+/)*");
+                i += 3;
+                continue;
+            }
+
+            if (atSegmentStart && pattern.AsSpan(i).SequenceEqual("**"))
+            {
+                regex.Append(".*");
+                i += 2;
+                continue;
+            }
+
+            var current = pattern[i];
+
+            switch (current)
+            {
+                case '*' when i + 1 < pattern.Length && pattern[i + 1] == '*':
+                    regex.Append(".*");
+                    i += 2;
+                    break;
+
+                case '*':
+                    regex.Append("[^/]*");
+                    i++;
+                    break;
+
+                case '?':
+                    regex.Append("[^/]");
+                    i++;
+                    break;
+
+                case '[':
+                    i = AppendCharacterClass(pattern, i, regex);
+                    break;
+
+                case '\\' when i + 1 < pattern.Length:
+                    regex.Append(Regex.Escape(pattern[i + 1].ToString()));
+                    i += 2;
+                    break;
+
+                default:
+                    regex.Append(Regex.Escape(current.ToString()));
+                    i++;
+                    break;
+            }
+        }
+
+        return regex.ToString();
+    }
+
+    private static int AppendCharacterClass(string pattern, int start, StringBuilder regex)
+    {
+        var end = pattern.IndexOf(']', start + 1);
+
+        if (end < 0)
+        {
+            // An unterminated class matches a literal bracket.
+            regex.Append(Regex.Escape("["));
+            return start + 1;
+        }
+
+        var body = pattern[(start + 1)..end];
+
+        if (body.StartsWith('!'))
+        {
+            body = "^" + body[1..];
+        }
+
+        regex.Append('[').Append(body).Append(']');
+        return end + 1;
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitIndex.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIndex.cs
@@ -1,0 +1,193 @@
+using System.Buffers.Binary;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A single entry of the <c>.git/index</c> file.
+/// </summary>
+/// <param name="Path">The repository-relative path, using forward slashes.</param>
+/// <param name="Mode">The file mode, e.g. <c>0b1000_000_110_100_100</c> (100644 octal) for a regular file.</param>
+/// <param name="ObjectId">The object id of the staged blob.</param>
+/// <param name="Stage">The merge stage: 0 for a normal entry, 1–3 during conflicts.</param>
+/// <param name="Size">The cached on-disk file size (truncated to 32 bits).</param>
+/// <param name="ModificationTimeSeconds">The cached modification time, in seconds since the epoch.</param>
+/// <param name="ModificationTimeNanoseconds">The nanosecond fraction of the cached modification time.</param>
+/// <param name="AssumeValid">Whether the assume-unchanged bit is set.</param>
+/// <param name="SkipWorktree">Whether the skip-worktree bit is set (sparse checkout).</param>
+/// <param name="IntentToAdd">Whether the intent-to-add bit is set (<c>git add -N</c>).</param>
+internal sealed record GitIndexEntry(
+    string Path,
+    uint Mode,
+    GitObjectId ObjectId,
+    int Stage,
+    uint Size,
+    uint ModificationTimeSeconds,
+    uint ModificationTimeNanoseconds,
+    bool AssumeValid,
+    bool SkipWorktree,
+    bool IntentToAdd)
+{
+    /// <summary>
+    /// Gets a value indicating whether the entry's file mode has the executable bit set.
+    /// </summary>
+    public bool IsExecutable => (Mode & 0b001_000_000) != 0;
+}
+
+/// <summary>
+/// Reads the <c>.git/index</c> file (the staging area), versions 2 to 4.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitformat-index"/>
+internal sealed class GitIndex
+{
+    private const int HeaderLength = 12;
+    private const int EntryFixedLength = 62;
+
+    private GitIndex(int version, IReadOnlyList<GitIndexEntry> entries)
+    {
+        Version = version;
+        Entries = entries;
+    }
+
+    /// <summary>
+    /// Gets the format version of the index file: 2, 3 or 4.
+    /// </summary>
+    public int Version { get; }
+
+    /// <summary>
+    /// Gets the entries of the index, in the order stored (sorted by path and stage).
+    /// </summary>
+    public IReadOnlyList<GitIndexEntry> Entries { get; }
+
+    /// <summary>
+    /// Reads an index file from disk. A missing file yields an empty index.
+    /// </summary>
+    /// <param name="path">The path to the index file.</param>
+    /// <returns>The parsed index.</returns>
+    public static GitIndex Read(string path) =>
+        File.Exists(path) ? Parse(File.ReadAllBytes(path)) : new(2, []);
+
+    /// <summary>
+    /// Parses the binary content of an index file.
+    /// </summary>
+    /// <param name="data">The raw bytes of the index file.</param>
+    /// <returns>The parsed index.</returns>
+    public static GitIndex Parse(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < HeaderLength || !data[..4].SequenceEqual("DIRC"u8))
+        {
+            throw new GitObjectStoreException("The index file has an invalid signature.");
+        }
+
+        var version = BinaryPrimitives.ReadInt32BigEndian(data[4..8]);
+
+        if (version is < 2 or > 4)
+        {
+            throw new GitObjectStoreException($"Index version {version} is not supported; only versions 2 to 4 are supported.");
+        }
+
+        var entryCount = BinaryPrimitives.ReadInt32BigEndian(data[8..12]);
+        var entries = new List<GitIndexEntry>(entryCount);
+        var offset = HeaderLength;
+        var previousPath = "";
+
+        for (var i = 0; i < entryCount; i++)
+        {
+            (var entry, offset) = ReadEntry(data, offset, version, previousPath);
+            entries.Add(entry);
+            previousPath = entry.Path;
+        }
+
+        // Extensions and the trailing checksum are not needed and are skipped.
+        return new(version, entries);
+    }
+
+    private static (GitIndexEntry Entry, int Offset) ReadEntry(ReadOnlySpan<byte> data, int offset, int version, string previousPath)
+    {
+        var entryStart = offset;
+        var fixedPart = data.Slice(offset, EntryFixedLength);
+
+        var modificationSeconds = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[8..12]);
+        var modificationNanoseconds = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[12..16]);
+        var mode = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[24..28]);
+        var size = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[36..40]);
+        var objectId = GitObjectId.Parse(fixedPart.Slice(40, GitObjectId.Sha1Size));
+        var flags = BinaryPrimitives.ReadUInt16BigEndian(fixedPart[60..62]);
+
+        var assumeValid = (flags & 0x8000) != 0;
+        var extended = (flags & 0x4000) != 0;
+        var stage = (flags >> 12) & 0x3;
+        var nameLength = flags & 0xFFF;
+
+        offset += EntryFixedLength;
+
+        var skipWorktree = false;
+        var intentToAdd = false;
+
+        if (extended)
+        {
+            if (version < 3)
+            {
+                throw new GitObjectStoreException("The index file is malformed: an extended entry appears in a version 2 index.");
+            }
+
+            var extendedFlags = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+            skipWorktree = (extendedFlags & 0x4000) != 0;
+            intentToAdd = (extendedFlags & 0x2000) != 0;
+            offset += 2;
+        }
+
+        string path;
+
+        if (version < 4)
+        {
+            var nameBytes = nameLength < 0xFFF
+                ? data.Slice(offset, nameLength)
+                : data[offset..(offset + data[offset..].IndexOf((byte)0))];
+            path = Encoding.UTF8.GetString(nameBytes);
+
+            // The entry is zero-padded so its total length is a multiple of eight,
+            // with at least one trailing NUL.
+            var entryLength = ((offset - entryStart) + nameBytes.Length + 8) & ~7;
+            offset = entryStart + entryLength;
+        }
+        else
+        {
+            // Version 4 prefix-compresses the path against the previous entry's path.
+            (var stripCount, offset) = ReadVariableWidthInt(data, offset);
+            var suffixEnd = data[offset..].IndexOf((byte)0);
+            var suffix = Encoding.UTF8.GetString(data.Slice(offset, suffixEnd));
+            path = previousPath[..(previousPath.Length - stripCount)] + suffix;
+            offset += suffixEnd + 1;
+        }
+
+        var entry = new GitIndexEntry(
+            path,
+            mode,
+            objectId,
+            stage,
+            size,
+            modificationSeconds,
+            modificationNanoseconds,
+            assumeValid,
+            skipWorktree,
+            intentToAdd);
+
+        return (entry, offset);
+    }
+
+    private static (int Value, int Offset) ReadVariableWidthInt(ReadOnlySpan<byte> data, int offset)
+    {
+        // Git's offset-encoded variable-width integer: each continuation adds one.
+        int current = data[offset++];
+        var value = current & 0x7F;
+
+        while ((current & 0x80) != 0)
+        {
+            value++;
+            current = data[offset++];
+            value = (value << 7) | (current & 0x7F);
+        }
+
+        return (value, offset);
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
+++ b/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 namespace GitVersion.Git;
@@ -78,7 +79,7 @@ internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectS
         }
     }
 
-    private void CompareIndexWithWorkingDirectory(
+    private static void CompareIndexWithWorkingDirectory(
         string workingDirectory,
         Dictionary<string, GitIndexEntry> indexEntries,
         HashSet<string> changed)
@@ -214,6 +215,7 @@ internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectS
         return isExecutable != entry.IsExecutable;
     }
 
+    [SuppressMessage("Critical Security Hotspot", "S4790:Using weak hashing algorithms is security-sensitive", Justification = "Git object ids are SHA-1 by definition; the hash is used for content identity, not security.")]
     private static GitObjectId HashFile(FileInfo fileInfo)
     {
         var header = Encoding.ASCII.GetBytes($"blob {fileInfo.Length}\0");

--- a/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
+++ b/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
@@ -1,0 +1,228 @@
+using System.Security.Cryptography;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Computes the number of uncommitted changes in a working directory, matching the
+/// semantics GitVersion has always used with libgit2: the number of distinct paths in
+/// a diff of the HEAD tree against the index and the working directory combined —
+/// untracked files included, ignored files excluded.
+/// </summary>
+internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectStore objectStore)
+{
+    private readonly GitRepositoryLayout layout = layout ?? throw new ArgumentNullException(nameof(layout));
+    private readonly GitTreeDiff treeDiff = new(objectStore);
+
+    /// <summary>
+    /// Counts the paths which differ between the given HEAD tree, the index, and the
+    /// working directory.
+    /// </summary>
+    /// <param name="headTreeId">The root tree of the HEAD commit.</param>
+    /// <returns>The number of changed paths.</returns>
+    public int CountUncommittedChanges(GitObjectId headTreeId)
+    {
+        var workingDirectory = RequireWorkingDirectory();
+        var index = GitIndex.Read(Path.Combine(this.layout.GitDirectory, "index"));
+        var headFiles = this.treeDiff.FlattenTree(headTreeId);
+        var indexEntries = index.Entries.ToDictionary(entry => entry.Path, StringComparer.Ordinal);
+
+        var changed = new HashSet<string>(StringComparer.Ordinal);
+
+        CompareHeadWithIndex(headFiles, indexEntries, changed);
+        CompareIndexWithWorkingDirectory(workingDirectory, indexEntries, changed);
+        changed.UnionWith(FindUntrackedFiles(workingDirectory, indexEntries));
+
+        return changed.Count;
+    }
+
+    /// <summary>
+    /// Counts the changes the way GitVersion counts them in a repository whose HEAD is
+    /// unborn (a brand-new repository): the untracked files.
+    /// </summary>
+    /// <returns>The number of changed paths.</returns>
+    public int CountChangesInEmptyRepository()
+    {
+        var workingDirectory = RequireWorkingDirectory();
+        var index = GitIndex.Read(Path.Combine(this.layout.GitDirectory, "index"));
+        var indexEntries = index.Entries.ToDictionary(entry => entry.Path, StringComparer.Ordinal);
+
+        return FindUntrackedFiles(workingDirectory, indexEntries).Count;
+    }
+
+    private string RequireWorkingDirectory() =>
+        this.layout.WorkingDirectory
+            ?? throw new GitObjectStoreException("The repository is bare: it has no working directory to compute uncommitted changes for.");
+
+    private static void CompareHeadWithIndex(
+        Dictionary<string, GitTreeEntry> headFiles,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        HashSet<string> changed)
+    {
+        foreach (var (path, headEntry) in headFiles)
+        {
+            if (!indexEntries.TryGetValue(path, out var indexEntry))
+            {
+                changed.Add(path);
+                continue;
+            }
+
+            if (indexEntry.ObjectId != headEntry.Sha || indexEntry.Mode != Convert.ToUInt32(headEntry.Mode, 8))
+            {
+                changed.Add(path);
+            }
+        }
+
+        foreach (var path in indexEntries.Keys.Where(path => !headFiles.ContainsKey(path)))
+        {
+            changed.Add(path);
+        }
+    }
+
+    private void CompareIndexWithWorkingDirectory(
+        string workingDirectory,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        HashSet<string> changed)
+    {
+        foreach (var (path, entry) in indexEntries)
+        {
+            if (entry.Stage != 0)
+            {
+                // A conflicted path is always a change.
+                changed.Add(path);
+                continue;
+            }
+
+            if (entry.AssumeValid || entry.SkipWorktree)
+            {
+                continue;
+            }
+
+            var filePath = Path.Combine(workingDirectory, path.Replace('/', Path.DirectorySeparatorChar));
+            var fileInfo = new FileInfo(filePath);
+
+            if (!fileInfo.Exists)
+            {
+                changed.Add(path);
+                continue;
+            }
+
+            if (fileInfo.Length != entry.Size || HasExecutableBitChanged(fileInfo, entry) || HashFile(fileInfo) != entry.ObjectId)
+            {
+                changed.Add(path);
+            }
+        }
+    }
+
+    private List<string> FindUntrackedFiles(string workingDirectory, Dictionary<string, GitIndexEntry> indexEntries)
+    {
+        var untracked = new List<string>();
+        var ignoreSources = new List<(string BasePrefix, GitIgnoreRules Rules)>();
+
+        if (GitIgnoreRules.Load(Path.Combine(this.layout.CommonDirectory, "info", "exclude")) is { } excludeRules)
+        {
+            ignoreSources.Add(("", excludeRules));
+        }
+
+        WalkDirectory(workingDirectory, relativePrefix: "", ignoreSources, indexEntries, untracked);
+        return untracked;
+    }
+
+    private static void WalkDirectory(
+        string directory,
+        string relativePrefix,
+        List<(string BasePrefix, GitIgnoreRules Rules)> ignoreSources,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        List<string> untracked)
+    {
+        var addedSource = false;
+
+        if (GitIgnoreRules.Load(Path.Combine(directory, ".gitignore")) is { } rules)
+        {
+            ignoreSources.Add((relativePrefix, rules));
+            addedSource = true;
+        }
+
+        try
+        {
+            foreach (var entryPath in Directory.EnumerateFileSystemEntries(directory).Order(StringComparer.Ordinal))
+            {
+                var name = Path.GetFileName(entryPath);
+
+                if (relativePrefix.Length == 0 && name == ".git")
+                {
+                    continue;
+                }
+
+                var relativePath = relativePrefix + name;
+                var isDirectory = Directory.Exists(entryPath);
+
+                if (IsIgnored(ignoreSources, relativePath, isDirectory))
+                {
+                    // Ignored directories are not descended into: nothing below them
+                    // can be re-included, matching git.
+                    continue;
+                }
+
+                if (isDirectory)
+                {
+                    WalkDirectory(entryPath, relativePath + "/", ignoreSources, indexEntries, untracked);
+                }
+                else if (!indexEntries.ContainsKey(relativePath))
+                {
+                    untracked.Add(relativePath);
+                }
+            }
+        }
+        finally
+        {
+            if (addedSource)
+            {
+                ignoreSources.RemoveAt(ignoreSources.Count - 1);
+            }
+        }
+    }
+
+    private static bool IsIgnored(
+        List<(string BasePrefix, GitIgnoreRules Rules)> ignoreSources,
+        string relativePath,
+        bool isDirectory)
+    {
+        // Deeper sources take precedence over shallower ones; .git/info/exclude is the
+        // shallowest of all.
+        for (var i = ignoreSources.Count - 1; i >= 0; i--)
+        {
+            var (basePrefix, rules) = ignoreSources[i];
+
+            if (rules.IsIgnored(relativePath[basePrefix.Length..], isDirectory) is { } decision)
+            {
+                return decision;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasExecutableBitChanged(FileInfo fileInfo, GitIndexEntry entry)
+    {
+        // Windows has no executable bit and git ignores file modes there.
+        if (OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        var isExecutable = (File.GetUnixFileMode(fileInfo.FullName) & UnixFileMode.UserExecute) != 0;
+        return isExecutable != entry.IsExecutable;
+    }
+
+    private static GitObjectId HashFile(FileInfo fileInfo)
+    {
+        var header = Encoding.ASCII.GetBytes($"blob {fileInfo.Length}\0");
+        var content = File.ReadAllBytes(fileInfo.FullName);
+
+        var buffer = new byte[header.Length + content.Length];
+        header.CopyTo(buffer, 0);
+        content.CopyTo(buffer, header.Length);
+
+        return GitObjectId.Parse(SHA1.HashData(buffer));
+    }
+}


### PR DESCRIPTION
Closes #5036. Part of #5031 — see `docs/design/managed-git-migration.md`. Builds on #5043 (B.1), #5045 (B.2), #5048 (B.3).

## What

Fourth layer of the vendored managed reader in `src/GitVersion.Git.Managed` (still no GitVersion.Core dependency, all types `internal`) — completes the read surface `IGitRepository` needs before the B.5 interface wiring:

- **`GitTreeDiff`** (`Diff/`) — recursive changed-paths diff matching the adapter's `ICommit.DiffPaths` (`Compare<TreeChanges>(commit.Tree, firstParent?.Tree)`): identical subtrees skipped by id, git's canonical tree ordering (directories compare with a virtual trailing slash), file↔directory type changes, root commits vs the empty tree, no rename detection (parity with libgit2's default)
- **`GitIndex`** (`Status/`) — `.git/index` v2–v4 reader: v3 extended flags (skip-worktree, intent-to-add), v4 prefix-compressed paths (git's offset-encoded varints), stat data for clean detection
- **`GitIgnoreRules`** — gitignore engine: negation, directory-only patterns, anchoring, `*`/`?`/character classes/`**`, per-directory precedence with last-match-wins, `.git/info/exclude` as the weakest source. Needed because an empirical probe showed the adapter's diff **includes untracked files but excludes ignored ones**
- **`GitStatusCalculator`** — `UncommittedChangesCount` matching the adapter's exact expression (`Compare<TreeChanges>(HEAD tree, DiffTargets.Index | DiffTargets.WorkingDirectory).Count`): staged (head vs index), unstaged (index vs workdir with stat check + content re-hash on suspicion), executable-bit changes (non-Windows), skip-worktree/assume-valid respected, untracked with ignores, and the adapter's unborn-HEAD fallback

## Tests

19 new tests (135 total, all green), validating against **the exact expressions the LibGit2Sharp adapter evaluates** on git-CLI fixtures:

- `DiffPaths` parity for every commit of merge / nested-delete / exec-bit / file↔directory-type-change histories
- index entries vs `git ls-files --stage` for v2, v3 (forced via skip-worktree) and v4 (`git update-index --index-version=4`)
- status: clean, staged+modified+deleted+untracked counted once per path, touched-but-identical (re-hash proves clean), gitignore semantics (negation, anchoring, nested files, ignored dirs), `info/exclude`, executable-bit change, empty repository, index-v4 working set

## Checks

- `dotnet build ./src/GitVersion.slnx` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)