### PR TITLE
test: migrate GitVersion.Testing fixtures from LibGit2Sharp to the git CLI (Phase D)

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -48,7 +48,9 @@ jobs:
           GITVERSION_GIT_BACKEND: ${{ matrix.git_backend }}
         with:
           shell: pwsh
-          timeout_minutes: 30
+          # Raised from 30 to 60 while the git-CLI test fixtures (managed-git migration, #5031)
+          # run ~3x slower on the macOS/Windows runners. Revert once the fixture speedup lands.
+          timeout_minutes: 60
           max_attempts: 3
           retry_on: error
           command: 'dotnet run/build.dll --target=UnitTest --dotnet_version=${{ matrix.dotnet_version }}'

--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -5,7 +5,6 @@ using GitVersion.Helpers;
 using GitVersion.Output;
 using GitVersion.Testing.Extensions;
 using GitVersion.Tests;
-using LibGit2Sharp;
 
 namespace GitVersion.App.Tests;
 
@@ -174,7 +173,7 @@ public class PullRequestInBuildAgentTest
     {
         var remoteRepositoryPath = FileSystemHelper.Path.GetRepositoryTempPath();
         RepositoryFixtureBase.Init(remoteRepositoryPath);
-        using var remoteRepository = new Repository(remoteRepositoryPath);
+        using var remoteRepository = new TestRepository(remoteRepositoryPath);
         remoteRepository.Config.Set("user.name", "Test");
         remoteRepository.Config.Set("user.email", "test@email.com");
         fixture.Repository.Network.Remotes.Add("origin", remoteRepositoryPath);
@@ -184,11 +183,11 @@ public class PullRequestInBuildAgentTest
         var branch = remoteRepository.CreateBranch("FeatureBranch");
         Commands.Checkout(remoteRepository, branch);
         remoteRepository.MakeCommits(2);
-        Commands.Checkout(remoteRepository, remoteRepository.Head.Tip.Sha);
+        Commands.Checkout(remoteRepository, remoteRepository.Head.Tip);
         //Emulate merge commit
         var mergeCommitSha = remoteRepository.MakeACommit().Sha;
         Commands.Checkout(remoteRepository, TestBase.MainBranch); // HEAD cannot be pointing at the merge commit
-        remoteRepository.Refs.Add(pullRequestRef, new ObjectId(mergeCommitSha));
+        remoteRepository.Refs.Add(pullRequestRef, mergeCommitSha);
 
         // Checkout PR commit
         Commands.Fetch(fixture.Repository, "origin", [], new FetchOptions(), null);

--- a/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
+++ b/src/GitVersion.App.Tests/TagCheckoutInBuildAgentTests.cs
@@ -2,7 +2,6 @@ using GitVersion.Agents;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.Tests;
-using LibGit2Sharp;
 
 namespace GitVersion.App.Tests;
 
@@ -38,7 +37,7 @@ public class TagCheckoutInBuildAgentTests
         using var fixture = new EmptyRepositoryFixture();
         var remoteRepositoryPath = FileSystemHelper.Path.GetRepositoryTempPath();
         RepositoryFixtureBase.Init(remoteRepositoryPath);
-        using (var remoteRepository = new Repository(remoteRepositoryPath))
+        using (var remoteRepository = new TestRepository(remoteRepositoryPath))
         {
             remoteRepository.Config.Set("user.name", "Test");
             remoteRepository.Config.Set("user.email", "test@email.com");

--- a/src/GitVersion.Core.Tests/Core/DualBackendParityTests.cs
+++ b/src/GitVersion.Core.Tests/Core/DualBackendParityTests.cs
@@ -184,17 +184,17 @@ public class DualBackendParityTests : TestBase
     public void UncommittedChangesCountIsIdenticalOnBothBackends()
     {
         using var fixture = new EmptyRepositoryFixture();
-        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
+        var signature = new Signature("unit test", "test@example.com", DateTimeOffset.Now);
 
         var trackedFile = FileSystemHelper.Path.Combine(fixture.RepositoryPath, "tracked.txt");
         File.WriteAllText(trackedFile, "one");
-        LibGit2Sharp.Commands.Stage(fixture.Repository, "tracked.txt");
-        fixture.Repository.Commit("add tracked file", signature, signature, new LibGit2Sharp.CommitOptions());
+        Commands.Stage(fixture.Repository, "tracked.txt");
+        fixture.Repository.Commit("add tracked file", signature, signature, new CommitOptions());
 
         File.WriteAllText(trackedFile, "two");
         File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "untracked.txt"), "new");
         File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "staged.txt"), "staged");
-        LibGit2Sharp.Commands.Stage(fixture.Repository, "staged.txt");
+        Commands.Stage(fixture.Repository, "staged.txt");
 
         using var backends = OpenBothBackends(fixture);
         backends.Managed.UncommittedChangesCount().ShouldBe(backends.LibGit2.UncommittedChangesCount());
@@ -219,7 +219,7 @@ public class DualBackendParityTests : TestBase
     {
         using var fixture = CreateComplexFixture();
         var detachAt = fixture.Repository.Head.Tip.Parents.First();
-        LibGit2Sharp.Commands.Checkout(fixture.Repository, detachAt);
+        Commands.Checkout(fixture.Repository, detachAt);
 
         using var backends = OpenBothBackends(fixture);
 
@@ -328,7 +328,7 @@ public class DualBackendParityTests : TestBase
         using var fixture = new EmptyRepositoryFixture();
         fixture.MakeACommit("only commit");
         fixture.ApplyTag("lightweight");
-        fixture.Repository.Tags.Add("annotated", fixture.Repository.Head.Tip, new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now), "the same commit, annotated");
+        fixture.Repository.Tags.Add("annotated", fixture.Repository.Head.Tip, new Signature("unit test", "test@example.com", DateTimeOffset.Now), "the same commit, annotated");
 
         using var backends = OpenBothBackends(fixture);
 
@@ -385,12 +385,12 @@ public class DualBackendParityTests : TestBase
     public void IndexVersionFourBehavesIdenticallyOnBothBackends()
     {
         using var fixture = new EmptyRepositoryFixture();
-        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
+        var signature = new Signature("unit test", "test@example.com", DateTimeOffset.Now);
 
         var trackedFile = FileSystemHelper.Path.Combine(fixture.RepositoryPath, "tracked.txt");
         File.WriteAllText(trackedFile, "one");
-        LibGit2Sharp.Commands.Stage(fixture.Repository, "tracked.txt");
-        fixture.Repository.Commit("add tracked file", signature, signature, new LibGit2Sharp.CommitOptions());
+        Commands.Stage(fixture.Repository, "tracked.txt");
+        fixture.Repository.Commit("add tracked file", signature, signature, new CommitOptions());
 
         GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} update-index --index-version 4", ".");
         File.WriteAllText(trackedFile, "two");
@@ -445,7 +445,7 @@ public class DualBackendParityTests : TestBase
         fixture.Checkout("main");
         fixture.MakeACommit("main two");
         fixture.MergeNoFF("develop");
-        fixture.Repository.Tags.Add("v2.0.0", fixture.Repository.Head.Tip, new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now), "an annotated tag");
+        fixture.Repository.Tags.Add("v2.0.0", fixture.Repository.Head.Tip, new Signature("unit test", "test@example.com", DateTimeOffset.Now), "an annotated tag");
         fixture.BranchTo("feature/complex");
         fixture.MakeACommit("feature one");
         fixture.Checkout("develop");
