### PR TITLE
test(msbuild): serialize process-wide env mutation across MsBuild fixtures

### DIFF
--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
@@ -50,7 +50,15 @@ public class MsBuildExeFixture
             }
         }
 
-        var results = analyzer.Build(environmentOptions);
+        // The MSBuild child process inherits the current process environment, so a build-agent
+        // variable set by a concurrent MsBuildTaskFixture (e.g. TF_BUILD) would otherwise leak into
+        // it and be wrongly detected. Entering the scope serializes against those fixtures and
+        // resets the process environment so the child starts from a clean, non-CI baseline.
+        IAnalyzerResults results;
+        using (MsBuildProcessEnvironment.Enter())
+        {
+            results = analyzer.Build(environmentOptions);
+        }
 
         return new MsBuildExeFixtureResult(this.fixture)
         {

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildProcessEnvironment.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildProcessEnvironment.cs
@@ -1,0 +1,80 @@
+using GitVersion.Agents;
+
+namespace GitVersion.MsBuild.Tests.Helpers;
+
+/// <summary>
+/// An exclusive scope over the *process-wide* environment-variable manipulation that the MsBuild
+/// task and MsBuild.exe fixtures depend on. The MsBuild task detects the current build agent from
+/// the real process environment, and the MsBuild.exe fixture launches a child process that inherits
+/// it, so both are sensitive to the environment being mutated by another fixture.
+/// </summary>
+/// <remarks>
+/// Under <c>[assembly: Parallelizable(ParallelScope.Fixtures)]</c> several fixtures run at the same
+/// time. Without coordination, one fixture setting a CI variable such as <c>TF_BUILD</c> could leak
+/// into another fixture's task or child process (making it wrongly detect a build agent), and one
+/// fixture's reset could clear another's variables mid-execution. <see cref="Enter"/> takes an
+/// exclusive lock, resets the build-agent variables to a clean baseline and applies the requested
+/// variables; disposing the scope resets them again and releases the lock, so the whole window is
+/// mutually exclusive:
+/// <code>
+/// using var environment = MsBuildProcessEnvironment.Enter(variables);
+/// // ... run the task or build ...
+/// </code>
+/// </remarks>
+internal sealed class MsBuildProcessEnvironment : IDisposable
+{
+    private static readonly object Lock = new();
+
+    private static readonly string[] BuildAgentVariableNames =
+    [
+        TeamCity.EnvironmentVariableName,
+        AppVeyor.EnvironmentVariableName,
+        TravisCi.EnvironmentVariableName,
+        Jenkins.EnvironmentVariableName,
+        AzurePipelines.EnvironmentVariableName,
+        GitHubActions.EnvironmentVariableName,
+        SpaceAutomation.EnvironmentVariableName
+    ];
+
+    private MsBuildProcessEnvironment(KeyValuePair<string, string?>[]? environmentVariables)
+    {
+        Monitor.Enter(Lock);
+        Reset();
+        Apply(environmentVariables);
+    }
+
+    /// <summary>
+    /// Acquires exclusive access to the process environment, resets the build-agent variables to a
+    /// clean, non-CI baseline and applies <paramref name="environmentVariables"/>. Dispose the
+    /// returned scope to reset again and release the lock.
+    /// </summary>
+    public static MsBuildProcessEnvironment Enter(KeyValuePair<string, string?>[]? environmentVariables = null) =>
+        new(environmentVariables);
+
+    public void Dispose()
+    {
+        Reset();
+        Monitor.Exit(Lock);
+    }
+
+    private static void Apply(KeyValuePair<string, string?>[]? environmentVariables)
+    {
+        if (environmentVariables == null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in environmentVariables)
+        {
+            SysEnv.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    private static void Reset()
+    {
+        foreach (var name in BuildAgentVariableNames)
+        {
+            SysEnv.SetEnvironmentVariable(name, null);
+        }
+    }
+}

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
@@ -1,4 +1,3 @@
-using GitVersion.Agents;
 using GitVersion.Helpers;
 using GitVersion.MsBuild.Tasks;
 using GitVersion.MsBuild.Tests.Mocks;
@@ -39,45 +38,9 @@ public class MsBuildTaskFixture(RepositoryFixtureBase fixture)
 
     private T UsingEnv<T>(Func<T> func)
     {
-        ResetEnvironment();
-        SetEnvironmentVariables(this.environmentVariables);
-
-        try
-        {
-            return func();
-        }
-        finally
-        {
-            ResetEnvironment();
-        }
-    }
-
-    private static void ResetEnvironment()
-    {
-        var environmentalVariables = new Dictionary<string, string?>
-        {
-            { TeamCity.EnvironmentVariableName, null },
-            { AppVeyor.EnvironmentVariableName, null },
-            { TravisCi.EnvironmentVariableName, null },
-            { Jenkins.EnvironmentVariableName, null },
-            { AzurePipelines.EnvironmentVariableName, null },
-            { GitHubActions.EnvironmentVariableName, null },
-            { SpaceAutomation.EnvironmentVariableName, null }
-        };
-
-        SetEnvironmentVariables([.. environmentalVariables]);
-    }
-
-    private static void SetEnvironmentVariables(KeyValuePair<string, string?>[]? envs)
-    {
-        if (envs == null)
-        {
-            return;
-        }
-
-        foreach (var (key, value) in envs)
-        {
-            SysEnv.SetEnvironmentVariable(key, value);
-        }
+        // The task reads the process-wide environment to detect the build agent, so serialize the
+        // whole set/execute/reset window against every other environment-sensitive fixture.
+        using var environment = MsBuildProcessEnvironment.Enter(this.environmentVariables);
+        return func();
     }
 }


### PR DESCRIPTION
## Description

Fixes an intermittent `WriteVersionInfoTask` test failure that showed up far more often under the managed Git backend. Investigation (dual-backend) traced it to a **pre-existing process-global environment-variable race in the MsBuild test fixtures**, not the git backend.

Part of #5031.

### Root cause

`MsBuildTaskFixture` mutates the real process environment (set/reset `TF_BUILD` etc.) so the task can detect the build agent, and `MsBuildExeFixture` launches a child process that inherits it. Under `[assembly: Parallelizable(ParallelScope.Fixtures)]` these race:
- an Azure task sees `TF_BUILD` cleared by a concurrent fixture → falls back to `LocalBuild`, emits no `##vso` output (empty log); or
- a non-CI MSBuild child inherits `TF_BUILD=true` left set by a concurrent Azure fixture → wrongly emits `##vso`.

The git backend computes the **correct version in every case** — the managed backend only *widened the race window* (~14×) because its CLI-driven normalization makes each task execution much slower (~2.8s vs libgit2 ~0.2s). The race is latent on libgit2 too.

### Fix (test-infra only; product code untouched)

New `MsBuildProcessEnvironment` helper with a shared lock + `Reset()`/`Apply()`. Both fixtures hold the lock across the whole reset→set→execute→reset window (and the exe fixture resets before launching the child), making the environment-sensitive sections mutually exclusive without disabling fixture parallelism.

### Verification

- Before: full managed-mode suite failed within 2–6 parallel runs.
- After: 14/14 (agent) + 5/5 (independent) clean full-suite managed-mode runs.
- `GitVersion.Git.Managed.Tests` 141/141; `src` + `new-cli` build 0/0; `dotnet format --verify-no-changes` clean. No product or libgit2 code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)