### PR TITLE
refactor(git): internalize LibGit2Sharp extensions, add ICommitish, fix cache key

### DIFF
--- a/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
+++ b/src/GitVersion.Core.Tests/Extensions/GitRepositoryTestingExtensions.cs
@@ -78,7 +78,7 @@ public static class GitRepositoryTestingExtensions
             => DumpGraph(repository.ToGitRepository().Path, writer, maxCommits);
     }
 
-    extension(RemoteCollection remotes)
+    extension(LibGit2Sharp.RemoteCollection remotes)
     {
         public void RenameRemote(string oldName, string newName)
         {

--- a/src/GitVersion.Core/Git/CommitFilter.cs
+++ b/src/GitVersion.Core/Git/CommitFilter.cs
@@ -6,11 +6,11 @@ public record CommitFilter
     /// <summary>Gets a value indicating whether only the first-parent chain should be traversed.</summary>
     public bool FirstParentOnly { get; init; }
 
-    /// <summary>Gets the commit, branch, or tag from which reachable commits are included.</summary>
-    public object? IncludeReachableFrom { get; init; }
+    /// <summary>Gets the commit or branch from which reachable commits are included.</summary>
+    public ICommitish? IncludeReachableFrom { get; init; }
 
-    /// <summary>Gets the commit, branch, or tag whose reachable commits are excluded from the result.</summary>
-    public object? ExcludeReachableFrom { get; init; }
+    /// <summary>Gets the commit or branch whose reachable commits are excluded from the result.</summary>
+    public ICommitish? ExcludeReachableFrom { get; init; }
 
     /// <summary>Gets the ordering strategy applied to the resulting commits.</summary>
     public CommitSortStrategies SortBy { get; init; }

--- a/src/GitVersion.Core/Git/IBranch.cs
+++ b/src/GitVersion.Core/Git/IBranch.cs
@@ -1,7 +1,7 @@
 namespace GitVersion.Git;
 
 /// <summary>Represents a Git branch, exposing its tip commit and tracking information.</summary>
-public interface IBranch : IEquatable<IBranch?>, IComparable<IBranch>, INamedReference
+public interface IBranch : IEquatable<IBranch?>, IComparable<IBranch>, INamedReference, ICommitish
 {
     /// <summary>Gets the most recent commit on this branch, or <see langword="null"/> for an empty branch.</summary>
     ICommit? Tip { get; }

--- a/src/GitVersion.Core/Git/ICommit.cs
+++ b/src/GitVersion.Core/Git/ICommit.cs
@@ -1,7 +1,7 @@
 namespace GitVersion.Git;
 
 /// <summary>Represents a single Git commit.</summary>
-public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>
+public interface ICommit : IEquatable<ICommit?>, IComparable<ICommit>, ICommitish
 {
     /// <summary>Gets the direct parent commits of this commit.</summary>
     IReadOnlyList<ICommit> Parents { get; }

--- a/src/GitVersion.Core/Git/ICommitish.cs
+++ b/src/GitVersion.Core/Git/ICommitish.cs
@@ -1,0 +1,4 @@
+namespace GitVersion.Git;
+
+/// <summary>Marker for objects that can serve as the starting point of a commit graph traversal (a commit or a branch tip).</summary>
+public interface ICommitish;

--- a/src/GitVersion.Core/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Shipped.txt
@@ -200,11 +200,11 @@ GitVersion.Git.BranchCommit.Equals(GitVersion.Git.BranchCommit? other) -> bool
 GitVersion.Git.CommitFilter
 GitVersion.Git.CommitFilter.CommitFilter() -> void
 GitVersion.Git.CommitFilter.CommitFilter(GitVersion.Git.CommitFilter! original) -> void
-GitVersion.Git.CommitFilter.ExcludeReachableFrom.get -> object?
+GitVersion.Git.CommitFilter.ExcludeReachableFrom.get -> GitVersion.Git.ICommitish?
 GitVersion.Git.CommitFilter.ExcludeReachableFrom.init -> void
 GitVersion.Git.CommitFilter.FirstParentOnly.get -> bool
 GitVersion.Git.CommitFilter.FirstParentOnly.init -> void
-GitVersion.Git.CommitFilter.IncludeReachableFrom.get -> object?
+GitVersion.Git.CommitFilter.IncludeReachableFrom.get -> GitVersion.Git.ICommitish?
 GitVersion.Git.CommitFilter.IncludeReachableFrom.init -> void
 GitVersion.Git.CommitFilter.SortBy.get -> GitVersion.Git.CommitSortStrategies
 GitVersion.Git.CommitFilter.SortBy.init -> void
@@ -234,6 +234,7 @@ GitVersion.Git.ICommit.When.get -> System.DateTimeOffset
 GitVersion.Git.ICommitCollection
 GitVersion.Git.ICommitCollection.GetCommitsPriorTo(System.DateTimeOffset olderThan) -> System.Collections.Generic.IEnumerable<GitVersion.Git.ICommit!>!
 GitVersion.Git.ICommitCollection.QueryBy(GitVersion.Git.CommitFilter! commitFilter) -> System.Collections.Generic.IEnumerable<GitVersion.Git.ICommit!>!
+GitVersion.Git.ICommitish
 GitVersion.Git.IGitRepository
 GitVersion.Git.IGitRepository.Branches.get -> GitVersion.Git.IBranchCollection!
 GitVersion.Git.IGitRepository.Commits.get -> GitVersion.Git.ICommitCollection!

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -41,8 +41,19 @@ internal class GitVersionCacheKeyFactory(
     {
         var dotGitDirectory = this.repositoryInfo.DotGitDirectory;
 
-        // traverse the directory and get a list of files, use that for GetHash
-        var contents = CalculateDirectoryContents(FileSystemHelper.Path.Combine(dotGitDirectory, "refs"));
+        // traverse the directory and get a list of files, use that for GetHash.
+        // The refs directory may not exist when all refs are packed (e.g. a fresh
+        // clone by recent versions of git writes refs to packed-refs only).
+        var refsPath = FileSystemHelper.Path.Combine(dotGitDirectory, "refs");
+        var contents = this.fileSystem.Directory.Exists(refsPath)
+            ? CalculateDirectoryContents(refsPath)
+            : [];
+
+        // Refs may live partially or entirely in packed-refs instead of loose files
+        // under refs/, so its content must contribute to the hash for packed ref
+        // updates (e.g. a fetched tag) to invalidate the cache.
+        var packedRefsPath = FileSystemHelper.Path.Combine(dotGitDirectory, "packed-refs");
+        AddFileContents([packedRefsPath], contents);
 
         return GetHash([.. contents]);
     }

--- a/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/CommitCollection.cs
@@ -34,17 +34,38 @@ internal sealed class CommitCollection : ICommitCollection
             IncludeReachableFrom = includeReachableFrom,
             ExcludeReachableFrom = excludeReachableFrom,
             FirstParentOnly = commitFilter.FirstParentOnly,
-            SortBy = (LibGit2Sharp.CommitSortStrategies)commitFilter.SortBy
+            SortBy = GetSortStrategies(commitFilter.SortBy)
         };
         var commitLog = ((IQueryableCommitLog)this.innerCollection).QueryBy(filter);
         return new CommitCollection(commitLog, this.diff, this.repositoryCache);
 
-        static object? GetReacheableFrom(object? item) =>
+        static object? GetReacheableFrom(ICommitish? item) =>
             item switch
             {
                 Commit c => (LibGit2Sharp.Commit)c,
                 Branch b => (LibGit2Sharp.Branch)b,
                 _ => null
             };
+
+        static LibGit2Sharp.CommitSortStrategies GetSortStrategies(CommitSortStrategies sortBy)
+        {
+            var result = LibGit2Sharp.CommitSortStrategies.None;
+            if (sortBy.HasFlag(CommitSortStrategies.Topological))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Topological;
+            }
+
+            if (sortBy.HasFlag(CommitSortStrategies.Time))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Time;
+            }
+
+            if (sortBy.HasFlag(CommitSortStrategies.Reverse))
+            {
+                result |= LibGit2Sharp.CommitSortStrategies.Reverse;
+            }
+
+            return result;
+        }
     }
 }

