### PR TITLE
fix(git): address code-review findings in the managed Git backend

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -55,22 +55,24 @@ jobs:
 
       - name: Test Summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
-        if: always() && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
+        if: always() && matrix.dotnet_version == '10.0'
         with:
           paths: artifacts/test-results/**/results.xml
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
+        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0'
         with:
           files: artifacts/test-results/**/results.xml
           report_type: 'test_results'
+          flags: ${{ matrix.git_backend }}
           use_oidc: true
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0' && matrix.git_backend == 'libgit2'
+        if: success() && inputs.publish_coverage && matrix.dotnet_version == '10.0'
         with:
           directory: artifacts/test-results
           report_type: 'coverage'
+          flags: ${{ matrix.git_backend }}
           use_oidc: true

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -81,7 +81,7 @@ For current command details and examples, see [CLI Arguments](/docs/usage/cli/ar
 
 ## Git backend
 
-GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable.
+GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable. Any value other than `libgit2` or `managed` (case-insensitive) is an error: GitVersion fails fast instead of silently running the default backend.
 
 :::{.alert .alert-info}
 In v7.0 the `libgit2` backend remains the **default** — behaviour is unchanged unless you opt in. Set `GITVERSION_GIT_BACKEND=managed` to try the managed backend and help validate it. In v7.1 the default flips to `managed`, with `GITVERSION_GIT_BACKEND=libgit2` available as a fallback. Both backends ship side by side for several releases before libgit2 is removed.

--- a/src/GitVersion.App/CliHost.cs
+++ b/src/GitVersion.App/CliHost.cs
@@ -1,6 +1,7 @@
 using GitVersion.Agents;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
+using GitVersion.Git;
 using GitVersion.Output;
 using Serilog;
 using Serilog.Core;
@@ -33,9 +34,9 @@ internal static class CliHost
         services.AddModule(new GitVersionConfigurationModule());
         services.AddModule(new GitVersionOutputModule());
 
-        var gitBackend = SysEnv.GetEnvironmentVariable("GITVERSION_GIT_BACKEND");
-        var useManagedBackend = string.Equals(gitBackend, "managed", StringComparison.OrdinalIgnoreCase);
-        services.AddModule(useManagedBackend ? new GitVersionManagedGitModule() : new GitVersionLibGit2SharpModule());
+        services.AddModule(GitBackendSelector.Resolve() == GitBackend.Managed
+            ? new GitVersionManagedGitModule()
+            : new GitVersionLibGit2SharpModule());
 
         var envValue = SysEnv.GetEnvironmentVariable("GITVERSION_USE_V6_ARGUMENT_PARSER");
         var useLegacyParser = string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);

--- a/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
@@ -1,0 +1,46 @@
+using GitVersion.Git;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class GitBackendSelectorTests : TestBase
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase("libgit2", false)]
+    [TestCase("LIBGIT2", false)]
+    [TestCase("managed", true)]
+    [TestCase("Managed", true)]
+    [TestCase(" managed ", true)]
+    public void ResolvesKnownValues(string? value, bool isManaged)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        GitBackendSelector.Resolve().ShouldBe(isManaged ? GitBackend.Managed : GitBackend.LibGit2);
+    }
+
+    [TestCase("manged")]
+    [TestCase("libgit2sharp")]
+    [TestCase("true")]
+    public void FailsFastOnUnknownValues(string value)
+    {
+        // A silently ignored typo would make a user believe they validated the
+        // managed backend while actually running libgit2.
+        using var scope = new EnvironmentVariableScope(value);
+
+        Should.Throw<InvalidOperationException>(() => GitBackendSelector.Resolve())
+            .Message.ShouldContain(value);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, this.original);
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
@@ -33,6 +33,32 @@ public class GitCliMutatorTests : TestBase
     }
 
     [Test]
+    [NonParallelizable]
+    public void CheckoutIgnoresAnInheritedGitDirEnvironmentVariable()
+    {
+        // git exports GIT_DIR when running hooks; the executor must scrub it so
+        // mutations target the working-directory repository, as libgit2 did.
+        using var otherFixture = new EmptyRepositoryFixture();
+        otherFixture.Repository.MakeACommit();
+
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.Repository.CreateBranch("only-here");
+
+        System.Environment.SetEnvironmentVariable("GIT_DIR", FileSystemHelper.Path.Combine(otherFixture.RepositoryPath, ".git"));
+        try
+        {
+            CreateMutator().Checkout(fixture.RepositoryPath, "only-here");
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("GIT_DIR", null);
+        }
+
+        fixture.Repository.Head.FriendlyName.ShouldBe("only-here");
+    }
+
+    [Test]
     public void CheckoutFailureIsNotMisclassifiedAsAnHttpError()
     {
         using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
@@ -33,6 +33,21 @@ public class GitCliMutatorTests : TestBase
     }
 
     [Test]
+    public void CheckoutFailureIsNotMisclassifiedAsAnHttpError()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+
+        // The failing spec echoes "404" in stderr; only network operations may map
+        // HTTP status codes, so the real pathspec error must surface unchanged.
+        var exception = Should.Throw<InvalidOperationException>(
+            () => CreateMutator().Checkout(fixture.RepositoryPath, "fix-404-page"));
+
+        exception.Message.ShouldContain("fix-404-page");
+        exception.Message.ShouldNotContain("The repository was not found");
+    }
+
+    [Test]
     public void FetchBringsNewRemoteCommitsIntoTheLocalRepository()
     {
         using var fixture = new RemoteRepositoryFixture();
@@ -75,6 +90,59 @@ public class GitCliMutatorTests : TestBase
         var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
 
         Should.Throw<InvalidOperationException>(() => CreateMutator().Clone(missingSource, targetPath, new AuthenticationInfo()));
+    }
+
+    [Test]
+    public void CloneOfMissingHttpRepositoryMapsGitsNotFoundPhrasing()
+    {
+        // Non-GitHub hosts produce "fatal: repository '<url>' not found" (no "404",
+        // no contiguous "Repository not found"); the message contract must still hold.
+        using var server = new HttpNotFoundServer();
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        var exception = Should.Throw<InvalidOperationException>(
+            () => CreateMutator().Clone($"{server.Url}/missing/repo.git", targetPath, new AuthenticationInfo()));
+
+        exception.Message.ShouldBe("Not found: The repository was not found");
+    }
+
+    private sealed class HttpNotFoundServer : IDisposable
+    {
+        private readonly System.Net.HttpListener listener = new();
+        public string Url { get; }
+
+        public HttpNotFoundServer()
+        {
+            var port = GetFreePort();
+            Url = $"http://127.0.0.1:{port}";
+            this.listener.Prefixes.Add($"{Url}/");
+            this.listener.Start();
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                while (this.listener.IsListening)
+                {
+                    try
+                    {
+                        var context = await this.listener.GetContextAsync().ConfigureAwait(false);
+                        context.Response.StatusCode = 404;
+                        context.Response.Close();
+                    }
+                    catch (Exception ex) when (ex is System.Net.HttpListenerException or ObjectDisposedException)
+                    {
+                        return;
+                    }
+                }
+            });
+        }
+
+        private static int GetFreePort()
+        {
+            using var socket = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            socket.Start();
+            return ((System.Net.IPEndPoint)socket.LocalEndpoint).Port;
+        }
+
+        public void Dispose() => this.listener.Stop();
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/Core/PullRequestBranchOperationsTests.cs
+++ b/src/GitVersion.Core.Tests/Core/PullRequestBranchOperationsTests.cs
@@ -1,0 +1,76 @@
+using GitVersion.Git;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+public class PullRequestBranchOperationsTests : TestBase
+{
+    private const string HeadTipSha = "0123456789012345678901234567890123456789";
+
+    [Test]
+    public void HeadAdvertisementIsNotACandidateTip()
+    {
+        // libgit2's remote listing resolves the HEAD symref into an extra entry pointing
+        // at the default branch tip; it must not count against the single-match check.
+        var repository = CreateRepository();
+
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            repository,
+            NullLogger.Instance,
+            _ => [new("HEAD", HeadTipSha), new("refs/pull/2/merge", HeadTipSha)]);
+
+        repository.References.Received().Add("refs/heads/pull/2/merge", HeadTipSha);
+        repository.Received().Checkout("refs/heads/pull/2/merge");
+    }
+
+    [Test]
+    public void PeeledAndDuplicateEntriesAreNotCandidateTips()
+    {
+        var repository = CreateRepository();
+
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            repository,
+            NullLogger.Instance,
+            _ =>
+            [
+                new("refs/pull/2/merge", HeadTipSha),
+                new("refs/pull/2/merge", HeadTipSha),      // duplicate (e.g. a resolved symref)
+                new("refs/tags/v1.0.0^{}", HeadTipSha)     // peeled tag entry
+            ]);
+
+        repository.References.Received().Add("refs/heads/pull/2/merge", HeadTipSha);
+    }
+
+    [Test]
+    public void MultipleDistinctCandidateTipsStillFail()
+    {
+        var repository = CreateRepository();
+
+        Should.Throw<WarningException>(() => PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+                repository,
+                NullLogger.Instance,
+                _ => [new("refs/pull/2/merge", HeadTipSha), new("refs/heads/main", HeadTipSha)]))
+            .Message.ShouldContain("more than one remote tip");
+    }
+
+    private static IMutatingGitRepository CreateRepository()
+    {
+        var tip = Substitute.For<ICommit>();
+        tip.Sha.Returns(HeadTipSha);
+
+        var head = Substitute.For<IBranch>();
+        head.Tip.Returns(tip);
+
+        var remote = Substitute.For<IRemote>();
+        remote.Name.Returns("origin");
+        remote.Url.Returns("https://example.com/repo.git");
+
+        var remotes = Substitute.For<IRemoteCollection>();
+        remotes.GetEnumerator().Returns(_ => new List<IRemote> { remote }.GetEnumerator());
+
+        var repository = Substitute.For<IMutatingGitRepository>();
+        repository.Head.Returns(head);
+        repository.Remotes.Returns(remotes);
+        return repository;
+    }
+}

--- a/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
+++ b/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
+using GitVersion.Git;
 using GitVersion.Output;
 
 namespace GitVersion.Tests;
