### PR TITLE
fix(git): unescape git config values in managed backend (Windows remote URL parity)

### DIFF
--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -38,6 +38,7 @@
         <InternalsVisibleTo Include="GitVersion.BuildAgents.Tests" />
         <InternalsVisibleTo Include="GitVersion.Configuration.Tests" />
         <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+        <InternalsVisibleTo Include="GitVersion.Git.Managed.Tests" />
         <InternalsVisibleTo Include="GitVersion.Output.Tests" />
         <InternalsVisibleTo Include="GitVersion.App.Tests" />
         <InternalsVisibleTo Include="GitVersion.MsBuild.Tests" />

--- a/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
@@ -7,7 +7,9 @@ public class GitConfigurationFileTests
 {
     private static GitConfigurationFile Load(string content)
     {
-        var path = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), $"gitconfig-{Guid.NewGuid():N}");
+        var directory = FileSystemHelper.Path.GetRepositoryTempPath();
+        System.IO.Directory.CreateDirectory(directory);
+        var path = FileSystemHelper.Path.Combine(directory, "config");
         File.WriteAllText(path, content);
         try
         {
@@ -15,7 +17,7 @@ public class GitConfigurationFileTests
         }
         finally
         {
-            File.Delete(path);
+            FileSystemHelper.Directory.DeleteDirectory(directory);
         }
     }
 

--- a/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
@@ -41,9 +41,9 @@ public class GitConfigurationFileTests
     [Test]
     public void KeepsForwardSlashPathUnchanged()
     {
-        var config = Load("[remote \"origin\"]\n\turl = /tmp/repositories/repo\n");
+        var config = Load("[remote \"origin\"]\n\turl = /srv/git/repositories/project.git\n");
 
-        config.GetString("remote", "origin", "url").ShouldBe("/tmp/repositories/repo");
+        config.GetString("remote", "origin", "url").ShouldBe("/srv/git/repositories/project.git");
     }
 
     [Test]