--- a/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
+++ b/src/GitVersion.LibGit2Sharp/Git/GitRepositoryInfo.cs
@@ -72,7 +72,7 @@ public class GitRepositoryInfo : IGitRepositoryInfo
             : Repository.Discover(this.gitVersionOptions.WorkingDirectory);
 
         gitDirectory = gitDirectory?.TrimEnd('/', '\\');
-        if (gitDirectory.IsNullOrEmpty())
+        if (string.IsNullOrEmpty(gitDirectory))
         {
             throw new DirectoryNotFoundException("Cannot find the .git directory");
         }

--- a/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
+++ b/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
@@ -8,4 +8,10 @@
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+        <InternalsVisibleTo Include="GitVersion.MsBuild.Tests" />
+        <InternalsVisibleTo Include="GitVersion.Output.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/GitVersion.LibGit2Sharp/LibGit2SharpExtensions.cs
+++ b/src/GitVersion.LibGit2Sharp/LibGit2SharpExtensions.cs
@@ -4,7 +4,7 @@ using LibGit2Sharp;
 
 namespace GitVersion;
 
-public static class LibGit2SharpExtensions
+internal static class LibGit2SharpExtensions
 {
     extension(IRepository repository)
     {

--- a/src/GitVersion.LibGit2Sharp/PublicAPI.Shipped.txt
+++ b/src/GitVersion.LibGit2Sharp/PublicAPI.Shipped.txt
@@ -8,7 +8,3 @@ GitVersion.Git.GitRepositoryInfo.ProjectRootDirectory.get -> string?
 GitVersion.GitVersionLibGit2SharpModule
 GitVersion.GitVersionLibGit2SharpModule.GitVersionLibGit2SharpModule() -> void
 GitVersion.GitVersionLibGit2SharpModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
-GitVersion.LibGit2SharpExtensions
-GitVersion.LibGit2SharpExtensions.extension(LibGit2Sharp.IRepository!)
-GitVersion.LibGit2SharpExtensions.extension(LibGit2Sharp.IRepository!).ToGitRepository() -> GitVersion.Git.IGitRepository!
-static GitVersion.LibGit2SharpExtensions.ToGitRepository(this LibGit2Sharp.IRepository! repository) -> GitVersion.Git.IGitRepository!

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildExeFixture.cs
@@ -50,7 +50,15 @@ public class MsBuildExeFixture
             }
         }
 