@@ -10,9 +11,9 @@ public class GitVersionCoreTestModule : IGitVersionModule
 {
     public void RegisterTypes(IServiceCollection services)
     {
-        var gitBackend = SysEnv.GetEnvironmentVariable("GITVERSION_GIT_BACKEND");
-        var useManagedBackend = string.Equals(gitBackend, "managed", StringComparison.OrdinalIgnoreCase);
-        services.AddModule(useManagedBackend ? new GitVersionManagedGitModule() : new GitVersionLibGit2SharpModule());
+        services.AddModule(GitBackendSelector.Resolve() == GitBackend.Managed
+            ? new GitVersionManagedGitModule()
+            : new GitVersionLibGit2SharpModule());
         services.AddModule(new GitVersionBuildAgentsModule());
         services.AddModule(new GitVersionOutputModule());
         services.AddModule(new GitVersionConfigurationModule());

--- a/src/GitVersion.Core/Git/GitBackend.cs
+++ b/src/GitVersion.Core/Git/GitBackend.cs
@@ -1,0 +1,45 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The Git backend implementations selectable via the <c>GITVERSION_GIT_BACKEND</c>
+/// environment variable during the dual-backend window (v7.0–v7.x).
+/// </summary>
+internal enum GitBackend
+{
+    /// <summary>The libgit2-based backend (the v7.0 default).</summary>
+    LibGit2,
+
+    /// <summary>The managed reader + git CLI mutator backend.</summary>
+    Managed
+}
+
+/// <summary>
+/// The single place where <c>GITVERSION_GIT_BACKEND</c> is interpreted: every composition
+/// root selects the backend through this class so production and tests cannot drift, and
+/// the v7.1 default flip is a one-line change.
+/// </summary>
+internal static class GitBackendSelector
+{
+    public const string EnvironmentVariableName = "GITVERSION_GIT_BACKEND";
+
+    /// <summary>
+    /// Resolves the backend from the environment: <c>libgit2</c> (the default when unset)
+    /// or <c>managed</c>. Unknown values fail fast — a silently ignored typo would make a
+    /// user believe they validated the managed backend while running libgit2.
+    /// </summary>
+    /// <returns>The selected backend.</returns>
+    /// <exception cref="InvalidOperationException">The variable is set to an unrecognized value.</exception>
+    public static GitBackend Resolve()
+    {
+        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
+
+        return value switch
+        {
+            null or "" => GitBackend.LibGit2,
+            _ when value.Equals("libgit2", StringComparison.OrdinalIgnoreCase) => GitBackend.LibGit2,
+            _ when value.Equals("managed", StringComparison.OrdinalIgnoreCase) => GitBackend.Managed,
+            _ => throw new InvalidOperationException(
+                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'libgit2' and 'managed'.")
+        };
+    }
+}

--- a/src/GitVersion.Core/Git/PullRequestBranchOperations.cs
+++ b/src/GitVersion.Core/Git/PullRequestBranchOperations.cs
@@ -67,7 +67,17 @@ internal static class PullRequestBranchOperations
                               Remote Refs:
                               {RemoteRefsList}
                               """, remoteRefsList);
-        var refs = remoteTips.Where(r => r.TargetSha == headTipSha).ToList();
+        // The advertised HEAD symref (which libgit2 resolves into a duplicate of the
+        // default branch's direct reference) and peeled "^{}" tag entries are not
+        // candidate tips: they would make the same commit appear twice and trip the
+        // single-match check below. Filtering here keeps both backends' candidate
+        // sets identical regardless of how their listing behaves.
+        var refs = remoteTips
+            .Where(r => r.CanonicalName.StartsWith("refs/", StringComparison.Ordinal)
+                && !r.CanonicalName.EndsWith("^{}", StringComparison.Ordinal))
+            .DistinctBy(r => r.CanonicalName)
+            .Where(r => r.TargetSha == headTipSha)
+            .ToList();
 
         switch (refs.Count)
         {

--- a/src/GitVersion.Core/Git/RepositoryPathResolution.cs
+++ b/src/GitVersion.Core/Git/RepositoryPathResolution.cs
@@ -29,12 +29,12 @@ internal static class RepositoryPathResolution
         string workingDirectory,
         Func<string, string?> discoverGitDirectory)
     {
-        var gitDirectory = !dynamicGitRepositoryPath.IsNullOrWhiteSpace()
-            ? dynamicGitRepositoryPath
-            : discoverGitDirectory(workingDirectory);
+        var gitDirectory = (!dynamicGitRepositoryPath.IsNullOrWhiteSpace()
+                ? dynamicGitRepositoryPath
+                : discoverGitDirectory(workingDirectory))
+            ?.TrimEnd('/', '\\');
 
-        gitDirectory = gitDirectory?.TrimEnd('/', '\\');
-        if (gitDirectory.IsNullOrEmpty())
+        if (string.IsNullOrEmpty(gitDirectory))
         {
             throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
         }

--- a/src/GitVersion.Core/Git/RepositoryPathResolution.cs
+++ b/src/GitVersion.Core/Git/RepositoryPathResolution.cs
@@ -1,0 +1,79 @@
+using System.IO.Abstractions;
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// The backend-agnostic part of resolving the repository paths GitVersion works with
+/// (<see cref="IGitRepositoryInfo"/>): the dot-git directory with its worktree handling,
+/// the project root, and the git root. Each Git backend supplies its own repository
+/// discovery and working-directory resolution.
+/// </summary>
+internal static class RepositoryPathResolution
+{
+    private const string DotGitDirectoryNotFoundMessage = "Cannot find the .git directory";
+
+    /// <summary>
+    /// Resolves the dot-git directory: the dynamic repository path when one is configured,
+    /// otherwise the discovered git directory — mapped to the main repository's directory
+    /// when it is a linked worktree's.
+    /// </summary>
+    /// <param name="fileSystem">The file system.</param>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="workingDirectory">The working directory to discover from.</param>
+    /// <param name="discoverGitDirectory">Discovers the git directory containing a path, or <see langword="null"/>.</param>
+    public static string? ResolveDotGitDirectory(
+        IFileSystem fileSystem,
+        string? dynamicGitRepositoryPath,
+        string workingDirectory,
+        Func<string, string?> discoverGitDirectory)
+    {
+        var gitDirectory = !dynamicGitRepositoryPath.IsNullOrWhiteSpace()
+            ? dynamicGitRepositoryPath
+            : discoverGitDirectory(workingDirectory);
+
+        gitDirectory = gitDirectory?.TrimEnd('/', '\\');
+        if (gitDirectory.IsNullOrEmpty())
+        {
+            throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+        }
+
+        var directoryInfo = fileSystem.Directory.GetParent(gitDirectory) ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+        return gitDirectory.Contains(FileSystemHelper.Path.Combine(".git", "worktrees"))
+            ? fileSystem.Directory.GetParent(directoryInfo.FullName)?.FullName
+            : gitDirectory;
+    }
+
+    /// <summary>
+    /// Resolves the project root: the working directory itself for dynamic repositories,
+    /// otherwise the discovered repository's working directory (with a trailing separator,
+    /// as libgit2 reports it).
+    /// </summary>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="workingDirectory">The working directory to discover from.</param>
+    /// <param name="resolveRepositoryWorkingDirectory">Resolves the working directory of the repository containing a path, or <see langword="null"/>.</param>
+    public static string ResolveProjectRootDirectory(
+        string? dynamicGitRepositoryPath,
+        string workingDirectory,
+        Func<string, string?> resolveRepositoryWorkingDirectory)
+    {
+        if (!dynamicGitRepositoryPath.IsNullOrWhiteSpace())
+        {
+            return workingDirectory;
+        }
+
+        return resolveRepositoryWorkingDirectory(workingDirectory)
+            ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+    }
+
+    /// <summary>
+    /// Resolves the git root: the dot-git directory for dynamic repositories, otherwise
+    /// the project root.
+    /// </summary>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="dotGitDirectory">The resolved dot-git directory.</param>
+    /// <param name="projectRootDirectory">The resolved project root.</param>
+    public static string? ResolveGitRootPath(string? dynamicGitRepositoryPath, string? dotGitDirectory, string? projectRootDirectory) =>
+        !dynamicGitRepositoryPath.IsNullOrWhiteSpace() ? dotGitDirectory : projectRootDirectory;
+}

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -48,6 +48,12 @@ internal class GitVersionCacheKeyFactory(
             ? CalculateDirectoryContents(refsPath)
             : [];
 
+        // Refs may live partially or entirely in packed-refs instead of loose files
+        // under refs/, so its content must contribute to the hash for packed ref
+        // updates (e.g. a fetched tag) to invalidate the cache.
+        var packedRefsPath = FileSystemHelper.Path.Combine(dotGitDirectory, "packed-refs");
+        AddFileContents([packedRefsPath], contents);
+
         return GetHash(contents);
     }
 

--- a/src/GitVersion.Git.Managed.Tests/DeltaStreamReaderTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/DeltaStreamReaderTests.cs
@@ -1,0 +1,37 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class DeltaStreamReaderTests
+{
+    [Test]
+    public void ReadsACompleteCopyInstruction()
+    {
+        // Copy with one offset byte (0x42) and one size byte (0x07).
+        using var stream = new MemoryStream([0b1001_0001, 0x42, 0x07]);
+
+        var instruction = DeltaStreamReader.Read(stream);
+
+        instruction.ShouldNotBeNull();
+        instruction.Value.InstructionType.ShouldBe(DeltaInstructionType.Copy);
+        instruction.Value.Offset.ShouldBe(0x42);
+        instruction.Value.Size.ShouldBe(0x07);
+    }
+
+    [Test]
+    public void ReturnsNullAtTheEndOfTheStream()
+    {
+        using var stream = new MemoryStream([]);
+
+        DeltaStreamReader.Read(stream).ShouldBeNull();
+    }
+
+    [Test]
+    public void ThrowsWhenTheStreamEndsInsideACopyInstruction()
+    {
+        // The instruction announces an offset byte and a size byte, but the stream is
+        // truncated: EOF must not be silently decoded as 0xFF (garbage copy target).
+        using var stream = new MemoryStream([0b1001_0001, 0x42]);
+
+        Should.Throw<EndOfStreamException>(() => DeltaStreamReader.Read(stream));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
@@ -23,6 +23,20 @@ public class GitRepositoryLayoutTests
     }
 
     [Test]
+    public void TryOpenDoesNotWalkUpToAnEnclosingRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("nested/dir/file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var nested = Path.Combine(repository.RepositoryPath, "nested", "dir");
+
+        GitRepositoryLayout.TryOpen(nested).ShouldBeNull();
+        GitRepositoryLayout.TryOpen(repository.RepositoryPath).ShouldNotBeNull();
+        GitRepositoryLayout.TryOpen(repository.GitDirectory).ShouldNotBeNull();
+    }
+
+    [Test]
     public void RejectsSha256RepositoriesWithAClearMessage()
     {
         using var directory = new TempDirectory();

--- a/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace GitVersion.Git.Managed.Tests;
 
 [TestFixture]
@@ -37,6 +39,7 @@ public class GitRepositoryLayoutTests
     }
 
     [Test]
+    [SuppressMessage("Minor Vulnerability", "S4036:Searching OS commands in PATH is security-sensitive", Justification = "git is deliberately resolved from the PATH, exactly like the production CLI executor and the other test fixtures.")]
     public void RejectsSha256RepositoriesWithAClearMessage()
     {
         using var directory = new TempDirectory();

--- a/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
@@ -23,6 +23,26 @@ public class GitRepositoryLayoutTests
     }
 
     [Test]
+    public void RejectsSha256RepositoriesWithAClearMessage()
+    {
+        using var directory = new TempDirectory();
+        Directory.CreateDirectory(directory.FullPath);
+
+        using var process = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            ArgumentList = { "init", "-q", "--object-format=sha256", directory.FullPath },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        });
+        process!.WaitForExit();
+        process.ExitCode.ShouldBe(0, "git init --object-format=sha256 should succeed");
+
+        var exception = Should.Throw<NotSupportedException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+        exception.Message.ShouldContain("sha256");
+    }
+
+    [Test]
     public void ReturnsNullOutsideOfARepository()
     {
         using var directory = new TempDirectory();

--- a/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
@@ -190,6 +190,20 @@ public class GitRevisionWalkerTests
         new GitRevisionWalker(store).Walk(options).Count.ShouldBe(2);
     }
 
+    [Test]
+    public void WalkingFromAMissingCommitFails()
+    {
+        using var repository = CreateLinearRepository();
+        using var store = repository.OpenObjectStore();
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(GitObjectId.Parse("0123456789012345678901234567890123456789"));
+
+        // libgit2's revwalk push fails on a missing commit; emitting a walk
+        // containing a null commit instead would blow up far from the cause.
+        Should.Throw<GitObjectStoreException>(() => new GitRevisionWalker(store).Walk(options));
+    }
+
     private static void AssertWalkParity(GitTestRepository repository, GitRevisionWalkOptions options, bool head, string? excludeSha = null)
     {
         if (head)

--- a/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
@@ -95,6 +95,36 @@ public class GitStatusCalculatorTests
     }
 
     [Test]
+    public void HonorsCoreIgnoreCaseForIgnorePatterns()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "BIN/\n*.LOG\n");
+        repository.Commit("commit");
+        repository.Run("config", "core.ignorecase", "true");
+
+        repository.WriteFile("bin/out.txt", "ignored\n");   // ignored by BIN/ under ignorecase
+        repository.WriteFile("noise.log", "ignored\n");     // ignored by *.LOG under ignorecase
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void MatchesIgnorePatternsCaseSensitivelyWhenIgnoreCaseIsOff()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "BIN/\n*.LOG\n");
+        repository.Commit("commit");
+        repository.Run("config", "core.ignorecase", "false");
+
+        repository.WriteFile("bin/out.txt", "kept\n");
+        repository.WriteFile("noise.log", "kept\n");
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 3);
+    }
+
+    [Test]
     public void CountsExecutableBitChanges()
     {
         if (OperatingSystem.IsWindows())

--- a/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
@@ -1,3 +1,5 @@
+using GitVersion.Helpers;
+
 namespace GitVersion.Git.Managed.Tests;
 
 /// <summary>
@@ -176,7 +178,9 @@ internal sealed class GitTestRepository : IDisposable
     {
         try
         {
-            Directory.Delete(RepositoryPath, recursive: true);
+            // Git marks pack and loose-object files read-only; a bare recursive delete
+            // fails on them on Windows. The helper resets attributes before deleting.
+            FileSystemHelper.Directory.DeleteDirectory(RepositoryPath);
         }
         catch (IOException)
         {

--- a/src/GitVersion.Git.Managed/Adapter/ManagedCommit.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedCommit.cs
@@ -23,7 +23,7 @@ internal sealed class ManagedCommit : ICommit
                 .Cast<ICommit>()]);
         Id = new ManagedObjectId(innerCommit.Sha);
         Sha = Id.Sha;
-        When = innerCommit.Committer.When;
+        When = innerCommit.CommitterWhen;
     }
 
     internal GitObjectId ObjectId => this.innerCommit.Sha;

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.cs
@@ -64,9 +64,12 @@ internal sealed partial class ManagedGitRepository
         otherCommit = otherCommit.NotNull();
 
         var session = Session;
-        var mergeBase = session.Walker.FindMergeBase(GitObjectId.Parse(commit.Sha), GitObjectId.Parse(otherCommit.Sha));
+        var mergeBase = session.Walker.FindMergeBase(ResolveObjectId(commit), ResolveObjectId(otherCommit));
         return mergeBase is { } id ? session.GetCommit(id) : null;
     }
+
+    private static GitObjectId ResolveObjectId(ICommit commit) =>
+        commit is ManagedCommit managed ? managed.ObjectId : GitObjectId.Parse(commit.Sha);
 
     public int UncommittedChangesCount()
     {

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
@@ -96,7 +96,10 @@ internal sealed class ManagedGitRepositoryInfo : IGitRepositoryInfo
     {
         try
         {
-            var layout = GitRepositoryLayout.TryDiscover(possiblePath);
+            // Only possiblePath itself may be the repository, matching the libgit2 backend's
+            // `new Repository(possiblePath)`; discovery walking up the hierarchy would match
+            // an enclosing repository and hand a nonexistent .git path to the caller.
+            var layout = GitRepositoryLayout.TryOpen(possiblePath);
             if (layout is null)
             {
                 return false;

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
@@ -1,14 +1,11 @@
 using System.IO.Abstractions;
 using GitVersion.Extensions;
-using GitVersion.Helpers;
 using SysPath = System.IO.Path;
 
 namespace GitVersion.Git;
 
 internal sealed class ManagedGitRepositoryInfo : IGitRepositoryInfo
 {
-    private const string DotGitDirectoryNotFoundMessage = "Cannot find the .git directory";
-
     private readonly IFileSystem fileSystem;
     private readonly GitVersionOptions gitVersionOptions;
 
@@ -39,50 +36,33 @@ internal sealed class ManagedGitRepositoryInfo : IGitRepositoryInfo
         return DynamicRepositoryPath.Get(this.fileSystem, repositoryInfo.TargetUrl, repositoryInfo.ClonePath, GitRepoHasMatchingRemote);
     }
 
-    private string? GetDotGitDirectory()
-    {
-        var gitDirectory = !DynamicGitRepositoryPath.IsNullOrWhiteSpace()
-            ? DynamicGitRepositoryPath
-            : Discover(this.gitVersionOptions.WorkingDirectory)?.GitDirectory;
+    private string? GetDotGitDirectory() =>
+        RepositoryPathResolution.ResolveDotGitDirectory(
+            this.fileSystem,
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            static workingDirectory => Discover(workingDirectory)?.GitDirectory);
 
-        gitDirectory = gitDirectory?.TrimEnd('/', '\\');
-        if (string.IsNullOrEmpty(gitDirectory))
-        {
-            throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
-        }
+    private string GetProjectRootDirectory() =>
+        RepositoryPathResolution.ResolveProjectRootDirectory(
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            static workingDirectory =>
+            {
+                var repositoryWorkingDirectory = Discover(workingDirectory)?.WorkingDirectory;
+                if (repositoryWorkingDirectory is null)
+                {
+                    return null;
+                }
 
-        var directoryInfo = this.fileSystem.Directory.GetParent(gitDirectory) ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
-        return gitDirectory.Contains(FileSystemHelper.Path.Combine(".git", "worktrees"))
-            ? this.fileSystem.Directory.GetParent(directoryInfo.FullName)?.FullName
-            : gitDirectory;
-    }
+                // Match libgit2's Info.WorkingDirectory, which carries a trailing directory separator.
+                return repositoryWorkingDirectory.EndsWith(SysPath.DirectorySeparatorChar) || repositoryWorkingDirectory.EndsWith('/')
+                    ? repositoryWorkingDirectory
+                    : repositoryWorkingDirectory + SysPath.DirectorySeparatorChar;
+            });
 
-    private string GetProjectRootDirectory()
-    {
-        if (!DynamicGitRepositoryPath.IsNullOrWhiteSpace())
-        {
-            return this.gitVersionOptions.WorkingDirectory;
-        }
-
-        var layout = Discover(this.gitVersionOptions.WorkingDirectory)
-            ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
-
-        var workingDirectory = layout.WorkingDirectory
-            ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
-
-        // Match libgit2's Info.WorkingDirectory, which carries a trailing directory separator.
-        return workingDirectory.EndsWith(SysPath.DirectorySeparatorChar) || workingDirectory.EndsWith('/')
-            ? workingDirectory
-            : workingDirectory + SysPath.DirectorySeparatorChar;
-    }
-
-    private string? GetGitRootPath()
-    {
-        var isDynamicRepo = !DynamicGitRepositoryPath.IsNullOrWhiteSpace();
-        var rootDirectory = isDynamicRepo ? DotGitDirectory : ProjectRootDirectory;
-
-        return rootDirectory;
-    }
+    private string? GetGitRootPath() =>
+        RepositoryPathResolution.ResolveGitRootPath(DynamicGitRepositoryPath, DotGitDirectory, ProjectRootDirectory);
 
     /// <summary>
     /// Discovers the repository containing <paramref name="startPath"/>, returning

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRepositorySession.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRepositorySession.cs
@@ -13,8 +13,8 @@ internal sealed class ManagedRepositorySession : IDisposable
     private const string RemoteSectionName = "remote";
 
     private readonly ManagedGitRepository repository;
-    private readonly ConcurrentDictionary<string, ManagedCommit> commits = new();
-    private readonly ConcurrentDictionary<string, IReadOnlyList<string>> diffPathsCache = new();
+    private readonly ConcurrentDictionary<GitObjectId, ManagedCommit> commits = new();
+    private readonly ConcurrentDictionary<GitObjectId, IReadOnlyList<string>> diffPathsCache = new();
     private readonly Lazy<GitConfigurationFile> configuration;
     private readonly Lazy<IReadOnlyList<ManagedBranch>> branches;
     private readonly Lazy<Dictionary<string, ManagedBranch>> branchesByCanonicalName;
@@ -110,33 +110,23 @@ internal sealed class ManagedRepositorySession : IDisposable
 
     public ManagedCommit? TryGetCommit(GitObjectId objectId)
     {
-        var key = objectId.ToString();
-
-        if (this.commits.TryGetValue(key, out var existing))
+        if (this.commits.TryGetValue(objectId, out var existing))
         {
             return existing;
         }
 
-        if (!ObjectStore.TryGetObject(objectId, GitObjectTypes.Commit, out var stream))
-        {
-            return null;
-        }
-
-        GitCommit innerCommit;
-
-        using (stream)
-        {
-            innerCommit = GitCommitReader.Read(stream, objectId);
-        }
-
-        return this.commits.GetOrAdd(key, _ => new(innerCommit, this.repository));
+        // The walker's parsed-commit cache is the single parse per session; walks
+        // load most commits first, so wrapping reuses those parses.
+        return Walker.TryLoadCommit(objectId) is { } innerCommit
+            ? WrapCommit(innerCommit)
+            : null;
     }
 
     public ManagedCommit WrapCommit(GitCommit innerCommit) =>
-        this.commits.GetOrAdd(innerCommit.Sha.ToString(), _ => new(innerCommit, this.repository));
+        this.commits.GetOrAdd(innerCommit.Sha, _ => new(innerCommit, this.repository));
 
     public IReadOnlyList<string> GetDiffPaths(ManagedCommit commit) =>
-        this.diffPathsCache.GetOrAdd(commit.Sha, _ =>
+        this.diffPathsCache.GetOrAdd(commit.ObjectId, _ =>
         {
             GitObjectId? parentTreeId = commit.FirstParentId is { } parentId ? TryGetCommit(parentId)?.TreeId : null;
             return TreeDiff.GetChangedPaths(parentTreeId, commit.TreeId);

--- a/src/GitVersion.Git.Managed/CommandLine/GitCliExecutor.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/GitCliExecutor.cs
@@ -45,6 +45,20 @@ internal sealed class GitCliExecutor(ILogger<GitCliExecutor> logger) : IGitCliEx
         startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
         startInfo.Environment["LC_ALL"] = "C";
 
+        // The repository is targeted via the working directory alone, like libgit2
+        // targets it via the discovered path. Inherited repo-targeting variables
+        // (git exports GIT_DIR when running hooks) would redirect the invocation
+        // to a different repository than the one the managed reader discovered.
+        string[] repoTargetingVariables =
+        [
+            "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+            "GIT_NAMESPACE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+        ];
+        foreach (var variable in repoTargetingVariables)
+        {
+            startInfo.Environment.Remove(variable);
+        }
+
         this.logger.LogDebug("Executing 'git {Arguments}' in '{WorkingDirectory}'", string.Join(' ', arguments), workingDirectory);
 
         using var process = new Process();

--- a/src/GitVersion.Git.Managed/CommandLine/GitCliMutator.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/GitCliMutator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using GitVersion.Extensions;
 
 namespace GitVersion.Git;
@@ -19,7 +20,7 @@ internal interface IGitCliMutator
     void CreateSymbolicReference(string workingDirectory, string name, string targetReferenceName);
 }
 
-internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecutor executor) : IGitCliMutator
+internal sealed partial class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecutor executor) : IGitCliMutator
 {
     private readonly ILogger<GitCliMutator> logger = logger.NotNull();
     private readonly IGitCliExecutor executor = executor.NotNull();
@@ -34,7 +35,7 @@ internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecut
         arguments.AddRange(["clone", "--no-checkout", sourceUrl, workdirPath]);
 
         var result = this.executor.Execute(null, arguments);
-        ThrowOnFailure(result);
+        ThrowOnFailure(result, isNetworkOperation: true);
         this.logger.LogInformation("Cloned repository '{SourceUrl}' into '{WorkdirPath}'", sourceUrl, workdirPath);
     }
 
@@ -46,7 +47,7 @@ internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecut
         arguments.AddRange(refSpecs);
 
         var result = this.executor.Execute(workingDirectory, arguments);
-        ThrowOnFailure(result);
+        ThrowOnFailure(result, isNetworkOperation: true);
     }
 
     public void Checkout(string workingDirectory, string commitOrBranchSpec)
@@ -70,7 +71,7 @@ internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecut
         arguments.AddRange(["ls-remote", "--quiet", remoteName]);
 
         var result = this.executor.Execute(workingDirectory, arguments);
-        ThrowOnFailure(result);
+        ThrowOnFailure(result, isNetworkOperation: true);
 
         var references = new List<GitRemoteReference>();
         foreach (var line in result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -129,7 +130,7 @@ internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecut
         arguments.AddRange(["-c", $"{scope}.extraHeader=Authorization: Basic {credentials}"]);
     }
 
-    private static void ThrowOnFailure(GitCliResult result)
+    private static void ThrowOnFailure(GitCliResult result, bool isNetworkOperation = false)
     {
         if (result.IsSuccess)
         {
@@ -137,26 +138,44 @@ internal sealed class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecut
         }
 
         var message = result.StandardError;
-        if (message.Contains(".lock", StringComparison.Ordinal) && message.Contains("Unable to create", StringComparison.OrdinalIgnoreCase))
+        if (IsLockContention(message))
         {
             throw new LockedFileException(message);
         }
 
-        if (message.Contains("401") || message.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase))
+        // HTTP status classification only applies to commands that talk to a remote;
+        // a local ref or pathspec can legitimately contain "401"/"404" in its name.
+        if (isNetworkOperation)
         {
-            throw new InvalidOperationException("Unauthorized: Incorrect username/password");
-        }
+            if (message.Contains("401") || message.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Unauthorized: Incorrect username/password");
+            }
 
-        if (message.Contains("403"))
-        {
-            throw new InvalidOperationException("Forbidden: Possibly Incorrect username/password");
-        }
+            if (message.Contains("403"))
+            {
+                throw new InvalidOperationException("Forbidden: Possibly Incorrect username/password");
+            }
 
-        if (message.Contains("404") || message.Contains("Repository not found", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException("Not found: The repository was not found");
+            // "Repository not found" is GitHub's server-side banner; other hosts produce
+            // git's own "fatal: repository '<url>' not found" with the URL in between.
+            if (message.Contains("404")
+                || message.Contains("Repository not found", StringComparison.OrdinalIgnoreCase)
+                || RepositoryNotFoundRegex().IsMatch(message))
+            {
+                throw new InvalidOperationException("Not found: The repository was not found");
+            }
         }
 
         throw new InvalidOperationException($"Git command failed with exit code {result.ExitCode}: {message}");
     }
+
+    private static bool IsLockContention(string message) =>
+        (message.Contains(".lock", StringComparison.Ordinal) && message.Contains("Unable to create", StringComparison.OrdinalIgnoreCase))
+        || message.Contains("could not lock", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("cannot lock ref", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("Another git process seems to be running", StringComparison.OrdinalIgnoreCase);
+
+    [GeneratedRegex(@"repository '[^']*' not found", RegexOptions.IgnoreCase)]
+    private static partial Regex RepositoryNotFoundRegex();
 }

--- a/src/GitVersion.Git.Managed/DeltaStreamReader.cs
+++ b/src/GitVersion.Git.Managed/DeltaStreamReader.cs
@@ -46,37 +46,37 @@ internal static class DeltaStreamReader
     {
         if ((instruction & 0b0000_0001) != 0)
         {
-            value.Offset |= (byte)stream.ReadByte();
+            value.Offset |= ReadByteOrThrow(stream);
         }
 
         if ((instruction & 0b0000_0010) != 0)
         {
-            value.Offset |= (byte)stream.ReadByte() << 8;
+            value.Offset |= ReadByteOrThrow(stream) << 8;
         }
 
         if ((instruction & 0b0000_0100) != 0)
         {
-            value.Offset |= (byte)stream.ReadByte() << 16;
+            value.Offset |= ReadByteOrThrow(stream) << 16;
         }
 
         if ((instruction & 0b0000_1000) != 0)
         {
-            value.Offset |= (byte)stream.ReadByte() << 24;
+            value.Offset |= ReadByteOrThrow(stream) << 24;
         }
 
         if ((instruction & 0b0001_0000) != 0)
         {
-            value.Size = (byte)stream.ReadByte();
+            value.Size = ReadByteOrThrow(stream);
         }
 
         if ((instruction & 0b0010_0000) != 0)
         {
-            value.Size |= (byte)stream.ReadByte() << 8;
+            value.Size |= ReadByteOrThrow(stream) << 8;
         }
 
         if ((instruction & 0b0100_0000) != 0)
         {
-            value.Size |= (byte)stream.ReadByte() << 16;
+            value.Size |= ReadByteOrThrow(stream) << 16;
         }
 
         // Size zero is automatically converted to 0x10000.
@@ -84,5 +84,13 @@ internal static class DeltaStreamReader
         {
             value.Size = 0x10000;
         }
+    }
+
+    private static int ReadByteOrThrow(Stream stream)
+    {
+        var value = stream.ReadByte();
+        return value == -1
+            ? throw new EndOfStreamException("The delta stream ended in the middle of a copy instruction.")
+            : value;
     }
 }

--- a/src/GitVersion.Git.Managed/GitCommit.cs
+++ b/src/GitVersion.Git.Managed/GitCommit.cs
@@ -3,10 +3,16 @@
 namespace GitVersion.Git;
 
 /// <summary>
-/// Represents a Git commit, as stored in the Git object database.
+/// Represents a Git commit, as stored in the Git object database. The signatures and the
+/// message are kept as raw bytes and decoded lazily: history walks load every traversed
+/// commit but only ever need the parents and the committer timestamp.
 /// </summary>
 internal sealed class GitCommit
 {
+    private GitSignature? author;
+    private GitSignature? committer;
+    private string? message;
+
     /// <summary>
     /// Gets the <see cref="GitObjectId"/> which uniquely identifies this commit.
     /// </summary>
@@ -23,19 +29,45 @@ internal sealed class GitCommit
     public required IReadOnlyList<GitObjectId> Parents { get; init; }
 
     /// <summary>
-    /// Gets the author of this commit.
+    /// Gets the committer timestamp. Parsed eagerly: the revision walk orders commits by it
+    /// and must not pay for decoding the full signatures or the message.
     /// </summary>
-    public required GitSignature Author { get; init; }
+    public required DateTimeOffset CommitterWhen { get; init; }
 
     /// <summary>
-    /// Gets the committer of this commit.
+    /// Gets the raw bytes of the <c>author</c> header value.
     /// </summary>
-    public required GitSignature Committer { get; init; }
+    public required byte[] RawAuthor { get; init; }
 
     /// <summary>
-    /// Gets the full commit message, decoded honoring the commit's <c>encoding</c> header.
+    /// Gets the raw bytes of the <c>committer</c> header value.
     /// </summary>
-    public required string Message { get; init; }
+    public required byte[] RawCommitter { get; init; }
+
+    /// <summary>
+    /// Gets the raw bytes of the commit message.
+    /// </summary>
+    public required byte[] RawMessage { get; init; }
+
+    /// <summary>
+    /// Gets the value of the commit's <c>encoding</c> header, if present.
+    /// </summary>
+    public string? EncodingName { get; init; }
+
+    /// <summary>
+    /// Gets the author of this commit, decoded on first access.
+    /// </summary>
+    public GitSignature Author => this.author ??= GitSignature.Parse(RawAuthor, EncodingName);
+
+    /// <summary>
+    /// Gets the committer of this commit, decoded on first access.
+    /// </summary>
+    public GitSignature Committer => this.committer ??= GitSignature.Parse(RawCommitter, EncodingName);
+
+    /// <summary>
+    /// Gets the full commit message, decoded on first access honoring the commit's <c>encoding</c> header.
+    /// </summary>
+    public string Message => this.message ??= GitTextDecoder.Decode(RawMessage, EncodingName);
 
     /// <inheritdoc/>
     public override string ToString() => $"Git Commit: {Sha}";

--- a/src/GitVersion.Git.Managed/GitCommitReader.cs
+++ b/src/GitVersion.Git.Managed/GitCommitReader.cs
@@ -109,9 +109,11 @@ internal static class GitCommitReader
             Sha = sha,
             Tree = tree.Value,
             Parents = parents,
-            Author = GitSignature.Parse(authorLine, encodingName),
-            Committer = GitSignature.Parse(committerLine, encodingName),
-            Message = GitTextDecoder.Decode(buffer, encodingName)
+            CommitterWhen = GitSignature.ParseWhen(committerLine),
+            RawAuthor = authorLine.ToArray(),
+            RawCommitter = committerLine.ToArray(),
+            RawMessage = buffer.ToArray(),
+            EncodingName = encodingName
         };
     }
 }

--- a/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
@@ -15,27 +15,63 @@ namespace GitVersion.Git;
 /// underlying <see cref="Stream"/> and cached in a <see cref="MemoryStream"/>. If the same data is read
 /// twice, it is read from the <see cref="MemoryStream"/>, rather than the underlying <see cref="Stream"/>.
 /// </para>
+/// <para>
+/// The cache is bounded: when the decompressed size of the retained entries exceeds the budget,
+/// the least recently used entries are evicted (and disposed once no view is reading them),
+/// so full-history walks over large repositories do not retain every object in memory.
+/// </para>
 /// </summary>
 internal sealed class GitPackMemoryCache : GitPackCache
 {
-    private readonly Dictionary<long, (GitPackMemoryCacheStream Stream, string ObjectType)> cache = [];
+    // libgit2 caps its object cache at 256 MB by default; the same budget keeps the
+    // hot delta-base entries while releasing objects no walk will read again.
+    private const long MaxTotalSize = 256 * 1024 * 1024;
+
+    private readonly object syncRoot = new();
+    private readonly Dictionary<long, LinkedListNode<CacheEntry>> cache = [];
+    private readonly LinkedList<CacheEntry> recency = new();
+    private long totalSize;
+
+    private sealed record CacheEntry(long Offset, GitPackMemoryCacheStream Stream, string ObjectType);
 
     /// <inheritdoc/>
     public override Stream Add(long offset, Stream stream, string objectType)
     {
         var cacheStream = new GitPackMemoryCacheStream(stream);
-        this.cache.Add(offset, (cacheStream, objectType));
-        return new GitPackMemoryCacheViewStream(cacheStream);
+        var view = new GitPackMemoryCacheViewStream(cacheStream);
+
+        lock (this.syncRoot)
+        {
+            if (this.cache.ContainsKey(offset))
+            {
+                // Someone cached this offset between the caller's TryOpen and this Add.
+                // Keep the existing entry; the returned view keeps its own stream alive.
+                cacheStream.Release();
+                return view;
+            }
+
+            var node = this.recency.AddFirst(new CacheEntry(offset, cacheStream, objectType));
+            this.cache.Add(offset, node);
+            this.totalSize += cacheStream.Length;
+            EvictWhileOverBudget();
+        }
+
+        return view;
     }
 
     /// <inheritdoc/>
     public override bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType)
     {
-        if (this.cache.TryGetValue(offset, out var entry))
+        lock (this.syncRoot)
         {
-            stream = new GitPackMemoryCacheViewStream(entry.Stream);
-            objectType = entry.ObjectType;
-            return true;
+            if (this.cache.TryGetValue(offset, out var node))
+            {
+                this.recency.Remove(node);
+                this.recency.AddFirst(node);
+                stream = new GitPackMemoryCacheViewStream(node.Value.Stream);
+                objectType = node.Value.ObjectType;
+                return true;
+            }
         }
 
         stream = null;
@@ -43,17 +79,35 @@ internal sealed class GitPackMemoryCache : GitPackCache
         return false;
     }
 
+    private void EvictWhileOverBudget()
+    {
+        // Never evict the most recent entry: a single object larger than the whole
+        // budget must still be readable through the entry just added.
+        while (this.totalSize > MaxTotalSize && this.recency.Count > 1 && this.recency.Last is { } tail)
+        {
+            this.recency.RemoveLast();
+            this.cache.Remove(tail.Value.Offset);
+            this.totalSize -= tail.Value.Stream.Length;
+            tail.Value.Stream.Release();
+        }
+    }
+
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            foreach (var (stream, _) in this.cache.Values)
+            lock (this.syncRoot)
             {
-                stream.Dispose();
-            }
+                foreach (var entry in this.recency)
+                {
+                    entry.Stream.Release();
+                }
 
-            this.cache.Clear();
+                this.recency.Clear();
+                this.cache.Clear();
+                this.totalSize = 0;
+            }
         }
 
         base.Dispose(disposing);

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
@@ -11,11 +11,32 @@ internal sealed class GitPackMemoryCacheStream : Stream
     private readonly Stream stream;
     private readonly MemoryStream cacheStream = new();
     private readonly long length;
+    private int referenceCount = 1;
+    private bool released;
 
     public GitPackMemoryCacheStream(Stream stream)
     {
         this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
         this.length = this.stream.Length;
+    }
+
+    /// <summary>
+    /// Registers an additional consumer (a <see cref="GitPackMemoryCacheViewStream"/>) of
+    /// this stream. The underlying data is only disposed once the cache has evicted the
+    /// entry and the last consumer has released it.
+    /// </summary>
+    public void AddReference() => Interlocked.Increment(ref this.referenceCount);
+
+    /// <summary>
+    /// Releases one consumer's reference, disposing the underlying streams when none remain.
+    /// </summary>
+    public void Release()
+    {
+        if (Interlocked.Decrement(ref this.referenceCount) == 0)
+        {
+            this.stream.Dispose();
+            this.cacheStream.Dispose();
+        }
     }
 
     /// <summary>
@@ -96,10 +117,10 @@ internal sealed class GitPackMemoryCacheStream : Stream
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
+        if (disposing && !this.released)
         {
-            this.stream.Dispose();
-            this.cacheStream.Dispose();
+            this.released = true;
+            Release();
         }
 
         base.Dispose(disposing);

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
@@ -11,9 +11,13 @@ internal sealed class GitPackMemoryCacheViewStream : Stream
     private readonly GitPackMemoryCacheStream baseStream;
 
     private long position;
+    private bool disposed;
 
-    public GitPackMemoryCacheViewStream(GitPackMemoryCacheStream baseStream) =>
+    public GitPackMemoryCacheViewStream(GitPackMemoryCacheStream baseStream)
+    {
         this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+        this.baseStream.AddReference();
+    }
 
     /// <inheritdoc/>
     public override bool CanRead => true;
@@ -76,4 +80,16 @@ internal sealed class GitPackMemoryCacheViewStream : Stream
 
     /// <inheritdoc/>
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !this.disposed)
+        {
+            this.disposed = true;
+            this.baseStream.Release();
+        }
+
+        base.Dispose(disposing);
+    }
 }

--- a/src/GitVersion.Git.Managed/GitPackReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackReader.cs
@@ -30,6 +30,14 @@ internal static class GitPackReader
                         var baseObjectRelativeOffset = ReadVariableLengthInteger(stream);
                         var baseObjectOffset = offset - baseObjectRelativeOffset;
 
+                        // The base of an ofs-delta always precedes the delta in the pack; a zero
+                        // relative offset would recurse into this same object until the stack
+                        // overflows, and a negative target would seek outside the pack.
+                        if (baseObjectOffset <= 0 || baseObjectOffset >= offset)
+                        {
+                            throw new GitObjectStoreException($"The deltified object at offset {offset} has an invalid base object offset {baseObjectOffset}.");
+                        }
+
                         var deltaStream = new GitZLibStream(stream, decompressedSize);
                         var (baseStream, baseType) = pack.GetObject(baseObjectOffset, objectType);
 

--- a/src/GitVersion.Git.Managed/GitSignature.cs
+++ b/src/GitVersion.Git.Managed/GitSignature.cs
@@ -21,6 +21,29 @@ internal readonly record struct GitSignature(string Name, string Email, DateTime
     /// <returns>The parsed <see cref="GitSignature"/>.</returns>
     public static GitSignature Parse(ReadOnlySpan<byte> value, string? encodingName = null)
     {
+        var (emailStart, emailEnd) = FindEmailDelimiters(value);
+
+        var name = value[..Math.Max(emailStart - 1, 0)];
+        var email = value[(emailStart + 1)..emailEnd];
+        var when = ParseTime(value[Math.Min(emailEnd + 2, value.Length)..]);
+
+        return new(GitTextDecoder.Decode(name, encodingName), GitTextDecoder.Decode(email, encodingName), when);
+    }
+
+    /// <summary>
+    /// Parses only the timestamp of a signature line value, without decoding the name
+    /// or the e-mail address into strings.
+    /// </summary>
+    /// <param name="value">The signature value (excluding the <c>author</c>/<c>committer</c>/<c>tagger</c> prefix).</param>
+    /// <returns>The date and time of the action, including the recorded UTC offset.</returns>
+    public static DateTimeOffset ParseWhen(ReadOnlySpan<byte> value)
+    {
+        var (_, emailEnd) = FindEmailDelimiters(value);
+        return ParseTime(value[Math.Min(emailEnd + 2, value.Length)..]);
+    }
+
+    private static (int EmailStart, int EmailEnd) FindEmailDelimiters(ReadOnlySpan<byte> value)
+    {
         var emailStart = value.IndexOf((byte)'<');
         var emailEnd = value.IndexOf((byte)'>');
 
@@ -29,10 +52,11 @@ internal readonly record struct GitSignature(string Name, string Email, DateTime
             throw new GitObjectStoreException("A signature line is malformed: no e-mail address found.");
         }
 
-        var name = value[..Math.Max(emailStart - 1, 0)];
-        var email = value[(emailStart + 1)..emailEnd];
-        var time = value[Math.Min(emailEnd + 2, value.Length)..];
+        return (emailStart, emailEnd);
+    }
 
+    private static DateTimeOffset ParseTime(ReadOnlySpan<byte> time)
+    {
         var offsetStart = time.IndexOf((byte)' ');
         if (offsetStart < 0)
         {
@@ -51,7 +75,7 @@ internal readonly record struct GitSignature(string Name, string Email, DateTime
             when = when.ToOffset(offset);
         }
 
-        return new(GitTextDecoder.Decode(name, encodingName), GitTextDecoder.Decode(email, encodingName), when);
+        return when;
     }
 
     private static bool TryParseOffset(ReadOnlySpan<byte> value, out TimeSpan offset)

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -97,28 +97,47 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
 
     private List<GitObjectId> PaintDownToCommon(GitObjectId first, GitObjectId second)
     {
-        const int flagFirst = 1;
-        const int flagSecond = 2;
-        const int flagStale = 4;
-        const int flagBoth = flagFirst | flagSecond;
+        var walk = new PaintDownWalk(this);
+        walk.Enqueue(first, PaintDownWalk.FlagFirst);
+        walk.Enqueue(second, PaintDownWalk.FlagSecond);
+        return walk.Run();
+    }
 
-        var flags = new Dictionary<GitObjectId, int>();
-        var queuedCounts = new Dictionary<GitObjectId, int>();
-        var candidates = new List<GitObjectId>();
-        var queue = new PriorityQueue<GitCommit, (long Time, long Sequence)>(TimeDescendingComparer.Instance);
-        var sequence = 0L;
+    /// <summary>
+    /// The paint-down-to-common walk of <c>git merge-base</c>: descend from both tips in
+    /// date order, painting each commit with the tips that reach it; commits reached by
+    /// both are candidates, and everything below a candidate is stale. The number of
+    /// queued non-stale entries is tracked incrementally: libgit2 rescans its whole queue
+    /// per iteration to decide whether anything interesting remains, which is quadratic
+    /// on the hottest path of version calculation. The count is equivalent to that scan.
+    /// </summary>
+    private sealed class PaintDownWalk(GitRevisionWalker walker)
+    {
+        public const int FlagFirst = 1;
+        public const int FlagSecond = 2;
+        private const int FlagStale = 4;
+        private const int FlagBoth = FlagFirst | FlagSecond;
 
-        // The number of queued entries whose commit is not (yet) stale, tracked
-        // incrementally: libgit2 rescans its whole queue per iteration to decide
-        // whether anything interesting remains, which is quadratic on the hottest
-        // path of version calculation. The count is equivalent to that scan.
-        var interesting = 0;
+        private readonly Dictionary<GitObjectId, int> flags = [];
+        private readonly Dictionary<GitObjectId, int> queuedCounts = [];
+        private readonly List<GitObjectId> candidates = [];
+        private readonly PriorityQueue<GitCommit, (long Time, long Sequence)> queue = new(TimeDescendingComparer.Instance);
+        private long sequence;
+        private int interesting;
 
-        void MarkQueuedEntriesStale(GitObjectId id) => interesting -= queuedCounts.GetValueOrDefault(id);
-
-        void Enqueue(GitObjectId id, int newFlags)
+        public List<GitObjectId> Run()
         {
-            var current = flags.GetValueOrDefault(id);
+            while (this.interesting > 0)
+            {
+                Process(this.queue.Dequeue());
+            }
+
+            return this.candidates;
+        }
+
+        public void Enqueue(GitObjectId id, int newFlags)
+        {
+            var current = this.flags.GetValueOrDefault(id);
             var updated = current | newFlags;
 
             if (updated == current)
@@ -126,52 +145,48 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
                 return;
             }
 
-            flags[id] = updated;
+            this.flags[id] = updated;
 
-            if ((current & flagStale) == 0 && (updated & flagStale) != 0)
+            if ((current & FlagStale) == 0 && (updated & FlagStale) != 0)
             {
                 MarkQueuedEntriesStale(id);
             }
 
-            if (TryLoad(id) is { } commit)
+            if (walker.TryLoad(id) is { } commit)
             {
-                queue.Enqueue(commit, (commit.CommitterWhen.ToUnixTimeSeconds(), sequence++));
-                queuedCounts[id] = queuedCounts.GetValueOrDefault(id) + 1;
+                this.queue.Enqueue(commit, (commit.CommitterWhen.ToUnixTimeSeconds(), this.sequence++));
+                this.queuedCounts[id] = this.queuedCounts.GetValueOrDefault(id) + 1;
 
-                if ((updated & flagStale) == 0)
+                if ((updated & FlagStale) == 0)
                 {
-                    interesting++;
+                    this.interesting++;
                 }
             }
         }
 
-        Enqueue(first, flagFirst);
-        Enqueue(second, flagSecond);
-
-        while (interesting > 0)
+        private void Process(GitCommit commit)
         {
-            var commit = queue.Dequeue();
-            var commitFlags = flags[commit.Sha];
-            queuedCounts[commit.Sha]--;
+            var commitFlags = this.flags[commit.Sha];
+            this.queuedCounts[commit.Sha]--;
 
-            if ((commitFlags & flagStale) == 0)
+            if ((commitFlags & FlagStale) == 0)
             {
-                interesting--;
+                this.interesting--;
             }
 
-            var paint = commitFlags & flagBoth;
+            var paint = commitFlags & FlagBoth;
 
-            if (paint == flagBoth)
+            if (paint == FlagBoth)
             {
-                if ((commitFlags & flagStale) == 0)
+                if ((commitFlags & FlagStale) == 0)
                 {
-                    candidates.Add(commit.Sha);
-                    flags[commit.Sha] = commitFlags | flagStale;
+                    this.candidates.Add(commit.Sha);
+                    this.flags[commit.Sha] = commitFlags | FlagStale;
                     MarkQueuedEntriesStale(commit.Sha);
                 }
 
                 // Everything below a common commit is stale: it cannot be a better candidate.
-                paint |= flagStale;
+                paint |= FlagStale;
             }
 
             foreach (var parentId in commit.Parents)
@@ -180,7 +195,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             }
         }
 
-        return candidates;
+        private void MarkQueuedEntriesStale(GitObjectId id) => this.interesting -= this.queuedCounts.GetValueOrDefault(id);
     }
 
     private GitObjectId? RemoveRedundantCandidates(List<GitObjectId> candidates)
@@ -308,8 +323,8 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             {
                 Parse(node);
 
-                // libgit2's revwalk push/hide fails when the commit cannot be looked up;
-                // flowing an unparsed seed through the walk would emit a null commit.
+                // A pushed or hidden commit whose object cannot be looked up fails the
+                // walk in libgit2, too; an unparsed seed would be emitted as a null commit.
                 if (!node.Parsed)
                 {
                     throw new GitObjectStoreException($"The commit '{node.Id}' could not be found in the repository.") { ObjectNotFound = true };

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace GitVersion.Git;
 
 /// <summary>
@@ -19,7 +21,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
     private const int Slop = 5;
 
     private readonly GitObjectStore objectStore = objectStore ?? throw new ArgumentNullException(nameof(objectStore));
-    private readonly Dictionary<GitObjectId, GitCommit?> commitCache = [];
+    private readonly ConcurrentDictionary<GitObjectId, GitCommit?> commitCache = new();
 
     /// <summary>
     /// Walks the commits described by <paramref name="options"/> and returns them in order.
@@ -216,6 +218,15 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
         return false;
     }
 
+    /// <summary>
+    /// Loads a commit through the walker's parsed-commit cache, or returns
+    /// <see langword="null"/> when the object does not exist. The cache is shared with the
+    /// adapter layer so each commit is read and parsed at most once per session.
+    /// </summary>
+    /// <param name="id">The id of the commit.</param>
+    /// <returns>The commit, or <see langword="null"/>.</returns>
+    public GitCommit? TryLoadCommit(GitObjectId id) => TryLoad(id);
+
     private GitCommit? TryLoad(GitObjectId id)
     {
         if (this.commitCache.TryGetValue(id, out var cached))
@@ -233,8 +244,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             }
         }
 
-        this.commitCache[id] = commit;
-        return commit;
+        return this.commitCache.GetOrAdd(id, commit);
     }
 
     /// <summary>

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -269,6 +269,13 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             {
                 Parse(node);
 
+                // libgit2's revwalk push/hide fails when the commit cannot be looked up;
+                // flowing an unparsed seed through the walk would emit a null commit.
+                if (!node.Parsed)
+                {
+                    throw new GitObjectStoreException($"The commit '{node.Id}' could not be found in the repository.") { ObjectNotFound = true };
+                }
+
                 if (node.Uninteresting)
                 {
                     MarkParentsUninteresting(node);

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -133,7 +133,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
 
             if (TryLoad(id) is { } commit)
             {
-                queue.Enqueue(commit, (commit.Committer.When.ToUnixTimeSeconds(), sequence++));
+                queue.Enqueue(commit, (commit.CommitterWhen.ToUnixTimeSeconds(), sequence++));
                 queuedCounts[id] = queuedCounts.GetValueOrDefault(id) + 1;
 
                 if ((updated & flagStale) == 0)
@@ -629,7 +629,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
             }
 
             node.Commit = commit;
-            node.Time = commit.Committer.When.ToUnixTimeSeconds();
+            node.Time = commit.CommitterWhen.ToUnixTimeSeconds();
             node.Parents.AddRange(commit.Parents.Select(LookupNode));
             node.Parsed = true;
         }

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -101,34 +101,62 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
         const int flagBoth = flagFirst | flagSecond;
 
         var flags = new Dictionary<GitObjectId, int>();
+        var queuedCounts = new Dictionary<GitObjectId, int>();
         var candidates = new List<GitObjectId>();
         var queue = new PriorityQueue<GitCommit, (long Time, long Sequence)>(TimeDescendingComparer.Instance);
         var sequence = 0L;
 
+        // The number of queued entries whose commit is not (yet) stale, tracked
+        // incrementally: libgit2 rescans its whole queue per iteration to decide
+        // whether anything interesting remains, which is quadratic on the hottest
+        // path of version calculation. The count is equivalent to that scan.
+        var interesting = 0;
+
+        void MarkQueuedEntriesStale(GitObjectId id) => interesting -= queuedCounts.GetValueOrDefault(id);
+
         void Enqueue(GitObjectId id, int newFlags)
         {
             var current = flags.GetValueOrDefault(id);
+            var updated = current | newFlags;
 
-            if ((current | newFlags) == current)
+            if (updated == current)
             {
                 return;
             }
 
-            flags[id] = current | newFlags;
+            flags[id] = updated;
+
+            if ((current & flagStale) == 0 && (updated & flagStale) != 0)
+            {
+                MarkQueuedEntriesStale(id);
+            }
 
             if (TryLoad(id) is { } commit)
             {
                 queue.Enqueue(commit, (commit.Committer.When.ToUnixTimeSeconds(), sequence++));
+                queuedCounts[id] = queuedCounts.GetValueOrDefault(id) + 1;
+
+                if ((updated & flagStale) == 0)
+                {
+                    interesting++;
+                }
             }
         }
 
         Enqueue(first, flagFirst);
         Enqueue(second, flagSecond);
 
-        while (queue.UnorderedItems.Any(entry => (flags[entry.Element.Sha] & flagStale) == 0))
+        while (interesting > 0)
         {
             var commit = queue.Dequeue();
             var commitFlags = flags[commit.Sha];
+            queuedCounts[commit.Sha]--;
+
+            if ((commitFlags & flagStale) == 0)
+            {
+                interesting--;
+            }
+
             var paint = commitFlags & flagBoth;
 
             if (paint == flagBoth)
@@ -137,6 +165,7 @@ internal sealed class GitRevisionWalker(GitObjectStore objectStore)
                 {
                     candidates.Add(commit.Sha);
                     flags[commit.Sha] = commitFlags | flagStale;
+                    MarkQueuedEntriesStale(commit.Sha);
                 }
 
                 // Everything below a common commit is stale: it cannot be a better candidate.

--- a/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
@@ -84,6 +84,25 @@ internal sealed class GitConfigurationFile
     }
 
     /// <summary>
+    /// Gets the effective value of a boolean key using git's boolean semantics,
+    /// or <see langword="null"/> when the key is not present or not a valid boolean.
+    /// </summary>
+    public bool? GetBoolean(string section, string? subsection, string key) =>
+        GetString(section, subsection, key) switch
+        {
+            null => null,
+            "" => false,
+            var value when value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("on", StringComparison.OrdinalIgnoreCase) => true,
+            var value when value.Equals("false", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("no", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("off", StringComparison.OrdinalIgnoreCase) => false,
+            var value when long.TryParse(value, out var number) => number != 0,
+            _ => null
+        };
+
+    /// <summary>
     /// Gets all values of a multi-valued key, in file order.
     /// </summary>
     public IReadOnlyList<string> GetAll(string section, string? subsection, string key) =>

--- a/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
@@ -117,6 +117,16 @@ internal sealed class GitRepositoryLayout
             throw new NotSupportedException("Repositories using the reftable reference storage format are not supported yet.");
         }
 
+        // SHA-256 repositories declare extensions.objectformat in their config. The managed
+        // reader only implements SHA-1 pack indexes so far; fail clearly at open instead of
+        // deep inside an object lookup (parity: libgit2 cannot read them either).
+        var objectFormat = GitConfigurationFile.Load(Path.Combine(commonDirectory, "config"))
+            .GetString("extensions", null, "objectformat");
+        if (objectFormat is not null && !objectFormat.Equals("sha1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"Repositories using the '{objectFormat}' object format are not supported yet.");
+        }
+
         return new()
         {
             GitDirectory = gitDirectory,

--- a/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
@@ -64,23 +64,46 @@ internal sealed class GitRepositoryLayout
 
         for (var current = Path.GetFullPath(startPath); current is not null; current = Path.GetDirectoryName(current))
         {
-            var dotGit = Path.Combine(current, GitDirectoryOrFileName);
-
-            if (Directory.Exists(dotGit))
+            if (TryOpenExact(current) is { } layout)
             {
-                return FromGitDirectory(dotGit, current);
+                return layout;
             }
+        }
 
-            if (File.Exists(dotGit))
-            {
-                return FromGitDirectory(ResolveGitDirFile(dotGit), current);
-            }
+        return null;
+    }
 
-            if (IsGitDirectory(current))
-            {
-                // A bare repository, or the .git directory itself.
-                return FromGitDirectory(current, workingDirectory: null);
-            }
+    /// <summary>
+    /// Opens the repository at exactly <paramref name="path"/> (a working directory with a
+    /// <c>.git</c> entry, or a git directory itself) without walking up the hierarchy —
+    /// the equivalent of libgit2's <c>new Repository(path)</c> as opposed to its discovery.
+    /// </summary>
+    /// <param name="path">The path of the repository.</param>
+    /// <returns>The layout of the repository, or <see langword="null"/> when the path is not itself a repository.</returns>
+    public static GitRepositoryLayout? TryOpen(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return TryOpenExact(Path.GetFullPath(path));
+    }
+
+    private static GitRepositoryLayout? TryOpenExact(string current)
+    {
+        var dotGit = Path.Combine(current, GitDirectoryOrFileName);
+
+        if (Directory.Exists(dotGit))
+        {
+            return FromGitDirectory(dotGit, current);
+        }
+
+        if (File.Exists(dotGit))
+        {
+            return FromGitDirectory(ResolveGitDirFile(dotGit), current);
+        }
+
+        if (IsGitDirectory(current))
+        {
+            // A bare repository, or the .git directory itself.
+            return FromGitDirectory(current, workingDirectory: null);
         }
 
         return null;

--- a/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
@@ -11,11 +11,11 @@ internal sealed class GitIgnoreRules
 {
     private readonly List<(Regex Pattern, bool DirectoryOnly, bool Negated)> rules = [];
 
-    private GitIgnoreRules(IEnumerable<string> lines)
+    private GitIgnoreRules(IEnumerable<string> lines, bool ignoreCase)
     {
         foreach (var line in lines)
         {
-            if (ParseLine(line) is { } rule)
+            if (ParseLine(line, ignoreCase) is { } rule)
             {
                 this.rules.Add(rule);
             }
@@ -26,15 +26,17 @@ internal sealed class GitIgnoreRules
     /// Loads the rules from an ignore file, or returns <see langword="null"/> when the file does not exist.
     /// </summary>
     /// <param name="path">The path of the ignore file.</param>
+    /// <param name="ignoreCase">Whether patterns match case-insensitively (<c>core.ignorecase</c>).</param>
     /// <returns>The parsed rules, if the file exists.</returns>
-    public static GitIgnoreRules? Load(string path) => File.Exists(path) ? new(File.ReadLines(path)) : null;
+    public static GitIgnoreRules? Load(string path, bool ignoreCase) => File.Exists(path) ? new(File.ReadLines(path), ignoreCase) : null;
 
     /// <summary>
     /// Parses ignore rules from text lines.
     /// </summary>
     /// <param name="lines">The lines of an ignore file.</param>
+    /// <param name="ignoreCase">Whether patterns match case-insensitively (<c>core.ignorecase</c>).</param>
     /// <returns>The parsed rules.</returns>
-    public static GitIgnoreRules Parse(IEnumerable<string> lines) => new(lines);
+    public static GitIgnoreRules Parse(IEnumerable<string> lines, bool ignoreCase) => new(lines, ignoreCase);
 
     /// <summary>
     /// Determines whether this source decides the ignored state of the given path.
@@ -66,7 +68,7 @@ internal sealed class GitIgnoreRules
         return null;
     }
 
-    private static (Regex Pattern, bool DirectoryOnly, bool Negated)? ParseLine(string line)
+    private static (Regex Pattern, bool DirectoryOnly, bool Negated)? ParseLine(string line, bool ignoreCase)
     {
         var pattern = TrimTrailingSpaces(line);
 
@@ -103,9 +105,12 @@ internal sealed class GitIgnoreRules
 
         pattern = pattern.TrimStart('/');
 
+        // git matches ignore patterns case-insensitively when core.ignorecase is set
+        // (the default in repositories created on case-insensitive filesystems).
+        var regexOptions = RegexOptions.CultureInvariant | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
         var regex = new Regex(
             "^" + TranslateToRegex(pattern) + "$",
-            RegexOptions.CultureInvariant,
+            regexOptions,
             TimeSpan.FromSeconds(1));
 
         return (regex, directoryOnly, negated);

--- a/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
+++ b/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
@@ -13,6 +13,9 @@ internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectS
 {
     private readonly GitRepositoryLayout layout = layout ?? throw new ArgumentNullException(nameof(layout));
     private readonly GitTreeDiff treeDiff = new(objectStore);
+    private readonly Lazy<bool> ignoreCase = new(() =>
+        GitConfigurationFile.Load(Path.Combine(layout.CommonDirectory, "config"))
+            .GetBoolean("core", null, "ignorecase") ?? false);
 
     /// <summary>
     /// Counts the paths which differ between the given HEAD tree, the index, and the
@@ -238,30 +241,31 @@ internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectS
 
         // Shallowest sources first: the user's global excludes file, then the repository's
         // info/exclude, then the per-directory .gitignore chain added while walking.
-        if (ResolveGlobalExcludesFile() is { } globalExcludesFile && GitIgnoreRules.Load(globalExcludesFile) is { } globalRules)
+        if (ResolveGlobalExcludesFile() is { } globalExcludesFile && GitIgnoreRules.Load(globalExcludesFile, this.ignoreCase.Value) is { } globalRules)
         {
             ignoreSources.Add(("", globalRules));
         }
 
-        if (GitIgnoreRules.Load(Path.Combine(this.layout.CommonDirectory, "info", "exclude")) is { } excludeRules)
+        if (GitIgnoreRules.Load(Path.Combine(this.layout.CommonDirectory, "info", "exclude"), this.ignoreCase.Value) is { } excludeRules)
         {
             ignoreSources.Add(("", excludeRules));
         }
 
-        WalkDirectory(workingDirectory, relativePrefix: "", ignoreSources, indexEntries, untracked);
+        WalkDirectory(workingDirectory, relativePrefix: "", this.ignoreCase.Value, ignoreSources, indexEntries, untracked);
         return untracked;
     }
 
     private static void WalkDirectory(
         string directory,
         string relativePrefix,
+        bool ignoreCase,
         List<(string BasePrefix, GitIgnoreRules Rules)> ignoreSources,
         Dictionary<string, GitIndexEntry> indexEntries,
         List<string> untracked)
     {
         var addedSource = false;
 
-        if (GitIgnoreRules.Load(Path.Combine(directory, ".gitignore")) is { } rules)
+        if (GitIgnoreRules.Load(Path.Combine(directory, ".gitignore"), ignoreCase) is { } rules)
         {
             ignoreSources.Add((relativePrefix, rules));
             addedSource = true;
@@ -290,7 +294,7 @@ internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectS
 
                 if (isDirectory)
                 {
-                    WalkDirectory(entryPath, relativePath + "/", ignoreSources, indexEntries, untracked);
+                    WalkDirectory(entryPath, relativePath + "/", ignoreCase, ignoreSources, indexEntries, untracked);
                 }
                 else if (!indexEntries.ContainsKey(relativePath))
                 {

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepository.cs
@@ -46,20 +46,6 @@ internal sealed partial class GitRepository
         this.repositoryLazy = new(() => new Repository(gitDirectory));
     }
 
-    /// <summary>
-    /// Drops the cached collection wrappers so that changes made outside this instance
-    /// (e.g. by the git CLI) become visible. The libgit2 repository itself re-reads refs
-    /// and objects from disk on demand, so it must not be disposed here — wrapper objects
-    /// already handed out still reference its native memory.
-    /// </summary>
-    internal void ResetCachedCollections()
-    {
-        this.tags = null;
-        this.commits = null;
-        this.remotes = null;
-        this.references = null;
-    }
-
     public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)
     {
         commit = commit.NotNull();

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using GitVersion.Extensions;
-using GitVersion.Helpers;
 using LibGit2Sharp;
 
 namespace GitVersion.Git;
@@ -37,49 +36,31 @@ public class GitRepositoryInfo : IGitRepositoryInfo
         return DynamicRepositoryPath.Get(this.fileSystem, repositoryInfo.TargetUrl, repositoryInfo.ClonePath, GitRepoHasMatchingRemote);
     }
 
-    private string? GetDotGitDirectory()
-    {
-        var gitDirectory = !DynamicGitRepositoryPath.IsNullOrWhiteSpace()
-            ? DynamicGitRepositoryPath
-            : Repository.Discover(this.gitVersionOptions.WorkingDirectory);
+    private string? GetDotGitDirectory() =>
+        RepositoryPathResolution.ResolveDotGitDirectory(
+            this.fileSystem,
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            Repository.Discover);
 
-        gitDirectory = gitDirectory?.TrimEnd('/', '\\');
-        if (gitDirectory.IsNullOrEmpty())
-        {
-            throw new DirectoryNotFoundException("Cannot find the .git directory");
-        }
+    private string GetProjectRootDirectory() =>
+        RepositoryPathResolution.ResolveProjectRootDirectory(
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            static workingDirectory =>
+            {
+                var gitDirectory = Repository.Discover(workingDirectory);
+                if (gitDirectory.IsNullOrEmpty())
+                {
+                    return null;
+                }
 
-        var directoryInfo = this.fileSystem.Directory.GetParent(gitDirectory) ?? throw new DirectoryNotFoundException("Cannot find the .git directory");
-        return gitDirectory.Contains(FileSystemHelper.Path.Combine(".git", "worktrees"))
-            ? this.fileSystem.Directory.GetParent(directoryInfo.FullName)?.FullName
-            : gitDirectory;
-    }
+                using var repo = new Repository(gitDirectory);
+                return repo.Info.WorkingDirectory;
+            });
 
-    private string GetProjectRootDirectory()
-    {
-        if (!DynamicGitRepositoryPath.IsNullOrWhiteSpace())
-        {
-            return this.gitVersionOptions.WorkingDirectory;
-        }
-
-        var gitDirectory = Repository.Discover(this.gitVersionOptions.WorkingDirectory);
-
-        if (gitDirectory.IsNullOrEmpty())
-        {
-            throw new DirectoryNotFoundException("Cannot find the .git directory");
-        }
-
-        using var repo = new Repository(gitDirectory);
-        return repo.Info.WorkingDirectory;
-    }
-
-    private string? GetGitRootPath()
-    {
-        var isDynamicRepo = !DynamicGitRepositoryPath.IsNullOrWhiteSpace();
-        var rootDirectory = isDynamicRepo ? DotGitDirectory : ProjectRootDirectory;
-
-        return rootDirectory;
-    }
+    private string? GetGitRootPath() =>
+        RepositoryPathResolution.ResolveGitRootPath(DynamicGitRepositoryPath, DotGitDirectory, ProjectRootDirectory);
 
     private static bool GitRepoHasMatchingRemote(string possiblePath, string targetUrl)
     {


### PR DESCRIPTION
Fixes for 19 findings from a design-doc-guided code review of `feature/managed-git` against `next/v7` (docs/design/managed-git-migration.md), one commit per finding.

## Correctness

- **Cache key**: hash packed-refs content into the git-system cache key — in packed-refs-only clones (fresh clones by recent git), ref updates never invalidated the cache and stale versions were served
- **Status parity**: honor `core.ignorecase` when matching gitignore patterns (libgit2 does; default true on Windows/macOS repos) — previously inflated `UncommittedChangesCount` on those platforms
- **CLI error mapping**: scope 401/403/404 stderr classification to network commands (a checkout of `fix-404-page` was reported as "repository not found"); recognize git's `repository '<url>' not found` phrasing from non-GitHub hosts; broaden lock-contention detection so the `LockedFileException` retry keeps engaging
- **Env hygiene**: scrub `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR`/`GIT_NAMESPACE`/object-dir vars in `GitCliExecutor` — git exports `GIT_DIR` in hooks, redirecting mutations away from the discovered repository (libgit2 ignores these vars)
- **SHA-256 repos**: detect `extensions.objectformat=sha256` at open and fail with a clear `NotSupportedException` (design-mandated), instead of a raw `ArgumentException` deep in the pack index reader
- **PR normalization parity**: filter the HEAD advertisement, peeled `^{}` entries and duplicates once in shared `PullRequestBranchOperations`, so both backends see the same candidate set for the more-than-one-remote-tip check
- **Corrupt packs**: truncated delta copy instructions throw `EndOfStreamException` instead of silently decoding EOF as 0xFF (wrong object content); ofs-delta base offsets are validated, preventing unbounded self-recursion (`StackOverflowException`) and negative seeks
- **Dynamic repos**: `GitRepoHasMatchingRemote` uses a new non-walking `GitRepositoryLayout.TryOpen` — discovery walking up could match an enclosing repository and hand back a nonexistent `.git` path
- **Revision walk**: fail fast when a pushed/hidden commit cannot be loaded (libgit2 parity) instead of emitting a null commit in walk results

## Performance

- Merge-base paint-down staleness check is an incremental counter instead of an O(queue) LINQ rescan per dequeue — `FindMergeBase` is the hottest repository call
- Commit signatures and message decode lazily; walks parse only parents + committer timestamp
- Commit caches keyed by `GitObjectId` (no 40-char hex string per lookup); the session shares the walker's parse cache so commits parse once per session
- Pack memory cache bounded at 256 MB (libgit2's default budget) with reference-counted LRU eviction

## Cleanup

- Worktree-aware repository-path resolution extracted into Core `RepositoryPathResolution`, shared by both backends (~70 duplicated lines removed)
- Dead `ResetCachedCollections` removed
- CI publishes test summaries and codecov uploads (flagged per backend) for the managed matrix leg too
- `GITVERSION_GIT_BACKEND` parsing centralized in `GitBackendSelector`: trims, case-insensitive, **fails fast on unknown values** (a silently ignored typo would invalidate backend testing during the validation window); docs updated
- Test temp-repo cleanup resets read-only file attributes (fixes a per-run leak on Windows)

## Validation

- `dotnet format --verify-no-changes` clean
- Full `GitVersion.Core.Tests` suite green under both `GITVERSION_GIT_BACKEND=libgit2` and `=managed` (36,160 tests each)
- Managed backend unit suite (149 tests) and `DualBackendParityTests` green
- New regression tests accompany most fixes (ignorecase parity, error classification incl. a live HTTP-404 clone, `GIT_DIR` scrubbing, SHA-256 rejection, remote-tip filtering, delta EOF, `TryOpen`, unloadable seeds, backend selector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