--- a/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
@@ -1,0 +1,68 @@
+using GitVersion.Helpers;
+
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitConfigurationFileTests
+{
+    private static GitConfigurationFile Load(string content)
+    {
+        var path = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPathLegacy(), $"gitconfig-{Guid.NewGuid():N}");
+        File.WriteAllText(path, content);
+        try
+        {
+            return GitConfigurationFile.Load(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void UnescapesBackslashesInUnquotedValue()
+    {
+        // git stores a Windows remote path with escaped backslashes and no surrounding quotes.
+        var config = Load("[remote \"origin\"]\n\turl = D:\\\\a\\\\_temp\\\\repo\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe(@"D:\a\_temp\repo");
+    }
+
+    [Test]
+    public void UnescapesBackslashesInQuotedValue()
+    {
+        var config = Load("[remote \"origin\"]\n\turl = \"D:\\\\a\\\\repo\"\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe(@"D:\a\repo");
+    }
+
+    [Test]
+    public void KeepsForwardSlashPathUnchanged()
+    {
+        var config = Load("[remote \"origin\"]\n\turl = /tmp/repositories/repo\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe("/tmp/repositories/repo");
+    }
+
+    [Test]
+    public void StripsInlineCommentOutsideQuotesButNotInside()
+    {
+        Load("[core]\n\tx = value ; trailing\n").GetString("core", null, "x").ShouldBe("value");
+        Load("[core]\n\tx = \"a ; b\"\n").GetString("core", null, "x").ShouldBe("a ; b");
+    }
+
+    [Test]
+    public void DecodesEscapeSequences()
+    {
+        var config = Load("[core]\n\tx = a\\tb\\nc\n");
+
+        config.GetString("core", null, "x").ShouldBe("a\tb\nc");
+    }
+
+    [Test]
+    public void TrimsUnquotedTrailingWhitespaceButKeepsQuotedWhitespace()
+    {
+        Load("[core]\n\tx = value   \n").GetString("core", null, "x").ShouldBe("value");
+        Load("[core]\n\tx = \"value   \"\n").GetString("core", null, "x").ShouldBe("value   ");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
@@ -7,7 +7,7 @@ public class GitConfigurationFileTests
 {
     private static GitConfigurationFile Load(string content)
     {
-        var path = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPathLegacy(), $"gitconfig-{Guid.NewGuid():N}");
+        var path = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), $"gitconfig-{Guid.NewGuid():N}");
         File.WriteAllText(path, content);
         try
         {

--- a/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
@@ -127,14 +127,62 @@ internal sealed class GitConfigurationFile
 
     private static string ParseValue(string raw)
     {
-        var value = StripComment(raw).Trim();
-
-        if (value.StartsWith('"') && value.EndsWith('"') && value.Length >= 2)
+        // git config values are unescaped regardless of whether they are quoted: backslash
+        // escapes (\\, \", \n, \t, \b) and double-quoted spans are processed inline, so an
+        // unquoted Windows path stored as D:\\a\\repo decodes back to D:\a\repo. Comments
+        // (# or ;) and trailing whitespace are only significant outside quotes.
+        var i = 0;
+        while (i < raw.Length && raw[i] is ' ' or '\t')
         {
-            value = value[1..^1].Replace("\\\\", "\\").Replace("\\\"", "\"");
+            i++;
         }
 
-        return value;
+        var result = new StringBuilder(raw.Length - i);
+        var inQuotes = false;
+        var contentEnd = 0;
+
+        for (; i < raw.Length; i++)
+        {
+            var current = raw[i];
+
+            if (current == '\\')
+            {
+                if (i + 1 >= raw.Length)
+                {
+                    break;
+                }
+
+                var next = raw[++i];
+                result.Append(next switch
+                {
+                    '\\' => '\\',
+                    '"' => '"',
+                    'n' => '\n',
+                    't' => '\t',
+                    'b' => '\b',
+                    _ => next
+                });
+                contentEnd = result.Length;
+            }
+            else if (current == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (!inQuotes && current is '#' or ';')
+            {
+                break;
+            }
+            else
+            {
+                result.Append(current);
+                if (inQuotes || current is not (' ' or '\t'))
+                {
+                    contentEnd = result.Length;
+                }
+            }
+        }
+
+        return result.ToString(0, contentEnd);
     }
 
     private static string StripComment(string value)

--- a/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
@@ -161,13 +161,13 @@ internal sealed class GitConfigurationFile
                 continue;
             }
 
-            if (!inQuotes && current is '#' or ';')
+            if (!inQuotes && IsCommentStart(current))
             {
                 break;
             }
 
             result.Append(current);
-            if (inQuotes || current is not (' ' or '\t'))
+            if (inQuotes || !IsWhitespace(current))
             {
                 contentEnd = result.Length;
             }
@@ -179,13 +179,17 @@ internal sealed class GitConfigurationFile
     private static int SkipLeadingWhitespace(string raw)
     {
         var index = 0;
-        while (index < raw.Length && raw[index] is ' ' or '\t')
+        while (index < raw.Length && IsWhitespace(raw[index]))
         {
             index++;
         }
 
         return index;
     }
+
+    private static bool IsWhitespace(char value) => value is ' ' or '\t';
+
+    private static bool IsCommentStart(char value) => value is '#' or ';';
 
     private static char DecodeEscape(char escaped) => escaped switch
     {

--- a/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
@@ -131,59 +131,69 @@ internal sealed class GitConfigurationFile
         // escapes (\\, \", \n, \t, \b) and double-quoted spans are processed inline, so an
         // unquoted Windows path stored as D:\\a\\repo decodes back to D:\a\repo. Comments
         // (# or ;) and trailing whitespace are only significant outside quotes.
-        var i = 0;
-        while (i < raw.Length && raw[i] is ' ' or '\t')
-        {
-            i++;
-        }
-
-        var result = new StringBuilder(raw.Length - i);
+        var index = SkipLeadingWhitespace(raw);
+        var result = new StringBuilder(raw.Length - index);
         var inQuotes = false;
         var contentEnd = 0;
 
-        for (; i < raw.Length; i++)
+        while (index < raw.Length)
         {
-            var current = raw[i];
+            var current = raw[index];
 
             if (current == '\\')
             {
-                if (i + 1 >= raw.Length)
+                if (index + 1 >= raw.Length)
                 {
                     break;
                 }
 
-                var next = raw[++i];
-                result.Append(next switch
-                {
-                    '\\' => '\\',
-                    '"' => '"',
-                    'n' => '\n',
-                    't' => '\t',
-                    'b' => '\b',
-                    _ => next
-                });
+                result.Append(DecodeEscape(raw[index + 1]));
                 contentEnd = result.Length;
+                index += 2;
+                continue;
             }
-            else if (current == '"')
+
+            index++;
+
+            if (current == '"')
             {
                 inQuotes = !inQuotes;
+                continue;
             }
-            else if (!inQuotes && current is '#' or ';')
+
+            if (!inQuotes && current is '#' or ';')
             {
                 break;
             }
-            else
+
+            result.Append(current);
+            if (inQuotes || current is not (' ' or '\t'))
             {
-                result.Append(current);
-                if (inQuotes || current is not (' ' or '\t'))
-                {
-                    contentEnd = result.Length;
-                }
+                contentEnd = result.Length;
             }
         }
 
         return result.ToString(0, contentEnd);
     }
+
+    private static int SkipLeadingWhitespace(string raw)
+    {
+        var index = 0;
+        while (index < raw.Length && raw[index] is ' ' or '\t')
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static char DecodeEscape(char escaped) => escaped switch
+    {
+        'n' => '\n',
+        't' => '\t',
+        'b' => '\b',
+        _ => escaped // covers \\ and \" and is lenient for any other escape
+    };
 
     private static string StripComment(string value)
     {


### PR DESCRIPTION
## Description

Fixes a Windows-only parity bug in the managed backend's `.git/config` parser, surfaced by the `RemotesAndRemoteBranchesAreIdenticalOnBothBackends` dual-backend test failing on the Windows CI legs (both backends, all TFMs). This is independent of the PR that exposed it (#5056 changes no source) — the bug was already on the metabranch from the B.5 config parser.

Part of #5031 (Phase B correctness).

### Root cause

`GitConfigurationFile.ParseValue` only un-escaped backslash sequences for values wrapped **entirely** in quotes. But git escapes backslashes in unquoted values too: a Windows local-clone remote URL is stored in `.git/config` as `url = D:\\a\\_temp\\repo`, which the parser returned verbatim with doubled backslashes — so the managed backend's remote URL differed from libgit2's (`D:\\a\\… ` vs `D:\a\…`). Linux/macOS use forward slashes (never escaped), so it only manifested on Windows.

### Fix

`ParseValue` is now a git-style single-pass scanner that decodes escapes (`\\`, `\"`, `\n`, `\t`, `\b`) and double-quoted spans anywhere in the value, treats `#`/`;` as comments only outside quotes, and trims unquoted trailing whitespace (quoted whitespace preserved).

### Tests

New `GitConfigurationFileTests` (6): unquoted and quoted escaped Windows paths, forward-slash paths unchanged, inline-comment stripping inside/outside quotes, escape-sequence decoding, quoted-vs-unquoted trailing whitespace. `GitVersion.Core` now grants `InternalsVisibleTo` to `GitVersion.Git.Managed.Tests` (for `FileSystemHelper`), matching the other test projects.

### Verification

- `dotnet build ./src/GitVersion.slnx` — 0 warnings, 0 errors
- Managed.Tests — 141/141
- `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