@@ -461,8 +461,8 @@ public class DualBackendParityTests : TestBase
     private static RepositoryFixtureBase CreateCrissCrossFixture()
     {
         var fixture = new EmptyRepositoryFixture();
-        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
-        var mergeOptions = new LibGit2Sharp.MergeOptions { FastForwardStrategy = LibGit2Sharp.FastForwardStrategy.NoFastForward };
+        var signature = new Signature("unit test", "test@example.com", DateTimeOffset.Now);
+        var mergeOptions = new MergeOptions { FastForwardStrategy = FastForwardStrategy.NoFastForward };
 
         fixture.MakeACommit("base");
         fixture.BranchTo("develop");

--- a/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
@@ -1,7 +1,6 @@
 using GitVersion.Git;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests;
 
@@ -56,7 +55,7 @@ public class GitCliMutatorTests : TestBase
         {
             CreateMutator().Clone(fixture.RepositoryPath, targetPath, new AuthenticationInfo());
 
-            using var clonedRepository = new Repository(targetPath);
+            using var clonedRepository = new TestRepository(targetPath);
             clonedRepository.Head.Tip.ShouldNotBeNull();
             Directory.EnumerateFileSystemEntries(targetPath)
                 .Where(entry => FileSystemHelper.Path.GetFileName(entry) != ".git")

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -6,7 +6,6 @@ using GitVersion.Git;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation.Caching;
-using LibGit2Sharp;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace GitVersion.Tests;
@@ -115,8 +114,7 @@ public class GitVersionExecutorTests : TestBase
         try
         {
             // create a branch and a new worktree for it
-            var repo = new Repository(fixture.RepositoryPath);
-            repo.Worktrees.Add("worktree", worktreePath, false);
+            fixture.Repository.Worktrees.Add("worktree", worktreePath, false);
 
             const string targetUrl = "https://github.com/GitTools/GitVersion.git";
 
@@ -329,8 +327,7 @@ public class GitVersionExecutorTests : TestBase
         try
         {
             // create a branch and a new worktree for it
-            var repo = new Repository(fixture.RepositoryPath);
-            repo.Worktrees.Add("worktree", worktreePath, false);
+            fixture.Repository.Worktrees.Add("worktree", worktreePath, false);
 
             const string targetUrl = "https://github.com/GitTools/GitVersion.git";
 
@@ -385,8 +382,7 @@ public class GitVersionExecutorTests : TestBase
         try
         {
             // create a branch and a new worktree for it
-            var repo = new Repository(fixture.RepositoryPath);
-            repo.Worktrees.Add("worktree", worktreePath, false);
+            fixture.Repository.Worktrees.Add("worktree", worktreePath, false);
 
             var gitVersionOptions = new GitVersionOptions { WorkingDirectory = worktreePath };
 

--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -6,7 +6,6 @@ using GitVersion.Helpers;
 using GitVersion.OutputVariables;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests;
 
@@ -72,38 +71,19 @@ public static class GitRepositoryTestingExtensions
             => DumpGraph(repository.Path, writer, maxCommits);
     }
 
-    extension(IRepository repository)
+    extension(TestRepository repository)
     {
-        public void DumpGraph(Action<string>? writer = null, int? maxCommits = null)
-            => DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
-    }
-
-    extension(LibGit2Sharp.RemoteCollection remotes)
-    {
-        public void RenameRemote(string oldName, string newName)
+        public IGitRepository ToGitRepository()
         {
-            if (oldName.IsEquivalentTo(newName))
-            {
-                return;
-            }
-
-            if (remotes.Any(remote => remote.Name == newName))
-            {
-                throw new InvalidOperationException($"A remote with the name '{newName}' already exists.");
-            }
-            if (remotes.All(remote => remote.Name != oldName))
-            {
-                throw new InvalidOperationException($"A remote with the name '{oldName}' does not exist.");
-            }
-            remotes.Add(newName, remotes[oldName].Url);
-            remotes.Remove(oldName);
+            using var libGit2Repository = new LibGit2Sharp.Repository(repository.Path);
+            return libGit2Repository.ToGitRepository();
         }
     }
 
     extension(RepositoryFixtureBase fixture)
     {
         public GitVersionVariables GetVersion(IGitVersionConfiguration? configuration = null,
-                                              IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
+                                              TestRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
         {
             repository ??= fixture.Repository;
             configuration ??= GitFlowConfigurationBuilder.New.Build();
@@ -111,7 +91,7 @@ public static class GitRepositoryTestingExtensions
             var overrideConfiguration = new Dictionary<object, object?>();
             var options = Options.Create(new GitVersionOptions
             {
-                WorkingDirectory = repository.Info.WorkingDirectory,
+                WorkingDirectory = repository.Path,
                 ConfigurationInfo = { OverrideConfiguration = overrideConfiguration },
                 RepositoryInfo =
                 {
@@ -159,7 +139,7 @@ public static class GitRepositoryTestingExtensions
         }
 
         public void AssertFullSemver(string fullSemver,
-                                     IGitVersionConfiguration? configuration = null, IRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
+                                     IGitVersionConfiguration? configuration = null, TestRepository? repository = null, string? commitId = null, bool onlyTrackedBranches = true, string? targetBranch = null)
         {
             repository ??= fixture.Repository;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/BranchWithoutCommitScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/BranchWithoutCommitScenarios.cs
@@ -1,5 +1,4 @@
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DevelopScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitFlow.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitHubFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForGitHubFlow.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/HotfixBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/HotfixBranchScenarios.cs
@@ -1,6 +1,5 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 
@@ -53,7 +52,7 @@ public class HotfixBranchScenarios : TestBase
         });
         // Merge hotfix branch to support
         var branch = fixture.Repository.CreateBranch(
-            "support-1.1", (Commit)fixture.Repository.Tags.Single(t => t.FriendlyName == "1.1.0").Target
+            "support-1.1", fixture.Repository.Tags.Single(t => t.FriendlyName == "1.1.0").Target
         );
         Commands.Checkout(fixture.Repository, branch);
         fixture.AssertFullSemver("1.1.0");
@@ -80,7 +79,7 @@ public class HotfixBranchScenarios : TestBase
         // Merge hotfix branch to support
         fixture.Checkout(MainBranch);
         var tag = fixture.Repository.Tags.Single(t => t.FriendlyName == "1.1.0");
-        fixture.Repository.CreateBranch("support-1.1", (Commit)tag.Target);
+        fixture.Repository.CreateBranch("support-1.1", tag.Target);
         fixture.Checkout("support-1.1");
         fixture.AssertFullSemver("1.1.0");
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreCommitScenarios.cs
@@ -344,7 +344,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("C");
         fixture.MakeACommit("D");
 
-        var ignoredPath = fixture.Repository.Diff.Compare<LibGit2Sharp.TreeChanges>(commitA.Tree, commitB.Tree).Select(element => element.Path).First();
+        var ignoredPath = fixture.Repository.DiffPaths(commitA, commitB).First();
 
         var configuration = TrunkBasedConfigurationBuilder.New
             .WithIgnoreConfiguration(new IgnoreConfiguration { Paths = { ignoredPath } })
@@ -364,7 +364,7 @@ public class IgnoreCommitScenarios : TestBase
         var commitC = fixture.Repository.MakeACommit("C");
         fixture.MakeACommit("D");
 
-        var ignoredPath = fixture.Repository.Diff.Compare<LibGit2Sharp.TreeChanges>(commitA.Tree, commitC.Tree).Select(element => element.Path).First();
+        var ignoredPath = fixture.Repository.DiffPaths(commitA, commitC).First();
 
         var configuration = TrunkBasedConfigurationBuilder.New
             .WithIgnoreConfiguration(new IgnoreConfiguration { Paths = { ignoredPath } })
@@ -384,7 +384,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.MakeACommit("C");
         fixture.MakeACommit("D");
 
-        var ignoredPath = fixture.Repository.Diff.Compare<LibGit2Sharp.TreeChanges>(commitA.Tree, commitB.Tree).Select(element => element.Path).First();
+        var ignoredPath = fixture.Repository.DiffPaths(commitA, commitB).First();
 
         var configuration = GitHubFlowConfigurationBuilder.New
             .WithIgnoreConfiguration(new IgnoreConfiguration { Paths = { ignoredPath } })
@@ -404,7 +404,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.ApplyTag("1.0.0");
         fixture.MakeACommit("C");
 
-        var ignoredPath = fixture.Repository.Diff.Compare<LibGit2Sharp.TreeChanges>(commitA.Tree, commitB.Tree).Select(element => element.Path).First();
+        var ignoredPath = fixture.Repository.DiffPaths(commitA, commitB).First();
 
         var configuration = TrunkBasedConfigurationBuilder.New
             .WithIgnoreConfiguration(new IgnoreConfiguration { Paths = { ignoredPath } })
@@ -424,7 +424,7 @@ public class IgnoreCommitScenarios : TestBase
         fixture.ApplyTag("1.0.0");
         fixture.MakeACommit("C");
 
-        var ignoredPath = fixture.Repository.Diff.Compare<LibGit2Sharp.TreeChanges>(commitA.Tree, commitB.Tree).Select(element => element.Path).First();
+        var ignoredPath = fixture.Repository.DiffPaths(commitA, commitB).First();
 
         var configuration = GitHubFlowConfigurationBuilder.New
             .WithIgnoreConfiguration(new IgnoreConfiguration { Paths = { ignoredPath } })

--- a/src/GitVersion.Core.Tests/IntegrationTests/MainScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/MainScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherBranchScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/OtherScenarios.cs
@@ -5,7 +5,6 @@ using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -1,6 +1,5 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ReleaseBranchScenarios.cs
@@ -1,6 +1,5 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -1,6 +1,5 @@
 using GitVersion.Agents;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 
@@ -22,10 +21,10 @@ public class RemoteRepositoryScenarios : TestBase
         using var fixture = new RemoteRepositoryFixture(
             path =>
             {
-                Repository.Init(path);
+                RepositoryFixtureBase.Init(path);
                 Console.WriteLine("Created git repository at '{0}'", path);
 
-                var repo = new Repository(path);
+                var repo = new TestRepository(path);
                 repo.MakeCommits(5);
 
                 repo.CreateBranch("develop");
@@ -78,7 +77,7 @@ public class RemoteRepositoryScenarios : TestBase
         fixture.Repository.MakeACommit();
         fixture.AssertFullSemver("0.0.1-6");
         fixture.AssertFullSemver("0.0.1-5", repository: fixture.LocalRepositoryFixture.Repository);
-        var buildSignature = fixture.LocalRepositoryFixture.Repository.Config.BuildSignature(new(DateTime.Now));
+        var buildSignature = Generate.SignatureNow();
         Commands.Pull(fixture.LocalRepositoryFixture.Repository, buildSignature, new());
         fixture.AssertFullSemver("0.0.1-6", repository: fixture.LocalRepositoryFixture.Repository);
     }
@@ -121,7 +120,7 @@ public class RemoteRepositoryScenarios : TestBase
         local.AssertFullSemver("1.0.2-bug-hotfix.1+1");
     }
 
-    private static void CopyRemoteBranchesToHeads(Repository repository)
+    private static void CopyRemoteBranchesToHeads(TestRepository repository)
     {
         foreach (var branch in repository.Branches)
         {
@@ -130,10 +129,10 @@ public class RemoteRepositoryScenarios : TestBase
                 continue;
             }
 
-            var localName = branch.FriendlyName.Replace($"{branch.RemoteName}/", "");
-            if (repository.Branches[localName] == null)
+            var localName = branch.FriendlyName[(branch.FriendlyName.IndexOf('/') + 1)..];
+            if (localName != "HEAD" && repository.Branches[localName] == null)
             {
-                repository.CreateBranch(localName, branch.FriendlyName);
+                repository.Branches.Add(localName, branch.FriendlyName);
             }
         }
     }

--- a/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SupportBranchScenarios.cs
@@ -1,6 +1,5 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/SwitchingToGitFlowScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/SwitchingToGitFlowScenarios.cs
@@ -1,5 +1,4 @@
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionBumpingScenarios.cs
@@ -1,7 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInCurrentBranchNameScenarios.cs
@@ -1,5 +1,4 @@
 using GitVersion.Configuration;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
@@ -1,5 +1,4 @@
 using GitVersion.Configuration;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/WorktreeScenarios.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 

--- a/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/NextVersionCalculatorTests.cs
@@ -1,6 +1,5 @@
 using GitVersion.Configuration;
 using GitVersion.VersionCalculation;
-using LibGit2Sharp;
 
 namespace GitVersion.Tests.VersionCalculation;
 

--- a/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
+++ b/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
@@ -5,6 +5,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Used directly by parity tests that compare the managed backend against libgit2. -->
+        <PackageReference Include="LibGit2Sharp" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="GitVersion.Git" />
     </ItemGroup>
 

--- a/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/TestTaskBase.cs
@@ -6,7 +6,6 @@ using GitVersion.MsBuild.Tasks;
 using GitVersion.MsBuild.Tests.Helpers;
 using GitVersion.Testing.Extensions;
 using GitVersion.Tests;
-using LibGit2Sharp;
 using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace GitVersion.MsBuild.Tests.Tasks;

--- a/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
+++ b/src/GitVersion.Output.Tests/Output/FormatArgumentTests.cs
@@ -1,7 +1,6 @@
 using GitVersion.Output.OutputGenerator;
 using GitVersion.Testing.Extensions;
 using GitVersion.Tests;
-using LibGit2Sharp;
 
 namespace GitVersion.Output.Tests;
 

--- a/src/GitVersion.Testing/Extensions/GitTestExtensions.cs
+++ b/src/GitVersion.Testing/Extensions/GitTestExtensions.cs
@@ -1,75 +1,9 @@
-using GitVersion.Helpers;
 using GitVersion.Testing.Internal;
-using LibGit2Sharp;
 
 namespace GitVersion.Testing.Extensions;
 
 public static class GitTestExtensions
 {
-    private static int _pad = 1;
-
-    extension(IRepository repository)
-    {
-        public Commit MakeACommit(string? commitMessage = null) => CreateFileAndCommit(repository, Guid.NewGuid().ToString(), commitMessage);
-        public void MergeNoFF(string branch) => MergeNoFF(repository, branch, Generate.SignatureNow());
-
-        public void MergeNoFF(string branch, Signature sig) => repository.Merge(repository.Branches[branch], sig, new MergeOptions
-        {
-            FastForwardStrategy = FastForwardStrategy.NoFastForward
-        });
-
-        public Commit[] MakeCommits(int numCommitsToMake)
-            => [.. Enumerable.Range(1, numCommitsToMake).Select(_ => repository.MakeACommit())];
-
-        private Commit CreateFileAndCommit(string relativeFileName, string? commitMessage = null)
-        {
-            var randomFile = FileSystemHelper.Path.Combine(repository.Info.WorkingDirectory, relativeFileName);
-            if (FileSystemHelper.File.Exists(randomFile))
-            {
-                FileSystemHelper.File.Delete(randomFile);
-            }
-
-            var totalWidth = 36 + (_pad++ % 10);
-            var contents = Guid.NewGuid().ToString().PadRight(totalWidth, '.');
-            FileSystemHelper.File.WriteAllText(randomFile, contents);
-
-            Commands.Stage(repository, randomFile);
-
-            return repository.Commit(commitMessage ?? $"Test Commit for file '{relativeFileName}'",
-                Generate.SignatureNow(), Generate.SignatureNow());
-        }
-
-        public Tag MakeATaggedCommit(string tag)
-        {
-            var commit = repository.MakeACommit();
-            var existingTag = repository.Tags.SingleOrDefault(t => t.FriendlyName == tag);
-            return existingTag ?? repository.Tags.Add(tag, commit);
-        }
-
-        public Commit CreatePullRequestRef(string from, string to, int prNumber = 2, bool normalise = false, bool allowFastForwardMerge = false)
-        {
-            Commands.Checkout(repository, repository.Branches[to].Tip);
-            if (allowFastForwardMerge)
-            {
-                repository.Merge(repository.Branches[from], Generate.SignatureNow());
-            }
-            else
-            {
-                repository.MergeNoFF(from);
-            }
-            var commit = repository.Head.Tip;
-            repository.Refs.Add("refs/pull/" + prNumber + "/merge", commit.Id);
-            Commands.Checkout(repository, to);
-            if (normalise)
-            {
-                // Turn the ref into a real branch
-                Commands.Checkout(repository, repository.Branches.Add("pull/" + prNumber + "/merge", commit));
-            }
-
-            return commit;
-        }
-    }
-
     public static void ExecuteGitCmd(string gitCmd, string workingDirectory, Action<string>? writer = null)
     {
         var output = new StringBuilder();

--- a/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
@@ -1,6 +1,4 @@
 using GitVersion.Helpers;
-using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 
 namespace GitVersion.Testing;
 
@@ -22,18 +20,18 @@ public class BaseGitFlowRepositoryFixture : EmptyRepositoryFixture
     /// <para>Creates a repo with a develop branch off main which is a single commit ahead of main</para>
     /// <para>The initial setup actions will be performed before branching develop</para>
     /// </summary>
-    public BaseGitFlowRepositoryFixture(Action<IRepository> initialMainAction, string branchName = "main") :
+    public BaseGitFlowRepositoryFixture(Action<TestRepository> initialMainAction, string branchName = "main") :
         base(branchName) => SetupRepo(initialMainAction);
 
-    private void SetupRepo(Action<IRepository> initialMainAction)
+    private void SetupRepo(Action<TestRepository> initialMainAction)
     {
-        var randomFile = FileSystemHelper.Path.Combine(Repository.Info.WorkingDirectory, Guid.NewGuid().ToString());
+        var randomFile = FileSystemHelper.Path.Combine(Repository.Path, Guid.NewGuid().ToString());
         FileSystemHelper.File.WriteAllText(randomFile, string.Empty);
-        Commands.Stage(Repository, randomFile);
+        Repository.Stage(randomFile);
 
         initialMainAction(Repository);
 
-        Commands.Checkout(Repository, Repository.CreateBranch("develop"));
+        Repository.Checkout(Repository.CreateBranch("develop"));
         Repository.MakeACommit();
     }
 }

--- a/src/GitVersion.Testing/Fixtures/LocalRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/LocalRepositoryFixture.cs
@@ -1,5 +1,3 @@
-using LibGit2Sharp;
-
 namespace GitVersion.Testing;
 
-public class LocalRepositoryFixture(Repository repository) : RepositoryFixtureBase(repository);
+public class LocalRepositoryFixture(TestRepository repository) : RepositoryFixtureBase(repository);

--- a/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
+++ b/src/GitVersion.Testing/Fixtures/RemoteRepositoryFixture.cs
@@ -1,5 +1,3 @@
-using LibGit2Sharp;
-
 namespace GitVersion.Testing;
 
 /// <summary>
@@ -9,7 +7,7 @@ namespace GitVersion.Testing;
 /// </summary>
 public class RemoteRepositoryFixture : RepositoryFixtureBase
 {
-    public RemoteRepositoryFixture(Func<string, Repository> builder)
+    public RemoteRepositoryFixture(Func<string, TestRepository> builder)
         : base(builder) => LocalRepositoryFixture = CloneRepository();
 
     public RemoteRepositoryFixture(string branchName = "main")

--- a/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
+++ b/src/GitVersion.Testing/Fixtures/RepositoryFixtureBase.cs
@@ -1,7 +1,6 @@
 using GitVersion.Extensions;
 using GitVersion.Helpers;
 using GitVersion.Testing.Extensions;
-using LibGit2Sharp;
 using Shouldly;
 
 namespace GitVersion.Testing;
@@ -11,12 +10,12 @@ namespace GitVersion.Testing;
 /// </summary>
 public abstract class RepositoryFixtureBase : IDisposable
 {
-    protected RepositoryFixtureBase(Func<string, Repository> repositoryBuilder)
+    protected RepositoryFixtureBase(Func<string, TestRepository> repositoryBuilder)
         : this(repositoryBuilder(FileSystemHelper.Path.GetRepositoryTempPath()))
     {
     }
 
-    protected RepositoryFixtureBase(Repository repository)
+    protected RepositoryFixtureBase(TestRepository repository)
     {
         SequenceDiagram = new();
         Repository = repository.ShouldNotBeNull();
@@ -24,9 +23,9 @@ public abstract class RepositoryFixtureBase : IDisposable
         Repository.Config.Set("user.email", "test@email.com");
     }
 
-    public Repository Repository { get; }
+    public TestRepository Repository { get; }
 
-    public string RepositoryPath => Repository.Info.WorkingDirectory.TrimEnd('\\');
+    public string RepositoryPath => Repository.Path;
 
     public SequenceDiagram SequenceDiagram { get; }
 
@@ -67,7 +66,7 @@ public abstract class RepositoryFixtureBase : IDisposable
         Console.WriteLine(SequenceDiagram.GetDiagram());
     }
 
-    public void Checkout(string branch) => Commands.Checkout(Repository, branch);
+    public void Checkout(string branch) => Repository.Checkout(branch);
 
     public void Remove(string branch)
     {
@@ -100,14 +99,14 @@ public abstract class RepositoryFixtureBase : IDisposable
     {
         SequenceDiagram.BranchTo(branchName, Repository.Head.FriendlyName, @as);
         var branch = Repository.CreateBranch(branchName);
-        Commands.Checkout(Repository, branch);
+        Repository.Checkout(branch);
     }
 
     public void BranchToFromTag(string branchName, string fromTag, string onBranch, string? @as = null)
     {
         SequenceDiagram.BranchToFromTag(branchName, fromTag, onBranch, @as);
         var branch = Repository.CreateBranch(branchName);
-        Commands.Checkout(Repository, branch);
+        Repository.Checkout(branch);
     }
 
     public string MakeACommit()
@@ -160,17 +159,17 @@ public abstract class RepositoryFixtureBase : IDisposable
     public LocalRepositoryFixture CloneRepository()
     {
         var localPath = FileSystemHelper.Path.GetRepositoryTempPath();
-        Repository.Clone(RepositoryPath, localPath);
+        var localRepository = TestRepository.Clone(RepositoryPath, localPath);
         Console.WriteLine($"Cloned repository to '{localPath}' from '{RepositoryPath}'");
-        return new LocalRepositoryFixture(new Repository(localPath));
+        return new(localRepository);
     }
 
-    protected static Repository CreateNewRepository(string path, string branchName, int commits = 0)
+    protected static TestRepository CreateNewRepository(string path, string branchName, int commits = 0)
     {
         Init(path, branchName);
         Console.WriteLine("Created git repository at '{0}'", path);
 
-        var repository = new Repository(path);
+        var repository = new TestRepository(path);
         if (commits > 0)
         {
             repository.MakeCommits(commits);
@@ -188,5 +187,8 @@ public abstract class RepositoryFixtureBase : IDisposable
     }
 
     public void Fetch(string remote, FetchOptions? options = null)
-        => Commands.Fetch(Repository, remote, [], options, null);
+    {
+        _ = options;
+        Repository.Fetch(remote);
+    }
 }

--- a/src/GitVersion.Testing/Generate.cs
+++ b/src/GitVersion.Testing/Generate.cs
@@ -1,5 +1,3 @@
-using LibGit2Sharp;
-
 namespace GitVersion.Testing;
 
 /// <summary>
@@ -8,7 +6,7 @@ namespace GitVersion.Testing;
 public static class Generate
 {
     /// <summary>
-    /// Create a libgit2sharp signature at VirtualTime.Now
+    /// Create a signature at VirtualTime.Now
     /// </summary>
     public static Signature SignatureNow()
     {
@@ -17,7 +15,7 @@ public static class Generate
     }
 
     /// <summary>
-    /// Creates a libgit2sharp signature at the specified time
+    /// Creates a signature at the specified time
     /// </summary>
     private static Signature Signature(DateTimeOffset dateTimeOffset) => new("A. U. Thor", "thor@valhalla.asgard.com", dateTimeOffset);
 }

--- a/src/GitVersion.Testing/Git/Commands.cs
+++ b/src/GitVersion.Testing/Git/Commands.cs
@@ -1,0 +1,29 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Static façade mirroring the shape of the git library's <c>Commands</c> class so existing
+///     test call sites keep compiling against <see cref="TestRepository" />.
+/// </summary>
+public static class Commands
+{
+    public static void Checkout(TestRepository repository, string committish) => repository.Checkout(committish);
+
+    public static void Checkout(TestRepository repository, TestBranch branch) => repository.Checkout(branch);
+
+    public static void Checkout(TestRepository repository, TestCommit commit) => repository.Checkout(commit);
+
+    public static void Stage(TestRepository repository, string path) => repository.Stage(path);
+
+    public static void Fetch(TestRepository repository, string remote, IEnumerable<string> refspecs, FetchOptions? options, string? logMessage)
+    {
+        _ = options;
+        _ = logMessage;
+        repository.Fetch(remote, refspecs);
+    }
+
+    public static void Pull(TestRepository repository, Signature merger, PullOptions? options)
+    {
+        _ = options;
+        repository.Run(merger, merger, ["pull", "--no-edit"]);
+    }
+}

--- a/src/GitVersion.Testing/Git/GitCliRunner.cs
+++ b/src/GitVersion.Testing/Git/GitCliRunner.cs
@@ -1,0 +1,76 @@
+namespace GitVersion.Testing.Internal;
+
+/// <summary>
+///     Runs the real `git` executable with a deterministic, machine-configuration-free environment.
+/// </summary>
+internal static class GitCliRunner
+{
+    /// <summary>
+    ///     A path that is guaranteed not to contain a git configuration file, used to make sure the
+    ///     user's global configuration never leaks into test repositories.
+    /// </summary>
+    private static readonly string EmptyGlobalConfigPath =
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), "gitversion-testing-empty-gitconfig");
+
+    private static readonly string[] IsolationArguments =
+    [
+        "-c", "commit.gpgsign=false",
+        "-c", "tag.gpgsign=false",
+        "-c", "gc.auto=0",
+        "-c", "core.autocrlf=false",
+        "-c", "protocol.file.allow=always"
+    ];
+
+    public static string Run(string workingDirectory, IReadOnlyCollection<string> arguments, Signature? author = null, Signature? committer = null)
+    {
+        var exitCode = TryRun(workingDirectory, arguments, out var output, out var error, author, committer);
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} (in '{workingDirectory}') exited with code {exitCode}:{SysEnv.NewLine}{output}{SysEnv.NewLine}{error}");
+        }
+
+        return output;
+    }
+
+    public static int TryRun(string workingDirectory, IReadOnlyCollection<string> arguments, out string output, out string error, Signature? author = null, Signature? committer = null)
+    {
+        var outputBuilder = new StringBuilder();
+        var errorBuilder = new StringBuilder();
+        var exitCode = ProcessHelper.Run(
+            o => outputBuilder.AppendLine(o),
+            e => errorBuilder.AppendLine(e),
+            null,
+            "git",
+            [.. IsolationArguments, .. arguments],
+            workingDirectory,
+            [.. GetEnvironmentVariables(author, committer)]);
+
+        output = outputBuilder.ToString();
+        error = errorBuilder.ToString();
+        return exitCode;
+    }
+
+    private static IEnumerable<KeyValuePair<string, string?>> GetEnvironmentVariables(Signature? author, Signature? committer)
+    {
+        yield return new("GIT_CONFIG_NOSYSTEM", "1");
+        yield return new("GIT_CONFIG_GLOBAL", EmptyGlobalConfigPath);
+        yield return new("GIT_TERMINAL_PROMPT", "0");
+
+        if (author is not null)
+        {
+            yield return new("GIT_AUTHOR_NAME", author.Name);
+            yield return new("GIT_AUTHOR_EMAIL", author.Email);
+            yield return new("GIT_AUTHOR_DATE", FormatDate(author.When));
+        }
+
+        if (committer is not null)
+        {
+            yield return new("GIT_COMMITTER_NAME", committer.Name);
+            yield return new("GIT_COMMITTER_EMAIL", committer.Email);
+            yield return new("GIT_COMMITTER_DATE", FormatDate(committer.When));
+        }
+    }
+
+    private static string FormatDate(DateTimeOffset when) => when.ToString("yyyy-MM-dd'T'HH:mm:sszzz");
+}

--- a/src/GitVersion.Testing/Git/GitOptions.cs
+++ b/src/GitVersion.Testing/Git/GitOptions.cs
@@ -1,0 +1,35 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Options controlling how <see cref="TestRepository.Commit(string, Signature, Signature, CommitOptions?)" /> creates a commit.
+/// </summary>
+public sealed class CommitOptions
+{
+    public bool AmendPreviousCommit { get; set; }
+    public bool AllowEmptyCommit { get; set; }
+}
+
+/// <summary>
+///     Options controlling how merges are performed.
+/// </summary>
+public sealed class MergeOptions
+{
+    public FastForwardStrategy FastForwardStrategy { get; set; }
+}
+
+public enum FastForwardStrategy
+{
+    Default = 0,
+    NoFastForward = 1,
+    FastForwardOnly = 2
+}
+
+/// <summary>
+///     Options controlling fetch behavior. Present for call-site compatibility; fetches always use default behavior.
+/// </summary>
+public sealed class FetchOptions;
+
+/// <summary>
+///     Options controlling pull behavior. Present for call-site compatibility; pulls always use default behavior.
+/// </summary>
+public sealed class PullOptions;

--- a/src/GitVersion.Testing/Git/Signature.cs
+++ b/src/GitVersion.Testing/Git/Signature.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     An author/committer/tagger identity with a fixed timestamp, mirroring the shape of a git signature.
+/// </summary>
+public sealed record Signature(string Name, string Email, DateTimeOffset When);

--- a/src/GitVersion.Testing/Git/TestBranch.cs
+++ b/src/GitVersion.Testing/Git/TestBranch.cs
@@ -1,0 +1,36 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     A lightweight view of a branch in a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestBranch
+{
+    private readonly TestRepository repository;
+    private readonly string target;
+
+    internal TestBranch(TestRepository repository, string canonicalName, string friendlyName, string? target = null)
+    {
+        this.repository = repository;
+        this.target = target ?? canonicalName;
+        CanonicalName = canonicalName;
+        FriendlyName = friendlyName;
+    }
+
+    public string CanonicalName { get; }
+
+    public string FriendlyName { get; }
+
+    public bool IsRemote => CanonicalName.StartsWith("refs/remotes/", StringComparison.Ordinal);
+
+    /// <summary>
+    ///     The commit the branch points at.
+    /// </summary>
+    public TestCommit Tip => this.repository.LookupRequired(this.target);
+
+    /// <summary>
+    ///     The commits reachable from the branch tip, newest first.
+    /// </summary>
+    public IReadOnlyList<TestCommit> Commits => this.repository.GetLog(this.target);
+
+    public override string ToString() => CanonicalName;
+}

--- a/src/GitVersion.Testing/Git/TestBranchCollection.cs
+++ b/src/GitVersion.Testing/Git/TestBranchCollection.cs
@@ -1,0 +1,86 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     The local and remote-tracking branches of a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestBranchCollection(TestRepository repository) : IEnumerable<TestBranch>
+{
+    /// <summary>
+    ///     Looks a branch up by its friendly name, e.g. <c>develop</c> or <c>origin/develop</c>.
+    ///     Like the previous git-library indexer this is declared non-nullable but returns <c>null</c>
+    ///     when the branch does not exist, so existing <c>== null</c> call sites keep working.
+    /// </summary>
+    public TestBranch this[string friendlyName]
+    {
+        get
+        {
+            var name = friendlyName;
+            if (name.StartsWith("refs/heads/", StringComparison.Ordinal))
+            {
+                name = name["refs/heads/".Length..];
+            }
+            else if (name.StartsWith("refs/remotes/", StringComparison.Ordinal))
+            {
+                name = name["refs/remotes/".Length..];
+            }
+            foreach (var canonicalName in new[] { $"refs/heads/{name}", $"refs/remotes/{name}" })
+            {
+                if (repository.TryRun(["rev-parse", "--verify", "--quiet", canonicalName]))
+                {
+                    return new(repository, canonicalName, name);
+                }
+            }
+
+            return null!;
+        }
+    }
+
+    public TestBranch Add(string name, TestCommit commit) => Add(name, commit.Sha);
+
+    public TestBranch Add(string name, string committish)
+    {
+        repository.Run("branch", name, committish);
+        return new(repository, $"refs/heads/{name}", name);
+    }
+
+    /// <summary>
+    ///     Deletes the branch; a no-op when the branch does not exist, mirroring the previous git-library behavior.
+    /// </summary>
+    public void Remove(string friendlyName)
+    {
+        var branch = this[friendlyName];
+        if (branch is not null)
+        {
+            Remove(branch);
+        }
+    }
+
+    public void Remove(TestBranch branch)
+    {
+        if (branch.IsRemote)
+        {
+            repository.Run("branch", "--remotes", "--delete", "--force", branch.FriendlyName);
+        }
+        else
+        {
+            repository.Run("branch", "--delete", "--force", branch.FriendlyName);
+        }
+    }
+
+    public IEnumerator<TestBranch> GetEnumerator()
+    {
+        var output = repository.Run("for-each-ref", "refs/heads", "refs/remotes", "--format=%(refname)");
+        var branches = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(canonicalName =>
+            {
+                var friendlyName = canonicalName.StartsWith("refs/heads/", StringComparison.Ordinal)
+                    ? canonicalName["refs/heads/".Length..]
+                    : canonicalName["refs/remotes/".Length..];
+                return new TestBranch(repository, canonicalName, friendlyName);
+            });
+        return branches.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/GitVersion.Testing/Git/TestCommit.cs
+++ b/src/GitVersion.Testing/Git/TestCommit.cs
@@ -1,0 +1,65 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     A lightweight, immutable view of a commit in a <see cref="TestRepository" />.
+///     Metadata other than the sha is hydrated lazily (a single <c>git log</c>) so that the very common
+///     case of creating a commit and only reading its <see cref="Sha" /> costs no extra git invocation.
+/// </summary>
+public sealed class TestCommit
+{
+    private readonly TestRepository repository;
+    private string? message;
+    private Signature? author;
+    private Signature? committer;
+    private string[]? parentShas;
+
+    /// <summary>
+    ///     Creates a fully-populated commit view (used when the metadata has already been read).
+    /// </summary>
+    internal TestCommit(TestRepository repository, string sha, string message, Signature author, Signature committer, string[] parentShas)
+    {
+        this.repository = repository;
+        this.message = message;
+        this.author = author;
+        this.committer = committer;
+        this.parentShas = parentShas;
+        Sha = sha;
+    }
+
+    /// <summary>
+    ///     Creates a commit view whose metadata is hydrated on first access.
+    /// </summary>
+    internal TestCommit(TestRepository repository, string sha)
+    {
+        this.repository = repository;
+        Sha = sha;
+    }
+
+    public string Sha { get; }
+
+    public string Message => this.message ??= Hydrate().message!;
+
+    public string MessageShort => Message.Split('\n')[0];
+
+    public Signature Author => this.author ??= Hydrate().author!;
+
+    public Signature Committer => this.committer ??= Hydrate().committer!;
+
+    public IReadOnlyList<TestCommit> Parents => [.. (this.parentShas ??= Hydrate().parentShas!).Select(this.repository.LookupRequired)];
+
+    public override string ToString() => Sha.Length >= 7 ? Sha[..7] : Sha;
+
+    public override bool Equals(object? obj) => obj is TestCommit other && other.Sha == Sha;
+
+    public override int GetHashCode() => Sha.GetHashCode();
+
+    private TestCommit Hydrate()
+    {
+        var hydrated = this.repository.LookupRequired(Sha);
+        this.message = hydrated.message;
+        this.author = hydrated.author;
+        this.committer = hydrated.committer;
+        this.parentShas = hydrated.parentShas;
+        return hydrated;
+    }
+}

--- a/src/GitVersion.Testing/Git/TestConfig.cs
+++ b/src/GitVersion.Testing/Git/TestConfig.cs
@@ -1,0 +1,15 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Repository-local configuration of a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestConfig(TestRepository repository)
+{
+    public void Set(string key, string value) => repository.Run("config", key, value);
+
+    public string? Get(string key)
+    {
+        var found = repository.TryRun(["config", "--get", key], out var output);
+        return found ? output.Trim() : null;
+    }
+}

--- a/src/GitVersion.Testing/Git/TestNetwork.cs
+++ b/src/GitVersion.Testing/Git/TestNetwork.cs
@@ -1,0 +1,9 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Network-related state of a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestNetwork(TestRepository repository)
+{
+    public TestRemoteCollection Remotes { get; } = new(repository);
+}

--- a/src/GitVersion.Testing/Git/TestReferenceCollection.cs
+++ b/src/GitVersion.Testing/Git/TestReferenceCollection.cs
@@ -1,0 +1,11 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Direct reference manipulation for a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestReferenceCollection(TestRepository repository)
+{
+    public void Add(string canonicalName, string targetSha) => repository.Run("update-ref", canonicalName, targetSha);
+
+    public void Add(string canonicalName, TestCommit target) => Add(canonicalName, target.Sha);
+}

--- a/src/GitVersion.Testing/Git/TestRemote.cs
+++ b/src/GitVersion.Testing/Git/TestRemote.cs
@@ -1,0 +1,13 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     A lightweight view of a configured remote in a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestRemote(string name, string url)
+{
+    public string Name { get; } = name;
+
+    public string Url { get; } = url;
+
+    public override string ToString() => $"{Name} ({Url})";
+}

--- a/src/GitVersion.Testing/Git/TestRemoteCollection.cs
+++ b/src/GitVersion.Testing/Git/TestRemoteCollection.cs
@@ -1,0 +1,41 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Testing;
+
+/// <summary>
+///     The configured remotes of a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestRemoteCollection(TestRepository repository) : IEnumerable<TestRemote>
+{
+    public TestRemote Add(string name, string url)
+    {
+        repository.Run("remote", "add", name, url);
+        return new(name, url);
+    }
+
+    public void RenameRemote(string oldName, string newName)
+    {
+        if (oldName.IsEquivalentTo(newName))
+        {
+            return;
+        }
+
+        if (this.Any(remote => remote.Name == newName))
+        {
+            throw new InvalidOperationException($"A remote with the name '{newName}' already exists.");
+        }
+
+        repository.Run("remote", "rename", oldName, newName);
+    }
+
+    public IEnumerator<TestRemote> GetEnumerator()
+    {
+        var names = repository
+            .Run("remote")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var remotes = names.Select(name => new TestRemote(name, repository.Run("remote", "get-url", name).Trim()));
+        return remotes.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/GitVersion.Testing/Git/TestRepository.cs
+++ b/src/GitVersion.Testing/Git/TestRepository.cs
@@ -1,0 +1,382 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+using GitVersion.Testing.Extensions;
+using GitVersion.Testing.Internal;
+using Shouldly;
+
+namespace GitVersion.Testing;
+
+/// <summary>
+///     A test repository whose write operations are performed by shelling out to the real `git` executable
+///     with a deterministic environment (fixed identities, virtual commit timestamps, isolated configuration).
+/// </summary>
+public sealed class TestRepository : IDisposable
+{
+    private static int _pad = 1;
+
+    public TestRepository(string path)
+    {
+        Path = FileSystemHelper.Path.GetFullPath(path).TrimEnd('/', '\\');
+        Branches = new(this);
+        Tags = new(this);
+        Network = new(this);
+        Refs = new(this);
+        Worktrees = new(this);
+        Config = new(this);
+    }
+
+    /// <summary>
+    ///     The working directory of the repository (no trailing directory separator).
+    /// </summary>
+    public string Path { get; }
+
+    public TestBranchCollection Branches { get; }
+
+    public TestTagCollection Tags { get; }
+
+    public TestNetwork Network { get; }
+
+    public TestReferenceCollection Refs { get; }
+
+    public TestWorktreeCollection Worktrees { get; }
+
+    public TestConfig Config { get; }
+
+    /// <summary>
+    ///     The branch (or detached state) HEAD currently points at.
+    /// </summary>
+    public TestBranch Head
+    {
+        get
+        {
+            // Fast path: read .git/HEAD directly (no process spawn) for the common attached-HEAD case.
+            if (TryReadGitFile("HEAD", out var head) && head.StartsWith("ref: ", StringComparison.Ordinal))
+            {
+                var canonicalName = head["ref: ".Length..].Trim();
+                var friendlyName = canonicalName.StartsWith("refs/heads/", StringComparison.Ordinal)
+                    ? canonicalName["refs/heads/".Length..]
+                    : canonicalName;
+                return new(this, canonicalName, friendlyName, "HEAD");
+            }
+
+            if (TryRun(["symbolic-ref", "--quiet", "HEAD"], out var output))
+            {
+                var canonicalName = output.Trim();
+                return new(this, canonicalName, canonicalName["refs/heads/".Length..], "HEAD");
+            }
+
+            return new(this, "(no branch)", "(no branch)", "HEAD");
+        }
+    }
+
+    /// <summary>
+    ///     Creates a commit of a new random file, mirroring the behavior of the previous library-based helper.
+    /// </summary>
+    public TestCommit MakeACommit(string? commitMessage = null) => CreateFileAndCommit(Guid.NewGuid().ToString(), commitMessage);
+
+    public TestCommit[] MakeCommits(int numCommitsToMake)
+        => [.. Enumerable.Range(1, numCommitsToMake).Select(_ => MakeACommit())];
+
+    public TestTag MakeATaggedCommit(string tag)
+    {
+        var commit = MakeACommit();
+        var existingTag = Tags.SingleOrDefault(t => t.FriendlyName == tag);
+        return existingTag ?? Tags.Add(tag, commit);
+    }
+
+    /// <summary>
+    ///     Creates a lightweight tag pointing at HEAD.
+    /// </summary>
+    public TestTag ApplyTag(string tag) => Tags.Add(tag, "HEAD");
+
+    /// <summary>
+    ///     Creates a branch pointing at HEAD without checking it out.
+    /// </summary>
+    public TestBranch CreateBranch(string branchName) => Branches.Add(branchName, "HEAD");
+
+    /// <summary>
+    ///     Creates a branch pointing at the given commit without checking it out.
+    /// </summary>
+    public TestBranch CreateBranch(string branchName, TestCommit target) => Branches.Add(branchName, target);
+
+    public void Checkout(string committish) => Run("checkout", committish);
+
+    public void Checkout(TestBranch branch) => Checkout(branch.FriendlyName);
+
+    public void Checkout(TestCommit commit) => Run("checkout", "--detach", commit.Sha);
+
+    /// <summary>
+    ///     Stages the given file (relative or absolute path).
+    /// </summary>
+    public void Stage(string path) => Run("add", "--", path);
+
+    public TestCommit Commit(string message, Signature author, Signature committer, CommitOptions? options = null)
+    {
+        List<string> arguments = ["commit", "--message", message];
+        if (options?.AmendPreviousCommit == true)
+        {
+            arguments.Add("--amend");
+        }
+
+        if (options?.AllowEmptyCommit == true)
+        {
+            arguments.Add("--allow-empty");
+        }
+
+        Run(author, committer, [.. arguments]);
+        return new(this, ResolveHeadSha());
+    }
+
+    public void Merge(string committish, Signature merger, MergeOptions? options = null)
+    {
+        List<string> arguments = ["merge", "--no-edit"];
+        switch (options?.FastForwardStrategy ?? FastForwardStrategy.Default)
+        {
+            case FastForwardStrategy.NoFastForward:
+                arguments.Add("--no-ff");
+                break;
+            case FastForwardStrategy.FastForwardOnly:
+                arguments.Add("--ff-only");
+                break;
+            case FastForwardStrategy.Default:
+                break;
+        }
+
+        arguments.Add(committish);
+        Run(merger, merger, [.. arguments]);
+    }
+
+    public void Merge(TestBranch branch, Signature merger, MergeOptions? options = null) => Merge(branch.FriendlyName, merger, options);
+
+    public void Merge(TestCommit commit, Signature merger, MergeOptions? options = null) => Merge(commit.Sha, merger, options);
+
+    public void MergeNoFF(string branch) => MergeNoFF(branch, Generate.SignatureNow());
+
+    public void MergeNoFF(string branch, Signature sig) => Merge(branch, sig, new() { FastForwardStrategy = FastForwardStrategy.NoFastForward });
+
+    public TestCommit CreatePullRequestRef(string from, string to, int prNumber = 2, bool normalise = false, bool allowFastForwardMerge = false)
+    {
+        var toTip = Branches[to].ShouldNotBeNull().Tip;
+        Checkout(toTip);
+        if (allowFastForwardMerge)
+        {
+            Merge(from, Generate.SignatureNow());
+        }
+        else
+        {
+            MergeNoFF(from);
+        }
+
+        var commit = Head.Tip;
+        Refs.Add($"refs/pull/{prNumber}/merge", commit.Sha);
+        Checkout(to);
+        if (normalise)
+        {
+            // Turn the ref into a real branch
+            Checkout(Branches.Add($"pull/{prNumber}/merge", commit));
+        }
+
+        return commit;
+    }
+
+    public void Fetch(string remote, IEnumerable<string>? refspecs = null)
+    {
+        var specs = refspecs?.ToArray() ?? [];
+        if (specs.Length == 0)
+        {
+            // Mirror the previous git-library behavior where an empty refspec downloaded the objects
+            // for every advertised ref (including custom pull/merge-request refs). Standard heads land
+            // in remote-tracking space; every other ref is mirrored into an isolated namespace purely to
+            // pull its objects into the object database without creating refs that branch discovery reads.
+            specs =
+            [
+                $"+refs/heads/*:refs/remotes/{remote}/*",
+                $"+refs/*:refs/{remote}-fetched/*"
+            ];
+        }
+
+        Run(["fetch", remote, .. specs]);
+    }
+
+    /// <summary>
+    ///     The paths changed between two commits, using git-native forward slashes.
+    /// </summary>
+    public IReadOnlyList<string> DiffPaths(TestCommit oldCommit, TestCommit newCommit)
+        => [.. Run("diff", "--name-only", oldCommit.Sha, newCommit.Sha).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+
+    public void DumpGraph(Action<string>? writer = null, int? maxCommits = null)
+        => GitTestExtensions.ExecuteGitCmd(GitExtensions.CreateGitLogArgs(maxCommits), Path, writer);
+
+    /// <summary>
+    ///     Resolves a committish to the full sha it points at.
+    /// </summary>
+    public string RevParse(string committish) => Run("rev-parse", "--verify", $"{committish}^{{commit}}").Trim();
+
+    /// <summary>
+    ///     Looks up the commit the given committish points at, or <c>null</c> when the object is not present
+    ///     (mirroring the previous git-library <c>Lookup</c> semantics).
+    /// </summary>
+    public TestCommit? Lookup(string committish)
+    {
+        var log = GetLog(committish, maxCount: 1);
+        return log.Count > 0 ? log[0] : null;
+    }
+
+    /// <summary>
+    ///     Looks up a commit that is expected to exist, throwing when it does not.
+    /// </summary>
+    internal TestCommit LookupRequired(string committish)
+        => Lookup(committish) ?? throw new InvalidOperationException($"No commit found for '{committish}'.");
+
+    internal IReadOnlyList<TestCommit> GetLog(string committish, int? maxCount = null)
+    {
+        List<string> arguments = ["log", "--format=%x1e%H%x1f%an%x1f%ae%x1f%aI%x1f%cn%x1f%ce%x1f%cI%x1f%P%x1f%B"];
+        if (maxCount is not null)
+        {
+            arguments.Add($"--max-count={maxCount}");
+        }
+
+        arguments.Add(committish);
+        arguments.Add("--");
+        if (!TryRun([.. arguments], out var output))
+        {
+            // Unknown committish (e.g. an object that has not been fetched yet): treat as no commits.
+            return [];
+        }
+
+        return
+        [
+            .. output
+                .Split('\x1e', StringSplitOptions.RemoveEmptyEntries)
+                .Where(record => record.Contains('\x1f'))
+                .Select(ParseCommitRecord)
+        ];
+    }
+
+    private TestCommit ParseCommitRecord(string record)
+    {
+        var fields = record.Split('\x1f');
+        var author = new Signature(fields[1], fields[2], DateTimeOffset.Parse(fields[3]));
+        var committer = new Signature(fields[4], fields[5], DateTimeOffset.Parse(fields[6]));
+        var parents = fields[7].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var message = fields[8].TrimEnd('\r', '\n');
+        return new(this, fields[0], message, author, committer, parents);
+    }
+
+    internal string Run(params string[] arguments) => GitCliRunner.Run(Path, arguments);
+
+    internal string Run(Signature author, Signature committer, string[] arguments) => GitCliRunner.Run(Path, arguments, author, committer);
+
+    internal bool TryRun(string[] arguments) => TryRun(arguments, out _);
+
+    internal bool TryRun(string[] arguments, out string output) => GitCliRunner.TryRun(Path, arguments, out output, out _) == 0;
+
+    /// <summary>
+    ///     Resolves the sha HEAD points at, reading the ref files directly when possible (no process spawn)
+    ///     and falling back to <c>git rev-parse</c> for packed refs or any unexpected layout.
+    /// </summary>
+    private string ResolveHeadSha()
+    {
+        if (TryReadGitFile("HEAD", out var head))
+        {
+            if (head.StartsWith("ref: ", StringComparison.Ordinal))
+            {
+                var refPath = head["ref: ".Length..].Trim();
+                if (TryReadGitFile(refPath, out var refSha) && IsSha(refSha))
+                {
+                    return refSha;
+                }
+            }
+            else if (IsSha(head))
+            {
+                return head;
+            }
+        }
+
+        return RevParse("HEAD");
+    }
+
+    private static bool IsSha(string value) => value.Length == 40 && value.All(Uri.IsHexDigit);
+
+    private string? gitDirectory;
+
+    private string GitDirectory => this.gitDirectory ??= ResolveGitDirectory();
+
+    private string ResolveGitDirectory()
+    {
+        var dotGit = FileSystemHelper.Path.Combine(Path, ".git");
+        if (FileSystemHelper.Directory.Exists(dotGit))
+        {
+            return dotGit;
+        }
+
+        // Worktrees and submodules use a `.git` file that points at the real git directory.
+        if (FileSystemHelper.File.Exists(dotGit))
+        {
+            var content = FileSystemHelper.File.ReadAllText(dotGit).Trim();
+            const string prefix = "gitdir:";
+            if (content.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                var dir = content[prefix.Length..].Trim();
+                return FileSystemHelper.Path.IsPathRooted(dir)
+                    ? dir
+                    : FileSystemHelper.Path.GetFullPath(FileSystemHelper.Path.Combine(Path, dir));
+            }
+        }
+
+        return dotGit;
+    }
+
+    private bool TryReadGitFile(string relativePath, out string content)
+    {
+        try
+        {
+            var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var fullPath = segments.Aggregate(GitDirectory, (current, segment) => FileSystemHelper.Path.Combine(current, segment));
+            if (FileSystemHelper.File.Exists(fullPath))
+            {
+                content = FileSystemHelper.File.ReadAllText(fullPath).Trim();
+                return true;
+            }
+        }
+        catch (IOException)
+        {
+            // Fall through to the caller's process-based fallback.
+        }
+
+        content = string.Empty;
+        return false;
+    }
+
+    private TestCommit CreateFileAndCommit(string relativeFileName, string? commitMessage = null)
+    {
+        var randomFile = FileSystemHelper.Path.Combine(Path, relativeFileName);
+        if (FileSystemHelper.File.Exists(randomFile))
+        {
+            FileSystemHelper.File.Delete(randomFile);
+        }
+
+        var totalWidth = 36 + (_pad++ % 10);
+        var contents = Guid.NewGuid().ToString().PadRight(totalWidth, '.');
+        FileSystemHelper.File.WriteAllText(randomFile, contents);
+
+        Stage(randomFile);
+
+        return Commit(commitMessage ?? $"Test Commit for file '{relativeFileName}'",
+            Generate.SignatureNow(), Generate.SignatureNow());
+    }
+
+    /// <summary>
+    ///     Clones the repository at <paramref name="sourcePath" /> into <paramref name="targetPath" />.
+    /// </summary>
+    public static TestRepository Clone(string sourcePath, string targetPath)
+    {
+        GitCliRunner.Run(FileSystemHelper.Path.GetTempPath(), ["clone", sourcePath, targetPath]);
+        return new(targetPath);
+    }
+
+    public void Dispose()
+    {
+        // Nothing to release; present so fixtures can treat the repository as a disposable resource.
+    }
+}

--- a/src/GitVersion.Testing/Git/TestTag.cs
+++ b/src/GitVersion.Testing/Git/TestTag.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     A lightweight view of a tag in a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestTag
+{
+    private readonly TestRepository repository;
+    private readonly string targetSha;
+
+    internal TestTag(TestRepository repository, string friendlyName, string targetSha)
+    {
+        this.repository = repository;
+        this.targetSha = targetSha;
+        FriendlyName = friendlyName;
+    }
+
+    public string FriendlyName { get; }
+
+    public string CanonicalName => $"refs/tags/{FriendlyName}";
+
+    /// <summary>
+    ///     The commit the tag (peeled, for annotated tags) points at.
+    /// </summary>
+    public TestCommit Target => this.repository.LookupRequired(this.targetSha);
+
+    public override string ToString() => CanonicalName;
+}

--- a/src/GitVersion.Testing/Git/TestTagCollection.cs
+++ b/src/GitVersion.Testing/Git/TestTagCollection.cs
@@ -1,0 +1,50 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     The tags of a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestTagCollection(TestRepository repository) : IEnumerable<TestTag>
+{
+    /// <summary>
+    ///     Creates a lightweight tag pointing at the given commit.
+    /// </summary>
+    public TestTag Add(string name, TestCommit target) => Add(name, target.Sha);
+
+    /// <summary>
+    ///     Creates a lightweight tag pointing at the given committish.
+    /// </summary>
+    public TestTag Add(string name, string committish)
+    {
+        repository.Run("tag", name, committish);
+        return new(repository, name, repository.RevParse(committish));
+    }
+
+    /// <summary>
+    ///     Creates an annotated tag pointing at the given commit.
+    /// </summary>
+    public TestTag Add(string name, TestCommit target, Signature tagger, string message)
+    {
+        repository.Run(tagger, tagger, ["tag", "--annotate", "--message", message, name, target.Sha]);
+        return new(repository, name, target.Sha);
+    }
+
+    public void Remove(TestTag tag) => Remove(tag.FriendlyName);
+
+    public void Remove(string friendlyName) => repository.Run("tag", "--delete", friendlyName);
+
+    public IEnumerator<TestTag> GetEnumerator()
+    {
+        var output = repository.Run("for-each-ref", "refs/tags", "--format=%(refname:short)%00%(objectname)%00%(*objectname)");
+        var tags = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(line =>
+            {
+                var fields = line.Split('\0');
+                var targetSha = fields[2].Length > 0 ? fields[2] : fields[1];
+                return new TestTag(repository, fields[0], targetSha);
+            });
+        return tags.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/GitVersion.Testing/Git/TestWorktreeCollection.cs
+++ b/src/GitVersion.Testing/Git/TestWorktreeCollection.cs
@@ -1,0 +1,44 @@
+namespace GitVersion.Testing;
+
+/// <summary>
+///     Worktree management for a <see cref="TestRepository" />.
+/// </summary>
+public sealed class TestWorktreeCollection(TestRepository repository)
+{
+    /// <summary>
+    ///     Adds a worktree at <paramref name="path" /> checked out at the given branch or committish.
+    /// </summary>
+    public void Add(string committishOrBranchSpec, string name, string path, bool isLocked)
+    {
+        _ = name;
+        var committish = committishOrBranchSpec.StartsWith("refs/heads/", StringComparison.Ordinal)
+            ? committishOrBranchSpec["refs/heads/".Length..]
+            : committishOrBranchSpec;
+        List<string> arguments = ["worktree", "add"];
+        if (isLocked)
+        {
+            arguments.Add("--lock");
+        }
+
+        arguments.Add(path);
+        arguments.Add(committish);
+        repository.Run([.. arguments]);
+    }
+
+    /// <summary>
+    ///     Adds a worktree at <paramref name="path" /> on a new branch <paramref name="name" /> created from HEAD.
+    /// </summary>
+    public void Add(string name, string path, bool isLocked)
+    {
+        List<string> arguments = ["worktree", "add"];
+        if (isLocked)
+        {
+            arguments.Add("--lock");
+        }
+
+        arguments.Add("-b");
+        arguments.Add(name);
+        arguments.Add(path);
+        repository.Run([.. arguments]);
+    }
+}

--- a/src/GitVersion.Testing/GitVersion.Testing.csproj
+++ b/src/GitVersion.Testing/GitVersion.Testing.csproj
@@ -5,7 +5,6 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="LibGit2Sharp" />
         <PackageReference Include="Shouldly" />
     <PackageReference Include="System.Collections.Immutable" />
         <PackageReference Include="System.IO.Abstractions" />

--- a/src/GitVersion.Testing/Helpers/ProcessHelper.cs
+++ b/src/GitVersion.Testing/Helpers/ProcessHelper.cs
@@ -6,70 +6,53 @@ namespace GitVersion.Testing;
 
 public static partial class ProcessHelper
 {
-    private static readonly object LockObject = new();
+    // Guards only the Windows-global SetErrorMode state (a no-op on other platforms). It deliberately
+    // does NOT serialize Process.Start: the fixtures spawn a great many short-lived git processes from
+    // parallel test fixtures, so serializing spawns here would collapse that parallelism.
+    private static readonly object ErrorModeLock = new();
 
     // http://social.msdn.microsoft.com/Forums/en/netfxbcl/thread/f6069441-4ab1-4299-ad6a-b8bb9ed36be3
     private static Process? Start(ProcessStartInfo startInfo)
     {
         Process? process;
 
-        lock (LockObject)
+        ChangeErrorMode errorMode;
+        lock (ErrorModeLock)
         {
-            using (new ChangeErrorMode(ErrorModes.FailCriticalErrors | ErrorModes.NoGpFaultErrorBox))
+            errorMode = new(ErrorModes.FailCriticalErrors | ErrorModes.NoGpFaultErrorBox);
+        }
+
+        try
+        {
+            process = Process.Start(startInfo);
+        }
+        catch (Win32Exception exception)
+        {
+            switch ((NativeErrorCode)exception.NativeErrorCode)
             {
-                try
-                {
-                    process = Process.Start(startInfo);
-                }
-                catch (Win32Exception exception)
-                {
-                    switch ((NativeErrorCode)exception.NativeErrorCode)
-                    {
-                        case NativeErrorCode.Success:
-                            // Success is not a failure.
-                            break;
+                case NativeErrorCode.Success:
+                    // Success is not a failure.
+                    break;
 
-                        case NativeErrorCode.FileNotFound:
-                            throw new FileNotFoundException($"The executable file '{startInfo.FileName}' could not be found.",
-                                startInfo.FileName,
-                                exception);
+                case NativeErrorCode.FileNotFound:
+                    throw new FileNotFoundException($"The executable file '{startInfo.FileName}' could not be found.",
+                        startInfo.FileName,
+                        exception);
 
-                        case NativeErrorCode.PathNotFound:
-                            throw new DirectoryNotFoundException($"The path to the executable file '{startInfo.FileName}' could not be found.",
-                                exception);
-                        default:
-                            throw new ArgumentOutOfRangeException($"The error code '{exception.NativeErrorCode}' is not supported.", nameof(exception));
-                    }
+                case NativeErrorCode.PathNotFound:
+                    throw new DirectoryNotFoundException($"The path to the executable file '{startInfo.FileName}' could not be found.",
+                        exception);
+                default:
+                    throw new ArgumentOutOfRangeException($"The error code '{exception.NativeErrorCode}' is not supported.", nameof(exception));
+            }
 
-                    throw;
-                }
-
-                try
-                {
-                    if (process != null)
-                    {
-                        process.PriorityClass = ProcessPriorityClass.Idle;
-                    }
-                }
-                catch
-                {
-                    // NOTE: It seems like in some situations, setting the priority class will throw a Win32Exception
-                    // with the error code set to "Success", which I think we can safely interpret as a success and
-                    // not an exception.
-                    //
-                    // See: https://travis-ci.org/GitTools/GitVersion/jobs/171288284#L2026
-                    // And: https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382.aspx
-                    //
-                    // There's also the case where the process might be killed before we try to adjust its priority
-                    // class, in which case it will throw an InvalidOperationException. What we ideally should do
-                    // is start the process in a "suspended" state, adjust the priority class, then resume it, but
-                    // that's not possible in pure .NET.
-                    //
-                    // See: https://travis-ci.org/GitTools/GitVersion/jobs/166709203#L2278
-                    // And: http://www.codeproject.com/Articles/230005/Launch-a-process-suspended
-                    //
-                    // -- @asbjornu
-                }
+            throw;
+        }
+        finally
+        {
+            lock (ErrorModeLock)
+            {
+                ((IDisposable)errorMode).Dispose();
             }
         }
 
@@ -80,21 +63,43 @@ public static partial class ProcessHelper
     public static int Run(Action<string> output, Action<string> errorOutput, TextReader? input, string exe, string args, string workingDirectory, params KeyValuePair<string, string?>[] environmentalVariables)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(exe);
-        ArgumentNullException.ThrowIfNull(output);
 
         var psi = new ProcessStartInfo
         {
-            UseShellExecute = false,
-            RedirectStandardError = true,
-            RedirectStandardOutput = true,
-            RedirectStandardInput = true,
-            WindowStyle = ProcessWindowStyle.Hidden,
-            CreateNoWindow = true,
-            ErrorDialog = false,
-            WorkingDirectory = workingDirectory,
             FileName = exe,
             Arguments = args
         };
+        return Run(output, errorOutput, input, psi, workingDirectory, environmentalVariables);
+    }
+
+    /// <summary>
+    ///     Runs the executable passing each argument verbatim (no shell quoting required).
+    /// </summary>
+    public static int Run(Action<string> output, Action<string> errorOutput, TextReader? input, string exe, IReadOnlyCollection<string> args, string workingDirectory, params KeyValuePair<string, string?>[] environmentalVariables)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(exe);
+
+        var psi = new ProcessStartInfo { FileName = exe };
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        return Run(output, errorOutput, input, psi, workingDirectory, environmentalVariables);
+    }
+
+    private static int Run(Action<string> output, Action<string> errorOutput, TextReader? input, ProcessStartInfo psi, string workingDirectory, params KeyValuePair<string, string?>[] environmentalVariables)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        psi.UseShellExecute = false;
+        psi.RedirectStandardError = true;
+        psi.RedirectStandardOutput = true;
+        psi.RedirectStandardInput = true;
+        psi.WindowStyle = ProcessWindowStyle.Hidden;
+        psi.CreateNoWindow = true;
+        psi.ErrorDialog = false;
+        psi.WorkingDirectory = workingDirectory;
         foreach (var (key, value) in environmentalVariables)
         {
             var psiEnvironmentVariables = psi.EnvironmentVariables;


### PR DESCRIPTION
## Description

Phase D of the LibGit2Sharp replacement (#5031): migrate `GitVersion.Testing` off LibGit2Sharp to the `git` CLI. This removes the LibGit2Sharp dependency from the test-fixture layer — a prerequisite for eventually removing it from the product (Phase E, post-7.0).

Closes #5038

### What changed (test-only — zero product source files)

- `GitVersion.Testing` no longer references LibGit2Sharp (no package reference, no source usage). A git-CLI-backed fixture API under `GitVersion.Testing/Git/` (`TestRepository`, `TestCommit`, `TestBranch`, `TestTag`, `TestReference`/`Remote`/`Worktree` collections, `Signature`, `CommitOptions`, `Commands` shim) replaces the LibGit2Sharp types, preserving the existing helper names/shapes so the vast majority of call sites compile unchanged.
- Determinism via `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env per invocation; hermetic isolation via `-c commit.gpgsign=false -c gc.auto=0 -c core.autocrlf=false` and `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL`.
- ~51 test files touched; 19 were a bare `using LibGit2Sharp;` removal, 7 had substantive edits. `GitVersion.Git.Managed.Tests` keeps a LibGit2Sharp reference (its parity tests legitimately compare against the libgit2 backend).

### Known tradeoff

Test-suite runtime increases (~3.5× on Core.Tests) because the git CLI spawns a process per write where libgit2 was in-process. Accepted for now; can be optimized later with batched history creation if it becomes a CI pain point.

### Verification

- `src` + `new-cli` build 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- Full suites green in both `GITVERSION_GIT_BACKEND` unset and `=managed` modes (Core 36144, App 345, BuildAgents 91, Configuration 95, Output 123, MsBuild 151, Managed 141).
- The managed-mode MsBuild flakiness seen during development was a separate pre-existing test-fixture env-var race, fixed independently in #5062 (now merged); this branch inherits it and runs clean (3/3 managed-mode MsBuild runs here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
