### PR TITLE
fix(new-cli): repair new-cli build broken by the dedup refactor (missing ILogger using)

### DIFF
--- a/src/GitVersion.Core/Git/PullRequestBranchOperations.cs
+++ b/src/GitVersion.Core/Git/PullRequestBranchOperations.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace GitVersion.Git;
 
 /// <summary>


### PR DESCRIPTION
## Description

Fixes a build regression on the metabranch: **`new-cli/GitVersion.slnx` fails to compile** while `src` builds fine.

The dedup commit `f590c6951` (merged via #5053) extracted `src/GitVersion.Core/Git/PullRequestBranchOperations.cs`, which uses `ILogger` and relies on the global `using Microsoft.Extensions.Logging` from `src/Directory.Build.props`. `new-cli/GitVersion.Common` source-links that file but its Build.props provides no such global using → CS0246. It slipped through because the PR CI (`ci.yml`) doesn't build new-cli; only the separate `new-cli.yml` workflow does.

Fix: add an explicit `using Microsoft.Extensions.Logging;` so the shared-source file is self-sufficient regardless of which project globs it.

Verified: `dotnet build ./src/GitVersion.slnx` and `./new-cli/GitVersion.slnx` both 0 warnings / 0 errors.

Part of #5031.