-        var results = analyzer.Build(environmentOptions);
+        // The MSBuild child process inherits the current process environment, so a build-agent
+        // variable set by a concurrent MsBuildTaskFixture (e.g. TF_BUILD) would otherwise leak into
+        // it and be wrongly detected. Entering the scope serializes against those fixtures and
+        // resets the process environment so the child starts from a clean, non-CI baseline.
+        IAnalyzerResults results;
+        using (MsBuildProcessEnvironment.Enter())
+        {
+            results = analyzer.Build(environmentOptions);
+        }
 
         return new MsBuildExeFixtureResult(this.fixture)
         {

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildProcessEnvironment.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildProcessEnvironment.cs
@@ -1,0 +1,80 @@
+using GitVersion.Agents;
+
+namespace GitVersion.MsBuild.Tests.Helpers;
+
+/// <summary>
+/// An exclusive scope over the *process-wide* environment-variable manipulation that the MsBuild
+/// task and MsBuild.exe fixtures depend on. The MsBuild task detects the current build agent from
+/// the real process environment, and the MsBuild.exe fixture launches a child process that inherits
+/// it, so both are sensitive to the environment being mutated by another fixture.
+/// </summary>
+/// <remarks>
+/// Under <c>[assembly: Parallelizable(ParallelScope.Fixtures)]</c> several fixtures run at the same
+/// time. Without coordination, one fixture setting a CI variable such as <c>TF_BUILD</c> could leak
+/// into another fixture's task or child process (making it wrongly detect a build agent), and one
+/// fixture's reset could clear another's variables mid-execution. <see cref="Enter"/> takes an
+/// exclusive lock, resets the build-agent variables to a clean baseline and applies the requested
+/// variables; disposing the scope resets them again and releases the lock, so the whole window is
+/// mutually exclusive:
+/// <code>
+/// using var environment = MsBuildProcessEnvironment.Enter(variables);
+/// // ... run the task or build ...
+/// </code>
+/// </remarks>
+internal sealed class MsBuildProcessEnvironment : IDisposable
+{
+    private static readonly object Lock = new();
+
+    private static readonly string[] BuildAgentVariableNames =
+    [
+        TeamCity.EnvironmentVariableName,
+        AppVeyor.EnvironmentVariableName,
+        TravisCi.EnvironmentVariableName,
+        Jenkins.EnvironmentVariableName,
+        AzurePipelines.EnvironmentVariableName,
+        GitHubActions.EnvironmentVariableName,
+        SpaceAutomation.EnvironmentVariableName
+    ];
+
+    private MsBuildProcessEnvironment(KeyValuePair<string, string?>[]? environmentVariables)
+    {
+        Monitor.Enter(Lock);
+        Reset();
+        Apply(environmentVariables);
+    }
+
+    /// <summary>
+    /// Acquires exclusive access to the process environment, resets the build-agent variables to a
+    /// clean, non-CI baseline and applies <paramref name="environmentVariables"/>. Dispose the
+    /// returned scope to reset again and release the lock.
+    /// </summary>
+    public static MsBuildProcessEnvironment Enter(KeyValuePair<string, string?>[]? environmentVariables = null) =>
+        new(environmentVariables);
+
+    public void Dispose()
+    {
+        Reset();
+        Monitor.Exit(Lock);
+    }
+
+    private static void Apply(KeyValuePair<string, string?>[]? environmentVariables)
+    {
+        if (environmentVariables == null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in environmentVariables)
+        {
+            SysEnv.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    private static void Reset()
+    {
+        foreach (var name in BuildAgentVariableNames)
+        {
+            SysEnv.SetEnvironmentVariable(name, null);
+        }
+    }
+}

--- a/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
+++ b/src/GitVersion.MsBuild.Tests/Helpers/MsBuildTaskFixture.cs
@@ -1,4 +1,3 @@
-using GitVersion.Agents;
 using GitVersion.Helpers;
 using GitVersion.MsBuild.Tasks;
 using GitVersion.MsBuild.Tests.Mocks;
@@ -39,45 +38,9 @@ public class MsBuildTaskFixture(RepositoryFixtureBase fixture)
 
     private T UsingEnv<T>(Func<T> func)
     {
-        ResetEnvironment();
-        SetEnvironmentVariables(this.environmentVariables);
-
-        try
-        {
-            return func();
-        }
-        finally
-        {
-            ResetEnvironment();
-        }
-    }
-
-    private static void ResetEnvironment()
-    {
-        var environmentalVariables = new Dictionary<string, string?>
-        {
-            { TeamCity.EnvironmentVariableName, null },
-            { AppVeyor.EnvironmentVariableName, null },
-            { TravisCi.EnvironmentVariableName, null },
-            { Jenkins.EnvironmentVariableName, null },
-            { AzurePipelines.EnvironmentVariableName, null },
-            { GitHubActions.EnvironmentVariableName, null },
-            { SpaceAutomation.EnvironmentVariableName, null }
-        };
-
-        SetEnvironmentVariables([.. environmentalVariables]);
-    }
-
-    private static void SetEnvironmentVariables(KeyValuePair<string, string?>[]? envs)
-    {
-        if (envs == null)
-        {
-            return;
-        }
-
-        foreach (var (key, value) in envs)
-        {
-            SysEnv.SetEnvironmentVariable(key, value);
-        }
+        // The task reads the process-wide environment to detect the build agent, so serialize the
+        // whole set/execute/reset window against every other environment-sensitive fixture.
+        using var environment = MsBuildProcessEnvironment.Enter(this.environmentVariables);
+        return func();
     }
 }

--- a/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
+++ b/src/GitVersion.Output.Tests/Output/AssemblyInfoFileUpdaterTests.cs
@@ -152,6 +152,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -190,6 +191,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -210,6 +212,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -230,6 +233,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -250,6 +254,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 !s.Contains("""AssemblyVersionAttribute("1.0.0.0")""") &&
                 !s.Contains("""AssemblyInformationalVersionAttribute("1.0.0.0")""") &&
                 !s.Contains("""AssemblyFileVersionAttribute("1.0.0.0")""") &&
@@ -273,6 +278,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -293,6 +299,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -313,6 +320,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.1.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -333,6 +341,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));
@@ -353,6 +362,7 @@ public class AssemblyInfoFileUpdaterTests : TestBase
             assemblyInfoFileUpdater.Execute(variables, new(this.workingDir, false, assemblyInfoFile));
 
             fs.Received().File.WriteAllText(fileName, Arg.Is<string>(s =>
+                s != null &&
                 s.Contains("""AssemblyVersion("2.3.0.0")""") &&
                 s.Contains("""AssemblyInformationalVersion("2.3.1+3.Branch.foo.Sha.hash")""") &&
                 s.Contains("""AssemblyFileVersion("2.3.1.0")""")));


### PR DESCRIPTION
## Summary

Batch of git-layer refactors, test hardening, and a caching fix from my fork's `main`:

- **fix(caching)**: include packed-refs in cache key calculation
- **refactor(git)**: use standard `string.IsNullOrEmpty` for git directory check
- **test(msbuild)**: synchronize process environment access in MSBuild fixtures
- **refactor(git)**: introduce `ICommitish` interface for commit graph traversal
- **refactor(git)**: internalize LibGit2Sharp extensions and improve commit sorting
- **test(output)**: add null checks to AssemblyInfoFileUpdater assertions

## Test plan

- [ ] `dotnet test ./src/GitVersion.slnx`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)