### PR TITLE
feat(git): fully managed Git backend selectable via GITVERSION_GIT_BACKEND

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   unit_test:
-    name: ${{ matrix.os }} - net${{ matrix.dotnet_version }}
+    name: ${{ matrix.os }} - net${{ matrix.dotnet_version }} - ${{ matrix.git_backend }}
     permissions:
       id-token: write
     strategy:
@@ -24,6 +24,9 @@ jobs:
       matrix:
         os: [ windows-2025-vs2026, ubuntu-24.04, macos-26 ]
         dotnet_version: ${{ fromJson(inputs.dotnet_versions) }}
+        # Run the suite against both Git backends until libgit2 is removed,
+        # see https://github.com/GitTools/GitVersion/issues/5031
+        git_backend: [ libgit2, managed ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,6 +44,8 @@ jobs:
 
       - name: '[Unit Test]'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          GITVERSION_GIT_BACKEND: ${{ matrix.git_backend }}
         with:
           shell: pwsh
           timeout_minutes: 30
@@ -60,6 +65,7 @@ jobs:
         with:
           files: artifacts/test-results/**/results.xml
           report_type: 'test_results'
+          flags: ${{ matrix.git_backend }}
           use_oidc: true
 
       - name: Upload Coverage
@@ -68,4 +74,5 @@ jobs:
         with:
           directory: artifacts/test-results
           report_type: 'coverage'
+          flags: ${{ matrix.git_backend }}
           use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
       - main
       - 'support/*'
       - 'next/*'
+      # gate managed-git phase PRs with the full test matrix pre-merge (#5031)
+      - 'feature/managed-git'
     paths:
       - '**'
       - '!docs/**'

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,20 @@
 ## Unreleased
 
+### Selectable Git backend (libgit2 vs. managed)
+
+GitVersion is migrating away from LibGit2Sharp and its native libgit2 binaries towards a managed implementation combined with the `git` CLI ([#5031](https://github.com/GitTools/GitVersion/issues/5031)). A single environment variable selects the backend:
+
+| Release | Default backend | Switch |
+| ------- | --------------- | ------ |
+| v7.0    | `libgit2`       | `GITVERSION_GIT_BACKEND=managed` to opt in to the new backend |
+| v7.1    | `managed`       | `GITVERSION_GIT_BACKEND=libgit2` to fall back |
+| later   | `managed`       | libgit2 backend removed |
+
+Behavioral notes when using the `managed` backend:
+
+* Mutating and network operations (repository normalization on CI build agents, dynamic repositories via `--url`, checkout, fetch) are performed by invoking the `git` executable, which must be available on the `PATH`. Plain version calculation on an already-prepared checkout does not require it.
+* v7.0 behavior is unchanged unless you opt in. Please test the `managed` backend and report issues — the libgit2 backend will be removed once the new backend has proven itself over several releases.
+
 ### Invalid label formatting is not ignored
 Previously bad label formatting config would be silently accepted. For example `{Branhc}` (when BranchName is misspelled) or even `{BranchName` (missing a closing brace). This is not ignored now and exceptions will be thrown if formatting problems exist in the label config. This brings it into line with how assembly string formatting is treated.
 

--- a/build/parity-corpus.md
+++ b/build/parity-corpus.md
@@ -1,0 +1,51 @@
+# parity-corpus.ps1 — real-world corpus parity check
+
+Phase B validation tooling for the managed-git migration
+(see `docs/design/managed-git-migration.md`, §5 Phase B and §7 item 3).
+
+Runs the locally built `GitVersion.App` twice per repository/checkout shape —
+once with `GITVERSION_GIT_BACKEND=libgit2`, once with `=managed` — using
+`--output json --no-cache --no-fetch --no-normalize` (read-only, deterministic)
+and diffs the JSON version variables field by field.
+
+## Usage
+
+```bash
+# default corpus: GitVersion, GitReleaseManager, and this checkout itself
+pwsh ./build/parity-corpus.ps1
+
+# custom corpus / subset of variants / reuse binaries
+pwsh ./build/parity-corpus.ps1 -Repos /path/to/repo -Variants full,worktree -SkipBuild
+
+# keep clones in a persistent cache
+pwsh ./build/parity-corpus.ps1 -WorkDir ~/.cache/gitversion-parity
+```
+
+## Parameters
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `-Repos` | GitVersion, GitReleaseManager, local checkout | Git URLs or local paths |
+| `-WorkDir` | `$TMPDIR/gitversion-parity-corpus` | Clone cache; repeat runs reuse it |
+| `-Variants` | `full,shallow,worktree` | Checkout shapes to exercise |
+| `-Configuration` / `-Framework` | `Release` / `net10.0` | Which App build to run |
+| `-SkipBuild` | off | Reuse existing `GitVersion.App` binaries |
+
+## What it does per repository
+
+1. Full clone into the cache (skipped when already present).
+2. Derives a **shallow** clone (`git clone --depth 1 file://<full-clone>`, run with
+   `--allow-shallow`) and a **linked worktree** (`git worktree add --detach`) — the two
+   CI-style shapes called out in the migration design.
+3. Runs both backends per variant, normalizes/parses the JSON, and reports:
+   - `MATCH` — identical variables,
+   - `DIFF` — any field difference, or one backend failing while the other succeeds
+     (a parity failure; a readable per-field diff is printed),
+   - `ERROR` — variant setup failed or *both* backends refused the shape
+     (environment limitation, not counted as a parity failure).
+4. Prints a summary table with per-backend elapsed milliseconds (coarse perf signal).
+
+## Exit code
+
+The number of repo/variant combinations with result `DIFF`. `0` = full parity.
+Errors do not abort the run; remaining repos/variants are still checked.

--- a/build/parity-corpus.ps1
+++ b/build/parity-corpus.ps1
@@ -1,0 +1,299 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Real-world corpus parity check between the libgit2 and managed git backends.
+
+.DESCRIPTION
+    For every repository in the corpus this script prepares three checkout shapes
+    (full clone, shallow clone, linked worktree), runs the locally built
+    GitVersion.App once per backend (GITVERSION_GIT_BACKEND=libgit2|managed) with
+    read-only, cache-free flags, and diffs the JSON outputs field by field.
+
+    Any field difference (or a one-sided failure) is a parity failure. The exit
+    code is the number of failing repo/variant combinations; 0 means full parity.
+
+.EXAMPLE
+    ./build/parity-corpus.ps1
+    ./build/parity-corpus.ps1 -Repos https://github.com/GitTools/GitReleaseManager.git -Variants full,shallow
+    ./build/parity-corpus.ps1 -Repos /path/to/local/repo -WorkDir ~/parity-cache -SkipBuild
+#>
+[CmdletBinding()]
+param(
+    # Git URLs or local paths to include in the corpus.
+    [string[]]$Repos,
+
+    # Cache directory for clones; repeat runs reuse it.
+    [string]$WorkDir = (Join-Path ([IO.Path]::GetTempPath()) 'gitversion-parity-corpus'),
+
+    # Checkout shapes to exercise per repository.
+    [ValidateSet('full', 'shallow', 'worktree')]
+    [string[]]$Variants = @('full', 'shallow', 'worktree'),
+
+    [string]$Configuration = 'Release',
+    [string]$Framework = 'net10.0',
+
+    # Skip building GitVersion.App (reuse existing binaries).
+    [switch]$SkipBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+if (-not $Repos) {
+    $Repos = @(
+        'https://github.com/GitTools/GitVersion.git'
+        'https://github.com/GitTools/GitReleaseManager.git'
+        $repoRoot
+    )
+}
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+function Invoke-Git {
+    param([string[]]$Arguments)
+    $output = & git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed ($LASTEXITCODE): $($output | Out-String)"
+    }
+    $output
+}
+
+function Get-CorpusName {
+    param([string]$Source)
+    $base = ([IO.Path]::GetFileName($Source.TrimEnd('/', '\'))) -replace '\.git$', ''
+    if (-not $base) { $base = 'repo' }
+    $hashBytes = [System.Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($Source))
+    $suffix = -join ($hashBytes[0..3] | ForEach-Object { $_.ToString('x2') })
+    "$base-$suffix"
+}
+
+function Invoke-GitVersion {
+    <# Runs gitversion.dll with the given backend; returns exit code, stdout, stderr, elapsed ms. #>
+    param(
+        [string]$AppDll,
+        [string]$RepoPath,
+        [string]$Backend,
+        [string[]]$ExtraArgs
+    )
+    $logFile = [IO.Path]::GetTempFileName()
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = 'dotnet'
+    $argList = @($AppDll, $RepoPath, '--output', 'json', '--no-cache', '--no-fetch', '--no-normalize', '-l', $logFile) + @($ExtraArgs)
+    foreach ($a in $argList) {
+        if (-not [string]::IsNullOrEmpty($a)) { $psi.ArgumentList.Add($a) }
+    }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.EnvironmentVariables['GITVERSION_GIT_BACKEND'] = $Backend
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $process = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    $sw.Stop()
+
+    # On failure the reason usually only appears in the log; pull the first error line out.
+    $errorSummary = ''
+    if ($process.ExitCode -ne 0) {
+        $errorSummary = ($stderr + "`n" + $stdout).Trim() -split '\r?\n' |
+            Where-Object { $_ } |
+            Select-Object -First 1
+        if (-not $errorSummary -and (Test-Path $logFile)) {
+            $errorSummary = Get-Content $logFile |
+                Where-Object { $_ -match 'EROR' -or $_ -match 'Exception' } |
+                Select-Object -First 2 |
+                Join-String -Separator ' '
+        }
+    }
+    Remove-Item $logFile -ErrorAction SilentlyContinue
+
+    [pscustomobject]@{
+        ExitCode     = $process.ExitCode
+        StdOut       = $stdout
+        StdErr       = $stderr
+        ErrorSummary = [string]$errorSummary
+        ElapsedMs    = $sw.ElapsedMilliseconds
+    }
+}
+
+function ConvertFrom-GitVersionJson {
+    <# Extracts the JSON object from gitversion stdout and returns a hashtable, or $null. #>
+    param([string]$Text)
+    $start = $Text.IndexOf('{')
+    $end = $Text.LastIndexOf('}')
+    if ($start -lt 0 -or $end -le $start) { return $null }
+    try {
+        $Text.Substring($start, $end - $start + 1) | ConvertFrom-Json -AsHashtable
+    } catch {
+        $null
+    }
+}
+
+function Compare-VersionVariables {
+    <# Field-by-field diff of two hashtables; returns a list of difference descriptions. #>
+    param([hashtable]$Left, [hashtable]$Right)
+    $differences = [System.Collections.Generic.List[string]]::new()
+    $keys = @($Left.Keys) + @($Right.Keys) | Sort-Object -Unique
+    foreach ($key in $keys) {
+        $l = if ($Left.ContainsKey($key)) { [string]$Left[$key] } else { '<absent>' }
+        $r = if ($Right.ContainsKey($key)) { [string]$Right[$key] } else { '<absent>' }
+        if ($l -cne $r) {
+            $differences.Add(("  {0,-28} libgit2: {1}  |  managed: {2}" -f $key, $l, $r))
+        }
+    }
+    $differences
+}
+
+function Get-VariantPath {
+    <# Ensures the requested checkout shape exists under the repo's cache dir; returns its path. #>
+    param([string]$RepoCacheDir, [string]$Source, [string]$Variant)
+
+    $fullDir = Join-Path $RepoCacheDir 'full'
+    if (-not (Test-Path (Join-Path $fullDir '.git'))) {
+        Write-Verbose "cloning $Source -> $fullDir"
+        $null = Invoke-Git @('clone', '--quiet', $Source, $fullDir)
+    }
+    if ($Variant -eq 'full') { return $fullDir }
+
+    if ($Variant -eq 'shallow') {
+        $shallowDir = Join-Path $RepoCacheDir 'shallow'
+        if (-not (Test-Path (Join-Path $shallowDir '.git'))) {
+            # Derive the shallow clone from the local full clone: deterministic and offline.
+            $fullUri = ([System.Uri]::new($fullDir)).AbsoluteUri
+            Write-Verbose "creating shallow clone -> $shallowDir"
+            $null = Invoke-Git @('clone', '--quiet', '--depth', '1', $fullUri, $shallowDir)
+        }
+        return $shallowDir
+    }
+
+    # worktree
+    $worktreeDir = Join-Path $RepoCacheDir 'worktree'
+    if (-not (Test-Path (Join-Path $worktreeDir '.git'))) {
+        Write-Verbose "creating linked worktree -> $worktreeDir"
+        $null = Invoke-Git @('-C', $fullDir, 'worktree', 'prune')
+        $null = Invoke-Git @('-C', $fullDir, 'worktree', 'add', '--detach', $worktreeDir)
+    }
+    return $worktreeDir
+}
+
+# ---------------------------------------------------------------------------
+# build once
+# ---------------------------------------------------------------------------
+
+$appDll = Join-Path $repoRoot "src/GitVersion.App/bin/$Configuration/$Framework/gitversion.dll"
+if (-not $SkipBuild) {
+    Write-Host "Building GitVersion.App ($Configuration, $Framework)..."
+    & dotnet build (Join-Path $repoRoot 'src/GitVersion.App/GitVersion.App.csproj') -c $Configuration -f $Framework --nologo -v q
+    if ($LASTEXITCODE -ne 0) { throw 'dotnet build failed.' }
+}
+if (-not (Test-Path $appDll)) { throw "GitVersion.App binary not found at $appDll (build it or drop -SkipBuild)." }
+
+$null = New-Item -ItemType Directory -Force -Path $WorkDir
+Write-Host "Corpus cache: $WorkDir"
+Write-Host "App: $appDll"
+Write-Host ''
+
+# ---------------------------------------------------------------------------
+# run corpus
+# ---------------------------------------------------------------------------
+
+$results = [System.Collections.Generic.List[pscustomobject]]::new()
+
+foreach ($source in $Repos) {
+    $name = Get-CorpusName $source
+    $repoCacheDir = Join-Path $WorkDir $name
+    $null = New-Item -ItemType Directory -Force -Path $repoCacheDir
+    Write-Host "=== $source ($name) ==="
+
+    foreach ($variant in $Variants) {
+        $record = [pscustomobject]@{
+            Repo      = $source
+            Variant   = $variant
+            Result    = 'ERROR'
+            Libgit2Ms = $null
+            ManagedMs = $null
+            Detail    = ''
+        }
+        $results.Add($record)
+
+        try {
+            $variantPath = Get-VariantPath -RepoCacheDir $repoCacheDir -Source $source -Variant $variant
+        } catch {
+            $record.Detail = "variant setup failed: $($_.Exception.Message)"
+            Write-Warning "[$name/$variant] $($record.Detail)"
+            continue
+        }
+
+        [string[]]$extraArgs = @()
+        if ($variant -eq 'shallow') { $extraArgs = @('--allow-shallow') }
+
+        $runs = @{}
+        foreach ($backend in 'libgit2', 'managed') {
+            $runs[$backend] = Invoke-GitVersion -AppDll $appDll -RepoPath $variantPath -Backend $backend -ExtraArgs $extraArgs
+        }
+        $record.Libgit2Ms = $runs['libgit2'].ElapsedMs
+        $record.ManagedMs = $runs['managed'].ElapsedMs
+
+        $failed = @('libgit2', 'managed').Where({ $runs[$_].ExitCode -ne 0 })
+        if ($failed.Count -eq 2) {
+            # Both backends refuse this shape identically: an environment limitation, not a parity break.
+            $record.Detail = 'both backends failed: ' + $runs['libgit2'].ErrorSummary
+            Write-Warning "[$name/$variant] $($record.Detail)"
+            continue
+        }
+        if ($failed.Count -eq 1) {
+            $only = $failed[0]
+            $record.Result = 'DIFF'
+            $record.Detail = "$only failed (exit $($runs[$only].ExitCode)) while the other backend succeeded: " + $runs[$only].ErrorSummary
+            Write-Host "[$name/$variant] PARITY FAILURE - $($record.Detail)" -ForegroundColor Red
+            continue
+        }
+
+        $libgit2Json = ConvertFrom-GitVersionJson $runs['libgit2'].StdOut
+        $managedJson = ConvertFrom-GitVersionJson $runs['managed'].StdOut
+        if (-not $libgit2Json -or -not $managedJson) {
+            $record.Detail = 'could not parse JSON output from one or both backends'
+            Write-Warning "[$name/$variant] $($record.Detail)"
+            continue
+        }
+
+        $differences = @(Compare-VersionVariables -Left $libgit2Json -Right $managedJson)
+        if ($differences.Count -eq 0) {
+            $record.Result = 'MATCH'
+            Write-Host "[$name/$variant] MATCH (libgit2 $($record.Libgit2Ms) ms, managed $($record.ManagedMs) ms)" -ForegroundColor Green
+        } else {
+            $record.Result = 'DIFF'
+            $record.Detail = "$($differences.Count) field(s) differ"
+            Write-Host "[$name/$variant] PARITY FAILURE - $($record.Detail):" -ForegroundColor Red
+            $differences | ForEach-Object { Write-Host $_ -ForegroundColor Red }
+        }
+    }
+    Write-Host ''
+}
+
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
+
+Write-Host '=== Summary ==='
+$results |
+    Format-Table Repo, Variant, Result, Libgit2Ms, ManagedMs, Detail -AutoSize |
+    Out-String -Width 500 |
+    Write-Host
+
+$failures = @($results | Where-Object Result -eq 'DIFF')
+$errors = @($results | Where-Object Result -eq 'ERROR')
+if ($failures.Count -eq 0 -and $errors.Count -eq 0) {
+    Write-Host 'Full parity across the corpus.' -ForegroundColor Green
+} elseif ($failures.Count -eq 0) {
+    Write-Host "No parity failures, but $($errors.Count) variant(s) could not be compared (ERROR)." -ForegroundColor Yellow
+} else {
+    Write-Host "$($failures.Count) repo/variant combination(s) failed parity." -ForegroundColor Red
+}
+exit $failures.Count

--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -1,0 +1,273 @@
+# Replacing LibGit2Sharp with a managed Git implementation
+
+Research and migration plan for [#236](https://github.com/arturcic/GitVersion/issues/236) — researched 2026-07, based on a full survey of the `next/v7` tree.
+
+## 1. Motivation
+
+LibGit2Sharp wraps the native `libgit2` library and has been a recurring source of pain for GitVersion for close to a decade:
+
+- **Native binary load failures** on end-user machines and CI images — GitTools/GitVersion
+  [#1097](https://github.com/GitTools/GitVersion/issues/1097),
+  [#1203](https://github.com/GitTools/GitVersion/issues/1203),
+  [#1744](https://github.com/GitTools/GitVersion/issues/1744),
+  [#1852](https://github.com/GitTools/GitVersion/issues/1852),
+  [#2615](https://github.com/GitTools/GitVersion/issues/2615),
+  [#2884](https://github.com/GitTools/GitVersion/issues/2884). The failure mode is always the same class:
+  the RID-specific `libgit2-*.so/.dylib/.dll` doesn't match the runtime OS/arch/libc (musl vs glibc,
+  new Ubuntu OpenSSL versions, ARM variants) or cannot be located by the MSBuild task's assembly-load context.
+- **Packaging weight**: `LibGit2Sharp.NativeBinaries` unpacks ~12 native binaries
+  (linux x64/arm/arm64/musl/ppc64le, osx x64/arm64, win x64/x86/arm64) into `runtimes/<rid>/native/`
+  of every published artifact — and `GitVersion.MsBuild` ships that payload **per TFM** (net8.0/net9.0/net10.0).
+- **Platform lag**: new RIDs, libcs and OS versions require waiting on libgit2 + LibGit2Sharp + NativeBinaries releases
+  (GitVersion is currently pinned to LibGit2Sharp 0.31.0).
+- **Feature lag**: libgit2 trails git itself (SHA-256 repos, reftable, partial clone), and its global native state
+  complicates concurrent use inside MSBuild.
+
+Precedent: Nerdbank.GitVersioning faced the same problem and built a managed read-only engine
+([dotnet/Nerdbank.GitVersioning#505](https://github.com/dotnet/Nerdbank.GitVersioning/issues/505),
+[#521](https://github.com/dotnet/Nerdbank.GitVersioning/pull/521)). It became their default backend and delivered
+**>10x throughput on history walks** compared to libgit2. NBGV kept libgit2 for write paths; the plan below goes one
+step further and removes the native dependency entirely.
+
+## 2. Landscape: managed Git options in .NET (2026)
+
+| Candidate | Reads | Writes | Fetch/clone | Maintained | Assessment |
+|---|---|---|---|---|---|
+| [NBGV ManagedGit](https://github.com/dotnet/Nerdbank.GitVersioning/tree/main/src/NerdBank.GitVersioning/ManagedGit) | objects, packs (incl. deltas), refs; tuned for version calculation | No | No | Active, but internal to NBGV (MIT) | **Primary porting source** — proven pack/idx/delta code, the source of the >10x speedup |
+| [GitReader](https://github.com/kekyo/GitReader) (kekyo) | full traversal: branches/tags/commits, packfiles, worktrees, index, .gitignore | No | No | Active (v1.18, .NET 10 TFMs, zero deps) | Porting inspiration for worktree handling and commit-graph; viable external dependency if vendoring were rejected |
+| [ManagedGitLib](https://github.com/GlebChili/ManagedGitLib) | standalone extraction of NBGV ManagedGit | No | No | Stale (~2022) | Proof that vendoring/extracting NBGV's code works; not a dependency to take |
+| DotGit, GitRead.Net, GitSharp, NGit | partial readers / ancient ports | No | No | Dead | Skip |
+| `git` CLI shell-out (MinVer-style) | yes | yes | yes, with system credential helpers | n/a | **Chosen for writes + network** — requires `git` on PATH, which every CI normalization scenario already implies |
+
+**The decisive fact:** no maintained managed .NET library implements git *write* operations or the smart-HTTP/SSH
+*transport* (fetch/clone). Every managed option is read-only. Any replacement strategy must therefore pair a managed
+reader with something else for the write/network surface — and that something is the `git` CLI, which is guaranteed
+present in exactly the scenarios (CI normalization, dynamic repositories) that need it.
+
+### Decisions
+
+1. **Hybrid backend**: vendored fully-managed reader for all read/history operations; `git` CLI shell-out for
+   writes and network. Zero native binaries ship with GitVersion afterwards.
+2. **Vendored, not an external package**: the managed reader lives in this repo (ported from NBGV ManagedGit, MIT,
+   with attribution), giving full control over revwalk semantics — which version output depends on.
+3. **`src/` (stable) tree first**; `new-cli` follows by source-linking the read-only subset, exactly as it
+   source-links the LibGit2Sharp adapter today.
+
+## 3. Current LibGit2Sharp surface (survey results)
+
+### 3.1 The seam is clean
+
+`GitVersion.Core` has **no LibGit2Sharp reference**. It consumes only its own abstraction in
+`src/GitVersion.Core/Git/` (~20 interfaces: `IGitRepository`, `IMutatingGitRepository`, `IGitRepositoryInfo`,
+`ICommit`, `IBranch`, `ITag`, `IReference`, `IRemote`, `IRefSpec`, `IObjectId`, their collections, and support types
+`CommitFilter`, `AuthenticationInfo`, `ReferenceName`). Only three projects reference LibGit2Sharp:
+
+1. `src/GitVersion.LibGit2Sharp` — the production adapter
+2. `src/GitVersion.Testing` — test fixtures
+3. `new-cli/GitVersion.Core.Libgit2Sharp` — source-links the adapter's files, read-only subset
+   (excludes `GitRepository.mutating.cs` and `GitRepositoryInfo.cs`)
+
+### 3.2 Read surface (the bulk — must be reimplemented)
+
+- Repository discovery and open: walk-up discovery, `.git` file indirection (worktrees/submodules),
+  commondir split, bare detection, shallow detection (`repo.Info.IsShallow`)
+- HEAD, branch/tag/reference/remote enumeration (incl. glob queries via `Refs.FromGlob`)
+- Commit metadata: id, parents, committer `When`, message
+- **Revwalk**: `CommitCollection.QueryBy(CommitFilter)` → libgit2 `IncludeReachableFrom` /
+  `ExcludeReachableFrom` / `FirstParentOnly` / `SortBy` (Topological, Time). Ordering is
+  version-output-affecting.
+- **Merge-base**: `repo.ObjectDatabase.FindMergeBase(c1, c2)`
+- **Tree diff**: `ICommit.DiffPaths` via `repo.Diff.Compare<TreeChanges>(tree, parentTree)` (changed paths only)
+- **Status**: `UncommittedChangesCount()` via `Diff.Compare<TreeChanges>(Head.Tip.Tree, DiffTargets.Index | DiffTargets.WorkingDirectory)` with `RetrieveStatus()` fallback
+
+### 3.3 Write + network surface (small, one consumer)
+
+Everything mutating funnels through **`src/GitVersion.Core/Core/GitPreparer.cs`** (CI normalization and dynamic
+repositories), implemented in `src/GitVersion.LibGit2Sharp/Git/GitRepository.mutating.cs` and the collection wrappers:
+
+- `Clone(url, workdir, auth)` — no-checkout clone with username/password credentials
+- `Fetch(remote, refSpecs, auth, log)` — authenticated HTTPS (username/password only; no SSH path exists today)
+- `Checkout(spec)`; `CreateBranchForPullRequestBranch(auth)` (uses network `ls-remote` under the hood)
+- `References.Add/UpdateTarget`, `Branches.UpdateTrackedBranch/Remove`, `Remotes.Update(refspec)/Remove`
+- Error mapping is already string-based (parses "401"/"404" out of exception messages);
+  `LockedFileException` is retried via Polly (`RepositoryExtensions.RunSafe`)
+
+### 3.4 Known abstraction leaks (to fix during migration)
+
+- Public `LibGit2SharpExtensions.ToGitRepository(IRepository)` exposes a LibGit2Sharp type
+- `CommitFilter.SortBy` is numerically cast to `LibGit2Sharp.CommitSortStrategies`
+- `CommitFilter.IncludeReachableFrom`/`ExcludeReachableFrom` are typed `object?`
+
+### 3.5 Test fixtures
+
+`src/GitVersion.Testing` (~300 LoC of real LibGit2Sharp usage in `Fixtures/RepositoryFixtureBase.cs` +
+`Extensions/GitTestExtensions.cs`) is *write-heavy*: stage/commit/tag/branch/merge-no-ff/checkout/clone/fetch/config.
+It already shells out to real `git` for `init -b`, shallow `pull --depth 1` and `gc` — so a pure git-CLI fixture
+backend is a natural completion of an existing pattern. Six test files additionally use LibGit2Sharp directly
+(mostly `ToGitRepository()` and `Signature`).
+
+## 4. Target architecture
+
+```
+src/
+  GitVersion.Git.Managed/          vendored managed reader; the raw git-format layers below
+                                   are Core-free, Core is referenced only once the interface
+                                   implementations land (final Phase B step)
+    Objects/    GitObjectId (hash-agnostic), pack + .idx v2 readers, delta streams,
+                pack cache, loose-object reader, multi-pack-index reader
+    Parsing/    commit parser (author/committer/when/message/encoding), tree parser,
+                annotated-tag parser
+    Refs/       loose refs, packed-refs, symbolic refs, HEAD, glob enumeration
+    Repository/ discovery (walk-up, .git file, commondir), worktree resolver, shallow info
+    History/    revwalk (topo/time, first-parent, exclusions — libgit2-parity),
+                merge-base (paint-down-to-common), commit-graph reader (later, optional)
+    Diff/       recursive tree-vs-tree changed-paths diff (no rename detection)
+    Status/     .git/index v2–v4 reader, workdir/index status for UncommittedChangesCount
+    CommandLine/ git CLI executor + mutator (writes + network only) — absorbed from the
+                 interim GitVersion.Git.CommandLine project at the final Phase B step
+```
+
+No separate adapter project: `GitVersion.Git.Managed` implements `IGitRepository` (managed reader)
+and `IMutatingGitRepository` (delegating to the CLI mutator) **directly**, mirroring how
+`GitVersion.LibGit2Sharp` implements the same interfaces over libgit2 today — same file layout,
+so the DI surface is unchanged.
+
+One-library end state: all git interaction (managed reads + CLI writes) lives in
+`GitVersion.Git.Managed`, just as `GitVersion.LibGit2Sharp` is the single libgit2 library today.
+`GitVersion.Git.CommandLine` exists only as an interim project (created in Phase A so the CLI
+mutator could ship while reads stayed on libgit2); when it folds into `GitVersion.Git.Managed`
+at the final Phase B step, `GitVersion.LibGit2Sharp` re-points its mutator `ProjectReference`
+to `GitVersion.Git.Managed` for the dual-backend window and that reference disappears with the
+project's deletion in Phase E.
+
+Port-vs-fresh decisions:
+
+| Component | Decision |
+|---|---|
+| Pack/idx/delta reading, pack cache, loose objects, object id | **Port from NBGV ManagedGit** (MIT, attribution in headers + NOTICE) |
+| Commit/tree parsing | Port + extend (NBGV skips author/message — GitVersion needs them) |
+| Annotated tags, multi-pack-index, discovery/worktrees, shallow | Fresh (small, well-specified formats) |
+| **Revwalk**, **merge-base**, tree diff, index/status | **Fresh** — highest-parity-risk pieces, written against libgit2's documented algorithms |
+| SHA-256 repos | Hash-agnostic `GitObjectId` from day one; detect `extensions.objectformat=sha256` and fail with a clear message initially (parity: libgit2 can't read them either) |
+| Reftable (`extensions.refstorage=reftable`) | Detect and fail with a clear message; reader in backlog |
+
+CLI executor hygiene:
+
+- Arguments via `ProcessStartInfo.ArgumentList` (no shell, no quoting bugs); `LC_ALL=C`, `GIT_TERMINAL_PROMPT=0`,
+  `-c core.quotepath=false`
+- **Plumbing-only parsing** (`rev-parse`, `ls-remote`, `update-ref`, `symbolic-ref`, `for-each-ref --format`,
+  `config`); porcelain commands (`clone`, `fetch`, `checkout`, `branch`) invoked for side effects only
+- Auth: per-invocation `-c http.<url>.extraHeader=Authorization: Basic <b64>` — never URL userinfo,
+  never persisted to config
+- stderr classification mapped to today's exceptions: `.lock` failures → `LockedFileException`
+  (keeps the Polly retry untouched), 401/403/404 → the same messages `GitPreparer` expects
+- One-time `git version` probe; require ≥ 2.30, actionable error if git is absent when a mutating
+  operation is requested
+
+## 5. Phased migration (every phase shippable)
+
+### Release strategy: one switch, two backends, a public testing window
+
+A single public environment variable — **`GITVERSION_GIT_BACKEND=libgit2|managed`** — selects the entire
+backend. `managed` opts into the new implementation stack as far as it exists at each release (first the
+CLI mutator, later also the managed reader). The version-to-default mapping is explicit:
+
+| Release | Default backend | Opt-in / opt-out |
+|---|---|---|
+| **v7.0** | `libgit2` | `GITVERSION_GIT_BACKEND=managed` to test the new backend |
+| **v7.1** | `managed` | `GITVERSION_GIT_BACKEND=libgit2` to fall back |
+| v7.x (later) | `managed` | libgit2 removed (Phase E) once the fallback has gone several releases unused/regression-free |
+
+Both backends ship side by side throughout the v7.0–v7.x window so users can validate `managed` against
+their real repositories and report issues before libgit2 is dropped. For that whole window, the CI
+unit-test matrix runs the full suite against both backends (`git_backend` dimension in `_unit_tests.yml`) —
+both legs must stay green.
+
+### Phase A — CLI mutator first (reads stay on libgit2) · ~2–3 weeks
+Replace `GitRepository.mutating.cs` + mutating collection members with `GitVersion.Git.CommandLine`
+(an interim project — it merges into `GitVersion.Git.Managed` at the final Phase B step, see §4).
+Reads keep using libgit2; the wrapper drops its cached collection wrappers after each CLI mutation so
+external ref changes become visible (the libgit2 handle itself must not be disposed — wrappers already
+handed out reference its native memory). Selected via `GITVERSION_GIT_BACKEND=managed`.
+This immediately retires the most fragile native code paths (network, SSL, credentials).
+
+### Phase B-pre — interface cleanups · ~3–5 days
+Core-owned `CommitSortStrategies` enum (explicit mapping in the libgit2 adapter instead of a numeric cast),
+typed `CommitFilter` reachable-from members, remove/internalize `ToGitRepository`.
+
+### Phase B — managed reader behind a flag · ~8–12 weeks
+Build `GitVersion.Git.Managed` bottom-up with per-layer unit tests against git-CLI-generated fixture repos
+(loose/packed/mixed objects, packed-refs, worktrees, shallow, multi-pack-index, index v4).
+The final B step takes the `GitVersion.Core` reference, lands the direct `IGitRepository`/
+`IMutatingGitRepository` implementations, absorbs `GitVersion.Git.CommandLine` (see §4), and wires
+backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2`). Validation:
+- **CI matrix**: full integration suites (`GitVersion.Core.Tests`, `GitVersion.App.Tests`) run on both backends,
+  three OSes — the suites assert exact SemVer strings over complex histories and are the strongest parity oracle
+- **DualBackendParityTests**: open the same fixture with both backends; deep-equality on ref enumeration,
+  order-sensitive `QueryBy` sequences, `FindMergeBase` over all commit pairs (incl. criss-cross and
+  equal-timestamp fixtures), `DiffPaths`, `UncommittedChangesCount`
+- **Real-world corpus script**: `gitversion /nocache /output json` diffed across backends on this repo,
+  GitReleaseManager, dotnet/runtime, a shallow CI-style clone, and a worktree checkout
+
+### Phase C — default flip in v7.1 · ~1 week + multi-release soak
+**v7.0 ships with default `libgit2`** (managed opt-in); **v7.1 flips the default to `managed`** with
+`GITVERSION_GIT_BACKEND=libgit2` as the fallback while users validate the new backend. The dual-backend
+CI matrix stays green throughout the window.
+
+### Phase D — fixture migration (parallel with B) · ~2–3 weeks
+`GitVersion.Testing` moves to pure git-CLI writes via the existing `ExecuteGitCmd` pattern:
+deterministic `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env (several tests advance commit time explicitly),
+`git commit --allow-empty`, `-c commit.gpgsign=false -c gc.auto=0`. Migrate the six direct-usage test files.
+If suite time regresses from process spawns, batch history creation with `git fast-import`.
+
+### Phase E — remove LibGit2Sharp · ~1–2 weeks
+Delete `src/GitVersion.LibGit2Sharp` and `new-cli/GitVersion.Core.Libgit2Sharp`; drop the package from
+`Directory.Packages.props`; re-point new-cli source-linking at `GitVersion.Git.Managed`
+(read-only subset). Add a packaging assertion test: **zero `runtimes/**/native/*` entries** in the
+`GitVersion.MsBuild` and `GitVersion.Tool` nupkgs. Document the new runtime requirement: `git` on PATH is needed
+**only** for dynamic-repo/CI-normalization scenarios — pure version calculation on a prepared checkout needs no
+git binary at all (a strict improvement for MSBuild-task users).
+
+### Phase F (optional) — performance accelerators · ~2–3 weeks
+Commit-graph reader (generation numbers for topo sort and merge-base), benchmark-driven pack cache tuning.
+
+## 6. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Revwalk ordering divergence → wrong versions** | Port libgit2's `revwalk.c` algorithm precisely (time-queue with insertion-order tiebreak, Kahn-style topo over it, mark-uninteresting propagation); order-sensitive dual-backend sequence tests; corpus diffing as the Phase C gate |
+| Merge-base candidate choice on criss-cross merges (libgit2 returns one of several) | Replicate libgit2's paint-down selection; assert *version output* on criss-cross fixtures plus one SHA-level canary test to detect drift |
+| Shallow clones (the CI default) | `.git/shallow` boundaries treated as parentless in the walker; existing `MakeShallow` fixture covers it |
+| Worktrees / `.git`-file / commondir | Dedicated `WorktreeResolver`; existing worktree tests + new fixtures |
+| Rename detection assumed in `DiffPaths` | Verify adapter options at Phase B kickoff — libgit2's default `Compare<TreeChanges>` doesn't do rename detection, so a plain recursive tree diff is expected to be exact parity |
+| Performance regressions | Port NBGV's pack cache; BenchmarkDotNet suite (end-to-end + revwalk/merge-base/status micro); Phase C gate: no scenario >20% slower — expectation is large wins per NBGV precedent |
+| git CLI availability/version drift | Only the mutator needs git; version probe (≥2.30) with actionable error; CI leg on a container with the oldest supported git |
+| CLI output stability | Plumbing + `--format` parsing only; stderr matching limited to error classification with conservative fallback (unknown → generic error carrying stderr, as today) |
+| Locale/encoding | `LC_ALL=C`; honor the commit `encoding` header with Latin-1 fallback (matching git); `core.quotepath=false` |
+| Concurrency (parallel MSBuild tasks) | Managed reader is read-only and lock-free; per-instance or thread-safe pack cache; removes libgit2's native global state entirely |
+| SHA-256 / reftable repos | Detect and fail with clear messages (no regression — libgit2 can't read them either); hash-agnostic design keeps the door open |
+| License/attribution of vendored code | MIT headers + NOTICE entries for NBGV ManagedGit (and GitReader if any code is taken) |
+
+## 7. Verification strategy
+
+1. Full integration suite × backend × OS matrix green through Phases B–D
+2. `DualBackendParityTests` structural deep-equality on adversarial fixtures (equal timestamps, criss-cross,
+   octopus merges, packed+loose refs, annotated+lightweight tags on one commit, shallow, worktree,
+   multi-pack-index, index v4)
+3. Real-world corpus JSON diffing recorded before the Phase C flip
+4. Benchmark gate (≥ parity everywhere, expected wins on history walks)
+5. Packaging assertion: no native binaries in shipped nupkgs (Phase E)
+
+## 8. Effort summary
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| A | git-CLI mutator + auth/error/lock mapping | 2–3 weeks |
+| B-pre | interface cleanups | 3–5 days |
+| B | managed reader + direct interface implementations + parity harness | 8–12 weeks |
+| C | default flip + soak | 1 week + 1 release |
+| D | fixture migration (parallel with B) | 2–3 weeks |
+| E | LibGit2Sharp removal, new-cli re-link, packaging tests | 1–2 weeks |
+| F | commit-graph accelerator (optional) | 2–3 weeks |
+
+**Total to a LibGit2Sharp-free GitVersion: ~4–5 months elapsed including soak cycles.**

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -78,3 +78,29 @@ gitversion --url https://github.com/org/repo.git --branch main --username user -
 ```
 
 For current command details and examples, see [CLI Arguments](/docs/usage/cli/arguments).
+
+## Git backend
+
+GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable. When the variable is not set (or empty), the release's default backend is used — you never need to set it. Setting it to any value other than `libgit2` or `managed` (case-insensitive) is an error: GitVersion fails fast instead of silently running the default backend with a typo unnoticed.
+
+:::{.alert .alert-info}
+In v7.0 the `libgit2` backend remains the **default** — behaviour is unchanged unless you opt in. Set `GITVERSION_GIT_BACKEND=managed` to try the managed backend and help validate it. In v7.1 the default flips to `managed`, with `GITVERSION_GIT_BACKEND=libgit2` available as a fallback. Both backends ship side by side for several releases before libgit2 is removed.
+:::
+
+- `libgit2` — the native, libgit2-based backend (default in v7.0).
+- `managed` — a managed implementation for all read/history operations, combined with the `git` command-line executable for network and write operations (clone, fetch, checkout, and CI repository normalization).
+
+:::{.alert .alert-warning}
+When using the `managed` backend, the `git` executable must be available on the `PATH` **only** for the network/normalization scenarios above (dynamic repositories, build-agent normalization). Plain version calculation on an already-prepared checkout does not require `git` on the `PATH`.
+:::
+
+## Environment variables
+
+The environment variables relevant to migrating from v6 to v7:
+
+| Variable                            | Purpose                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `GITVERSION_GIT_BACKEND`            | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
+| `GITVERSION_USE_V6_ARGUMENT_PARSER` | Set to `true` to temporarily restore the legacy v6 (`/switch`) argument parser. Removed in a future release.        |
+| `GITVERSION_REMOTE_USERNAME`        | Alternative to `--username` for dynamic-repository credentials.                                                     |
+| `GITVERSION_REMOTE_PASSWORD`        | Alternative to `--password` for dynamic-repository credentials.                                                     |

--- a/new-cli/GitVersion.Common/GitVersion.Common.csproj
+++ b/new-cli/GitVersion.Common/GitVersion.Common.csproj
@@ -6,6 +6,10 @@
         <PackageReference Include="System.IO.Abstractions" />
     </ItemGroup>
     <ItemGroup>
+        <!-- src/GitVersion.Core gets this via src/Directory.Build.props; the source-linked Git/ files rely on it -->
+        <Using Include="Microsoft.Extensions.Logging" />
+    </ItemGroup>
+    <ItemGroup>
         <Compile Include="..\..\src\GitVersion.Core\Core\Abstractions\IEnvironment.cs" Link="Infrastructure\%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Core\Exceptions\WarningException.cs" Link="Exceptions\%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Core\RegexPatterns.cs" Link="%(Filename)%(Extension)" />

--- a/src/.run/cli (libgit2sharp).run.xml
+++ b/src/.run/cli (libgit2sharp).run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="cli (libgit2sharp)" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0/gitversion" />
+    <option name="PROGRAM_PARAMETERS" value="--no-cache --log-file console" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="GITVERSION_GIT_BACKEND" value="libgit2" />
+    </envs>
+    <option name="ENV_FILE_PATHS" value="" />
+    <option name="REDIRECT_INPUT_PATH" value="" />
+    <option name="MIXED_MODE_DEBUG" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="AUTO_ATTACH_CHILDREN" value="0" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/GitVersion.App/GitVersion.App.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/src/.run/cli (managed).run.xml
+++ b/src/.run/cli (managed).run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="cli (managed)" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0/gitversion" />
+    <option name="PROGRAM_PARAMETERS" value="--no-cache --log-file console" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="GITVERSION_GIT_BACKEND" value="managed" />
+    </envs>
+    <option name="ENV_FILE_PATHS" value="" />
+    <option name="REDIRECT_INPUT_PATH" value="" />
+    <option name="MIXED_MODE_DEBUG" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="AUTO_ATTACH_CHILDREN" value="0" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/GitVersion.App/GitVersion.App.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/src/.run/cli (version).run.xml
+++ b/src/.run/cli (version).run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="cli (version)" type="DotNetProject" factoryName=".NET Project">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0/gitversion" />
+    <option name="PROGRAM_PARAMETERS" value="-version" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GitVersion.App/bin/Debug/net10.0" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="ENV_FILE_PATHS" value="" />
+    <option name="REDIRECT_INPUT_PATH" value="" />
+    <option name="MIXED_MODE_DEBUG" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="AUTO_ATTACH_CHILDREN" value="0" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/GitVersion.App/GitVersion.App.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/src/GitVersion.App/CliHost.cs
+++ b/src/GitVersion.App/CliHost.cs
@@ -1,6 +1,7 @@
 using GitVersion.Agents;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
+using GitVersion.Git;
 using GitVersion.Output;
 using Serilog;
 using Serilog.Core;
@@ -33,7 +34,9 @@ internal static class CliHost
         services.AddModule(new GitVersionConfigurationModule());
         services.AddModule(new GitVersionOutputModule());
 
-        services.AddModule(new GitVersionLibGit2SharpModule());
+        services.AddModule(GitBackendSelector.Resolve() == GitBackend.Managed
+            ? new GitVersionManagedGitModule()
+            : new GitVersionLibGit2SharpModule());
 
         var envValue = SysEnv.GetEnvironmentVariable("GITVERSION_USE_V6_ARGUMENT_PARSER");
         var useLegacyParser = string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);

--- a/src/GitVersion.App/GitVersion.App.csproj
+++ b/src/GitVersion.App/GitVersion.App.csproj
@@ -26,6 +26,7 @@
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" />
         <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />
+        <ProjectReference Include="..\GitVersion.Git.Managed\GitVersion.Git.Managed.csproj" />
         <ProjectReference Include="..\GitVersion.LibGit2Sharp\GitVersion.LibGit2Sharp.csproj" />
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
         <ProjectReference Include="..\GitVersion.Output\GitVersion.Output.csproj" />

--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -124,6 +124,8 @@ internal class GitVersionExecutor(
         {
             this.logger.LogInformation("Working directory: {WorkingDirectory}", workingDirectory);
         }
+
+        this.logger.LogInformation("Git backend: {GitBackend}", GitBackendSelector.ResolveName());
     }
 
     private bool VerifyAndDisplayConfiguration(GitVersionOptions gitVersionOptions)

--- a/src/GitVersion.Core.Tests/Core/DualBackendParityTests.cs
+++ b/src/GitVersion.Core.Tests/Core/DualBackendParityTests.cs
@@ -1,0 +1,551 @@
+using System.IO.Abstractions;
+using GitVersion.Git;
+using GitVersion.Helpers;
+using GitVersion.Testing.Extensions;
+
+namespace GitVersion.Tests;
+
+/// <summary>
+/// Opens the same on-disk repository with both Git backends (libgit2 and managed) and
+/// deep-compares every read surface: reference/branch/tag enumeration, order-sensitive
+/// commit walks, merge bases over all commit pairs, diff paths and the uncommitted
+/// changes count. This is the direct parity oracle demanded by the managed-git
+/// migration plan, independent of which backend the test run selects globally.
+/// </summary>
+[TestFixture]
+public class DualBackendParityTests : TestBase
+{
+    private static readonly CommitSortStrategies[] SortCombinations =
+    [
+        CommitSortStrategies.None,
+        CommitSortStrategies.Time,
+        CommitSortStrategies.Topological,
+        CommitSortStrategies.Topological | CommitSortStrategies.Time,
+        CommitSortStrategies.Time | CommitSortStrategies.Reverse,
+        CommitSortStrategies.Topological | CommitSortStrategies.Time | CommitSortStrategies.Reverse
+    ];
+
+    [Test]
+    public void ReferencesAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.References.Select(r => $"{r.Name.Canonical} -> {r.TargetIdentifier} ({r.ReferenceTargetId?.Sha ?? "symbolic"})");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+
+        var libGit2Head = backends.LibGit2.References.Head.ShouldNotBeNull();
+        var managedHead = backends.Managed.References.Head.ShouldNotBeNull();
+        managedHead.Name.Canonical.ShouldBe(libGit2Head.Name.Canonical);
+        managedHead.TargetIdentifier.ShouldBe(libGit2Head.TargetIdentifier);
+
+        static IEnumerable<string> FromGlob(IGitRepository repository) =>
+            repository.References.FromGlob("refs/heads/*").Select(r => $"{r.Name.Canonical} -> {r.TargetIdentifier}");
+
+        FromGlob(backends.Managed).ShouldBe(FromGlob(backends.LibGit2));
+    }
+
+    [Test]
+    public void BranchesAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.Branches.Select(b => $"{b.Name.Canonical}@{b.Tip?.Sha} remote:{b.IsRemote} tracking:{b.IsTracking} detached:{b.IsDetachedHead}");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+
+        foreach (var name in new[] { "main", "develop", "refs/heads/develop", "feature/complex", "missing" })
+        {
+            var libGit2Branch = backends.LibGit2.Branches[name];
+            var managedBranch = backends.Managed.Branches[name];
+            (managedBranch?.Name.Canonical).ShouldBe(libGit2Branch?.Name.Canonical, $"lookup of '{name}'");
+            (managedBranch?.Tip?.Sha).ShouldBe(libGit2Branch?.Tip?.Sha, $"tip of '{name}'");
+        }
+
+        backends.Managed.Head.Name.Canonical.ShouldBe(backends.LibGit2.Head.Name.Canonical);
+        (backends.Managed.Head.Tip?.Sha).ShouldBe(backends.LibGit2.Head.Tip?.Sha);
+        backends.Managed.IsHeadDetached.ShouldBe(backends.LibGit2.IsHeadDetached);
+        backends.Managed.IsShallow.ShouldBe(backends.LibGit2.IsShallow);
+    }
+
+    [Test]
+    public void TagsAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.Tags.Select(t => $"{t.Name.Canonical} target:{t.TargetSha} commit:{t.Commit.Sha}");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+    }
+
+    [Test]
+    public void CommitLogsAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.Commits.Select(c => $"{c.Sha} when:{c.When:O} merge:{c.IsMergeCommit} parents:{string.Join(',', c.Parents.Select(p => p.Sha))} message:{c.Message}");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+
+        foreach (var branchName in new[] { "main", "develop", "feature/complex" })
+        {
+            var libGit2Commits = backends.LibGit2.Branches[branchName].ShouldNotBeNull().Commits.Select(c => c.Sha);
+            var managedCommits = backends.Managed.Branches[branchName].ShouldNotBeNull().Commits.Select(c => c.Sha);
+            managedCommits.ShouldBe(libGit2Commits, $"commits of '{branchName}'");
+        }
+    }
+
+    [Test]
+    public void QueryBySequencesAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateCrissCrossFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        var libGit2Commits = CollectAllCommits(backends.LibGit2);
+        var managedCommits = CollectAllCommits(backends.Managed);
+        managedCommits.Keys.Order().ShouldBe(libGit2Commits.Keys.Order());
+
+        string?[] excludeCandidates = [null, .. libGit2Commits.Keys.Order().Take(3)];
+
+        foreach (var sortBy in SortCombinations)
+        {
+            foreach (var firstParentOnly in new[] { false, true })
+            {
+                foreach (var excludeSha in excludeCandidates)
+                {
+                    var description = $"sort:{sortBy} firstParent:{firstParentOnly} exclude:{excludeSha ?? "none"}";
+
+                    var libGit2Result = backends.LibGit2.Commits.QueryBy(new CommitFilter
+                    {
+                        IncludeReachableFrom = backends.LibGit2.Branches["main"],
+                        ExcludeReachableFrom = excludeSha is null ? null : libGit2Commits[excludeSha],
+                        SortBy = sortBy,
+                        FirstParentOnly = firstParentOnly
+                    }).Select(c => c.Sha);
+
+                    var managedResult = backends.Managed.Commits.QueryBy(new CommitFilter
+                    {
+                        IncludeReachableFrom = backends.Managed.Branches["main"],
+                        ExcludeReachableFrom = excludeSha is null ? null : managedCommits[excludeSha],
+                        SortBy = sortBy,
+                        FirstParentOnly = firstParentOnly
+                    }).Select(c => c.Sha);
+
+                    managedResult.ShouldBe(libGit2Result, description);
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void MergeBasesAreIdenticalOnBothBackendsForAllCommitPairs()
+    {
+        using var fixture = CreateCrissCrossFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        var libGit2Commits = CollectAllCommits(backends.LibGit2);
+        var managedCommits = CollectAllCommits(backends.Managed);
+        var shas = libGit2Commits.Keys.Order().ToList();
+
+        foreach (var first in shas)
+        {
+            foreach (var second in shas)
+            {
+                var libGit2MergeBase = backends.LibGit2.FindMergeBase(libGit2Commits[first], libGit2Commits[second]);
+                var managedMergeBase = backends.Managed.FindMergeBase(managedCommits[first], managedCommits[second]);
+                (managedMergeBase?.Sha).ShouldBe(libGit2MergeBase?.Sha, $"merge base of {first[..7]} and {second[..7]}");
+            }
+        }
+    }
+
+    [Test]
+    public void DiffPathsAreIdenticalOnBothBackendsForAllCommits()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        var libGit2Commits = CollectAllCommits(backends.LibGit2);
+        var managedCommits = CollectAllCommits(backends.Managed);
+
+        foreach (var sha in libGit2Commits.Keys.Order())
+        {
+            managedCommits[sha].DiffPaths.ShouldBe(libGit2Commits[sha].DiffPaths, $"diff paths of {sha[..7]}");
+        }
+    }
+
+    [Test]
+    public void UncommittedChangesCountIsIdenticalOnBothBackends()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
+
+        var trackedFile = FileSystemHelper.Path.Combine(fixture.RepositoryPath, "tracked.txt");
+        File.WriteAllText(trackedFile, "one");
+        LibGit2Sharp.Commands.Stage(fixture.Repository, "tracked.txt");
+        fixture.Repository.Commit("add tracked file", signature, signature, new LibGit2Sharp.CommitOptions());
+
+        File.WriteAllText(trackedFile, "two");
+        File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "untracked.txt"), "new");
+        File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "staged.txt"), "staged");
+        LibGit2Sharp.Commands.Stage(fixture.Repository, "staged.txt");
+
+        using var backends = OpenBothBackends(fixture);
+        backends.Managed.UncommittedChangesCount().ShouldBe(backends.LibGit2.UncommittedChangesCount());
+    }
+
+    [Test]
+    public void EmptyRepositoryBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "untracked.txt"), "new");
+
+        using var backends = OpenBothBackends(fixture);
+
+        backends.Managed.Head.Name.Canonical.ShouldBe(backends.LibGit2.Head.Name.Canonical);
+        backends.Managed.Head.Tip.ShouldBe(backends.LibGit2.Head.Tip);
+        backends.Managed.IsHeadDetached.ShouldBe(backends.LibGit2.IsHeadDetached);
+        backends.Managed.UncommittedChangesCount().ShouldBe(backends.LibGit2.UncommittedChangesCount());
+    }
+
+    [Test]
+    public void DetachedHeadBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        var detachAt = fixture.Repository.Head.Tip.Parents.First();
+        LibGit2Sharp.Commands.Checkout(fixture.Repository, detachAt);
+
+        using var backends = OpenBothBackends(fixture);
+
+        backends.Managed.IsHeadDetached.ShouldBeTrue();
+        backends.Managed.IsHeadDetached.ShouldBe(backends.LibGit2.IsHeadDetached);
+        backends.Managed.Head.Name.Canonical.ShouldBe(backends.LibGit2.Head.Name.Canonical);
+        backends.Managed.Head.IsDetachedHead.ShouldBe(backends.LibGit2.Head.IsDetachedHead);
+        (backends.Managed.Head.Tip?.Sha).ShouldBe(backends.LibGit2.Head.Tip?.Sha);
+    }
+
+    [Test]
+    public void RemotesAndRemoteBranchesAreIdenticalOnBothBackends()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        using var backends = OpenBothBackends(fixture.LocalRepositoryFixture);
+
+        static IEnumerable<string> DescribeRemotes(IGitRepository repository) =>
+            repository.Remotes.Select(r =>
+                $"{r.Name} {r.Url} fetch:[{string.Join(';', r.FetchRefSpecs.Select(s => s.Specification))}] push:[{string.Join(';', r.PushRefSpecs.Select(s => s.Specification))}]");
+
+        DescribeRemotes(backends.Managed).ShouldBe(DescribeRemotes(backends.LibGit2));
+
+        var libGit2Remote = backends.LibGit2.Remotes["origin"].ShouldNotBeNull();
+        var managedRemote = backends.Managed.Remotes["origin"].ShouldNotBeNull();
+        managedRemote.Url.ShouldBe(libGit2Remote.Url);
+
+        foreach (var (managedSpec, libGit2Spec) in managedRemote.FetchRefSpecs.Zip(libGit2Remote.FetchRefSpecs))
+        {
+            managedSpec.Specification.ShouldBe(libGit2Spec.Specification);
+            managedSpec.Direction.ShouldBe(libGit2Spec.Direction);
+            managedSpec.Source.ShouldBe(libGit2Spec.Source);
+            managedSpec.Destination.ShouldBe(libGit2Spec.Destination);
+        }
+
+        static IEnumerable<string> DescribeBranches(IGitRepository repository) =>
+            repository.Branches.Select(b => $"{b.Name.Canonical}@{b.Tip?.Sha} remote:{b.IsRemote} tracking:{b.IsTracking}");
+
+        DescribeBranches(backends.Managed).ShouldBe(DescribeBranches(backends.LibGit2));
+    }
+
+    [Test]
+    public void RepositoryPathsAreIdenticalOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        using var backends = OpenBothBackends(fixture);
+
+        backends.Managed.Path.ShouldBe(backends.LibGit2.Path);
+        backends.Managed.WorkingDirectory.ShouldBe(backends.LibGit2.WorkingDirectory);
+    }
+
+    [Test]
+    public void BareRepositoryHasNullProjectRootDirectoryOnBothBackends()
+    {
+        var barePath = FileSystemHelper.Path.GetRepositoryTempPath();
+        LibGit2Sharp.Repository.Init(barePath, isBare: true);
+        try
+        {
+            var fileSystem = new FileSystem();
+            var options = Options.Create(new GitVersionOptions { WorkingDirectory = barePath });
+
+            IGitRepositoryInfo libGit2Info = new GitRepositoryInfo(fileSystem, options);
+            IGitRepositoryInfo managedInfo = new ManagedGitRepositoryInfo(fileSystem, options);
+
+            // Discovery succeeds for a bare repository, but there is no working directory:
+            // the project root is legitimately null and resolving it must not throw.
+            libGit2Info.ProjectRootDirectory.ShouldBeNull();
+            managedInfo.ProjectRootDirectory.ShouldBeNull();
+
+            managedInfo.DotGitDirectory.ShouldNotBeNull();
+            managedInfo.DotGitDirectory.ShouldBe(libGit2Info.DotGitDirectory);
+        }
+        finally
+        {
+            FileSystemHelper.Directory.DeleteDirectory(barePath);
+        }
+    }
+
+    [Test]
+    public void OctopusMergeBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit("base");
+        fixture.BranchTo("topic/one");
+        fixture.MakeACommit("topic one");
+        fixture.Checkout("main");
+        fixture.BranchTo("topic/two");
+        fixture.MakeACommit("topic two");
+        fixture.Checkout("main");
+        fixture.MakeACommit("main one");
+        GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} -c user.name=test -c user.email=test@example.com merge topic/one topic/two -m octopus", ".");
+
+        using var backends = OpenBothBackends(fixture);
+
+        backends.Managed.Head.Tip.ShouldNotBeNull().Parents.Count.ShouldBe(3);
+        AssertCommitLogParity(backends);
+        AssertMergeBaseParity(backends);
+        AssertDiffPathsParity(backends);
+    }
+
+    [Test]
+    public void PackedAndLooseReferencesBehaveIdenticallyOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+
+        // Pack everything, then shadow one packed ref with a loose one and add brand-new loose refs,
+        // so both stores must merge packed and loose entries (and their peeled annotated-tag lines).
+        GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} pack-refs --all", ".");
+        fixture.MakeACommit("shadows the packed main entry");
+        fixture.BranchTo("loose/branch");
+        fixture.ApplyTag("loose-tag");
+
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> DescribeReferences(IGitRepository repository) =>
+            repository.References.Select(r => $"{r.Name.Canonical} -> {r.TargetIdentifier}");
+
+        DescribeReferences(backends.Managed).ShouldBe(DescribeReferences(backends.LibGit2));
+
+        static IEnumerable<string> DescribeTags(IGitRepository repository) =>
+            repository.Tags.Select(t => $"{t.Name.Canonical} target:{t.TargetSha} commit:{t.Commit.Sha}");
+
+        DescribeTags(backends.Managed).ShouldBe(DescribeTags(backends.LibGit2));
+
+        static IEnumerable<string> DescribeBranches(IGitRepository repository) =>
+            repository.Branches.Select(b => $"{b.Name.Canonical}@{b.Tip?.Sha}");
+
+        DescribeBranches(backends.Managed).ShouldBe(DescribeBranches(backends.LibGit2));
+    }
+
+    [Test]
+    public void LightweightAndAnnotatedTagOnTheSameCommitBehaveIdenticallyOnBothBackends()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit("only commit");
+        fixture.ApplyTag("lightweight");
+        fixture.Repository.Tags.Add("annotated", fixture.Repository.Head.Tip, new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now), "the same commit, annotated");
+
+        using var backends = OpenBothBackends(fixture);
+
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.Tags.Select(t => $"{t.Name.Canonical} target:{t.TargetSha} commit:{t.Commit.Sha}");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+    }
+
+    [Test]
+    public void ShallowCloneBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        using var localFixture = fixture.CloneRepository();
+        localFixture.MakeShallow();
+
+        using var backends = OpenBothBackends(localFixture);
+
+        backends.Managed.IsShallow.ShouldBeTrue();
+        backends.Managed.IsShallow.ShouldBe(backends.LibGit2.IsShallow);
+        AssertCommitLogParity(backends);
+    }
+
+    [Test]
+    public void WorktreeBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = CreateComplexFixture();
+        var worktreePath = FileSystemHelper.Path.GetRepositoryTempPath();
+        GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} worktree add {worktreePath} develop", ".");
+
+        try
+        {
+            using var backends = OpenBothBackendsAt(worktreePath);
+
+            backends.Managed.Path.ShouldBe(backends.LibGit2.Path);
+            backends.Managed.WorkingDirectory.ShouldBe(backends.LibGit2.WorkingDirectory);
+            backends.Managed.Head.Name.Canonical.ShouldBe(backends.LibGit2.Head.Name.Canonical);
+            (backends.Managed.Head.Tip?.Sha).ShouldBe(backends.LibGit2.Head.Tip?.Sha);
+            backends.Managed.UncommittedChangesCount().ShouldBe(backends.LibGit2.UncommittedChangesCount());
+
+            static IEnumerable<string> DescribeReferences(IGitRepository repository) =>
+                repository.References.Select(r => $"{r.Name.Canonical} -> {r.TargetIdentifier}");
+
+            DescribeReferences(backends.Managed).ShouldBe(DescribeReferences(backends.LibGit2));
+            AssertCommitLogParity(backends);
+        }
+        finally
+        {
+            GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} worktree remove --force {worktreePath}", ".");
+        }
+    }
+
+    [Test]
+    public void IndexVersionFourBehavesIdenticallyOnBothBackends()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
+
+        var trackedFile = FileSystemHelper.Path.Combine(fixture.RepositoryPath, "tracked.txt");
+        File.WriteAllText(trackedFile, "one");
+        LibGit2Sharp.Commands.Stage(fixture.Repository, "tracked.txt");
+        fixture.Repository.Commit("add tracked file", signature, signature, new LibGit2Sharp.CommitOptions());
+
+        GitTestExtensions.ExecuteGitCmd($"-C {fixture.RepositoryPath} update-index --index-version 4", ".");
+        File.WriteAllText(trackedFile, "two");
+        File.WriteAllText(FileSystemHelper.Path.Combine(fixture.RepositoryPath, "untracked.txt"), "new");
+
+        using var backends = OpenBothBackends(fixture);
+        backends.Managed.UncommittedChangesCount().ShouldBe(backends.LibGit2.UncommittedChangesCount());
+    }
+
+    private static void AssertCommitLogParity(BackendPair backends)
+    {
+        static IEnumerable<string> Describe(IGitRepository repository) =>
+            repository.Commits.Select(c => $"{c.Sha} merge:{c.IsMergeCommit} parents:{string.Join(',', c.Parents.Select(p => p.Sha))}");
+
+        Describe(backends.Managed).ShouldBe(Describe(backends.LibGit2));
+    }
+
+    private static void AssertMergeBaseParity(BackendPair backends)
+    {
+        var libGit2Commits = CollectAllCommits(backends.LibGit2);
+        var managedCommits = CollectAllCommits(backends.Managed);
+
+        foreach (var first in libGit2Commits.Keys.Order())
+        {
+            foreach (var second in libGit2Commits.Keys.Order())
+            {
+                var libGit2MergeBase = backends.LibGit2.FindMergeBase(libGit2Commits[first], libGit2Commits[second]);
+                var managedMergeBase = backends.Managed.FindMergeBase(managedCommits[first], managedCommits[second]);
+                (managedMergeBase?.Sha).ShouldBe(libGit2MergeBase?.Sha, $"merge base of {first[..7]} and {second[..7]}");
+            }
+        }
+    }
+
+    private static void AssertDiffPathsParity(BackendPair backends)
+    {
+        var libGit2Commits = CollectAllCommits(backends.LibGit2);
+        var managedCommits = CollectAllCommits(backends.Managed);
+
+        foreach (var sha in libGit2Commits.Keys.Order())
+        {
+            managedCommits[sha].DiffPaths.ShouldBe(libGit2Commits[sha].DiffPaths, $"diff paths of {sha[..7]}");
+        }
+    }
+
+    private static RepositoryFixtureBase CreateComplexFixture()
+    {
+        var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit("initial commit");
+        fixture.ApplyTag("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit("develop one");
+        fixture.Checkout("main");
+        fixture.MakeACommit("main two");
+        fixture.MergeNoFF("develop");
+        fixture.Repository.Tags.Add("v2.0.0", fixture.Repository.Head.Tip, new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now), "an annotated tag");
+        fixture.BranchTo("feature/complex");
+        fixture.MakeACommit("feature one");
+        fixture.Checkout("develop");
+        fixture.MakeACommit("develop two");
+        fixture.Checkout("main");
+        return fixture;
+    }
+
+    /// <summary>
+    /// Builds a criss-cross history (two merge commits whose parents are swapped), which is
+    /// the classic ambiguous merge-base scenario, plus commits with equal timestamps.
+    /// </summary>
+    private static RepositoryFixtureBase CreateCrissCrossFixture()
+    {
+        var fixture = new EmptyRepositoryFixture();
+        var signature = new LibGit2Sharp.Signature("unit test", "test@example.com", DateTimeOffset.Now);
+        var mergeOptions = new LibGit2Sharp.MergeOptions { FastForwardStrategy = LibGit2Sharp.FastForwardStrategy.NoFastForward };
+
+        fixture.MakeACommit("base");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit("develop one");
+        var developHead = fixture.Repository.Head.Tip;
+        fixture.Checkout("main");
+        fixture.MakeACommit("main one");
+        var mainHead = fixture.Repository.Head.Tip;
+
+        // main merges develop's old head while develop merges main's old head: criss-cross.
+        fixture.Repository.Merge(developHead, signature, mergeOptions);
+        fixture.Checkout("develop");
+        fixture.Repository.Merge(mainHead, signature, mergeOptions);
+
+        fixture.MakeACommit("develop two");
+        fixture.Checkout("main");
+        fixture.MakeACommit("main two");
+        return fixture;
+    }
+
+    private static BackendPair OpenBothBackends(RepositoryFixtureBase fixture) => OpenBothBackendsAt(fixture.RepositoryPath);
+
+    private static BackendPair OpenBothBackendsAt(string repositoryPath)
+    {
+        var libGit2 = new GitRepository(NullLogger<GitRepository>.Instance);
+        libGit2.DiscoverRepository(repositoryPath);
+
+        var cliMutator = new GitCliMutator(NullLogger<GitCliMutator>.Instance, new GitCliExecutor(NullLogger<GitCliExecutor>.Instance));
+        var managed = new ManagedGitRepository(NullLogger<ManagedGitRepository>.Instance, cliMutator);
+        managed.DiscoverRepository(repositoryPath);
+
+        return new(libGit2, managed);
+    }
+
+    private static Dictionary<string, ICommit> CollectAllCommits(IGitRepository repository)
+    {
+        var commits = new Dictionary<string, ICommit>(StringComparer.Ordinal);
+
+        foreach (var branch in repository.Branches)
+        {
+            foreach (var commit in branch.Commits)
+            {
+                commits[commit.Sha] = commit;
+            }
+        }
+
+        return commits;
+    }
+
+    private sealed record BackendPair(IGitRepository LibGit2, IGitRepository Managed) : IDisposable
+    {
+        public void Dispose()
+        {
+            LibGit2.Dispose();
+            Managed.Dispose();
+        }
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
@@ -1,0 +1,46 @@
+using GitVersion.Git;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class GitBackendSelectorTests : TestBase
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase("libgit2", false)]
+    [TestCase("LIBGIT2", false)]
+    [TestCase("managed", true)]
+    [TestCase("Managed", true)]
+    [TestCase(" managed ", true)]
+    public void ResolvesKnownValues(string? value, bool isManaged)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        GitBackendSelector.Resolve().ShouldBe(isManaged ? GitBackend.Managed : GitBackend.LibGit2);
+    }
+
+    [TestCase("manged")]
+    [TestCase("libgit2sharp")]
+    [TestCase("true")]
+    public void FailsFastOnUnknownValues(string value)
+    {
+        // A silently ignored typo would make a user believe they validated the
+        // managed backend while actually running libgit2.
+        using var scope = new EnvironmentVariableScope(value);
+
+        Should.Throw<InvalidOperationException>(() => GitBackendSelector.Resolve())
+            .Message.ShouldContain(value);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, this.original);
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitCliMutatorTests.cs
@@ -1,0 +1,185 @@
+using GitVersion.Git;
+using GitVersion.Helpers;
+using GitVersion.Testing.Extensions;
+using LibGit2Sharp;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+public class GitCliMutatorTests : TestBase
+{
+    private static GitCliMutator CreateMutator() =>
+        new(NullLogger<GitCliMutator>.Instance, new GitCliExecutor(NullLogger<GitCliExecutor>.Instance));
+
+    [Test]
+    public void CheckoutSwitchesToTheGivenBranch()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.Repository.CreateBranch("feature/cli");
+
+        CreateMutator().Checkout(fixture.RepositoryPath, "feature/cli");
+
+        fixture.Repository.Head.FriendlyName.ShouldBe("feature/cli");
+    }
+
+    [Test]
+    public void CheckoutOfUnknownSpecThrows()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+
+        Should.Throw<InvalidOperationException>(() => CreateMutator().Checkout(fixture.RepositoryPath, "does-not-exist"));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void CheckoutIgnoresAnInheritedGitDirEnvironmentVariable()
+    {
+        // git exports GIT_DIR when running hooks; the executor must scrub it so
+        // mutations target the working-directory repository, as libgit2 did.
+        using var otherFixture = new EmptyRepositoryFixture();
+        otherFixture.Repository.MakeACommit();
+
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        fixture.Repository.CreateBranch("only-here");
+
+        System.Environment.SetEnvironmentVariable("GIT_DIR", FileSystemHelper.Path.Combine(otherFixture.RepositoryPath, ".git"));
+        try
+        {
+            CreateMutator().Checkout(fixture.RepositoryPath, "only-here");
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("GIT_DIR", null);
+        }
+
+        fixture.Repository.Head.FriendlyName.ShouldBe("only-here");
+    }
+
+    [Test]
+    public void CheckoutFailureIsNotMisclassifiedAsAnHttpError()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+
+        // The failing spec echoes "404" in stderr; only network operations may map
+        // HTTP status codes, so the real pathspec error must surface unchanged.
+        var exception = Should.Throw<InvalidOperationException>(
+            () => CreateMutator().Checkout(fixture.RepositoryPath, "fix-404-page"));
+
+        exception.Message.ShouldContain("fix-404-page");
+        exception.Message.ShouldNotContain("The repository was not found");
+    }
+
+    [Test]
+    public void FetchBringsNewRemoteCommitsIntoTheLocalRepository()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        var newCommit = fixture.Repository.MakeACommit();
+        var localRepository = fixture.LocalRepositoryFixture.Repository;
+        localRepository.Lookup(newCommit.Sha).ShouldBeNull();
+
+        CreateMutator().Fetch(fixture.LocalRepositoryFixture.RepositoryPath, "origin", [], new AuthenticationInfo());
+
+        localRepository.Lookup(newCommit.Sha).ShouldNotBeNull();
+    }
+
+    [Test]
+    public void CloneCreatesRepositoryWithoutCheckingOutTheWorkingDirectory()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        try
+        {
+            CreateMutator().Clone(fixture.RepositoryPath, targetPath, new AuthenticationInfo());
+
+            using var clonedRepository = new Repository(targetPath);
+            clonedRepository.Head.Tip.ShouldNotBeNull();
+            Directory.EnumerateFileSystemEntries(targetPath)
+                .Where(entry => FileSystemHelper.Path.GetFileName(entry) != ".git")
+                .ShouldBeEmpty();
+        }
+        finally
+        {
+            FileSystemHelper.Directory.DeleteDirectory(targetPath);
+        }
+    }
+
+    [Test]
+    public void CloneOfMissingRepositoryThrows()
+    {
+        var missingSource = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPathLegacy(), "gitversion-does-not-exist");
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        Should.Throw<InvalidOperationException>(() => CreateMutator().Clone(missingSource, targetPath, new AuthenticationInfo()));
+    }
+
+    [Test]
+    public void CloneOfMissingHttpRepositoryMapsGitsNotFoundPhrasing()
+    {
+        // Non-GitHub hosts produce "fatal: repository '<url>' not found" (no "404",
+        // no contiguous "Repository not found"); the message contract must still hold.
+        using var server = new HttpNotFoundServer();
+        var targetPath = FileSystemHelper.Path.GetRepositoryTempPath();
+
+        var exception = Should.Throw<InvalidOperationException>(
+            () => CreateMutator().Clone($"{server.Url}/missing/repo.git", targetPath, new AuthenticationInfo()));
+
+        exception.Message.ShouldBe("Not found: The repository was not found");
+    }
+
+    private sealed class HttpNotFoundServer : IDisposable
+    {
+        private readonly System.Net.HttpListener listener = new();
+        public string Url { get; }
+
+        public HttpNotFoundServer()
+        {
+            var port = GetFreePort();
+            Url = $"http://127.0.0.1:{port}";
+            this.listener.Prefixes.Add($"{Url}/");
+            this.listener.Start();
+            _ = Task.Run(async () =>
+            {
+                while (this.listener.IsListening)
+                {
+                    try
+                    {
+                        var context = await this.listener.GetContextAsync().ConfigureAwait(false);
+                        context.Response.StatusCode = 404;
+                        context.Response.Close();
+                    }
+                    catch (Exception ex) when (ex is System.Net.HttpListenerException or ObjectDisposedException)
+                    {
+                        return;
+                    }
+                }
+            });
+        }
+
+        private static int GetFreePort()
+        {
+            using var socket = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            socket.Start();
+            return ((System.Net.IPEndPoint)socket.LocalEndpoint).Port;
+        }
+
+        public void Dispose() => this.listener.Stop();
+    }
+
+    [Test]
+    public void ListRemoteReferencesReturnsBranchTips()
+    {
+        using var fixture = new RemoteRepositoryFixture();
+        var remoteTipSha = fixture.Repository.Head.Tip.Sha;
+
+        var references = CreateMutator().ListRemoteReferences(fixture.LocalRepositoryFixture.RepositoryPath, "origin", new AuthenticationInfo());
+
+        references.Single(r => r.CanonicalName == "refs/heads/main").TargetSha.ShouldBe(remoteTipSha);
+        references.ShouldNotContain(r => r.CanonicalName == "HEAD");
+    }
+}

--- a/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
+++ b/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" />
         <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />
+        <ProjectReference Include="..\GitVersion.Git.Managed\GitVersion.Git.Managed.csproj" />
         <ProjectReference Include="..\GitVersion.LibGit2Sharp\GitVersion.LibGit2Sharp.csproj" />
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
         <ProjectReference Include="..\GitVersion.Output\GitVersion.Output.csproj" />

--- a/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
+++ b/src/GitVersion.Core.Tests/Helpers/GitVersionCoreTestModule.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions;
 using GitVersion.Agents;
 using GitVersion.Configuration;
 using GitVersion.Extensions;
+using GitVersion.Git;
 using GitVersion.Output;
 
 namespace GitVersion.Tests;
@@ -10,7 +11,9 @@ public class GitVersionCoreTestModule : IGitVersionModule
 {
     public void RegisterTypes(IServiceCollection services)
     {
-        services.AddModule(new GitVersionLibGit2SharpModule());
+        services.AddModule(GitBackendSelector.Resolve() == GitBackend.Managed
+            ? new GitVersionManagedGitModule()
+            : new GitVersionLibGit2SharpModule());
         services.AddModule(new GitVersionBuildAgentsModule());
         services.AddModule(new GitVersionOutputModule());
         services.AddModule(new GitVersionConfigurationModule());

--- a/src/GitVersion.Core/Git/GitBackend.cs
+++ b/src/GitVersion.Core/Git/GitBackend.cs
@@ -1,0 +1,53 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The Git backend implementations selectable via the <c>GITVERSION_GIT_BACKEND</c>
+/// environment variable during the dual-backend window (v7.0–v7.x).
+/// </summary>
+internal enum GitBackend
+{
+    /// <summary>The libgit2-based backend (the v7.0 default).</summary>
+    LibGit2,
+
+    /// <summary>The managed reader + git CLI mutator backend.</summary>
+    Managed
+}
+
+/// <summary>
+/// The single place where <c>GITVERSION_GIT_BACKEND</c> is interpreted: every composition
+/// root selects the backend through this class so production and tests cannot drift, and
+/// the v7.1 default flip is a one-line change. This is configuration, not Git logic — it
+/// names no backend internals, so it lives at the composition seam that every root already
+/// shares rather than inside one of the backend assemblies.
+/// </summary>
+internal static class GitBackendSelector
+{
+    public const string EnvironmentVariableName = "GITVERSION_GIT_BACKEND";
+
+    /// <summary>
+    /// The canonical configuration name of the resolved backend, as users set it
+    /// in <c>GITVERSION_GIT_BACKEND</c>: <c>libgit2</c> or <c>managed</c>.
+    /// </summary>
+    public static string ResolveName() => Resolve() == GitBackend.Managed ? "managed" : "libgit2";
+
+    /// <summary>
+    /// Resolves the backend from the environment: <c>libgit2</c> (the default when unset)
+    /// or <c>managed</c>. Unknown values fail fast — a silently ignored typo would make a
+    /// user believe they validated the managed backend while running libgit2.
+    /// </summary>
+    /// <returns>The selected backend.</returns>
+    /// <exception cref="InvalidOperationException">The variable is set to an unrecognized value.</exception>
+    public static GitBackend Resolve()
+    {
+        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
+
+        return value switch
+        {
+            null or "" => GitBackend.LibGit2,
+            _ when value.Equals("libgit2", StringComparison.OrdinalIgnoreCase) => GitBackend.LibGit2,
+            _ when value.Equals("managed", StringComparison.OrdinalIgnoreCase) => GitBackend.Managed,
+            _ => throw new InvalidOperationException(
+                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'libgit2' and 'managed'.")
+        };
+    }
+}

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -30,6 +30,7 @@
         <InternalsVisibleTo Include="GitVersion.App" />
         <InternalsVisibleTo Include="GitVersion.BuildAgents" />
         <InternalsVisibleTo Include="GitVersion.Configuration" />
+        <InternalsVisibleTo Include="GitVersion.Git.Managed" />
         <InternalsVisibleTo Include="GitVersion.LibGit2Sharp" />
         <InternalsVisibleTo Include="GitVersion.MsBuild" />
         <InternalsVisibleTo Include="GitVersion.Output" />
@@ -37,6 +38,7 @@
         <InternalsVisibleTo Include="GitVersion.BuildAgents.Tests" />
         <InternalsVisibleTo Include="GitVersion.Configuration.Tests" />
         <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+        <InternalsVisibleTo Include="GitVersion.Git.Managed.Tests" />
         <InternalsVisibleTo Include="GitVersion.Output.Tests" />
         <InternalsVisibleTo Include="GitVersion.App.Tests" />
         <InternalsVisibleTo Include="GitVersion.MsBuild.Tests" />

--- a/src/GitVersion.Git.Managed.Tests/AssemblyParallelizable.cs
+++ b/src/GitVersion.Git.Managed.Tests/AssemblyParallelizable.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/src/GitVersion.Git.Managed.Tests/DeltaStreamReaderTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/DeltaStreamReaderTests.cs
@@ -1,0 +1,37 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class DeltaStreamReaderTests
+{
+    [Test]
+    public void ReadsACompleteCopyInstruction()
+    {
+        // Copy with one offset byte (0x42) and one size byte (0x07).
+        using var stream = new MemoryStream([0b1001_0001, 0x42, 0x07]);
+
+        var instruction = DeltaStreamReader.Read(stream);
+
+        instruction.ShouldNotBeNull();
+        instruction.Value.InstructionType.ShouldBe(DeltaInstructionType.Copy);
+        instruction.Value.Offset.ShouldBe(0x42);
+        instruction.Value.Size.ShouldBe(0x07);
+    }
+
+    [Test]
+    public void ReturnsNullAtTheEndOfTheStream()
+    {
+        using var stream = new MemoryStream([]);
+
+        DeltaStreamReader.Read(stream).ShouldBeNull();
+    }
+
+    [Test]
+    public void ThrowsWhenTheStreamEndsInsideACopyInstruction()
+    {
+        // The instruction announces an offset byte and a size byte, but the stream is
+        // truncated: EOF must not be silently decoded as 0xFF (garbage copy target).
+        using var stream = new MemoryStream([0b1001_0001, 0x42]);
+
+        Should.Throw<EndOfStreamException>(() => DeltaStreamReader.Read(stream));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitConfigurationFileTests.cs
@@ -1,0 +1,70 @@
+using GitVersion.Helpers;
+
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitConfigurationFileTests
+{
+    private static GitConfigurationFile Load(string content)
+    {
+        var directory = FileSystemHelper.Path.GetRepositoryTempPath();
+        Directory.CreateDirectory(directory);
+        var path = FileSystemHelper.Path.Combine(directory, "config");
+        File.WriteAllText(path, content);
+        try
+        {
+            return GitConfigurationFile.Load(path);
+        }
+        finally
+        {
+            FileSystemHelper.Directory.DeleteDirectory(directory);
+        }
+    }
+
+    [Test]
+    public void UnescapesBackslashesInUnquotedValue()
+    {
+        // git stores a Windows remote path with escaped backslashes and no surrounding quotes.
+        var config = Load("[remote \"origin\"]\n\turl = D:\\\\a\\\\_temp\\\\repo\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe(@"D:\a\_temp\repo");
+    }
+
+    [Test]
+    public void UnescapesBackslashesInQuotedValue()
+    {
+        var config = Load("[remote \"origin\"]\n\turl = \"D:\\\\a\\\\repo\"\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe(@"D:\a\repo");
+    }
+
+    [Test]
+    public void KeepsForwardSlashPathUnchanged()
+    {
+        var config = Load("[remote \"origin\"]\n\turl = /srv/git/repositories/project.git\n");
+
+        config.GetString("remote", "origin", "url").ShouldBe("/srv/git/repositories/project.git");
+    }
+
+    [Test]
+    public void StripsInlineCommentOutsideQuotesButNotInside()
+    {
+        Load("[core]\n\tx = value ; trailing\n").GetString("core", null, "x").ShouldBe("value");
+        Load("[core]\n\tx = \"a ; b\"\n").GetString("core", null, "x").ShouldBe("a ; b");
+    }
+
+    [Test]
+    public void DecodesEscapeSequences()
+    {
+        var config = Load("[core]\n\tx = a\\tb\\nc\n");
+
+        config.GetString("core", null, "x").ShouldBe("a\tb\nc");
+    }
+
+    [Test]
+    public void TrimsUnquotedTrailingWhitespaceButKeepsQuotedWhitespace()
+    {
+        Load("[core]\n\tx = value   \n").GetString("core", null, "x").ShouldBe("value");
+        Load("[core]\n\tx = \"value   \"\n").GetString("core", null, "x").ShouldBe("value   ");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitIndexTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitIndexTests.cs
@@ -1,0 +1,96 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitIndexTests
+{
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    public void IndexEntriesMatchGitLsFiles(int indexVersion)
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.WriteFile("sub/deep/c.txt", "three\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--chmod=+x", "a.txt");
+
+        if (indexVersion == 3)
+        {
+            // Git only writes version 3 when an entry actually carries extended flags.
+            repository.Run("update-index", "--skip-worktree", "sub/b.txt");
+        }
+
+        repository.Run("update-index", $"--index-version={indexVersion}");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+
+        index.Version.ShouldBe(indexVersion);
+
+        // git ls-files --stage prints: <mode> SP <sha> SP <stage> TAB <path>
+        var expected = repository
+            .Run("ls-files", "--stage")
+            .Split('\n')
+            .Select(line =>
+            {
+                var parts = line.Split('\t');
+                var meta = parts[0].Split(' ');
+                return (Mode: Convert.ToUInt32(meta[0], 8), Sha: meta[1], Stage: int.Parse(meta[2]), Path: parts[1]);
+            })
+            .ToList();
+
+        index.Entries.Count.ShouldBe(expected.Count);
+
+        for (var i = 0; i < expected.Count; i++)
+        {
+            var entry = index.Entries[i];
+            entry.Path.ShouldBe(expected[i].Path);
+            entry.Mode.ShouldBe(expected[i].Mode);
+            entry.ObjectId.ToString().ShouldBe(expected[i].Sha);
+            entry.Stage.ShouldBe(expected[i].Stage);
+        }
+
+        index.Entries.Single(entry => entry.Path == "a.txt").IsExecutable.ShouldBeTrue();
+        index.Entries.Single(entry => entry.Path == "sub/b.txt").IsExecutable.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsStatDataUsedForCleanDetection()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "content\n");
+        repository.Commit("commit");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+        var entry = index.Entries.ShouldHaveSingleItem();
+
+        entry.Size.ShouldBe((uint)"content\n".Length);
+        entry.ModificationTimeSeconds.ShouldBeGreaterThan(0u);
+        entry.AssumeValid.ShouldBeFalse();
+        entry.SkipWorktree.ShouldBeFalse();
+        entry.IntentToAdd.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsSkipWorktreeExtendedFlags()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("b.txt", "two\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--skip-worktree", "a.txt");
+
+        var index = GitIndex.Read(Path.Combine(repository.GitDirectory, "index"));
+
+        index.Entries.Single(entry => entry.Path == "a.txt").SkipWorktree.ShouldBeTrue();
+        index.Entries.Single(entry => entry.Path == "b.txt").SkipWorktree.ShouldBeFalse();
+    }
+
+    [Test]
+    public void AMissingIndexFileYieldsAnEmptyIndex()
+    {
+        var index = GitIndex.Read(Path.Combine(Path.GetTempPath(), "does-not-exist", "index"));
+
+        index.Entries.ShouldBeEmpty();
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitObjectIdTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitObjectIdTests.cs
@@ -1,0 +1,160 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitObjectIdTests
+{
+    private const string Sha1Hex = "4e912736c27e40b389904d046dc63dc9f578117f";
+    private const string Sha256Hex = "9c5e01e5827b7a2e0f9b2ecabf5ee89f4fd8b7c153bf8dd9b1f38f9b7d6f2a3c";
+
+    [Test]
+    public void ParsesA40CharacterSha1HexString()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha1Size);
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesUpperCaseHexAndNormalizesToLowerCase()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex.ToUpperInvariant().AsSpan());
+
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesA64CharacterSha256HexString()
+    {
+        var objectId = GitObjectId.Parse(Sha256Hex);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha256Size);
+        objectId.ToString().ShouldBe(Sha256Hex);
+    }
+
+    [Test]
+    public void ParsesRawBytes()
+    {
+        var bytes = Convert.FromHexString(Sha1Hex);
+
+        var objectId = GitObjectId.Parse(bytes);
+
+        objectId.HashLength.ShouldBe(GitObjectId.Sha1Size);
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [Test]
+    public void ParsesAsciiEncodedHex()
+    {
+        var asciiHex = Encoding.ASCII.GetBytes(Sha1Hex);
+
+        var objectId = GitObjectId.ParseHex(asciiHex);
+
+        objectId.ToString().ShouldBe(Sha1Hex);
+    }
+
+    [TestCase(0)]
+    [TestCase(19)]
+    [TestCase(39)]
+    [TestCase(41)]
+    public void ParseRejectsInvalidHexLengths(int length) =>
+        Should.Throw<ArgumentException>(() => GitObjectId.Parse(new string('a', length)));
+
+    [Test]
+    public void ParseRejectsInvalidRawByteLengths() =>
+        Should.Throw<ArgumentException>(() => GitObjectId.Parse(new byte[21]));
+
+    [Test]
+    public void ParseRejectsNonHexCharacters() =>
+        Should.Throw<FormatException>(() => GitObjectId.Parse("zz12736c27e40b389904d046dc63dc9f578117f4"));
+
+    [Test]
+    public void EqualObjectIdsAreEqualAndHaveTheSameHashCode()
+    {
+        var left = GitObjectId.Parse(Sha1Hex);
+        var right = GitObjectId.ParseHex(Encoding.ASCII.GetBytes(Sha1Hex));
+
+        left.ShouldBe(right);
+        (left == right).ShouldBeTrue();
+        (left != right).ShouldBeFalse();
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+        left.Equals((object)right).ShouldBeTrue();
+    }
+
+    [Test]
+    public void DifferentObjectIdsAreNotEqual()
+    {
+        var left = GitObjectId.Parse(Sha1Hex);
+        var right = GitObjectId.Parse("4e912736c27e40b389904d046dc63dc9f5781180");
+
+        left.ShouldNotBe(right);
+        (left == right).ShouldBeFalse();
+        (left != right).ShouldBeTrue();
+    }
+
+    [Test]
+    public void ASha1IdIsNotEqualToASha256IdWithTheSamePrefix()
+    {
+        var sha1 = GitObjectId.Parse(Sha1Hex);
+        var sha256 = GitObjectId.Parse(Sha1Hex + new string('0', 24));
+
+        sha1.ShouldNotBe(sha256);
+    }
+
+    [Test]
+    public void CanBeUsedAsADictionaryKey()
+    {
+        var dictionary = new Dictionary<GitObjectId, string>
+        {
+            [GitObjectId.Parse(Sha1Hex)] = "value"
+        };
+
+        dictionary[GitObjectId.ParseHex(Encoding.ASCII.GetBytes(Sha1Hex))].ShouldBe("value");
+    }
+
+    [TestCase(0, "")]
+    [TestCase(1, "4")]
+    [TestCase(7, "4e91273")]
+    [TestCase(40, Sha1Hex)]
+    public void ToStringWithLengthReturnsAHexPrefix(int length, string expected)
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.ToString(length).ShouldBe(expected);
+    }
+
+    [Test]
+    public void ToStringWithInvalidLengthThrows()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        Should.Throw<ArgumentOutOfRangeException>(() => objectId.ToString(41));
+        Should.Throw<ArgumentOutOfRangeException>(() => objectId.ToString(-1));
+    }
+
+    [Test]
+    public void CopyToCopiesTheRawBytes()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+        var buffer = new byte[GitObjectId.Sha1Size];
+
+        objectId.CopyTo(buffer);
+
+        buffer.ShouldBe(Convert.FromHexString(Sha1Hex));
+    }
+
+    [Test]
+    public void AsUInt16ReturnsTheFirstTwoBytes()
+    {
+        var objectId = GitObjectId.Parse(Sha1Hex);
+
+        objectId.AsUInt16().ShouldBe((ushort)0x4e91);
+    }
+
+    [Test]
+    public void EmptyHasAZeroHashLength()
+    {
+        GitObjectId.Empty.HashLength.ShouldBe(0);
+        GitObjectId.Empty.ShouldBe(default(GitObjectId));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitReferenceStoreTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitReferenceStoreTests.cs
@@ -1,0 +1,216 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitReferenceStoreTests
+{
+    [Test]
+    public void ResolvesALooseBranchToItsCommit()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+        var reference = store.GetReference("refs/heads/main");
+
+        reference.ShouldNotBeNull();
+        reference.IsSymbolic.ShouldBeFalse();
+        reference.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void EnumerationMatchesGitForEachRef()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("first");
+        repository.Run("branch", "feature/a");
+        repository.Run("tag", "lightweight");
+        repository.Run("tag", "-a", "v1.0.0", "-m", "annotated");
+        repository.WriteFile("file.txt", "more content\n");
+        repository.Commit("second");
+
+        var store = repository.OpenReferenceStore();
+        var actual = store.EnumerateReferences()
+            .Select(reference => $"{reference.CanonicalName} {reference.ObjectId}")
+            .ToList();
+
+        var expected = repository
+            .Run("for-each-ref", "--format=%(refname) %(objectname)")
+            .Split('\n');
+
+        actual.ShouldBe(expected);
+    }
+
+    [Test]
+    public void EnumerationSkipsTransientLockFiles()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        // Simulate git being in the middle of updating a reference.
+        File.WriteAllText(Path.Combine(repository.GitDirectory, "refs", "heads", "main.lock"), sha + "\n");
+
+        var references = repository.OpenReferenceStore().EnumerateReferences().ToList();
+
+        references.ShouldNotContain(reference => reference.CanonicalName.EndsWith(".lock"));
+        references.ShouldHaveSingleItem().CanonicalName.ShouldBe("refs/heads/main");
+    }
+
+    [Test]
+    public void ReadsPackedRefsIncludingPeeledTargets()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v1.0.0", "-m", "annotated");
+        var tagSha = repository.RevParse("v1.0.0");
+
+        repository.Run("pack-refs", "--all", "--prune");
+        File.Exists(Path.Combine(repository.GitDirectory, "refs", "heads", "main")).ShouldBeFalse();
+
+        var store = repository.OpenReferenceStore();
+
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(commitSha));
+
+        var tag = store.GetReference("refs/tags/v1.0.0");
+        tag.ShouldNotBeNull();
+        tag.ObjectId.ShouldBe(GitObjectId.Parse(tagSha));
+        tag.PeeledObjectId.ShouldBe(GitObjectId.Parse(repository.RevParse("v1.0.0^{}")));
+    }
+
+    [Test]
+    public void LooseReferencesWinOverPackedReferences()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("first");
+        repository.Run("pack-refs", "--all", "--prune");
+
+        repository.WriteFile("file.txt", "more content\n");
+        var newSha = repository.Commit("second");
+
+        var store = repository.OpenReferenceStore();
+
+        store.ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(newSha));
+        store.EnumerateReferences("refs/heads/")
+            .ShouldHaveSingleItem()
+            .ObjectId.ShouldBe(GitObjectId.Parse(newSha));
+    }
+
+    [Test]
+    public void HeadIsSymbolicWhenABranchIsCheckedOut()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+        var head = store.GetHead();
+
+        head.ShouldNotBeNull();
+        head.IsSymbolic.ShouldBeTrue();
+        head.SymbolicTargetName.ShouldBe("refs/heads/main");
+
+        var resolved = store.Resolve("HEAD");
+        resolved.ShouldNotBeNull();
+        resolved.CanonicalName.ShouldBe("refs/heads/main");
+        resolved.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void HeadIsDirectWhenDetached()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+        repository.Run("checkout", "-q", "--detach");
+
+        var head = repository.OpenReferenceStore().GetHead();
+
+        head.ShouldNotBeNull();
+        head.IsSymbolic.ShouldBeFalse();
+        head.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void HeadOfAnUnbornBranchResolvesToNull()
+    {
+        using var repository = new GitTestRepository();
+
+        var store = repository.OpenReferenceStore();
+
+        store.GetHead().ShouldNotBeNull().IsSymbolic.ShouldBeTrue();
+        store.Resolve("HEAD").ShouldBeNull();
+        store.ResolveToObjectId("HEAD").ShouldBeNull();
+    }
+
+    [Test]
+    public void FollowsChainsOfSymbolicReferences()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+        repository.Run("symbolic-ref", "refs/sym/one", "refs/heads/main");
+        repository.Run("symbolic-ref", "refs/sym/two", "refs/sym/one");
+
+        var store = repository.OpenReferenceStore();
+        var resolved = store.Resolve("refs/sym/two");
+
+        resolved.ShouldNotBeNull();
+        resolved.CanonicalName.ShouldBe("refs/heads/main");
+        resolved.ObjectId.ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void ReturnsNullForAMissingReference()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var store = repository.OpenReferenceStore();
+
+        store.GetReference("refs/heads/does-not-exist").ShouldBeNull();
+        store.Resolve("refs/heads/does-not-exist").ShouldBeNull();
+    }
+
+    [Test]
+    public void EnumerationCanBeFilteredByPrefix()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("branch", "feature/a");
+        repository.Run("tag", "v1.0.0");
+        repository.Run("tag", "v2.0.0");
+
+        var store = repository.OpenReferenceStore();
+
+        store.EnumerateReferences("refs/tags/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/tags/v1.0.0", "refs/tags/v2.0.0"]);
+
+        store.EnumerateReferences("refs/heads/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/heads/feature/a", "refs/heads/main"]);
+    }
+
+    [Test]
+    public void ResolvedHeadCanBeReadFromTheObjectStore()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("readable through refs");
+
+        var store = repository.OpenReferenceStore();
+        var headId = store.ResolveToObjectId("HEAD");
+
+        headId.ShouldNotBeNull();
+
+        using var objectStore = repository.OpenObjectStore();
+        objectStore.GetCommit(headId.Value).Message.ShouldBe("readable through refs\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRepositoryLayoutTests.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class GitRepositoryLayoutTests
+{
+    [Test]
+    public void DiscoversARepositoryFromItsRootAndFromANestedDirectory()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("sub/dir/file.txt", "content\n");
+        repository.Commit("a commit");
+
+        foreach (var startPath in new[] { repository.RepositoryPath, Path.Combine(repository.RepositoryPath, "sub", "dir") })
+        {
+            var layout = GitRepositoryLayout.Discover(startPath);
+
+            layout.GitDirectory.ShouldBe(Path.GetFullPath(repository.GitDirectory));
+            layout.CommonDirectory.ShouldBe(layout.GitDirectory);
+            layout.WorkingDirectory.ShouldBe(Path.GetFullPath(repository.RepositoryPath));
+            layout.ObjectsDirectory.ShouldBe(Path.GetFullPath(repository.ObjectsDirectory));
+            layout.IsShallow.ShouldBeFalse();
+        }
+    }
+
+    [Test]
+    public void TryOpenDoesNotWalkUpToAnEnclosingRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("nested/dir/file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var nested = Path.Combine(repository.RepositoryPath, "nested", "dir");
+
+        GitRepositoryLayout.TryOpen(nested).ShouldBeNull();
+        GitRepositoryLayout.TryOpen(repository.RepositoryPath).ShouldNotBeNull();
+        GitRepositoryLayout.TryOpen(repository.GitDirectory).ShouldNotBeNull();
+    }
+
+    [Test]
+    [SuppressMessage("Minor Vulnerability", "S4036:Searching OS commands in PATH is security-sensitive", Justification = "git is deliberately resolved from the PATH, exactly like the production CLI executor and the other test fixtures.")]
+    public void RejectsSha256RepositoriesWithAClearMessage()
+    {
+        using var directory = new TempDirectory();
+        Directory.CreateDirectory(directory.FullPath);
+
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "git",
+            ArgumentList = { "init", "-q", "--object-format=sha256", directory.FullPath },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        });
+        process!.WaitForExit();
+        process.ExitCode.ShouldBe(0, "git init --object-format=sha256 should succeed");
+
+        var exception = Should.Throw<NotSupportedException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+        exception.Message.ShouldContain("sha256");
+    }
+
+    [Test]
+    public void ReturnsNullOutsideOfARepository()
+    {
+        using var directory = new TempDirectory();
+        Directory.CreateDirectory(directory.FullPath);
+
+        GitRepositoryLayout.TryDiscover(directory.FullPath).ShouldBeNull();
+        Should.Throw<GitObjectStoreException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+    }
+
+    [Test]
+    public void ResolvesLinkedWorktrees()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var worktree = new TempDirectory();
+        repository.Run("worktree", "add", "-q", "-b", "wt-branch", worktree.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(worktree.FullPath);
+
+        layout.WorkingDirectory.ShouldBe(Path.GetFullPath(worktree.FullPath));
+        layout.GitDirectory.ShouldContain(Path.Combine(".git", "worktrees"));
+        layout.CommonDirectory.ShouldBe(Path.GetFullPath(repository.GitDirectory));
+
+        // HEAD is per-worktree; the refs are shared with the main repository.
+        var store = layout.CreateReferenceStore();
+        var head = store.GetHead();
+        head.ShouldNotBeNull();
+        head.SymbolicTargetName.ShouldBe("refs/heads/wt-branch");
+        store.ResolveToObjectId("HEAD").ShouldBe(GitObjectId.Parse(sha));
+        store.EnumerateReferences("refs/heads/")
+            .Select(reference => reference.CanonicalName)
+            .ShouldBe(["refs/heads/main", "refs/heads/wt-branch"]);
+
+        using var objectStore = layout.CreateObjectStore();
+        objectStore.GetCommit(GitObjectId.Parse(sha)).Message.ShouldBe("a commit\n");
+    }
+
+    [Test]
+    public void DetectsShallowClones()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "one\n");
+        repository.Commit("first");
+        repository.WriteFile("file.txt", "two\n");
+        var tipSha = repository.Commit("second");
+
+        using var clone = new TempDirectory();
+        repository.Run("clone", "-q", "--depth", "1", "file://" + repository.RepositoryPath, clone.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(clone.FullPath);
+
+        layout.IsShallow.ShouldBeTrue();
+        var shallowCommits = layout.ReadShallowCommits();
+        shallowCommits.ShouldHaveSingleItem().ShouldBe(GitObjectId.Parse(tipSha));
+
+        // The boundary commit object still records its parent (the shallow file, not the
+        // object, cuts the history), but the parent object is absent from the clone.
+        using var objectStore = layout.CreateObjectStore();
+        var boundary = objectStore.GetCommit(shallowCommits[0]);
+        boundary.Parents.ShouldHaveSingleItem();
+        objectStore.TryGetObject(boundary.Parents[0], "commit", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public void DiscoversABareRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var bare = new TempDirectory();
+        repository.Run("clone", "-q", "--bare", "file://" + repository.RepositoryPath, bare.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(bare.FullPath);
+
+        layout.WorkingDirectory.ShouldBeNull();
+        layout.GitDirectory.ShouldBe(Path.GetFullPath(bare.FullPath));
+        layout.CommonDirectory.ShouldBe(layout.GitDirectory);
+
+        layout.CreateReferenceStore().ResolveToObjectId("refs/heads/main").ShouldBe(GitObjectId.Parse(sha));
+    }
+
+    [Test]
+    public void ThrowsForReftableRepositories()
+    {
+        using var directory = new TempDirectory();
+
+        using var repository = new GitTestRepository();
+
+        try
+        {
+            repository.Run("init", "-q", "--ref-format=reftable", "-b", "main", directory.FullPath);
+        }
+        catch (InvalidOperationException)
+        {
+            Assert.Ignore("The installed git version does not support the reftable ref format.");
+        }
+
+        Should.Throw<NotSupportedException>(() => GitRepositoryLayout.Discover(directory.FullPath));
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitRevisionWalkerTests.cs
@@ -1,0 +1,427 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitRevisionWalker"/> ordering and merge-base results against libgit2
+/// (via LibGit2Sharp) on the same fixture repositories — the parity GitVersion's version
+/// calculation depends on.
+/// </summary>
+[TestFixture]
+public class GitRevisionWalkerTests
+{
+    private static readonly string[] SortCombinations =
+    [
+        "None",
+        "Time",
+        "Topological",
+        "Topological, Time",
+        "Topological, Reverse",
+        "Time, Reverse",
+        "Topological, Time, Reverse"
+    ];
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void LinearHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateLinearRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void MergedHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateMergedRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void MergedHistoryWithExcludesMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateMergedRepository();
+        var excluded = repository.RevParse("v0");
+
+        var options = new GitRevisionWalkOptions { Sort = sort };
+        options.Include.Add(repository.ResolveId("HEAD"));
+        options.Exclude.Add(GitObjectId.Parse(excluded));
+
+        AssertWalkParity(repository, options, head: false, excludeSha: excluded);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void EqualCommitterTimestampsMatchLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateEqualTimestampRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void CrissCrossHistoryMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateCrissCrossRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCaseSource(nameof(SortCombinations))]
+    public void OctopusMergeMatchesLibGit2(string sortName)
+    {
+        var sort = Enum.Parse<GitRevisionSortStrategies>(sortName);
+        using var repository = CreateOctopusRepository();
+
+        AssertWalkParity(repository, new() { Sort = sort }, head: true);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void FirstParentWalksMatchLibGit2(bool withExclude)
+    {
+        using var repository = CreateMergedRepository();
+
+        var options = new GitRevisionWalkOptions { FirstParentOnly = true };
+        options.Include.Add(repository.ResolveId("HEAD"));
+        string? excluded = null;
+
+        if (withExclude)
+        {
+            excluded = repository.RevParse("v0");
+            options.Exclude.Add(GitObjectId.Parse(excluded));
+        }
+
+        AssertWalkParity(repository, options, head: false, excludeSha: excluded);
+    }
+
+    [Test]
+    public void MultipleIncludesMatchLibGit2()
+    {
+        using var repository = CreateMergedRepository();
+        // Include two historic points rather than the merged tip.
+        var first = repository.RevParse("HEAD^1^");
+        var second = repository.RevParse("HEAD^2");
+
+        var options = new GitRevisionWalkOptions { Sort = GitRevisionSortStrategies.Topological | GitRevisionSortStrategies.Time };
+        options.Include.Add(GitObjectId.Parse(first));
+        options.Include.Add(GitObjectId.Parse(second));
+
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).Walk(options).Select(commit => commit.Sha.ToString()).ToList();
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var filter = new global::LibGit2Sharp.CommitFilter
+        {
+            IncludeReachableFrom = new[] { first, second },
+            SortBy = global::LibGit2Sharp.CommitSortStrategies.Topological | global::LibGit2Sharp.CommitSortStrategies.Time
+        };
+        var expected = libgit2.Commits.QueryBy(filter).Select(commit => commit.Sha).ToList();
+
+        actual.ShouldBe(expected);
+    }
+
+    [Test]
+    public void FindsTheMergeBaseOfDivergedBranches()
+    {
+        using var repository = CreateMergedRepository();
+
+        AssertMergeBaseParity(repository, repository.RevParse("main"), repository.RevParse("feature"));
+    }
+
+    [Test]
+    public void FindsTheMergeBaseOfCrissCrossBranches()
+    {
+        using var repository = CreateCrissCrossRepository();
+
+        AssertMergeBaseParity(repository, repository.RevParse("main"), repository.RevParse("dev"));
+        AssertMergeBaseParity(repository, repository.RevParse("dev"), repository.RevParse("main"));
+    }
+
+    [Test]
+    public void TheMergeBaseOfACommitAndItsAncestorIsTheAncestor()
+    {
+        using var repository = CreateLinearRepository();
+        var ancestor = repository.RevParse("HEAD~3");
+        var tip = repository.RevParse("HEAD");
+
+        using var store = repository.OpenObjectStore();
+        var walker = new GitRevisionWalker(store);
+
+        walker.FindMergeBase(GitObjectId.Parse(tip), GitObjectId.Parse(ancestor)).ShouldBe(GitObjectId.Parse(ancestor));
+        walker.FindMergeBase(GitObjectId.Parse(ancestor), GitObjectId.Parse(tip)).ShouldBe(GitObjectId.Parse(ancestor));
+        walker.FindMergeBase(GitObjectId.Parse(tip), GitObjectId.Parse(tip)).ShouldBe(GitObjectId.Parse(tip));
+    }
+
+    [Test]
+    public void UnrelatedHistoriesHaveNoMergeBase()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        var main = repository.Commit("on main");
+        repository.Run("checkout", "-q", "--orphan", "detached-root");
+        repository.WriteFile("b.txt", "b\n");
+        var orphan = repository.Commit("orphan root");
+
+        using var store = repository.OpenObjectStore();
+        new GitRevisionWalker(store)
+            .FindMergeBase(GitObjectId.Parse(main), GitObjectId.Parse(orphan))
+            .ShouldBeNull();
+    }
+
+    [Test]
+    public void WalksUpToTheShallowBoundary()
+    {
+        using var repository = CreateLinearRepository();
+        using var clone = new TempDirectory();
+        repository.Run("clone", "-q", "--depth", "2", "file://" + repository.RepositoryPath, clone.FullPath);
+
+        var layout = GitRepositoryLayout.Discover(clone.FullPath);
+        using var store = layout.CreateObjectStore();
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(layout.CreateReferenceStore().ResolveToObjectId("HEAD")!.Value);
+
+        // The commits listed in .git/shallow are grafted parentless, so the walk stops
+        // exactly at the boundary instead of chasing the missing parents.
+        new GitRevisionWalker(store, layout.ReadShallowCommits().ToHashSet()).Walk(options).Count.ShouldBe(2);
+    }
+
+    [Test]
+    public void TheShallowBoundaryWinsOverPresentParentObjects()
+    {
+        // A .git/shallow file naming a mid-history commit of a full repository: the parent
+        // objects exist, but git and libgit2 honor the graft and stop at the boundary anyway.
+        using var repository = CreateLinearRepository();
+        var boundary = repository.RevParse("HEAD~2");
+        File.WriteAllText(Path.Combine(repository.GitDirectory, "shallow"), boundary + "\n");
+
+        var layout = GitRepositoryLayout.Discover(repository.RepositoryPath);
+        using var store = layout.CreateObjectStore();
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(repository.ResolveId("HEAD"));
+
+        var walked = new GitRevisionWalker(store, layout.ReadShallowCommits().ToHashSet()).Walk(options);
+
+        walked.Count.ShouldBe(3);
+        walked[^1].Sha.ShouldBe(GitObjectId.Parse(boundary));
+        walked[^1].Parents.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void AMissingParentObjectFailsTheWalkInsteadOfTruncatingHistory()
+    {
+        using var repository = CreateLinearRepository();
+        var missingParent = repository.RevParse("HEAD~2");
+        DeleteLooseObject(repository, missingParent);
+
+        using var store = repository.OpenObjectStore();
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(repository.ResolveId("HEAD"));
+
+        // Without a shallow boundary explaining the gap, the repository is corrupt: libgit2
+        // fails the walk on a missing parent, and truncating silently would yield a wrong version.
+        var exception = Should.Throw<GitObjectStoreException>(() => new GitRevisionWalker(store).Walk(options));
+
+        exception.ObjectNotFound.ShouldBeTrue();
+        exception.Message.ShouldContain(missingParent);
+    }
+
+    [Test]
+    public void WalkingFromAMissingCommitFails()
+    {
+        using var repository = CreateLinearRepository();
+        using var store = repository.OpenObjectStore();
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(GitObjectId.Parse("0123456789012345678901234567890123456789"));
+
+        // libgit2's revwalk push fails on a missing commit; emitting a walk
+        // containing a null commit instead would blow up far from the cause.
+        Should.Throw<GitObjectStoreException>(() => new GitRevisionWalker(store).Walk(options));
+    }
+
+    private static void AssertWalkParity(GitTestRepository repository, GitRevisionWalkOptions options, bool head, string? excludeSha = null)
+    {
+        if (head)
+        {
+            options.Include.Add(repository.ResolveId("HEAD"));
+        }
+
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).Walk(options).Select(commit => commit.Sha.ToString()).ToList();
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var filter = new global::LibGit2Sharp.CommitFilter
+        {
+            IncludeReachableFrom = options.Include[0].ToString(),
+            SortBy = ToLibGit2Sort(options.Sort),
+            FirstParentOnly = options.FirstParentOnly
+        };
+
+        if (excludeSha is not null)
+        {
+            filter.ExcludeReachableFrom = excludeSha;
+        }
+
+        var expected = libgit2.Commits.QueryBy(filter).Select(commit => commit.Sha).ToList();
+
+        actual.ShouldBe(expected, $"sort: {options.Sort}, firstParent: {options.FirstParentOnly}, exclude: {excludeSha}");
+        actual.ShouldNotBeEmpty();
+    }
+
+    private static void AssertMergeBaseParity(GitTestRepository repository, string first, string second)
+    {
+        using var store = repository.OpenObjectStore();
+        var actual = new GitRevisionWalker(store).FindMergeBase(GitObjectId.Parse(first), GitObjectId.Parse(second));
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+        var expected = libgit2.ObjectDatabase.FindMergeBase(libgit2.Lookup<Commit>(first), libgit2.Lookup<Commit>(second));
+
+        expected.ShouldNotBeNull();
+        actual.ShouldNotBeNull();
+        actual.Value.ToString().ShouldBe(expected.Sha);
+    }
+
+    private static global::LibGit2Sharp.CommitSortStrategies ToLibGit2Sort(GitRevisionSortStrategies sort)
+    {
+        var result = global::LibGit2Sharp.CommitSortStrategies.None;
+
+        if (sort.HasFlag(GitRevisionSortStrategies.Topological))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Topological;
+        }
+
+        if (sort.HasFlag(GitRevisionSortStrategies.Time))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Time;
+        }
+
+        if (sort.HasFlag(GitRevisionSortStrategies.Reverse))
+        {
+            result |= global::LibGit2Sharp.CommitSortStrategies.Reverse;
+        }
+
+        return result;
+    }
+
+    private static void DeleteLooseObject(GitTestRepository repository, string sha)
+    {
+        // Git marks loose object files read-only; reset the attribute so the delete
+        // succeeds on Windows.
+        var path = Path.Combine(repository.ObjectsDirectory, sha[..2], sha[2..]);
+        File.SetAttributes(path, FileAttributes.Normal);
+        File.Delete(path);
+    }
+
+    private static GitTestRepository CreateLinearRepository()
+    {
+        var repository = new GitTestRepository();
+
+        for (var i = 0; i < 6; i++)
+        {
+            repository.WriteFile("file.txt", $"content {i}\n");
+            repository.Commit($"commit {i}");
+
+            if (i == 0)
+            {
+                repository.Run("tag", "v0");
+            }
+        }
+
+        return repository;
+    }
+
+    private static GitTestRepository CreateMergedRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+        repository.Run("tag", "v0");
+
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1");
+        repository.WriteFile("feature.txt", "2\n");
+        repository.Commit("feature 2");
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.WriteFile("main.txt", "2\n");
+        repository.Commit("main 2");
+
+        repository.Merge("feature");
+        return repository;
+    }
+
+    private static GitTestRepository CreateEqualTimestampRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1", advanceClock: false);
+        repository.WriteFile("feature.txt", "2\n");
+        repository.Commit("feature 2", advanceClock: false);
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1", advanceClock: false);
+        repository.WriteFile("main.txt", "2\n");
+        repository.Commit("main 2", advanceClock: false);
+
+        repository.Merge("feature", advanceClock: false);
+        return repository;
+    }
+
+    private static GitTestRepository CreateCrissCrossRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("root");
+
+        repository.Run("checkout", "-q", "-b", "dev");
+        repository.WriteFile("dev.txt", "1\n");
+        var devCommit = repository.Commit("dev 1");
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        var mainCommit = repository.Commit("main 1");
+
+        // Merge in both directions to create a criss-cross: two best common ancestors.
+        repository.Merge(devCommit);
+        repository.Run("checkout", "-q", "dev");
+        repository.Merge(mainCommit);
+
+        return repository;
+    }
+
+    private static GitTestRepository CreateOctopusRepository()
+    {
+        var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("root");
+
+        foreach (var branch in new[] { "b1", "b2" })
+        {
+            repository.Run("checkout", "-q", "-b", branch, "main");
+            repository.WriteFile($"{branch}.txt", "1\n");
+            repository.Commit($"{branch} 1");
+        }
+
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.Merge("b1", "b2");
+
+        return repository;
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitStatusCalculatorTests.cs
@@ -1,0 +1,241 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitStatusCalculator"/> against the exact expression the
+/// LibGit2Sharp adapter uses for <c>IGitRepository.UncommittedChangesCount</c>.
+/// </summary>
+[TestFixture]
+public class GitStatusCalculatorTests
+{
+    [Test]
+    public void ACleanWorkingDirectoryHasNoChanges()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.Commit("commit");
+
+        AssertParity(repository, expectedCount: 0);
+    }
+
+    [Test]
+    public void CountsModifiedStagedDeletedAndUntrackedPathsOnce()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("modified.txt", "one\n");
+        repository.WriteFile("both.txt", "one\n");
+        repository.WriteFile("staged.txt", "one\n");
+        repository.WriteFile("deleted.txt", "one\n");
+        repository.WriteFile("removed.txt", "one\n");
+        repository.Commit("commit");
+
+        repository.WriteFile("modified.txt", "two\n");            // modified, unstaged
+        repository.WriteFile("staged.txt", "two\n");
+        repository.Run("add", "staged.txt");                       // modified, staged
+        repository.WriteFile("both.txt", "two\n");
+        repository.Run("add", "both.txt");
+        repository.WriteFile("both.txt", "three\n");               // staged and modified again
+        File.Delete(Path.Combine(repository.RepositoryPath, "deleted.txt")); // deleted, unstaged
+        repository.Run("rm", "-q", "removed.txt");                 // deleted, staged
+        repository.WriteFile("untracked.txt", "new\n");            // untracked
+        repository.WriteFile("sub/untracked.txt", "new\n");        // untracked in new directory
+
+        AssertParity(repository, expectedCount: 7);
+    }
+
+    [Test]
+    public void ContentRestoredToTheCommittedStateIsClean()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        // Touch the file (mtime changes, content identical): requires re-hashing to prove clean.
+        repository.WriteFile("a.txt", "one\n");
+
+        AssertParity(repository, expectedCount: 0);
+    }
+
+    [Test]
+    public void RespectsGitIgnoreRules()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "*.log\nbuild/\n!important.log\n/anchored.txt\n");
+        repository.WriteFile("sub/.gitignore", "local-*\n");
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        repository.WriteFile("noise.log", "ignored\n");            // ignored by *.log
+        repository.WriteFile("important.log", "kept\n");           // re-included by negation
+        repository.WriteFile("build/out.txt", "ignored\n");        // ignored directory
+        repository.WriteFile("anchored.txt", "ignored\n");         // anchored to root
+        repository.WriteFile("sub/anchored.txt", "not anchored\n");// same name below root is not ignored
+        repository.WriteFile("sub/local-cache", "ignored\n");      // nested .gitignore
+        repository.WriteFile("sub/tracked-new.txt", "new\n");      // untracked
+
+        AssertParity(repository, expectedCount: 3); // important.log, sub/anchored.txt, sub/tracked-new.txt
+    }
+
+    [Test]
+    public void TreatsNonBoundaryConsecutiveAsterisksAsSlashExcluding()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "out**txt\n");
+        repository.Commit("commit");
+
+        repository.WriteFile("output.txt", "ignored\n");       // matched by out**txt
+        repository.WriteFile("out/nested/file.txt", "kept\n"); // ** without a boundary must not cross '/'
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void RespectsInfoExclude()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        Directory.CreateDirectory(Path.Combine(repository.GitDirectory, "info"));
+        File.WriteAllText(Path.Combine(repository.GitDirectory, "info", "exclude"), "*.tmp\n");
+
+        repository.WriteFile("scratch.tmp", "ignored\n");
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void HonorsCoreIgnoreCaseForIgnorePatterns()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "BIN/\n*.LOG\n");
+        repository.Commit("commit");
+        repository.Run("config", "core.ignorecase", "true");
+
+        repository.WriteFile("bin/out.txt", "ignored\n");   // ignored by BIN/ under ignorecase
+        repository.WriteFile("noise.log", "ignored\n");     // ignored by *.LOG under ignorecase
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void MatchesIgnorePatternsCaseSensitivelyWhenIgnoreCaseIsOff()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile(".gitignore", "BIN/\n*.LOG\n");
+        repository.Commit("commit");
+        repository.Run("config", "core.ignorecase", "false");
+
+        repository.WriteFile("bin/out.txt", "kept\n");
+        repository.WriteFile("noise.log", "kept\n");
+        repository.WriteFile("kept.txt", "untracked\n");
+
+        AssertParity(repository, expectedCount: 3);
+    }
+
+    [Test]
+    public void CountsExecutableBitChanges()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The executable bit does not exist on Windows.");
+            return;
+        }
+
+        using var repository = new GitTestRepository();
+        repository.WriteFile("script.sh", "#!/bin/sh\n");
+        repository.Commit("commit");
+
+        var scriptPath = Path.Combine(repository.RepositoryPath, "script.sh");
+        File.SetUnixFileMode(scriptPath, File.GetUnixFileMode(scriptPath) | UnixFileMode.UserExecute);
+
+        AssertParity(repository, expectedCount: 1);
+    }
+
+    [Test]
+    public void CountsAnUntrackedDirectorySymbolicLinkAsASingleEntry()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Creating symbolic links requires elevated privileges on Windows.");
+            return;
+        }
+
+        using var repository = new GitTestRepository();
+        repository.WriteFile("target/one.txt", "one\n");
+        repository.WriteFile("target/two.txt", "two\n");
+        repository.Commit("commit");
+
+        // A symbolic link to a directory is a single untracked entry (its blob is the raw
+        // link target), and a self-referencing link must not cause unbounded recursion.
+        Directory.CreateSymbolicLink(Path.Combine(repository.RepositoryPath, "link"), "target");
+        Directory.CreateSymbolicLink(Path.Combine(repository.RepositoryPath, "self"), ".");
+
+        AssertParity(repository, expectedCount: 2);
+    }
+
+    [Test]
+    public void CountsUntrackedFilesInAnEmptyRepository()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("untracked.txt", "new\n");
+        repository.WriteFile("also-untracked.txt", "new\n");
+
+        AssertParity(repository, expectedCount: 2);
+    }
+
+    [Test]
+    public void WorksAgainstAnIndexInVersion4Format()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "two\n");
+        repository.Commit("commit");
+        repository.Run("update-index", "--index-version=4");
+
+        repository.WriteFile("a.txt", "two\n");
+        repository.WriteFile("untracked.txt", "new\n");
+
+        AssertParity(repository, expectedCount: 2);
+    }
+
+    private static void AssertParity(GitTestRepository repository, int expectedCount)
+    {
+        var actual = ManagedCount(repository);
+        var expected = LibGit2Count(repository);
+
+        actual.ShouldBe(expected, "managed count should match the libgit2 adapter");
+        actual.ShouldBe(expectedCount, "scenario expectation");
+    }
+
+    private static int ManagedCount(GitTestRepository repository)
+    {
+        var layout = GitRepositoryLayout.Discover(repository.RepositoryPath);
+        using var store = layout.CreateObjectStore();
+        var calculator = new GitStatusCalculator(layout, store);
+
+        return layout.CreateReferenceStore().ResolveToObjectId("HEAD") is { } headId
+            ? calculator.CountUncommittedChanges(store.GetCommit(headId).Tree)
+            : calculator.CountChangesInEmptyRepository();
+    }
+
+    private static int LibGit2Count(GitTestRepository repository)
+    {
+        // The exact expression from GitVersion.LibGit2Sharp's GetUncommittedChangesCountInternal.
+        using var libgit2 = new Repository(repository.RepositoryPath);
+
+        if (libgit2.Head?.Tip == null)
+        {
+            var status = libgit2.RetrieveStatus();
+            return status.Untracked.Count() + status.Staged.Count();
+        }
+
+        return libgit2.Diff
+            .Compare<TreeChanges>(libgit2.Head.Tip.Tree, DiffTargets.Index | DiffTargets.WorkingDirectory)
+            .Count;
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTestRepository.cs
@@ -1,0 +1,194 @@
+using GitVersion.Helpers;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Creates a real Git repository in a temporary directory by invoking the <c>git</c>
+/// command-line executable, with deterministic author/committer identities and dates.
+/// </summary>
+internal sealed class GitTestRepository : IDisposable
+{
+    public const string AuthorName = "Test Author";
+    public const string AuthorEmail = "author@example.com";
+    public const string CommitterName = "Test Committer";
+    public const string CommitterEmail = "committer@example.com";
+
+    private static readonly DateTimeOffset BaseDate = new(2023, 6, 1, 10, 0, 0, TimeSpan.FromHours(2));
+
+    private int ticks;
+
+    public GitTestRepository()
+    {
+        RepositoryPath = Path.Combine(Path.GetTempPath(), "managed-git-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(RepositoryPath);
+        Run("init", "-q", "-b", "main");
+
+        // Use the path exactly as git sees it (symlinks resolved, e.g. /var -> /private/var on
+        // macOS), so paths git writes into gitdir/commondir files compare equal to ours.
+        RepositoryPath = Path.GetFullPath(Run("rev-parse", "--show-toplevel"));
+    }
+
+    public string RepositoryPath { get; }
+
+    public string GitDirectory => Path.Combine(RepositoryPath, ".git");
+
+    public string ObjectsDirectory => Path.Combine(GitDirectory, "objects");
+
+    /// <summary>
+    /// Gets the date used for the author and the committer of the most recent commit or tag.
+    /// </summary>
+    public DateTimeOffset CurrentDate => BaseDate.AddMinutes(this.ticks);
+
+    /// <summary>
+    /// Runs <c>git</c> with the given arguments in the repository and returns its standard output.
+    /// </summary>
+    public string Run(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = RepositoryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        var date = $"{CurrentDate.ToUnixTimeSeconds()} +0200";
+        startInfo.Environment["GIT_AUTHOR_NAME"] = AuthorName;
+        startInfo.Environment["GIT_AUTHOR_EMAIL"] = AuthorEmail;
+        startInfo.Environment["GIT_AUTHOR_DATE"] = date;
+        startInfo.Environment["GIT_COMMITTER_NAME"] = CommitterName;
+        startInfo.Environment["GIT_COMMITTER_EMAIL"] = CommitterEmail;
+        startInfo.Environment["GIT_COMMITTER_DATE"] = date;
+        startInfo.Environment["GIT_CONFIG_GLOBAL"] = Path.Combine(RepositoryPath, "no-global-config");
+        startInfo.Environment["GIT_CONFIG_NOSYSTEM"] = "1";
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+        process.Start();
+
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"'git {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}: {standardError}");
+        }
+
+        return standardOutput.TrimEnd('\n');
+    }
+
+    /// <summary>
+    /// Writes a file (relative to the repository root), creating parent directories as needed.
+    /// </summary>
+    public void WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(RepositoryPath, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+    }
+
+    /// <summary>
+    /// Stages all changes and creates a commit with a deterministic date. Returns the commit sha.
+    /// </summary>
+    /// <param name="message">The commit message.</param>
+    /// <param name="advanceClock">
+    /// Whether to advance the deterministic clock before committing. Pass <see langword="false"/>
+    /// to create commits sharing the same committer timestamp.
+    /// </param>
+    public string Commit(string message, bool advanceClock = true)
+    {
+        if (advanceClock)
+        {
+            this.ticks++;
+        }
+
+        Run("add", "--all");
+        Run("commit", "-q", "--no-verify", "--allow-empty", "-m", message);
+        return RevParse("HEAD");
+    }
+
+    /// <summary>
+    /// Creates a commit whose message is taken verbatim from the given bytes.
+    /// </summary>
+    public string CommitWithMessageBytes(byte[] messageBytes, string? commitEncoding = null)
+    {
+        this.ticks++;
+        var messageFile = Path.Combine(RepositoryPath, "..", $"message-{Guid.NewGuid():N}.txt");
+        File.WriteAllBytes(messageFile, messageBytes);
+
+        try
+        {
+            Run("add", "--all");
+            var arguments = new List<string>();
+            if (commitEncoding is not null)
+            {
+                arguments.AddRange(["-c", $"i18n.commitEncoding={commitEncoding}"]);
+            }
+
+            arguments.AddRange(["commit", "-q", "--no-verify", "--allow-empty", "-F", messageFile]);
+            Run([.. arguments]);
+            return RevParse("HEAD");
+        }
+        finally
+        {
+            File.Delete(messageFile);
+        }
+    }
+
+    /// <summary>
+    /// Merges the given commits or branches into the current branch with a deterministic date.
+    /// </summary>
+    public string Merge(string firstBranch, string? secondBranch = null, bool advanceClock = true)
+    {
+        if (advanceClock)
+        {
+            this.ticks++;
+        }
+
+        List<string> arguments = ["merge", "-q", "--no-ff", "--no-edit", firstBranch];
+
+        if (secondBranch is not null)
+        {
+            arguments.Add(secondBranch);
+        }
+
+        Run([.. arguments]);
+        return RevParse("HEAD");
+    }
+
+    public string RevParse(string reference) => Run("rev-parse", reference);
+
+    public GitObjectId ResolveId(string reference) => GitObjectId.Parse(RevParse(reference));
+
+    public GitObjectStore OpenObjectStore() => new(ObjectsDirectory);
+
+    public GitReferenceStore OpenReferenceStore() => new(GitDirectory);
+
+    public void Dispose()
+    {
+        try
+        {
+            // Git marks pack and loose-object files read-only; a bare recursive delete
+            // fails on them on Windows. The helper resets attributes before deleting.
+            FileSystemHelper.Directory.DeleteDirectory(RepositoryPath);
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitTreeDiffTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/GitTreeDiffTests.cs
@@ -1,0 +1,158 @@
+using LibGit2Sharp;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Validates <see cref="GitTreeDiff"/> against libgit2's default <c>TreeChanges</c> path
+/// list, which is what GitVersion exposes as <c>ICommit.DiffPaths</c>.
+/// </summary>
+[TestFixture]
+public class GitTreeDiffTests
+{
+    [Test]
+    public void ChangedPathsMatchLibGit2ForEveryCommit()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "one\n");
+        repository.WriteFile("sub/deep/c.txt", "one\n");
+        repository.Commit("root commit");
+
+        repository.WriteFile("a.txt", "two\n");
+        repository.WriteFile("sub/new.txt", "new\n");
+        repository.Commit("modify and add");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "sub", "b.txt"));
+        repository.Commit("delete nested file");
+
+        repository.WriteFile("d.txt", "d\n");
+        repository.Run("update-index", "--chmod=+x", "a.txt");
+        repository.Commit("exec bit and new file");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void ChangedPathsMatchLibGit2WhenAFileBecomesADirectory()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("thing", "file\n");
+        repository.WriteFile("z.txt", "z\n");
+        repository.Commit("file");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing"));
+        repository.WriteFile("thing/inner.txt", "dir\n");
+        repository.WriteFile("thing/other.txt", "dir\n");
+        repository.Commit("becomes a directory");
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing", "inner.txt"));
+        File.Delete(Path.Combine(repository.RepositoryPath, "thing", "other.txt"));
+        Directory.Delete(Path.Combine(repository.RepositoryPath, "thing"));
+        repository.WriteFile("thing", "file again\n");
+        repository.Commit("becomes a file again");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void ChangedPathsOfMergeCommitsUseTheFirstParent()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("main.txt", "0\n");
+        repository.Commit("main 0");
+        repository.Run("checkout", "-q", "-b", "feature");
+        repository.WriteFile("feature.txt", "1\n");
+        repository.Commit("feature 1");
+        repository.Run("checkout", "-q", "main");
+        repository.WriteFile("main.txt", "1\n");
+        repository.Commit("main 1");
+        repository.Merge("feature");
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void ChangedPathsAlignEntriesByRawByteOrderNotUtf16Order()
+    {
+        // "\uE000" (EE 80 80 in UTF-8) sorts after "\U0001F600" (F0 9F 98 80) in UTF-16
+        // code units (0xD83D < 0xE000) but before it in git's raw unsigned byte order
+        // (0xEE < 0xF0). Comparing the decoded strings misaligns the two-pointer merge
+        // and reports the unchanged emoji file as changed.
+        using var repository = new GitTestRepository();
+        repository.WriteFile("\uE000.txt", "private use\n");
+        repository.WriteFile("\U0001F600.txt", "emoji\n");
+        var first = repository.ResolveId(repository.Commit("both files"));
+
+        File.Delete(Path.Combine(repository.RepositoryPath, "\uE000.txt"));
+        var second = repository.ResolveId(repository.Commit("delete the private-use file"));
+
+        using var store = repository.OpenObjectStore();
+        var treeDiff = new GitTreeDiff(store);
+
+        treeDiff.GetChangedPaths(store.GetCommit(first).Tree, store.GetCommit(second).Tree)
+            .ShouldBe(["\uE000.txt"]);
+
+        AssertDiffPathsParityForAllCommits(repository);
+    }
+
+    [Test]
+    public void IdenticalTreesProduceNoChangedPaths()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.Commit("commit");
+
+        using var store = repository.OpenObjectStore();
+        var tree = store.GetCommit(repository.ResolveId("HEAD")).Tree;
+
+        new GitTreeDiff(store).GetChangedPaths(tree, tree).ShouldBeEmpty();
+    }
+
+    [Test]
+    public void FlattenTreeListsAllBlobPaths()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "one\n");
+        repository.WriteFile("sub/b.txt", "one\n");
+        repository.WriteFile("sub/deep/c.txt", "one\n");
+        repository.Commit("commit");
+
+        using var store = repository.OpenObjectStore();
+        var tree = store.GetCommit(repository.ResolveId("HEAD")).Tree;
+
+        var files = new GitTreeDiff(store).FlattenTree(tree);
+
+        files.Keys.Order(StringComparer.Ordinal).ShouldBe(["a.txt", "sub/b.txt", "sub/deep/c.txt"]);
+        files["a.txt"].Sha.ToString().ShouldBe(repository.RevParse("HEAD:a.txt"));
+    }
+
+    private static void AssertDiffPathsParityForAllCommits(GitTestRepository repository)
+    {
+        using var store = repository.OpenObjectStore();
+        var treeDiff = new GitTreeDiff(store);
+        var walker = new GitRevisionWalker(store);
+
+        var options = new GitRevisionWalkOptions();
+        options.Include.Add(repository.ResolveId("HEAD"));
+
+        using var libgit2 = new Repository(repository.RepositoryPath);
+
+        foreach (var commit in walker.Walk(options))
+        {
+            var parentTree = commit.Parents.Count > 0
+                ? store.GetCommit(commit.Parents[0]).Tree
+                : (GitObjectId?)null;
+
+            var actual = treeDiff.GetChangedPaths(parentTree, commit.Tree);
+
+            // The adapter's DiffPaths: Compare<TreeChanges>(commit.Tree, firstParent?.Tree).Paths
+            var libgit2Commit = libgit2.Lookup<Commit>(commit.Sha.ToString())!;
+            var expected = libgit2.Diff
+                .Compare<TreeChanges>(libgit2Commit.Tree, libgit2Commit.Parents.FirstOrDefault()?.Tree)
+                .Select(element => element.Path)
+                .ToList();
+
+            actual.ShouldBe(expected, $"commit: {commit.Message.TrimEnd()}");
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
+++ b/src/GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <ProjectReference Include="..\GitVersion.Git.Managed\GitVersion.Git.Managed.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="GitVersion.Git" />
+    </ItemGroup>
+
+</Project>

--- a/src/GitVersion.Git.Managed.Tests/LooseObjectTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/LooseObjectTests.cs
@@ -1,0 +1,190 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class LooseObjectTests
+{
+    [Test]
+    public void ReadsACommitFromLooseObjects()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var firstSha = repository.Commit("first commit");
+        repository.WriteFile("file.txt", "hello world\n");
+        var secondSha = repository.Commit("second commit");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(secondSha));
+
+        commit.Sha.ToString().ShouldBe(secondSha);
+        commit.Tree.ToString().ShouldBe(repository.RevParse("HEAD^{tree}"));
+        commit.Parents.Count.ShouldBe(1);
+        commit.Parents[0].ToString().ShouldBe(firstSha);
+        commit.Message.ShouldBe("second commit\n");
+
+        commit.Author.Name.ShouldBe(GitTestRepository.AuthorName);
+        commit.Author.Email.ShouldBe(GitTestRepository.AuthorEmail);
+        commit.Committer.Name.ShouldBe(GitTestRepository.CommitterName);
+        commit.Committer.Email.ShouldBe(GitTestRepository.CommitterEmail);
+    }
+
+    [Test]
+    public void ReadsARootCommitWithoutParents()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var sha = repository.Commit("initial");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Parents.ShouldBeEmpty();
+        commit.Message.ShouldBe("initial\n");
+    }
+
+    [Test]
+    public void CommitMatchesGitLogOutput()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("subject line\n\nbody line one\nbody line two");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        var expected = repository
+            .Run("log", "-1", "--format=%an%n%ae%n%at%n%cn%n%ce%n%ct", sha)
+            .Split('\n');
+
+        commit.Author.Name.ShouldBe(expected[0]);
+        commit.Author.Email.ShouldBe(expected[1]);
+        commit.Author.When.ToUnixTimeSeconds().ShouldBe(long.Parse(expected[2]));
+        commit.Committer.Name.ShouldBe(expected[3]);
+        commit.Committer.Email.ShouldBe(expected[4]);
+        commit.Committer.When.ToUnixTimeSeconds().ShouldBe(long.Parse(expected[5]));
+
+        commit.Author.When.Offset.ShouldBe(TimeSpan.FromHours(2));
+        commit.Author.When.ShouldBe(repository.CurrentDate);
+        commit.Message.ShouldBe("subject line\n\nbody line one\nbody line two\n");
+    }
+
+    [Test]
+    public void CommitMessageMatchesGitCatFileOutput()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a message with special characters: äöü — ✓");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        var raw = repository.Run("cat-file", "commit", sha);
+        var expectedMessage = raw[(raw.IndexOf("\n\n", StringComparison.Ordinal) + 2)..];
+
+        commit.Message.TrimEnd('\n').ShouldBe(expectedMessage);
+    }
+
+    [Test]
+    public void ReadsACommitMessageHonoringTheEncodingHeader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var messageBytes = Encoding.Latin1.GetBytes("café à la crème\n");
+        var sha = repository.CommitWithMessageBytes(messageBytes, "ISO-8859-1");
+
+        repository.Run("cat-file", "commit", sha).ShouldContain("encoding ISO-8859-1");
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("café à la crème\n");
+    }
+
+    [Test]
+    public void FallsBackToLatin1ForInvalidUtf8WithoutAnEncodingHeader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var messageBytes = Encoding.Latin1.GetBytes("café\n");
+        var sha = repository.CommitWithMessageBytes(messageBytes);
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("café\n");
+    }
+
+    [Test]
+    public void ReadsABlobFromLooseObjects()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "blob content\n");
+        repository.Commit("add file");
+
+        using var store = repository.OpenObjectStore();
+        using var blob = store.GetBlob(repository.ResolveId("HEAD:file.txt"));
+        using var reader = new StreamReader(blob);
+
+        reader.ReadToEnd().ShouldBe("blob content\n");
+    }
+
+    [Test]
+    public void ReportsTheObjectTypeWhenItIsNotKnownUpFront()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(GitObjectId.Parse(sha), out var stream, out var objectType).ShouldBeTrue();
+
+        using (stream)
+        {
+            objectType.ShouldBe("commit");
+        }
+    }
+
+    [Test]
+    public void DoesNotFindAMissingObject()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+
+        var missing = GitObjectId.Parse("0123456789abcdef0123456789abcdef01234567");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(missing, "commit", out _).ShouldBeFalse();
+
+        var exception = Should.Throw<GitObjectStoreException>(() => store.GetCommit(missing));
+        exception.ObjectNotFound.ShouldBeTrue();
+    }
+
+    [Test]
+    public void DoesNotFindAnObjectWhenRequestedWithTheWrongType()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var sha = repository.Commit("a commit");
+
+        using var store = repository.OpenObjectStore();
+        store.TryGetObject(GitObjectId.Parse(sha), "blob", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public void ReadsObjectsFromAnAlternateObjectDatabase()
+    {
+        using var upstream = new GitTestRepository();
+        upstream.WriteFile("file.txt", "shared content\n");
+        var sha = upstream.Commit("shared commit");
+
+        using var dependent = new GitTestRepository();
+        var infoDirectory = Path.Combine(dependent.ObjectsDirectory, "info");
+        Directory.CreateDirectory(infoDirectory);
+        File.WriteAllText(Path.Combine(infoDirectory, "alternates"), upstream.ObjectsDirectory + "\n");
+
+        using var store = dependent.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(sha));
+
+        commit.Message.ShouldBe("shared commit\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/MultiPackIndexTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/MultiPackIndexTests.cs
@@ -1,0 +1,82 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class MultiPackIndexTests
+{
+    [Test]
+    public void ReadsObjectsFromMultiplePacksThroughTheMultiPackIndex()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        var firstSha = repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+
+        repository.WriteFile("file.txt", "second\n");
+        var secondSha = repository.Commit("second commit");
+        repository.Run("repack", "-d", "-q");
+
+        repository.Run("multi-pack-index", "write");
+
+        var packDirectory = Path.Combine(repository.ObjectsDirectory, "pack");
+        File.Exists(Path.Combine(packDirectory, "multi-pack-index")).ShouldBeTrue();
+        Directory.GetFiles(packDirectory, "*.pack").Length.ShouldBe(2);
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(firstSha)).Message.ShouldBe("first commit\n");
+
+        var second = store.GetCommit(GitObjectId.Parse(secondSha));
+        second.Message.ShouldBe("second commit\n");
+        second.Parents[0].ToString().ShouldBe(firstSha);
+    }
+
+    [Test]
+    public void TheMultiPackIndexReaderLooksUpObjectsAcrossPacks()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        var firstSha = repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+
+        repository.WriteFile("file.txt", "second\n");
+        var secondSha = repository.Commit("second commit");
+        repository.Run("repack", "-d", "-q");
+
+        repository.Run("multi-pack-index", "write");
+
+        using var stream = File.OpenRead(Path.Combine(repository.ObjectsDirectory, "pack", "multi-pack-index"));
+        using var reader = new GitMultiPackIndexReader(stream);
+
+        reader.PackNames.Count.ShouldBe(2);
+        reader.PackNames.ShouldAllBe(name => name.StartsWith("pack-"));
+
+        var first = reader.GetOffset(GitObjectId.Parse(firstSha));
+        var second = reader.GetOffset(GitObjectId.Parse(secondSha));
+
+        first.ShouldNotBeNull();
+        second.ShouldNotBeNull();
+        first.Value.PackIndex.ShouldNotBe(second.Value.PackIndex, "the two commits live in different packs");
+        first.Value.Offset.ShouldBeGreaterThan(0);
+        second.Value.Offset.ShouldBeGreaterThan(0);
+
+        reader.GetOffset(GitObjectId.Parse("0123456789abcdef0123456789abcdef01234567")).ShouldBeNull();
+    }
+
+    [Test]
+    public void ReadsLooseObjectsWhenAMultiPackIndexIsPresent()
+    {
+        using var repository = new GitTestRepository();
+
+        repository.WriteFile("file.txt", "first\n");
+        repository.Commit("first commit");
+        repository.Run("repack", "-a", "-d", "-q");
+        repository.Run("multi-pack-index", "write");
+
+        repository.WriteFile("file.txt", "second\n");
+        var looseSha = repository.Commit("loose commit");
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(looseSha)).Message.ShouldBe("loose commit\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/PackedObjectTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/PackedObjectTests.cs
@@ -1,0 +1,139 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class PackedObjectTests
+{
+    [Test]
+    public void ReadsCommitsFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var firstSha = repository.Commit("first commit");
+        repository.WriteFile("file.txt", "hello world\n");
+        var secondSha = repository.Commit("second commit");
+
+        repository.Run("gc", "-q");
+        AssertHasNoLooseObjects(repository);
+
+        using var store = repository.OpenObjectStore();
+        var commit = store.GetCommit(GitObjectId.Parse(secondSha));
+
+        commit.Tree.ToString().ShouldBe(repository.RevParse("HEAD^{tree}"));
+        commit.Parents[0].ToString().ShouldBe(firstSha);
+        commit.Message.ShouldBe("second commit\n");
+        commit.Author.Name.ShouldBe(GitTestRepository.AuthorName);
+        commit.Committer.When.ShouldBe(repository.CurrentDate);
+    }
+
+    [Test]
+    public void ReadsDeltifiedObjectsFromAPackWithDeepDeltaChains()
+    {
+        using var repository = new GitTestRepository();
+        var commits = CreateDeltaFriendlyHistory(repository);
+
+        repository.Run("repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+        AssertHasNoLooseObjects(repository);
+
+        AssertWholeHistoryIsReadable(repository, commits);
+    }
+
+    [Test]
+    public void ReadsRefDeltaObjectsFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        var commits = CreateDeltaFriendlyHistory(repository);
+
+        repository.Run("-c", "repack.useDeltaBaseOffset=false", "repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+        AssertHasNoLooseObjects(repository);
+
+        AssertWholeHistoryIsReadable(repository, commits);
+    }
+
+    [Test]
+    public void ReadsBlobsAndTreesFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        var expectedContent = new StringBuilder();
+        for (var i = 0; i < 20; i++)
+        {
+            expectedContent.AppendLine($"line {i} of a delta friendly file with some repeating content");
+            repository.WriteFile("file.txt", expectedContent.ToString());
+            repository.Commit($"commit {i}");
+        }
+
+        repository.Run("repack", "-a", "-d", "-q", "--depth=50", "--window=50");
+
+        using var store = repository.OpenObjectStore();
+        using var blob = store.GetBlob(repository.ResolveId("HEAD:file.txt"));
+        using var reader = new StreamReader(blob);
+        reader.ReadToEnd().ShouldBe(expectedContent.ToString());
+
+        var tree = store.GetTree(repository.ResolveId("HEAD^{tree}"));
+        tree.Entries.Count.ShouldBe(1);
+        tree.Entries[0].Name.ShouldBe("file.txt");
+    }
+
+    [Test]
+    public void ReadsLooseObjectsCreatedAfterThePack()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "hello\n");
+        var packedSha = repository.Commit("packed commit");
+        repository.Run("gc", "-q");
+
+        repository.WriteFile("file.txt", "hello again\n");
+        var looseSha = repository.Commit("loose commit");
+
+        using var store = repository.OpenObjectStore();
+        store.GetCommit(GitObjectId.Parse(packedSha)).Message.ShouldBe("packed commit\n");
+        store.GetCommit(GitObjectId.Parse(looseSha)).Message.ShouldBe("loose commit\n");
+    }
+
+    private static List<(string Sha, string Message)> CreateDeltaFriendlyHistory(GitTestRepository repository)
+    {
+        List<(string Sha, string Message)> commits = [];
+        var content = new StringBuilder();
+
+        for (var i = 0; i < 30; i++)
+        {
+            content.AppendLine($"line {i} of a delta friendly file with some repeating content");
+            repository.WriteFile("file.txt", content.ToString());
+            var message = $"commit {i}";
+            commits.Add((repository.Commit(message), message));
+        }
+
+        return commits;
+    }
+
+    private static void AssertWholeHistoryIsReadable(GitTestRepository repository, List<(string Sha, string Message)> commits)
+    {
+        using var store = repository.OpenObjectStore();
+
+        for (var i = 0; i < commits.Count; i++)
+        {
+            var commit = store.GetCommit(GitObjectId.Parse(commits[i].Sha));
+
+            commit.Message.ShouldBe(commits[i].Message + "\n");
+            commit.Parents.Count.ShouldBe(i == 0 ? 0 : 1);
+            if (i > 0)
+            {
+                commit.Parents[0].ToString().ShouldBe(commits[i - 1].Sha);
+            }
+
+            using var blob = store.GetBlob(repository.ResolveId($"{commits[i].Sha}:file.txt"));
+            using var reader = new StreamReader(blob);
+            var lines = reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            lines.Length.ShouldBe(i + 1);
+        }
+    }
+
+    private static void AssertHasNoLooseObjects(GitTestRepository repository)
+    {
+        var looseObjects = Directory
+            .EnumerateDirectories(repository.ObjectsDirectory)
+            .Where(directory => Path.GetFileName(directory) is { Length: 2 })
+            .SelectMany(Directory.EnumerateFiles);
+
+        looseObjects.ShouldBeEmpty();
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/PullRequestBranchOperationsTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/PullRequestBranchOperationsTests.cs
@@ -1,0 +1,98 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class PullRequestBranchOperationsTests
+{
+    private const string HeadTipSha = "0123456789012345678901234567890123456789";
+
+    [Test]
+    public void HeadAdvertisementIsNotACandidateTip()
+    {
+        // libgit2's remote listing resolves the HEAD symref into an extra entry pointing
+        // at the default branch tip; it must not count against the single-match check.
+        var repository = CreateRepository();
+
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            repository,
+            NullLogger.Instance,
+            _ => [new("HEAD", HeadTipSha), new("refs/pull/2/merge", HeadTipSha)]);
+
+        repository.References.Received().Add("refs/heads/pull/2/merge", HeadTipSha);
+        repository.Received().Checkout("refs/heads/pull/2/merge");
+    }
+
+    [Test]
+    public void PeeledAndDuplicateEntriesAreNotCandidateTips()
+    {
+        const string tagObjectSha = "1111111111111111111111111111111111111111";
+        const string otherCommitSha = "2222222222222222222222222222222222222222";
+        var repository = CreateRepository();
+
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            repository,
+            NullLogger.Instance,
+            _ =>
+            [
+                new("refs/pull/2/merge", HeadTipSha),
+                new("refs/pull/2/merge", HeadTipSha),      // duplicate (e.g. a resolved symref)
+                new("refs/tags/v1.0.0", tagObjectSha),     // annotated tag pointing elsewhere
+                new("refs/tags/v1.0.0^{}", otherCommitSha) // its peeled entry
+            ]);
+
+        repository.References.Received().Add("refs/heads/pull/2/merge", HeadTipSha);
+    }
+
+    [Test]
+    public void AnnotatedTagIsMatchedThroughItsPeeledEntry()
+    {
+        // A detached HEAD at an annotated tag's commit: the tag ref itself carries the
+        // tag-object sha, so only the peeled "^{}" entry points at the head tip. It must
+        // fold into the base tag ref and take the tag checkout path.
+        const string tagObjectSha = "1111111111111111111111111111111111111111";
+        var repository = CreateRepository();
+
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            repository,
+            NullLogger.Instance,
+            _ =>
+            [
+                new("refs/tags/v1.0.0", tagObjectSha),
+                new("refs/tags/v1.0.0^{}", HeadTipSha)
+            ]);
+
+        repository.Received().Checkout(HeadTipSha);
+    }
+
+    [Test]
+    public void MultipleDistinctCandidateTipsStillFail()
+    {
+        var repository = CreateRepository();
+
+        Should.Throw<WarningException>(() => PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+                repository,
+                NullLogger.Instance,
+                _ => [new("refs/pull/2/merge", HeadTipSha), new("refs/heads/main", HeadTipSha)]))
+            .Message.ShouldContain("more than one remote tip");
+    }
+
+    private static IMutatingGitRepository CreateRepository()
+    {
+        var tip = Substitute.For<ICommit>();
+        tip.Sha.Returns(HeadTipSha);
+
+        var head = Substitute.For<IBranch>();
+        head.Tip.Returns(tip);
+
+        var remote = Substitute.For<IRemote>();
+        remote.Name.Returns("origin");
+        remote.Url.Returns("https://example.com/repo.git");
+
+        var remotes = Substitute.For<IRemoteCollection>();
+        remotes.GetEnumerator().Returns(_ => new List<IRemote> { remote }.GetEnumerator());
+
+        var repository = Substitute.For<IMutatingGitRepository>();
+        repository.Head.Returns(head);
+        repository.Remotes.Returns(remotes);
+        return repository;
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/TagTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/TagTests.cs
@@ -1,0 +1,80 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class TagTests
+{
+    [Test]
+    public void ReadsAnAnnotatedTag()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v1.2.3", "-m", "release 1.2.3");
+
+        var tagSha = repository.RevParse("v1.2.3");
+        tagSha.ShouldNotBe(commitSha, "an annotated tag should be its own object");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(GitObjectId.Parse(tagSha));
+
+        tag.Sha.ToString().ShouldBe(tagSha);
+        tag.Name.ShouldBe("v1.2.3");
+        tag.TargetType.ShouldBe("commit");
+        tag.Target.ToString().ShouldBe(commitSha);
+        tag.Message.ShouldBe("release 1.2.3\n");
+
+        tag.Tagger.ShouldNotBeNull();
+        tag.Tagger.Value.Name.ShouldBe(GitTestRepository.CommitterName);
+        tag.Tagger.Value.Email.ShouldBe(GitTestRepository.CommitterEmail);
+        tag.Tagger.Value.When.ShouldBe(repository.CurrentDate);
+    }
+
+    [Test]
+    public void ReadsAnAnnotatedTagWithAMultiLineMessage()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("tag", "-a", "v2.0.0", "-m", "subject\n\nbody with details");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(repository.ResolveId("v2.0.0"));
+
+        tag.Message.ShouldBe("subject\n\nbody with details\n");
+    }
+
+    [Test]
+    public void ReadsANestedAnnotatedTag()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        repository.Commit("a commit");
+        repository.Run("tag", "-a", "inner", "-m", "inner tag");
+        repository.Run("tag", "-a", "outer", "-m", "outer tag", "inner");
+
+        using var store = repository.OpenObjectStore();
+        var outer = store.GetTag(repository.ResolveId("outer"));
+
+        outer.TargetType.ShouldBe("tag");
+        outer.Target.ToString().ShouldBe(repository.RevParse("inner"));
+    }
+
+    [Test]
+    public void ReadsAnAnnotatedTagFromAPackFile()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("file.txt", "content\n");
+        var commitSha = repository.Commit("a commit");
+        repository.Run("tag", "-a", "v3.0.0", "-m", "packed tag");
+        var tagSha = repository.RevParse("v3.0.0");
+
+        repository.Run("gc", "-q");
+
+        using var store = repository.OpenObjectStore();
+        var tag = store.GetTag(GitObjectId.Parse(tagSha));
+
+        tag.Name.ShouldBe("v3.0.0");
+        tag.Target.ToString().ShouldBe(commitSha);
+        tag.Message.ShouldBe("packed tag\n");
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/TempDirectory.cs
+++ b/src/GitVersion.Git.Managed.Tests/TempDirectory.cs
@@ -1,0 +1,33 @@
+using GitVersion.Helpers;
+
+namespace GitVersion.Git.Managed.Tests;
+
+/// <summary>
+/// Reserves a unique temporary directory path (without creating it, so it can be used as
+/// a target for <c>git clone</c> or <c>git worktree add</c>) and deletes it on dispose.
+/// </summary>
+internal sealed class TempDirectory : IDisposable
+{
+    public string FullPath { get; } = Path.Combine(Path.GetTempPath(), "managed-git-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(FullPath))
+            {
+                // Git marks pack and loose-object files read-only; a bare recursive delete
+                // fails on them on Windows. The helper resets attributes before deleting.
+                FileSystemHelper.Directory.DeleteDirectory(FullPath);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup of the temporary directory.
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed.Tests/TreeTests.cs
+++ b/src/GitVersion.Git.Managed.Tests/TreeTests.cs
@@ -1,0 +1,90 @@
+namespace GitVersion.Git.Managed.Tests;
+
+[TestFixture]
+public class TreeTests
+{
+    [Test]
+    public void ReadsTheRootTreeEntriesMatchingGitLsTree()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        repository.WriteFile("b.txt", "b\n");
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add files");
+
+        using var store = repository.OpenObjectStore();
+        var treeId = repository.ResolveId("HEAD^{tree}");
+        var tree = store.GetTree(treeId);
+
+        tree.Sha.ShouldBe(treeId);
+
+        // git ls-tree prints: <mode> SP <type> SP <sha> TAB <name>
+        var expectedEntries = repository
+            .Run("ls-tree", treeId.ToString())
+            .Split('\n')
+            .Select(line =>
+            {
+                var parts = line.Split('\t');
+                var meta = parts[0].Split(' ');
+                return (Mode: meta[0], Type: meta[1], Sha: meta[2], Name: parts[1]);
+            })
+            .ToList();
+
+        tree.Entries.Count.ShouldBe(expectedEntries.Count);
+
+        for (var i = 0; i < expectedEntries.Count; i++)
+        {
+            var entry = tree.Entries[i];
+            var expected = expectedEntries[i];
+
+            entry.Name.ShouldBe(expected.Name);
+            entry.Mode.PadLeft(6, '0').ShouldBe(expected.Mode);
+            entry.Sha.ToString().ShouldBe(expected.Sha);
+            entry.IsTree.ShouldBe(expected.Type == "tree");
+        }
+    }
+
+    [Test]
+    public void ReadsANestedTree()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add nested file");
+
+        using var store = repository.OpenObjectStore();
+        var rootTree = store.GetTree(repository.ResolveId("HEAD^{tree}"));
+
+        var subEntry = rootTree.FindEntry("sub");
+        subEntry.ShouldNotBeNull();
+        subEntry.IsTree.ShouldBeTrue();
+
+        var subTree = store.GetTree(subEntry.Sha);
+        subTree.Entries.Count.ShouldBe(1);
+        subTree.Entries[0].Name.ShouldBe("c.txt");
+        subTree.Entries[0].IsTree.ShouldBeFalse();
+        subTree.Entries[0].Sha.ToString().ShouldBe(repository.RevParse("HEAD:sub/c.txt"));
+    }
+
+    [Test]
+    public void FindsANodeUsingTheStreamingReader()
+    {
+        using var repository = new GitTestRepository();
+        repository.WriteFile("a.txt", "a\n");
+        repository.WriteFile("sub/c.txt", "c\n");
+        repository.Commit("add files");
+
+        using var store = repository.OpenObjectStore();
+        var treeId = repository.ResolveId("HEAD^{tree}");
+
+        using (var treeStream = store.GetObject(treeId, "tree"))
+        {
+            var node = GitTreeStreamingReader.FindNode(treeStream, "sub"u8);
+            node.ToString().ShouldBe(repository.RevParse("HEAD:sub"));
+        }
+
+        using (var treeStream = store.GetObject(treeId, "tree"))
+        {
+            GitTreeStreamingReader.FindNode(treeStream, "missing"u8).ShouldBe(GitObjectId.Empty);
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/DynamicRepositoryPath.cs
+++ b/src/GitVersion.Git.Managed/Adapter/DynamicRepositoryPath.cs
@@ -1,0 +1,51 @@
+using System.IO.Abstractions;
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Computes the path of the dynamically created Git repository used for remote-URL
+/// scenarios. The managed backend supplies its own way of checking whether an existing
+/// directory is a repository with a matching remote.
+/// </summary>
+internal static class DynamicRepositoryPath
+{
+    private static readonly char[] DirectorySeparators = ['/', '\\'];
+
+    /// <summary>
+    /// Gets the path of the dynamic repository for <paramref name="targetUrl"/>, or
+    /// <see langword="null"/> when no target URL is configured.
+    /// </summary>
+    /// <param name="fileSystem">The file system.</param>
+    /// <param name="targetUrl">The URL of the remote repository.</param>
+    /// <param name="clonePath">The directory to clone into, or <see langword="null"/> for the temp directory.</param>
+    /// <param name="gitRepoHasMatchingRemote">Checks whether the repository at the given path has a remote with the given URL.</param>
+    public static string? Get(IFileSystem fileSystem, string? targetUrl, string? clonePath, Func<string, string, bool> gitRepoHasMatchingRemote)
+    {
+        if (targetUrl.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        var userTemp = clonePath ?? FileSystemHelper.Path.GetTempPath();
+        var repositoryName = targetUrl.Split(DirectorySeparators)[^1].Replace(".git", string.Empty);
+        var possiblePath = FileSystemHelper.Path.Combine(userTemp, repositoryName);
+
+        // Verify that the existing directory is ok for us to use
+        if (fileSystem.Directory.Exists(possiblePath) && !gitRepoHasMatchingRemote(possiblePath, targetUrl))
+        {
+            var i = 1;
+            var originalPath = possiblePath;
+            bool possiblePathExists;
+            do
+            {
+                possiblePath = $"{originalPath}_{i++}";
+                possiblePathExists = fileSystem.Directory.Exists(possiblePath);
+            } while (possiblePathExists && !gitRepoHasMatchingRemote(possiblePath, targetUrl));
+        }
+
+        var repositoryPath = FileSystemHelper.Path.Combine(possiblePath, ".git");
+        return repositoryPath;
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedBranch.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedBranch.cs
@@ -1,0 +1,34 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedBranch : IBranch
+{
+    private static readonly LambdaEqualityHelper<IBranch> equalityHelper = new(x => x.Name.Canonical);
+    private static readonly LambdaKeyComparer<IBranch, string> comparerHelper = new(x => x.Name.Canonical);
+
+    private readonly ManagedGitRepository repository;
+
+    internal ManagedBranch(ReferenceName name, ManagedCommit? tip, ManagedGitRepository repository)
+    {
+        Name = name.NotNull();
+        Tip = tip;
+        this.repository = repository.NotNull();
+        Commits = ManagedCommitCollection.ReachableFrom(repository, tip);
+    }
+
+    public ReferenceName Name { get; }
+    public ICommit? Tip { get; }
+    public ICommitCollection Commits { get; }
+
+    public bool IsDetachedHead => Name.Canonical.Equals("(no branch)", StringComparison.OrdinalIgnoreCase);
+    public bool IsRemote => Name.IsRemoteBranch;
+    public bool IsTracking => this.repository.Session.IsTracking(this);
+
+    public int CompareTo(IBranch? other) => comparerHelper.Compare(this, other);
+    public bool Equals(IBranch? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as IBranch);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name.ToString();
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedBranchCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedBranchCollection.cs
@@ -1,0 +1,57 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedBranchCollection(ManagedGitRepository repository) : IBranchCollection
+{
+    private readonly ManagedGitRepository repository = repository.NotNull();
+
+    public IEnumerator<IBranch> GetEnumerator() => this.repository.Session.Branches.Cast<IBranch>().GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IBranch? this[string name]
+    {
+        get
+        {
+            name = name.NotNull();
+            return this.repository.Session.FindBranch(name);
+        }
+    }
+
+    public IEnumerable<IBranch> ExcludeBranches(IEnumerable<IBranch> branchesToExclude)
+    {
+        var toExclude = branchesToExclude as IBranch[] ?? [.. branchesToExclude];
+
+        return this.Where(BranchIsNotExcluded);
+
+        bool BranchIsNotExcluded(IBranch branch) => toExclude.All(branchToExclude => !branch.Equals(branchToExclude));
+    }
+
+    public void UpdateTrackedBranch(IBranch branch, string remoteTrackingReferenceName)
+    {
+        branch.NotNull();
+        remoteTrackingReferenceName.NotNull();
+
+        if (!remoteTrackingReferenceName.StartsWith(ReferenceName.RemoteTrackingBranchPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"The reference '{remoteTrackingReferenceName}' is not a remote-tracking branch.");
+        }
+
+        var remoteAndBranch = remoteTrackingReferenceName[ReferenceName.RemoteTrackingBranchPrefix.Length..];
+        var separator = remoteAndBranch.IndexOf('/');
+
+        if (separator <= 0 || separator == remoteAndBranch.Length - 1)
+        {
+            throw new InvalidOperationException($"The reference '{remoteTrackingReferenceName}' is not a remote-tracking branch.");
+        }
+
+        var remoteName = remoteAndBranch[..separator];
+        var mergeReference = ReferenceName.LocalBranchPrefix + remoteAndBranch[(separator + 1)..];
+        var friendlyName = branch.Name.Friendly;
+
+        var workingDirectory = this.repository.CliWorkingDirectory;
+        this.repository.CliMutator.SetConfig(workingDirectory, $"branch.{friendlyName}.remote", remoteName);
+        this.repository.CliMutator.SetConfig(workingDirectory, $"branch.{friendlyName}.merge", mergeReference);
+        this.repository.Invalidate();
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedCommit.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedCommit.cs
@@ -1,0 +1,56 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedCommit : ICommit
+{
+    private static readonly LambdaEqualityHelper<ICommit> equalityHelper = new(x => x.Id);
+    private static readonly LambdaKeyComparer<ICommit, string> comparerHelper = new(x => x.Sha);
+
+    private readonly GitCommit innerCommit;
+    private readonly ManagedGitRepository repository;
+    private readonly Lazy<IReadOnlyList<ICommit>> parentsLazy;
+
+    internal ManagedCommit(GitCommit innerCommit, ManagedGitRepository repository)
+    {
+        this.innerCommit = innerCommit;
+        this.repository = repository.NotNull();
+        this.parentsLazy = new(() =>
+            [.. innerCommit.Parents
+                .Select(parentId => this.repository.Session.TryGetCommit(parentId))
+                .Where(parent => parent is not null)
+                .Cast<ICommit>()]);
+        Id = new ManagedObjectId(innerCommit.Sha);
+        Sha = Id.Sha;
+        When = innerCommit.CommitterWhen;
+    }
+
+    internal GitObjectId ObjectId => this.innerCommit.Sha;
+    internal GitObjectId TreeId => this.innerCommit.Tree;
+    internal GitObjectId? FirstParentId => this.innerCommit.Parents.Count > 0 ? this.innerCommit.Parents[0] : null;
+
+    public IReadOnlyList<ICommit> Parents => this.parentsLazy.Value;
+    public IObjectId Id { get; }
+    public string Sha { get; }
+    public DateTimeOffset When { get; }
+    public string Message => this.innerCommit.Message;
+    public bool IsMergeCommit => Parents.Count >= 2;
+    public IReadOnlyList<string> DiffPaths => this.repository.Session.GetDiffPaths(this);
+
+    public int CompareTo(ICommit? other) => comparerHelper.Compare(this, other);
+    public bool Equals(ICommit? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as ICommit);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => $"'{Id.ToString(7)}' - {MessageShort}";
+
+    private string MessageShort
+    {
+        get
+        {
+            var message = this.innerCommit.Message;
+            var lineEnd = message.IndexOf('\n');
+            return (lineEnd < 0 ? message : message[..lineEnd]).TrimEnd('\r');
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedCommitCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedCommitCollection.cs
@@ -1,0 +1,140 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedCommitCollection : ICommitCollection
+{
+    private readonly ManagedGitRepository repository;
+    private readonly bool fromHead;
+    private readonly IReadOnlyList<GitObjectId> include;
+    private readonly IReadOnlyList<GitObjectId> exclude;
+    private readonly GitRevisionSortStrategies sort;
+    private readonly bool firstParentOnly;
+
+    // Memoizes the walk result for the session it was computed against, so repeated
+    // enumerations are cheap while mutations (which replace the session) stay visible.
+    private (ManagedRepositorySession Session, IReadOnlyList<ICommit> Commits)? cached;
+
+    private ManagedCommitCollection(
+        ManagedGitRepository repository,
+        bool fromHead,
+        IReadOnlyList<GitObjectId> include,
+        IReadOnlyList<GitObjectId> exclude,
+        GitRevisionSortStrategies sort,
+        bool firstParentOnly)
+    {
+        this.repository = repository.NotNull();
+        this.fromHead = fromHead;
+        this.include = include;
+        this.exclude = exclude;
+        this.sort = sort;
+        this.firstParentOnly = firstParentOnly;
+    }
+
+    /// <summary>
+    /// The commits reachable from HEAD in reverse chronological order, matching libgit2's
+    /// default commit log. HEAD is resolved lazily at enumeration time.
+    /// </summary>
+    public static ManagedCommitCollection FromHead(ManagedGitRepository repository) =>
+        new(repository, fromHead: true, [], [], GitRevisionSortStrategies.Time, firstParentOnly: false);
+
+    /// <summary>
+    /// The commits reachable from the given tip in reverse chronological order,
+    /// matching libgit2's <c>Branch.Commits</c>.
+    /// </summary>
+    public static ManagedCommitCollection ReachableFrom(ManagedGitRepository repository, ManagedCommit? tip) =>
+        new(repository, fromHead: false, tip is null ? [] : [tip.ObjectId], [], GitRevisionSortStrategies.Time, firstParentOnly: false);
+
+    public IEnumerator<ICommit> GetEnumerator() => GetCommits().GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerable<ICommit> GetCommitsPriorTo(DateTimeOffset olderThan)
+        => this.SkipWhile(c => c.When > olderThan);
+
+    public IEnumerable<ICommit> QueryBy(CommitFilter commitFilter)
+    {
+        var includeId = ResolveCommitish(commitFilter.IncludeReachableFrom);
+        var excludeId = ResolveCommitish(commitFilter.ExcludeReachableFrom);
+
+        return new ManagedCommitCollection(
+            this.repository,
+            fromHead: false,
+            includeId is { } incl ? [incl] : [],
+            excludeId is { } excl ? [excl] : [],
+            MapSortStrategies(commitFilter.SortBy),
+            commitFilter.FirstParentOnly);
+    }
+
+    private IReadOnlyList<ICommit> GetCommits()
+    {
+        var session = this.repository.Session;
+
+        if (this.cached is { } memo && ReferenceEquals(memo.Session, session))
+        {
+            return memo.Commits;
+        }
+
+        var options = new GitRevisionWalkOptions
+        {
+            Sort = this.sort,
+            FirstParentOnly = this.firstParentOnly
+        };
+
+        if (this.fromHead)
+        {
+            if (session.HeadTipId is { } headId)
+            {
+                options.Include.Add(headId);
+            }
+        }
+        else
+        {
+            foreach (var id in this.include)
+            {
+                options.Include.Add(id);
+            }
+        }
+
+        foreach (var id in this.exclude)
+        {
+            options.Exclude.Add(id);
+        }
+
+        IReadOnlyList<ICommit> commits = options.Include.Count == 0
+            ? []
+            : [.. session.Walker.Walk(options).Select(session.WrapCommit)];
+
+        this.cached = (session, commits);
+        return commits;
+    }
+
+    private static GitObjectId? ResolveCommitish(ICommitish? item) =>
+        item switch
+        {
+            ManagedCommit commit => commit.ObjectId,
+            ManagedBranch branch => (branch.Tip as ManagedCommit)?.ObjectId,
+            _ => null
+        };
+
+    private static GitRevisionSortStrategies MapSortStrategies(CommitSortStrategies sortBy)
+    {
+        var result = GitRevisionSortStrategies.None;
+
+        if (sortBy.HasFlag(CommitSortStrategies.Topological))
+        {
+            result |= GitRevisionSortStrategies.Topological;
+        }
+
+        if (sortBy.HasFlag(CommitSortStrategies.Time))
+        {
+            result |= GitRevisionSortStrategies.Time;
+        }
+
+        if (sortBy.HasFlag(CommitSortStrategies.Reverse))
+        {
+            result |= GitRevisionSortStrategies.Reverse;
+        }
+
+        return result;
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.cs
@@ -1,0 +1,167 @@
+using GitVersion.Extensions;
+using SysPath = System.IO.Path;
+
+namespace GitVersion.Git;
+
+internal sealed partial class ManagedGitRepository
+{
+    private readonly object sessionLock = new();
+    private readonly List<ManagedRepositorySession> retiredSessions = [];
+    private Lazy<ManagedRepositorySession>? sessionLazy;
+    private string? gitDirectory;
+
+    private ITagCollection? tags;
+    private IBranchCollection? branches;
+    private ICommitCollection? commits;
+    private IRemoteCollection? remotes;
+    private IReferenceCollection? references;
+
+    internal ManagedRepositorySession Session
+    {
+        get
+        {
+            var lazy = this.sessionLazy ?? throw new InvalidOperationException("Repository not initialized. Call DiscoverRepository() first.");
+            return lazy.Value;
+        }
+    }
+
+    internal string CliWorkingDirectory => Session.Layout.WorkingDirectory ?? Session.Layout.GitDirectory;
+
+    public string Path => WithTrailingSeparator(Session.Layout.GitDirectory);
+
+    public string WorkingDirectory =>
+        Session.Layout.WorkingDirectory is { } workingDirectory
+            ? WithTrailingSeparator(workingDirectory)
+            : throw new InvalidOperationException("The repository is bare: it has no working directory.");
+
+    public bool IsHeadDetached => Session.ReferenceStore.GetHead() is { IsSymbolic: false };
+    public bool IsShallow => Session.Layout.IsShallow;
+    public IBranch Head => Session.GetHead();
+
+    public ITagCollection Tags => this.tags ??= new ManagedTagCollection(this);
+    public IBranchCollection Branches => this.branches ??= new ManagedBranchCollection(this);
+    public ICommitCollection Commits => this.commits ??= ManagedCommitCollection.FromHead(this);
+    public IRemoteCollection Remotes => this.remotes ??= new ManagedRemoteCollection(this);
+    public IReferenceCollection References => this.references ??= new ManagedReferenceCollection(this);
+
+    public void DiscoverRepository(string? gitDirectory)
+    {
+        this.gitDirectory = gitDirectory;
+        ResetSession();
+    }
+
+    /// <summary>
+    /// Retires the current snapshot of the repository so that changes made through the git CLI
+    /// (new objects, moved references, updated configuration) become visible on next access.
+    /// Retired snapshots stay alive until the repository is disposed because wrappers handed
+    /// out earlier may still be enumerating them.
+    /// </summary>
+    internal void Invalidate() => ResetSession();
+
+    public ICommit? FindMergeBase(ICommit commit, ICommit otherCommit)
+    {
+        commit = commit.NotNull();
+        otherCommit = otherCommit.NotNull();
+
+        var session = Session;
+        var mergeBase = session.Walker.FindMergeBase(ResolveObjectId(commit), ResolveObjectId(otherCommit));
+        return mergeBase is { } id ? session.GetCommit(id) : null;
+    }
+
+    private static GitObjectId ResolveObjectId(ICommit commit) =>
+        commit is ManagedCommit managed ? managed.ObjectId : GitObjectId.Parse(commit.Sha);
+
+    public int UncommittedChangesCount()
+    {
+        var session = Session;
+        var headTip = Head.Tip;
+
+        if (headTip is ManagedCommit managedTip)
+        {
+            return session.StatusCalculator.CountUncommittedChanges(managedTip.TreeId);
+        }
+
+        // A brand-new repository without commits: count the untracked files, mirroring the
+        // libgit2 adapter's behavior (including its "the repo is really dirty" fallback).
+        try
+        {
+            return session.StatusCalculator.CountChangesInEmptyRepository();
+        }
+        catch (Exception)
+        {
+            return int.MaxValue;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (this.sessionLock)
+        {
+            if (this.sessionLazy is { IsValueCreated: true } lazy)
+            {
+                lazy.Value.Dispose();
+            }
+
+            this.sessionLazy = null;
+
+            foreach (var session in this.retiredSessions)
+            {
+                session.Dispose();
+            }
+
+            this.retiredSessions.Clear();
+        }
+    }
+
+    private void ResetSession()
+    {
+        lock (this.sessionLock)
+        {
+            if (this.sessionLazy is { IsValueCreated: true } lazy)
+            {
+                this.retiredSessions.Add(lazy.Value);
+            }
+
+            this.sessionLazy = new(() => new(this, CreateLayout(this.gitDirectory)));
+        }
+    }
+
+    private static GitRepositoryLayout CreateLayout(string? gitDirectory)
+    {
+        if (gitDirectory.IsNullOrWhiteSpace())
+        {
+            throw new InvalidOperationException("Cannot find the .git directory");
+        }
+
+        var path = gitDirectory.TrimEnd('/', '\\');
+
+        if (!Directory.Exists(path))
+        {
+            throw new DirectoryNotFoundException($"Cannot find the .git directory in path '{gitDirectory}'.");
+        }
+
+        if (!path.EndsWith(".git", StringComparison.Ordinal))
+        {
+            return GitRepositoryLayout.Discover(path);
+        }
+
+        // A dynamically cloned repository uses a working directory that is itself named
+        // '.git' and contains a nested '.git' directory — treat it as a working directory,
+        // the way libgit2 opens any path that contains a '.git' entry.
+        var nestedDotGit = SysPath.Combine(path, ".git");
+
+        if (Directory.Exists(nestedDotGit) || File.Exists(nestedDotGit))
+        {
+            return GitRepositoryLayout.Discover(path);
+        }
+
+        return SysPath.GetFileName(path) == ".git"
+            ? GitRepositoryLayout.FromGitDirectory(path, SysPath.GetDirectoryName(path))
+            : GitRepositoryLayout.FromGitDirectory(path, workingDirectory: null);
+    }
+
+    private static string WithTrailingSeparator(string path) =>
+        path.EndsWith(SysPath.DirectorySeparatorChar) || path.EndsWith('/')
+            ? path
+            : path + SysPath.DirectorySeparatorChar;
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.mutating.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepository.mutating.cs
@@ -1,0 +1,31 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed partial class ManagedGitRepository(ILogger<ManagedGitRepository> logger, IGitCliMutator cliMutator) : IMutatingGitRepository
+{
+    private readonly ILogger<ManagedGitRepository> logger = logger.NotNull();
+
+    internal IGitCliMutator CliMutator { get; } = cliMutator.NotNull();
+
+    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth) =>
+        CliMutator.Clone(sourceUrl, workdirPath, auth);
+
+    public void Checkout(string commitOrBranchSpec)
+    {
+        CliMutator.Checkout(CliWorkingDirectory, commitOrBranchSpec);
+        Invalidate();
+    }
+
+    public void Fetch(string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth, string? logMessage)
+    {
+        CliMutator.Fetch(CliWorkingDirectory, remote, refSpecs, auth);
+        Invalidate();
+    }
+
+    public void CreateBranchForPullRequestBranch(AuthenticationInfo auth) =>
+        PullRequestBranchOperations.CreateBranchForPullRequestBranch(
+            this,
+            this.logger,
+            remoteName => CliMutator.ListRemoteReferences(CliWorkingDirectory, remoteName, auth));
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedGitRepositoryInfo.cs
@@ -1,0 +1,98 @@
+using System.IO.Abstractions;
+using GitVersion.Extensions;
+using SysPath = System.IO.Path;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedGitRepositoryInfo : IGitRepositoryInfo
+{
+    private readonly IFileSystem fileSystem;
+    private readonly GitVersionOptions gitVersionOptions;
+
+    private readonly Lazy<string?> dynamicGitRepositoryPath;
+    private readonly Lazy<string?> dotGitDirectory;
+    private readonly Lazy<string?> gitRootPath;
+    private readonly Lazy<string?> projectRootDirectory;
+
+    public ManagedGitRepositoryInfo(IFileSystem fileSystem, IOptions<GitVersionOptions> options)
+    {
+        this.fileSystem = fileSystem.NotNull();
+        this.gitVersionOptions = options.NotNull().Value;
+
+        this.dynamicGitRepositoryPath = new(GetDynamicGitRepositoryPath);
+        this.dotGitDirectory = new(GetDotGitDirectory);
+        this.gitRootPath = new(GetGitRootPath);
+        this.projectRootDirectory = new(GetProjectRootDirectory);
+    }
+
+    public string? DynamicGitRepositoryPath => this.dynamicGitRepositoryPath.Value;
+    public string? DotGitDirectory => this.dotGitDirectory.Value;
+    public string? GitRootPath => this.gitRootPath.Value;
+    public string? ProjectRootDirectory => this.projectRootDirectory.Value;
+
+    private string? GetDynamicGitRepositoryPath()
+    {
+        var repositoryInfo = this.gitVersionOptions.RepositoryInfo;
+        return DynamicRepositoryPath.Get(this.fileSystem, repositoryInfo.TargetUrl, repositoryInfo.ClonePath, GitRepoHasMatchingRemote);
+    }
+
+    private string? GetDotGitDirectory() =>
+        RepositoryPathResolution.ResolveDotGitDirectory(
+            this.fileSystem,
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            static workingDirectory => Discover(workingDirectory)?.GitDirectory);
+
+    private string? GetProjectRootDirectory() =>
+        RepositoryPathResolution.ResolveProjectRootDirectory(
+            DynamicGitRepositoryPath,
+            this.gitVersionOptions.WorkingDirectory,
+            static workingDirectory => Discover(workingDirectory)?.GitDirectory,
+            static workingDirectory =>
+            {
+                var repositoryWorkingDirectory = Discover(workingDirectory)?.WorkingDirectory;
+                if (repositoryWorkingDirectory is null)
+                {
+                    return null;
+                }
+
+                // Match libgit2's Info.WorkingDirectory, which carries a trailing directory separator.
+                return repositoryWorkingDirectory.EndsWith(SysPath.DirectorySeparatorChar) || repositoryWorkingDirectory.EndsWith('/')
+                    ? repositoryWorkingDirectory
+                    : repositoryWorkingDirectory + SysPath.DirectorySeparatorChar;
+            });
+
+    private string? GetGitRootPath() =>
+        RepositoryPathResolution.ResolveGitRootPath(DynamicGitRepositoryPath, DotGitDirectory, ProjectRootDirectory);
+
+    /// <summary>
+    /// Discovers the repository containing <paramref name="startPath"/>, returning
+    /// <see langword="null"/> when the path does not exist — matching libgit2's
+    /// <c>Repository.Discover</c>, which never walks up from a nonexistent directory.
+    /// </summary>
+    private static GitRepositoryLayout? Discover(string startPath) =>
+        Directory.Exists(startPath) ? GitRepositoryLayout.TryDiscover(startPath) : null;
+
+    private static bool GitRepoHasMatchingRemote(string possiblePath, string targetUrl)
+    {
+        try
+        {
+            // Only possiblePath itself may be the repository, matching the libgit2 backend's
+            // `new Repository(possiblePath)`; discovery walking up the hierarchy would match
+            // an enclosing repository and hand a nonexistent .git path to the caller.
+            var layout = GitRepositoryLayout.TryOpen(possiblePath);
+            if (layout is null)
+            {
+                return false;
+            }
+
+            var configuration = GitConfigurationFile.Load(SysPath.Combine(layout.CommonDirectory, "config"));
+            return configuration.GetSubsections("remote")
+                .Any(remoteName => configuration.GetString("remote", remoteName, "url") == targetUrl);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedObjectId.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedObjectId.cs
@@ -1,0 +1,26 @@
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedObjectId : IObjectId
+{
+    private static readonly LambdaEqualityHelper<IObjectId> equalityHelper = new(x => x.Sha);
+    private static readonly LambdaKeyComparer<IObjectId, string> comparerHelper = new(x => x.Sha);
+
+    internal ManagedObjectId(GitObjectId objectId)
+    {
+        ObjectId = objectId;
+        Sha = objectId.ToString();
+    }
+
+    internal GitObjectId ObjectId { get; }
+
+    public string Sha { get; }
+
+    public int CompareTo(IObjectId? other) => comparerHelper.Compare(this, other);
+    public bool Equals(IObjectId? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as IObjectId);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => ToString(7);
+    public string ToString(int prefixLength) => ObjectId.ToString(prefixLength);
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRefSpec.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRefSpec.cs
@@ -1,0 +1,43 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedRefSpec : IRefSpec
+{
+    private static readonly LambdaEqualityHelper<IRefSpec> equalityHelper = new(x => x.Specification);
+    private static readonly LambdaKeyComparer<IRefSpec, string> comparerHelper = new(x => x.Specification);
+
+    internal ManagedRefSpec(string specification, RefSpecDirection direction)
+    {
+        Specification = specification.NotNull();
+        Direction = direction;
+
+        // The leading '+' (force) marker is part of the specification but not of the
+        // source/destination patterns, matching libgit2's refspec parsing.
+        var body = specification.StartsWith('+') ? specification[1..] : specification;
+        var separator = body.IndexOf(':');
+
+        if (separator < 0)
+        {
+            Source = body;
+            Destination = string.Empty;
+        }
+        else
+        {
+            Source = body[..separator];
+            Destination = body[(separator + 1)..];
+        }
+    }
+
+    public string Specification { get; }
+    public RefSpecDirection Direction { get; }
+    public string Source { get; }
+    public string Destination { get; }
+
+    public int CompareTo(IRefSpec? other) => comparerHelper.Compare(this, other);
+    public bool Equals(IRefSpec? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as IRefSpec);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Specification;
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRefSpecCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRefSpecCollection.cs
@@ -1,0 +1,9 @@
+namespace GitVersion.Git;
+
+internal sealed class ManagedRefSpecCollection(IReadOnlyList<IRefSpec> refSpecs) : IRefSpecCollection
+{
+    private readonly IReadOnlyList<IRefSpec> refSpecs = refSpecs ?? throw new ArgumentNullException(nameof(refSpecs));
+
+    public IEnumerator<IRefSpec> GetEnumerator() => this.refSpecs.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedReference.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedReference.cs
@@ -1,0 +1,37 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedReference : IReference
+{
+    private static readonly LambdaEqualityHelper<IReference> equalityHelper = new(x => x.Name.Canonical);
+    private static readonly LambdaKeyComparer<IReference, string> comparerHelper = new(x => x.Name.Canonical);
+
+    private readonly GitReference innerReference;
+
+    internal ManagedReference(GitReference reference)
+    {
+        this.innerReference = reference.NotNull();
+        Name = new ReferenceName(reference.CanonicalName);
+
+        if (!reference.IsSymbolic && reference.ObjectId is { } objectId)
+        {
+            ReferenceTargetId = new ManagedObjectId(objectId);
+        }
+    }
+
+    public ReferenceName Name { get; }
+    public IObjectId? ReferenceTargetId { get; }
+
+    public string TargetIdentifier =>
+        this.innerReference.IsSymbolic
+            ? this.innerReference.SymbolicTargetName!
+            : this.innerReference.ObjectId!.Value.ToString();
+
+    public int CompareTo(IReference? other) => comparerHelper.Compare(this, other);
+    public bool Equals(IReference? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as IReference);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name.ToString();
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedReferenceCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedReferenceCollection.cs
@@ -1,0 +1,76 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedReferenceCollection(ManagedGitRepository repository) : IReferenceCollection
+{
+    private readonly ManagedGitRepository repository = repository.NotNull();
+
+    public IEnumerator<IReference> GetEnumerator() => this.repository.Session.References.Cast<IReference>().GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IReference? Head => this["HEAD"];
+
+    public IReference? this[string name]
+    {
+        get
+        {
+            name = name.NotNull();
+            return this.repository.Session.GetReference(name);
+        }
+    }
+
+    public IReference? this[ReferenceName referenceName] => this[referenceName.Canonical];
+
+    public IEnumerable<IReference> FromGlob(string prefix)
+    {
+        prefix = prefix.NotNull();
+
+        // GitVersion only uses trailing-wildcard globs ('*' and 'refs/remotes/<remote>/*'),
+        // which map onto a canonical-name prefix enumeration.
+        var referencePrefix = prefix.EndsWith('*') ? prefix[..^1] : prefix;
+
+        if (referencePrefix.Length == 0)
+        {
+            referencePrefix = "refs/";
+        }
+
+        return this.repository.Session.EnumerateReferences(referencePrefix);
+    }
+
+    public void Add(string name, string canonicalRefNameOrObject, bool allowOverwrite = false)
+    {
+        name = name.NotNull();
+        canonicalRefNameOrObject = canonicalRefNameOrObject.NotNull();
+
+        if (!allowOverwrite && this[name] is not null)
+        {
+            throw new InvalidOperationException($"A reference with the name '{name}' already exists.");
+        }
+
+        var workingDirectory = this.repository.CliWorkingDirectory;
+
+        if (IsObjectId(canonicalRefNameOrObject))
+        {
+            this.repository.CliMutator.UpdateReference(workingDirectory, name, canonicalRefNameOrObject);
+        }
+        else
+        {
+            this.repository.CliMutator.CreateSymbolicReference(workingDirectory, name, canonicalRefNameOrObject);
+        }
+
+        this.repository.Invalidate();
+    }
+
+    public void UpdateTarget(IReference directRef, IObjectId targetId)
+    {
+        directRef.NotNull();
+        targetId.NotNull();
+
+        this.repository.CliMutator.UpdateReference(this.repository.CliWorkingDirectory, directRef.Name.Canonical, targetId.Sha);
+        this.repository.Invalidate();
+    }
+
+    private static bool IsObjectId(string value) =>
+        value.Length is 40 or 64 && value.All(Uri.IsHexDigit);
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRemote.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRemote.cs
@@ -1,0 +1,35 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedRemote : IRemote
+{
+    private static readonly LambdaEqualityHelper<IRemote> equalityHelper = new(x => x.Name);
+    private static readonly LambdaKeyComparer<IRemote, string> comparerHelper = new(x => x.Name);
+
+    private readonly ManagedRefSpecCollection refSpecs;
+
+    internal ManagedRemote(string name, string url, IReadOnlyList<string> fetchRefSpecs, IReadOnlyList<string> pushRefSpecs)
+    {
+        Name = name.NotNull();
+        Url = url.NotNull();
+        this.refSpecs = new(
+        [
+            .. fetchRefSpecs.Select(IRefSpec (spec) => new ManagedRefSpec(spec, RefSpecDirection.Fetch)),
+            .. pushRefSpecs.Select(IRefSpec (spec) => new ManagedRefSpec(spec, RefSpecDirection.Push))
+        ]);
+    }
+
+    public string Name { get; }
+    public string Url { get; }
+
+    public IEnumerable<IRefSpec> FetchRefSpecs => this.refSpecs.Where(x => x.Direction == RefSpecDirection.Fetch);
+    public IEnumerable<IRefSpec> PushRefSpecs => this.refSpecs.Where(x => x.Direction == RefSpecDirection.Push);
+
+    public int CompareTo(IRemote? other) => comparerHelper.Compare(this, other);
+    public bool Equals(IRemote? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as IRemote);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name;
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRemoteCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRemoteCollection.cs
@@ -1,0 +1,35 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedRemoteCollection(ManagedGitRepository repository) : IRemoteCollection
+{
+    private readonly ManagedGitRepository repository = repository.NotNull();
+
+    public IEnumerator<IRemote> GetEnumerator() => this.repository.Session.Remotes.Cast<IRemote>().GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IRemote? this[string name]
+    {
+        get
+        {
+            name = name.NotNull();
+            return this.repository.Session.Remotes.FirstOrDefault(remote => remote.Name == name);
+        }
+    }
+
+    public void Remove(string remoteName)
+    {
+        remoteName = remoteName.NotNull();
+        this.repository.CliMutator.RemoveRemote(this.repository.CliWorkingDirectory, remoteName);
+        this.repository.Invalidate();
+    }
+
+    public void Update(string remoteName, string refSpec)
+    {
+        remoteName = remoteName.NotNull();
+        refSpec = refSpec.NotNull();
+        this.repository.CliMutator.AddConfig(this.repository.CliWorkingDirectory, $"remote.{remoteName}.fetch", refSpec);
+        this.repository.Invalidate();
+    }
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedRepositorySession.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedRepositorySession.cs
@@ -1,0 +1,259 @@
+using System.Collections.Concurrent;
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// An immutable snapshot of the repository state (objects, references, configuration) with
+/// per-snapshot wrapper caches. Mutating operations replace the current session on the owning
+/// <see cref="ManagedGitRepository"/> so that changes made through the git CLI become visible.
+/// </summary>
+internal sealed class ManagedRepositorySession : IDisposable
+{
+    private const string RemoteSectionName = "remote";
+
+    private readonly ManagedGitRepository repository;
+    private readonly ConcurrentDictionary<GitObjectId, ManagedCommit> commits = new();
+    private readonly ConcurrentDictionary<GitObjectId, IReadOnlyList<string>> diffPathsCache = new();
+    private readonly Lazy<GitConfigurationFile> configuration;
+    private readonly Lazy<IReadOnlyList<ManagedBranch>> branches;
+    private readonly Lazy<Dictionary<string, ManagedBranch>> branchesByCanonicalName;
+    private readonly Lazy<IReadOnlyList<ManagedTag>> tags;
+    private readonly Lazy<IReadOnlyList<ManagedReference>> references;
+    private readonly Lazy<IReadOnlyList<ManagedRemote>> remotes;
+
+    public ManagedRepositorySession(ManagedGitRepository repository, GitRepositoryLayout layout)
+    {
+        this.repository = repository.NotNull();
+        Layout = layout.NotNull();
+        ObjectStore = layout.CreateObjectStore();
+        ReferenceStore = layout.CreateReferenceStore();
+        // Shallow boundaries are part of the snapshot: the walker grafts the commits listed
+        // in .git/shallow as parentless, the way git and libgit2 treat them.
+        Walker = new(ObjectStore, layout.ReadShallowCommits().ToHashSet());
+        TreeDiff = new(ObjectStore);
+        StatusCalculator = new(layout, ObjectStore);
+        this.configuration = new(() => GitConfigurationFile.Load(Path.Combine(Layout.CommonDirectory, "config")));
+        this.branches = new(ReadBranches);
+        this.branchesByCanonicalName = new(() => this.branches.Value.ToDictionary(branch => branch.Name.Canonical, StringComparer.Ordinal));
+        this.tags = new(() => [.. EnumerateStoreReferencesInLibGit2Order("refs/tags/").Select(reference => new ManagedTag(reference, this.repository))]);
+        this.references = new(() => [.. EnumerateStoreReferencesInLibGit2Order("refs/").Select(reference => new ManagedReference(reference))]);
+        this.remotes = new(ReadRemotes);
+    }
+
+    public GitRepositoryLayout Layout { get; }
+    public GitObjectStore ObjectStore { get; }
+    public GitReferenceStore ReferenceStore { get; }
+    public GitRevisionWalker Walker { get; }
+    public GitTreeDiff TreeDiff { get; }
+    public GitStatusCalculator StatusCalculator { get; }
+    public GitConfigurationFile Configuration => this.configuration.Value;
+
+    public IReadOnlyList<ManagedBranch> Branches => this.branches.Value;
+    public IReadOnlyList<ManagedTag> Tags => this.tags.Value;
+    public IReadOnlyList<ManagedReference> References => this.references.Value;
+    public IReadOnlyList<ManagedRemote> Remotes => this.remotes.Value;
+
+    public GitObjectId? HeadTipId => ReferenceStore.Resolve("HEAD")?.ObjectId;
+
+    public ManagedBranch GetHead()
+    {
+        var head = ReferenceStore.GetHead()
+            ?? throw new InvalidOperationException("The repository has no HEAD reference.");
+
+        if (head.IsSymbolic)
+        {
+            var targetName = head.SymbolicTargetName!;
+            var tipId = ReferenceStore.Resolve(targetName)?.ObjectId;
+            var tip = tipId is { } id ? TryGetCommit(id) : null;
+            return this.branchesByCanonicalName.Value.GetValueOrDefault(targetName)
+                ?? new ManagedBranch(new(targetName), tip, this.repository);
+        }
+
+        // Detached HEAD: libgit2 exposes it as a branch named "(no branch)".
+        var commit = head.ObjectId is { } commitId ? TryGetCommit(commitId) : null;
+        return new(new("(no branch)"), commit, this.repository);
+    }
+
+    public ManagedBranch? FindBranch(string name)
+    {
+        var byCanonicalName = this.branchesByCanonicalName.Value;
+
+        if (name.StartsWith("refs/", StringComparison.Ordinal))
+        {
+            return byCanonicalName.GetValueOrDefault(name);
+        }
+
+        return byCanonicalName.GetValueOrDefault(ReferenceName.LocalBranchPrefix + name)
+            ?? byCanonicalName.GetValueOrDefault(ReferenceName.RemoteTrackingBranchPrefix + name);
+    }
+
+    public ManagedReference? GetReference(string canonicalName) =>
+        ReferenceStore.GetReference(canonicalName) is { } reference ? new ManagedReference(reference) : null;
+
+    public IEnumerable<IReference> EnumerateReferences(string prefix) =>
+        EnumerateStoreReferencesInLibGit2Order(prefix).Select(reference => new ManagedReference(reference));
+
+    /// <summary>
+    /// Enumerates references the way libgit2's refdb iterates them: loose references first
+    /// (in name order), then the packed references that are not shadowed by a loose one
+    /// (in name order). The store itself yields git's globally sorted for-each-ref order.
+    /// </summary>
+    private IEnumerable<GitReference> EnumerateStoreReferencesInLibGit2Order(string prefix)
+    {
+        var storeReferences = ReferenceStore.EnumerateReferences(prefix).ToList();
+        return storeReferences.Where(reference => !reference.IsPacked)
+            .Concat(storeReferences.Where(reference => reference.IsPacked));
+    }
+
+    public ManagedCommit GetCommit(GitObjectId objectId) =>
+        TryGetCommit(objectId)
+            ?? throw new InvalidOperationException($"The commit '{objectId}' does not exist in the repository.");
+
+    public ManagedCommit? TryGetCommit(GitObjectId objectId)
+    {
+        if (this.commits.TryGetValue(objectId, out var existing))
+        {
+            return existing;
+        }
+
+        // The walker's parsed-commit cache is the single parse per session; walks
+        // load most commits first, so wrapping reuses those parses.
+        return Walker.TryLoadCommit(objectId) is { } innerCommit
+            ? WrapCommit(innerCommit)
+            : null;
+    }
+
+    public ManagedCommit WrapCommit(GitCommit innerCommit) =>
+        this.commits.GetOrAdd(innerCommit.Sha, _ => new(innerCommit, this.repository));
+
+    public IReadOnlyList<string> GetDiffPaths(ManagedCommit commit) =>
+        this.diffPathsCache.GetOrAdd(commit.ObjectId, _ =>
+        {
+            GitObjectId? parentTreeId = commit.FirstParentId is { } parentId ? TryGetCommit(parentId)?.TreeId : null;
+            return TreeDiff.GetChangedPaths(parentTreeId, commit.TreeId);
+        });
+
+    /// <summary>
+    /// Returns what libgit2 exposes as a tag's target sha: for an annotated tag the sha of
+    /// the object the tag annotation points at (a single dereference), for a lightweight
+    /// tag the ref target itself.
+    /// </summary>
+    public string GetTagTargetSha(GitReference reference)
+    {
+        var targetId = reference.ObjectId
+            ?? throw new InvalidOperationException($"The tag '{reference.CanonicalName}' does not point at an object.");
+
+        if (!ObjectStore.TryGetObject(targetId, out var stream, out var objectType))
+        {
+            throw new InvalidOperationException($"The object '{targetId}' does not exist in the repository.");
+        }
+
+        using (stream)
+        {
+            return objectType == GitObjectTypes.Tag
+                ? GitTagReader.Read(stream, targetId).Target.ToString()
+                : targetId.ToString();
+        }
+    }
+
+    public ICommit PeelToCommit(GitReference reference)
+    {
+        if (reference.PeeledObjectId is { } peeledId)
+        {
+            return GetCommit(peeledId);
+        }
+
+        var targetId = reference.ObjectId
+            ?? throw new InvalidOperationException($"The reference '{reference.CanonicalName}' does not point at an object.");
+
+        while (true)
+        {
+            if (!ObjectStore.TryGetObject(targetId, out var stream, out var objectType))
+            {
+                throw new InvalidOperationException($"The object '{targetId}' does not exist in the repository.");
+            }
+
+            switch (objectType)
+            {
+                case GitObjectTypes.Commit:
+                    stream.Dispose();
+                    return GetCommit(targetId);
+                case GitObjectTypes.Tag:
+                    using (stream)
+                    {
+                        targetId = GitTagReader.Read(stream, targetId).Target;
+                    }
+
+                    break;
+                default:
+                    stream.Dispose();
+                    throw new InvalidOperationException($"The reference '{reference.CanonicalName}' does not ultimately point at a commit.");
+            }
+        }
+    }
+
+    public bool IsTracking(ManagedBranch branch)
+    {
+        if (branch.IsRemote || branch.IsDetachedHead)
+        {
+            return false;
+        }
+
+        var friendlyName = branch.Name.Friendly;
+        var remoteName = Configuration.GetString("branch", friendlyName, "remote");
+        var mergeReference = Configuration.GetString("branch", friendlyName, "merge");
+
+        if (remoteName is null || mergeReference is null)
+        {
+            return false;
+        }
+
+        if (remoteName == ".")
+        {
+            return ReferenceStore.GetReference(mergeReference) is not null;
+        }
+
+        if (!mergeReference.StartsWith(ReferenceName.LocalBranchPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var upstream = $"{ReferenceName.RemoteTrackingBranchPrefix}{remoteName}/{mergeReference[ReferenceName.LocalBranchPrefix.Length..]}";
+        return ReferenceStore.GetReference(upstream) is not null;
+    }
+
+    public void Dispose() => ObjectStore.Dispose();
+
+    private IReadOnlyList<ManagedBranch> ReadBranches()
+    {
+        // libgit2's branch iterator walks the whole refdb once (loose first, then packed)
+        // and filters to branch namespaces, so local and remote-tracking branches interleave
+        // in that reference order.
+        var result = new List<ManagedBranch>();
+
+        foreach (var reference in EnumerateStoreReferencesInLibGit2Order("refs/"))
+        {
+            if (!reference.CanonicalName.StartsWith(ReferenceName.LocalBranchPrefix, StringComparison.Ordinal)
+                && !reference.CanonicalName.StartsWith(ReferenceName.RemoteTrackingBranchPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var objectId = reference.ObjectId
+                ?? (reference.IsSymbolic ? ReferenceStore.Resolve(reference.CanonicalName)?.ObjectId : null);
+            var tip = objectId is { } id ? TryGetCommit(id) : null;
+            result.Add(new(new(reference.CanonicalName), tip, this.repository));
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<ManagedRemote> ReadRemotes() =>
+        [.. Configuration.GetSubsections(RemoteSectionName)
+            .Select(name => new ManagedRemote(
+                name,
+                Configuration.GetString(RemoteSectionName, name, "url") ?? string.Empty,
+                Configuration.GetAll(RemoteSectionName, name, "fetch"),
+                Configuration.GetAll(RemoteSectionName, name, "push")))];
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedTag.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedTag.cs
@@ -1,0 +1,37 @@
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedTag : ITag
+{
+    private static readonly LambdaEqualityHelper<ITag> equalityHelper = new(x => x.Name.Canonical);
+    private static readonly LambdaKeyComparer<ITag, string> comparerHelper = new(x => x.Name.Canonical);
+
+    private readonly Lazy<ICommit> commitLazy;
+    private readonly Lazy<string> targetShaLazy;
+
+    internal ManagedTag(GitReference reference, ManagedGitRepository repository)
+    {
+        this.commitLazy = new(() => repository.NotNull().Session.PeelToCommit(reference.NotNull()));
+        this.targetShaLazy = new(() => repository.NotNull().Session.GetTagTargetSha(reference.NotNull()));
+        Name = new(reference.CanonicalName);
+    }
+
+    public ReferenceName Name { get; }
+
+    /// <summary>
+    /// Matches libgit2: for an annotated tag this is the sha of the object the tag
+    /// annotation points at (one dereference, usually the commit); for a lightweight
+    /// tag it is the ref target itself.
+    /// </summary>
+    public string TargetSha => this.targetShaLazy.Value;
+
+    public ICommit Commit => this.commitLazy.Value;
+
+    public int CompareTo(ITag? other) => comparerHelper.Compare(this, other);
+    public bool Equals(ITag? other) => equalityHelper.Equals(this, other);
+    public override bool Equals(object? obj) => Equals(obj as ITag);
+    public override int GetHashCode() => equalityHelper.GetHashCode(this);
+    public override string ToString() => Name.ToString();
+}

--- a/src/GitVersion.Git.Managed/Adapter/ManagedTagCollection.cs
+++ b/src/GitVersion.Git.Managed/Adapter/ManagedTagCollection.cs
@@ -1,0 +1,11 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+internal sealed class ManagedTagCollection(ManagedGitRepository repository) : ITagCollection
+{
+    private readonly ManagedGitRepository repository = repository.NotNull();
+
+    public IEnumerator<ITag> GetEnumerator() => this.repository.Session.Tags.Cast<ITag>().GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/GitVersion.Git.Managed/Adapter/RepositoryPathResolution.cs
+++ b/src/GitVersion.Git.Managed/Adapter/RepositoryPathResolution.cs
@@ -1,0 +1,87 @@
+using System.IO.Abstractions;
+using GitVersion.Extensions;
+using GitVersion.Helpers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// The part of resolving the repository paths GitVersion works with
+/// (<see cref="IGitRepositoryInfo"/>) that is independent of Git plumbing: the dot-git
+/// directory with its worktree handling, the project root, and the git root. The managed
+/// backend supplies its own repository discovery and working-directory resolution.
+/// </summary>
+internal static class RepositoryPathResolution
+{
+    private const string DotGitDirectoryNotFoundMessage = "Cannot find the .git directory";
+
+    /// <summary>
+    /// Resolves the dot-git directory: the dynamic repository path when one is configured,
+    /// otherwise the discovered git directory — mapped to the main repository's directory
+    /// when it is a linked worktree's.
+    /// </summary>
+    /// <param name="fileSystem">The file system.</param>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="workingDirectory">The working directory to discover from.</param>
+    /// <param name="discoverGitDirectory">Discovers the git directory containing a path, or <see langword="null"/>.</param>
+    public static string? ResolveDotGitDirectory(
+        IFileSystem fileSystem,
+        string? dynamicGitRepositoryPath,
+        string workingDirectory,
+        Func<string, string?> discoverGitDirectory)
+    {
+        var gitDirectory = (!dynamicGitRepositoryPath.IsNullOrWhiteSpace()
+                ? dynamicGitRepositoryPath
+                : discoverGitDirectory(workingDirectory))
+            ?.TrimEnd('/', '\\');
+
+        if (string.IsNullOrEmpty(gitDirectory))
+        {
+            throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+        }
+
+        var directoryInfo = fileSystem.Directory.GetParent(gitDirectory) ?? throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+        return gitDirectory.Contains(FileSystemHelper.Path.Combine(".git", "worktrees"))
+            ? fileSystem.Directory.GetParent(directoryInfo.FullName)?.FullName
+            : gitDirectory;
+    }
+
+    /// <summary>
+    /// Resolves the project root: the working directory itself for dynamic repositories,
+    /// otherwise the discovered repository's working directory (with a trailing separator,
+    /// as libgit2 reports it) — <see langword="null"/> for bare repositories, which have none.
+    /// Throws only when repository discovery itself fails.
+    /// </summary>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="workingDirectory">The working directory to discover from.</param>
+    /// <param name="discoverGitDirectory">Discovers the git directory containing a path, or <see langword="null"/>.</param>
+    /// <param name="resolveRepositoryWorkingDirectory">Resolves the working directory of the repository containing a path, or <see langword="null"/> when the repository is bare.</param>
+    public static string? ResolveProjectRootDirectory(
+        string? dynamicGitRepositoryPath,
+        string workingDirectory,
+        Func<string, string?> discoverGitDirectory,
+        Func<string, string?> resolveRepositoryWorkingDirectory)
+    {
+        if (!dynamicGitRepositoryPath.IsNullOrWhiteSpace())
+        {
+            return workingDirectory;
+        }
+
+        if (discoverGitDirectory(workingDirectory).IsNullOrEmpty())
+        {
+            throw new DirectoryNotFoundException(DotGitDirectoryNotFoundMessage);
+        }
+
+        // Discovery succeeded; a null working directory means the repository is bare.
+        return resolveRepositoryWorkingDirectory(workingDirectory);
+    }
+
+    /// <summary>
+    /// Resolves the git root: the dot-git directory for dynamic repositories, otherwise
+    /// the project root.
+    /// </summary>
+    /// <param name="dynamicGitRepositoryPath">The dynamic repository path, when configured.</param>
+    /// <param name="dotGitDirectory">The resolved dot-git directory.</param>
+    /// <param name="projectRootDirectory">The resolved project root.</param>
+    public static string? ResolveGitRootPath(string? dynamicGitRepositoryPath, string? dotGitDirectory, string? projectRootDirectory) =>
+        !dynamicGitRepositoryPath.IsNullOrWhiteSpace() ? dotGitDirectory : projectRootDirectory;
+}

--- a/src/GitVersion.Git.Managed/CommandLine/GitCliExecutor.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/GitCliExecutor.cs
@@ -1,0 +1,118 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+/// <summary>Executes the <c>git</c> command-line executable and captures its output.</summary>
+internal interface IGitCliExecutor
+{
+    /// <summary>Runs <c>git</c> with the given arguments and returns the completed result without throwing on failure.</summary>
+    GitCliResult Execute(string? workingDirectory, IReadOnlyList<string> arguments);
+}
+
+/// <summary>The outcome of a single <c>git</c> invocation.</summary>
+internal sealed record GitCliResult(int ExitCode, string StandardOutput, string StandardError)
+{
+    public bool IsSuccess => ExitCode == 0;
+}
+
+internal sealed class GitCliExecutor(ILogger<GitCliExecutor> logger) : IGitCliExecutor
+{
+    private readonly ILogger<GitCliExecutor> logger = logger.NotNull();
+
+    public GitCliResult Execute(string? workingDirectory, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        if (workingDirectory != null)
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        // Deterministic, non-interactive invocations: never prompt for credentials
+        // and keep any parsed output locale-independent.
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+        startInfo.Environment["LC_ALL"] = "C";
+
+        // The repository is targeted via the working directory alone, like libgit2
+        // targets it via the discovered path. Inherited repo-targeting variables
+        // (git exports GIT_DIR when running hooks) would redirect the invocation
+        // to a different repository than the one the managed reader discovered.
+        string[] repoTargetingVariables =
+        [
+            "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+            "GIT_NAMESPACE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+        ];
+        foreach (var variable in repoTargetingVariables)
+        {
+            startInfo.Environment.Remove(variable);
+        }
+
+        this.logger.LogDebug("Executing 'git {Arguments}' in '{WorkingDirectory}'", FormatArgumentsForLog(arguments), workingDirectory);
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+
+        var standardOutput = new StringBuilder();
+        var standardError = new StringBuilder();
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                standardOutput.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                standardError.AppendLine(e.Data);
+            }
+        };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or PlatformNotSupportedException)
+        {
+            throw new InvalidOperationException(
+                "The 'git' executable could not be started. Ensure Git is installed and available on the PATH.", ex);
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        var result = new GitCliResult(process.ExitCode, standardOutput.ToString(), standardError.ToString());
+        if (!result.IsSuccess)
+        {
+            this.logger.LogDebug("'git {Arguments}' exited with code {ExitCode}: {StandardError}", FormatArgumentsForLog(arguments), result.ExitCode, result.StandardError);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Joins the arguments for logging, redacting credential-bearing values such as the
+    /// per-invocation <c>http.*.extraHeader=Authorization: …</c> configuration.
+    /// </summary>
+    private static string FormatArgumentsForLog(IReadOnlyList<string> arguments) =>
+        string.Join(' ', arguments.Select(static argument =>
+        {
+            const string marker = ".extraHeader=Authorization:";
+            var index = argument.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            return index < 0 ? argument : argument[..(index + marker.Length)] + " ********";
+        }));
+}

--- a/src/GitVersion.Git.Managed/CommandLine/GitCliMutator.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/GitCliMutator.cs
@@ -1,0 +1,182 @@
+using System.Text.RegularExpressions;
+using GitVersion.Extensions;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Performs the mutating and network Git operations GitVersion needs (repository normalization)
+/// by invoking the <c>git</c> command-line executable instead of libgit2.
+/// </summary>
+internal interface IGitCliMutator
+{
+    void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth);
+    void Fetch(string workingDirectory, string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth);
+    void Checkout(string workingDirectory, string commitOrBranchSpec);
+    IReadOnlyList<GitRemoteReference> ListRemoteReferences(string workingDirectory, string remoteName, AuthenticationInfo auth);
+    void SetConfig(string workingDirectory, string key, string value);
+    void AddConfig(string workingDirectory, string key, string value);
+    void RemoveRemote(string workingDirectory, string remoteName);
+    void UpdateReference(string workingDirectory, string name, string targetSha);
+    void CreateSymbolicReference(string workingDirectory, string name, string targetReferenceName);
+}
+
+internal sealed partial class GitCliMutator(ILogger<GitCliMutator> logger, IGitCliExecutor executor) : IGitCliMutator
+{
+    private readonly ILogger<GitCliMutator> logger = logger.NotNull();
+    private readonly IGitCliExecutor executor = executor.NotNull();
+
+    public void Clone(string? sourceUrl, string? workdirPath, AuthenticationInfo auth)
+    {
+        ArgumentNullException.ThrowIfNull(sourceUrl);
+        ArgumentNullException.ThrowIfNull(workdirPath);
+
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl, auth);
+        arguments.AddRange(["clone", "--no-checkout", sourceUrl, workdirPath]);
+
+        var result = this.executor.Execute(null, arguments);
+        ThrowOnFailure(result, isNetworkOperation: true);
+        this.logger.LogInformation("Cloned repository '{SourceUrl}' into '{WorkdirPath}'", sourceUrl, workdirPath);
+    }
+
+    public void Fetch(string workingDirectory, string remote, IEnumerable<string> refSpecs, AuthenticationInfo auth)
+    {
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl: null, auth);
+        arguments.AddRange(["fetch", remote]);
+        arguments.AddRange(refSpecs);
+
+        var result = this.executor.Execute(workingDirectory, arguments);
+        ThrowOnFailure(result, isNetworkOperation: true);
+    }
+
+    public void Checkout(string workingDirectory, string commitOrBranchSpec)
+    {
+        // libgit2's Commands.Checkout attaches HEAD when given a canonical local branch name,
+        // while `git checkout refs/heads/x` would detach — use the branch shortname instead.
+        // `--no-guess` suppresses git's remote-branch DWIM, which libgit2 does not have.
+        const string localBranchPrefix = "refs/heads/";
+        var spec = commitOrBranchSpec.StartsWith(localBranchPrefix, StringComparison.Ordinal)
+            ? commitOrBranchSpec[localBranchPrefix.Length..]
+            : commitOrBranchSpec;
+
+        var result = this.executor.Execute(workingDirectory, ["checkout", "--no-guess", spec]);
+        ThrowOnFailure(result);
+    }
+
+    public IReadOnlyList<GitRemoteReference> ListRemoteReferences(string workingDirectory, string remoteName, AuthenticationInfo auth)
+    {
+        var arguments = new List<string>();
+        AddAuthentication(arguments, sourceUrl: null, auth);
+        arguments.AddRange(["ls-remote", "--quiet", remoteName]);
+
+        var result = this.executor.Execute(workingDirectory, arguments);
+        ThrowOnFailure(result, isNetworkOperation: true);
+
+        var references = new List<GitRemoteReference>();
+        foreach (var line in result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = line.IndexOf('\t');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var sha = line[..separator];
+            var name = line[(separator + 1)..];
+
+            // Skip the symbolic HEAD advertisement: it is not part of libgit2's ListReferences
+            // result that this replaces, and it would show up as a duplicate of the branch it
+            // points at. Peeled entries ("<ref>^{}") are kept: they carry an annotated tag's
+            // commit sha, which PullRequestBranchOperations folds into the base tag ref.
+            if (!name.StartsWith("refs/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            references.Add(new(name, sha));
+        }
+
+        return references;
+    }
+
+    public void SetConfig(string workingDirectory, string key, string value) =>
+        ThrowOnFailure(this.executor.Execute(workingDirectory, ["config", key, value]));
+
+    public void AddConfig(string workingDirectory, string key, string value) =>
+        ThrowOnFailure(this.executor.Execute(workingDirectory, ["config", "--add", key, value]));
+
+    public void RemoveRemote(string workingDirectory, string remoteName) =>
+        ThrowOnFailure(this.executor.Execute(workingDirectory, ["remote", "remove", remoteName]));
+
+    public void UpdateReference(string workingDirectory, string name, string targetSha) =>
+        ThrowOnFailure(this.executor.Execute(workingDirectory, ["update-ref", name, targetSha]));
+
+    public void CreateSymbolicReference(string workingDirectory, string name, string targetReferenceName) =>
+        ThrowOnFailure(this.executor.Execute(workingDirectory, ["symbolic-ref", name, targetReferenceName]));
+
+    private static void AddAuthentication(List<string> arguments, string? sourceUrl, AuthenticationInfo auth)
+    {
+        if (auth.Username.IsNullOrWhiteSpace())
+        {
+            return;
+        }
+
+        // Same credential semantics as the libgit2 UsernamePasswordCredentials provider: basic auth
+        // over HTTPS. Passed per invocation via configuration so it is never persisted and never
+        // appears in the remote URL. ArgumentList passes it without shell interpolation, and the
+        // value is not echoed by git in error output.
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{auth.Username}:{auth.Password ?? string.Empty}"));
+        var scope = sourceUrl == null ? "http" : $"http.{sourceUrl}";
+        arguments.AddRange(["-c", $"{scope}.extraHeader=Authorization: Basic {credentials}"]);
+    }
+
+    private static void ThrowOnFailure(GitCliResult result, bool isNetworkOperation = false)
+    {
+        if (result.IsSuccess)
+        {
+            return;
+        }
+
+        var message = result.StandardError;
+        if (IsLockContention(message))
+        {
+            throw new LockedFileException(message);
+        }
+
+        // HTTP status classification only applies to commands that talk to a remote;
+        // a local ref or pathspec can legitimately contain "401"/"404" in its name.
+        if (isNetworkOperation)
+        {
+            if (message.Contains("401") || message.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Unauthorized: Incorrect username/password");
+            }
+
+            if (message.Contains("403"))
+            {
+                throw new InvalidOperationException("Forbidden: Possibly Incorrect username/password");
+            }
+
+            // "Repository not found" is GitHub's server-side banner; other hosts produce
+            // git's own "fatal: repository '<url>' not found" with the URL in between.
+            if (message.Contains("404")
+                || message.Contains("Repository not found", StringComparison.OrdinalIgnoreCase)
+                || RepositoryNotFoundRegex().IsMatch(message))
+            {
+                throw new InvalidOperationException("Not found: The repository was not found");
+            }
+        }
+
+        throw new InvalidOperationException($"Git command failed with exit code {result.ExitCode}: {message}");
+    }
+
+    private static bool IsLockContention(string message) =>
+        (message.Contains(".lock", StringComparison.Ordinal) && message.Contains("Unable to create", StringComparison.OrdinalIgnoreCase))
+        || message.Contains("could not lock", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("cannot lock ref", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("Another git process seems to be running", StringComparison.OrdinalIgnoreCase);
+
+    [GeneratedRegex(@"repository '[^']*' not found", RegexOptions.IgnoreCase)]
+    private static partial Regex RepositoryNotFoundRegex();
+}

--- a/src/GitVersion.Git.Managed/CommandLine/GitRemoteReference.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/GitRemoteReference.cs
@@ -1,0 +1,4 @@
+namespace GitVersion.Git;
+
+/// <summary>A remote reference as advertised by the remote (e.g. by <c>git ls-remote</c>).</summary>
+internal sealed record GitRemoteReference(string CanonicalName, string TargetSha);

--- a/src/GitVersion.Git.Managed/CommandLine/PullRequestBranchOperations.cs
+++ b/src/GitVersion.Git.Managed/CommandLine/PullRequestBranchOperations.cs
@@ -1,0 +1,107 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The Git-plumbing-independent part of turning a pull-request ref into a real local
+/// branch: finding the remote tip that points at HEAD and checking out a fake local
+/// branch for it. The managed backend drives this with its own way of listing remote
+/// references.
+/// </summary>
+internal static class PullRequestBranchOperations
+{
+    /// <summary>
+    /// Creates a local branch that tracks the pull-request ref pointing at the current HEAD tip.
+    /// </summary>
+    /// <param name="repository">The repository to operate on.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="listRemoteReferences">Lists the references advertised by the remote with the given name.</param>
+    public static void CreateBranchForPullRequestBranch(
+        IMutatingGitRepository repository,
+        ILogger logger,
+        Func<string, IReadOnlyList<GitRemoteReference>> listRemoteReferences)
+    {
+        logger.LogInformation("Fetching remote refs to see if there is a pull request ref");
+
+        // An unborn HEAD (empty repository or a failed checkout) has no tip to match remote
+        // refs against, so there is nothing to normalize — same behavior as the libgit2 backend.
+        if (repository.Head.Tip == null)
+        {
+            return;
+        }
+
+        var headTipSha = repository.Head.Tip.Sha;
+        var remote = repository.Remotes.Single();
+        var (canonicalName, targetSha) = GetPullRequestReference(logger, remote, listRemoteReferences(remote.Name), headTipSha);
+        var referenceName = ReferenceName.Parse(canonicalName);
+        logger.LogInformation("Found remote tip '{CanonicalName}' pointing at the commit '{HeadTipSha}'.", canonicalName, headTipSha);
+
+        if (referenceName.IsTag)
+        {
+            logger.LogInformation("Checking out tag '{CanonicalName}'", canonicalName);
+            repository.Checkout(targetSha);
+        }
+        else if (referenceName.IsPullRequest)
+        {
+            var fakeBranchName = canonicalName.Replace("refs/pull/", "refs/heads/pull/").Replace("refs/pull-requests/", "refs/heads/pull-requests/");
+
+            logger.LogInformation("Creating fake local branch '{FakeBranchName}'.", fakeBranchName);
+            repository.References.Add(fakeBranchName, headTipSha);
+
+            logger.LogInformation("Checking local branch '{FakeBranchName}' out.", fakeBranchName);
+            repository.Checkout(fakeBranchName);
+        }
+        else
+        {
+            var message = $"Remote tip '{canonicalName}' from remote '{remote.Url}' doesn't look like a valid pull request.";
+            throw new WarningException(message);
+        }
+    }
+
+    private static (string CanonicalName, string TargetSha) GetPullRequestReference(
+        ILogger logger,
+        IRemote remote,
+        IReadOnlyList<GitRemoteReference> remoteTips,
+        string headTipSha)
+    {
+        var remoteRefsList = string.Join(SysEnv.NewLine, remoteTips.Select(r => r.CanonicalName));
+        logger.LogInformation("""
+                              Remote Refs:
+                              {RemoteRefsList}
+                              """, remoteRefsList);
+        // The advertised HEAD symref (which libgit2 resolves into a duplicate of the
+        // default branch's direct reference) is not a candidate tip: it would make the
+        // same commit appear twice and trip the single-match check below. Peeled "^{}"
+        // entries are folded into their base ref instead of contributing their own
+        // candidate: an annotated tag's ref carries the tag-object sha, so only the
+        // peeled entry's commit sha can ever match a detached HEAD tip. Grouping here
+        // keeps both backends' candidate sets identical regardless of how their
+        // listing behaves.
+        const string peeledSuffix = "^{}";
+        var refs = remoteTips
+            .Where(r => r.CanonicalName.StartsWith("refs/", StringComparison.Ordinal))
+            .GroupBy(r => r.CanonicalName.EndsWith(peeledSuffix, StringComparison.Ordinal)
+                ? r.CanonicalName[..^peeledSuffix.Length]
+                : r.CanonicalName)
+            .Select(g => new GitRemoteReference(
+                g.Key,
+                (g.FirstOrDefault(r => r.CanonicalName.EndsWith(peeledSuffix, StringComparison.Ordinal)) ?? g.First()).TargetSha))
+            .Where(r => r.TargetSha == headTipSha)
+            .ToList();
+
+        switch (refs.Count)
+        {
+            case 0:
+                {
+                    var message = $"Couldn't find any remote tips from remote '{remote.Url}' pointing at the commit '{headTipSha}'.";
+                    throw new WarningException(message);
+                }
+            case > 1:
+                {
+                    var names = string.Join(", ", refs.Select(r => r.CanonicalName));
+                    var message = $"Found more than one remote tip from remote '{remote.Url}' pointing at the commit '{headTipSha}'. Unable to determine which one to use ({names}).";
+                    throw new WarningException(message);
+                }
+        }
+
+        return (refs[0].CanonicalName, refs[0].TargetSha);
+    }
+}

--- a/src/GitVersion.Git.Managed/DeltaInstruction.cs
+++ b/src/GitVersion.Git.Managed/DeltaInstruction.cs
@@ -1,0 +1,43 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Enumerates the instruction types which can be found in a deltified stream.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal enum DeltaInstructionType
+{
+    /// <summary>
+    /// Instructs the caller to insert a new byte range into the object.
+    /// </summary>
+    Insert = 0,
+
+    /// <summary>
+    /// Instructs the caller to copy a byte range from the source object.
+    /// </summary>
+    Copy = 1
+}
+
+/// <summary>
+/// Represents an instruction in a deltified stream.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal struct DeltaInstruction
+{
+    /// <summary>
+    /// The type of the current instruction.
+    /// </summary>
+    public DeltaInstructionType InstructionType;
+
+    /// <summary>
+    /// If the <see cref="InstructionType"/> is <see cref="DeltaInstructionType.Copy"/>,
+    /// the offset of the base stream to start copying from.
+    /// </summary>
+    public int Offset;
+
+    /// <summary>
+    /// The number of bytes to copy or insert.
+    /// </summary>
+    public int Size;
+}

--- a/src/GitVersion.Git.Managed/DeltaStreamReader.cs
+++ b/src/GitVersion.Git.Managed/DeltaStreamReader.cs
@@ -1,0 +1,96 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads delta instructions from a <see cref="Stream"/>.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal static class DeltaStreamReader
+{
+    /// <summary>
+    /// Reads the next instruction from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">The stream from which to read the instruction.</param>
+    /// <returns>The next instruction if found; otherwise, <see langword="null"/>.</returns>
+    public static DeltaInstruction? Read(Stream stream)
+    {
+        var next = stream.ReadByte();
+
+        if (next == -1)
+        {
+            return null;
+        }
+
+        var instruction = (byte)next;
+
+        DeltaInstruction value;
+        value.Offset = 0;
+        value.Size = 0;
+
+        value.InstructionType = (DeltaInstructionType)((instruction & 0b1000_0000) >> 7);
+
+        if (value.InstructionType == DeltaInstructionType.Insert)
+        {
+            value.Size = instruction & 0b0111_1111;
+        }
+        else
+        {
+            ReadCopyInstruction(stream, instruction, ref value);
+        }
+
+        return value;
+    }
+
+    private static void ReadCopyInstruction(Stream stream, byte instruction, ref DeltaInstruction value)
+    {
+        if ((instruction & 0b0000_0001) != 0)
+        {
+            value.Offset |= ReadByteOrThrow(stream);
+        }
+
+        if ((instruction & 0b0000_0010) != 0)
+        {
+            value.Offset |= ReadByteOrThrow(stream) << 8;
+        }
+
+        if ((instruction & 0b0000_0100) != 0)
+        {
+            value.Offset |= ReadByteOrThrow(stream) << 16;
+        }
+
+        if ((instruction & 0b0000_1000) != 0)
+        {
+            value.Offset |= ReadByteOrThrow(stream) << 24;
+        }
+
+        if ((instruction & 0b0001_0000) != 0)
+        {
+            value.Size = ReadByteOrThrow(stream);
+        }
+
+        if ((instruction & 0b0010_0000) != 0)
+        {
+            value.Size |= ReadByteOrThrow(stream) << 8;
+        }
+
+        if ((instruction & 0b0100_0000) != 0)
+        {
+            value.Size |= ReadByteOrThrow(stream) << 16;
+        }
+
+        // Size zero is automatically converted to 0x10000.
+        if (value.Size == 0)
+        {
+            value.Size = 0x10000;
+        }
+    }
+
+    private static int ReadByteOrThrow(Stream stream)
+    {
+        var value = stream.ReadByte();
+        return value == -1
+            ? throw new EndOfStreamException("The delta stream ended in the middle of a copy instruction.")
+            : value;
+    }
+}

--- a/src/GitVersion.Git.Managed/Diff/GitTreeDiff.cs
+++ b/src/GitVersion.Git.Managed/Diff/GitTreeDiff.cs
@@ -1,0 +1,182 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Computes the paths changed between two trees: a recursive tree-vs-tree diff with no
+/// rename detection, matching libgit2's default <c>TreeChanges</c> path list (which is
+/// what GitVersion's <c>ICommit.DiffPaths</c> exposes). Identical subtrees are skipped
+/// by object id; entries align using git's canonical tree order, where directory names
+/// compare as if they had a trailing slash.
+/// </summary>
+internal sealed class GitTreeDiff(GitObjectStore objectStore)
+{
+    private readonly GitObjectStore objectStore = objectStore ?? throw new ArgumentNullException(nameof(objectStore));
+
+    /// <summary>
+    /// Returns the repository-relative paths which differ between the two trees,
+    /// in path order. Either side may be <see langword="null"/> to diff against the
+    /// empty tree (e.g. for root commits).
+    /// </summary>
+    /// <param name="oldTreeId">The object id of the old tree, or <see langword="null"/> for the empty tree.</param>
+    /// <param name="newTreeId">The object id of the new tree, or <see langword="null"/> for the empty tree.</param>
+    /// <returns>The changed paths.</returns>
+    public IReadOnlyList<string> GetChangedPaths(GitObjectId? oldTreeId, GitObjectId? newTreeId)
+    {
+        if (Nullable.Equals(oldTreeId, newTreeId))
+        {
+            return [];
+        }
+
+        var paths = new List<string>();
+        DiffTrees(LoadTree(oldTreeId), LoadTree(newTreeId), prefix: "", paths);
+        return paths;
+    }
+
+    /// <summary>
+    /// Flattens a tree into all of its blob paths and their entries.
+    /// </summary>
+    /// <param name="treeId">The object id of the tree, or <see langword="null"/> for the empty tree.</param>
+    /// <returns>A dictionary of repository-relative path to tree entry.</returns>
+    public Dictionary<string, GitTreeEntry> FlattenTree(GitObjectId? treeId)
+    {
+        var files = new Dictionary<string, GitTreeEntry>(StringComparer.Ordinal);
+
+        if (treeId is { } id)
+        {
+            Flatten(this.objectStore.GetTree(id), prefix: "", files);
+        }
+
+        return files;
+    }
+
+    private void Flatten(GitTree tree, string prefix, Dictionary<string, GitTreeEntry> files)
+    {
+        foreach (var entry in tree.Entries)
+        {
+            if (entry.IsTree)
+            {
+                Flatten(this.objectStore.GetTree(entry.Sha), prefix + entry.Name + "/", files);
+            }
+            else
+            {
+                files[prefix + entry.Name] = entry;
+            }
+        }
+    }
+
+    private GitTree? LoadTree(GitObjectId? treeId) => treeId is { } id ? this.objectStore.GetTree(id) : null;
+
+    private void DiffTrees(GitTree? oldTree, GitTree? newTree, string prefix, List<string> paths)
+    {
+        var oldEntries = oldTree?.Entries ?? [];
+        var newEntries = newTree?.Entries ?? [];
+        var oldIndex = 0;
+        var newIndex = 0;
+
+        while (oldIndex < oldEntries.Count || newIndex < newEntries.Count)
+        {
+            var comparison = (oldIndex < oldEntries.Count, newIndex < newEntries.Count) switch
+            {
+                (true, false) => -1,
+                (false, true) => 1,
+                _ => CompareTreeNames(oldEntries[oldIndex], newEntries[newIndex])
+            };
+
+            if (comparison < 0)
+            {
+                EmitAll(oldEntries[oldIndex++], prefix, paths);
+            }
+            else if (comparison > 0)
+            {
+                EmitAll(newEntries[newIndex++], prefix, paths);
+            }
+            else
+            {
+                DiffAlignedEntries(oldEntries[oldIndex++], newEntries[newIndex++], prefix, paths);
+            }
+        }
+    }
+
+    private void DiffAlignedEntries(GitTreeEntry oldEntry, GitTreeEntry newEntry, string prefix, List<string> paths)
+    {
+        if (oldEntry.Sha == newEntry.Sha && oldEntry.Mode == newEntry.Mode)
+        {
+            return;
+        }
+
+        if (oldEntry.IsTree && newEntry.IsTree)
+        {
+            if (oldEntry.Sha != newEntry.Sha)
+            {
+                DiffTrees(LoadTree(oldEntry.Sha), LoadTree(newEntry.Sha), prefix + oldEntry.Name + "/", paths);
+            }
+
+            return;
+        }
+
+        if (!oldEntry.IsTree && !newEntry.IsTree)
+        {
+            paths.Add(prefix + oldEntry.Name);
+            return;
+        }
+
+        // The name changed type between a file and a directory: the file path sorts
+        // before the paths inside the directory.
+        var (file, tree) = oldEntry.IsTree ? (newEntry, oldEntry) : (oldEntry, newEntry);
+        paths.Add(prefix + file.Name);
+        EmitAll(tree, prefix, paths);
+    }
+
+    private void EmitAll(GitTreeEntry entry, string prefix, List<string> paths)
+    {
+        if (!entry.IsTree)
+        {
+            paths.Add(prefix + entry.Name);
+            return;
+        }
+
+        var tree = this.objectStore.GetTree(entry.Sha);
+
+        foreach (var child in tree.Entries)
+        {
+            EmitAll(child, prefix + entry.Name + "/", paths);
+        }
+    }
+
+    private static int CompareTreeNames(GitTreeEntry left, GitTreeEntry right)
+    {
+        // Git sorts tree entries by their raw unsigned bytes, not by the decoded
+        // strings: UTF-16 comparison inverts e.g. U+E000..U+FFFF versus surrogate
+        // pairs, and Latin-1-fallback names do not round-trip through the string.
+        var leftName = left.NameBytes.Span;
+        var rightName = right.NameBytes.Span;
+
+        // Entries with the same name align even when their type differs, so a
+        // file-to-directory change on one name is detected as such.
+        if (leftName.SequenceEqual(rightName))
+        {
+            return 0;
+        }
+
+        var commonLength = Math.Min(leftName.Length, rightName.Length);
+        var comparison = leftName[..commonLength].SequenceCompareTo(rightName[..commonLength]);
+
+        if (comparison != 0)
+        {
+            return comparison;
+        }
+
+        // One name is a prefix of the other. Git's canonical tree order: directory
+        // names sort as if they ended with '/', while an exhausted file name ends.
+        return NextByte(leftName, commonLength, left.IsTree) - NextByte(rightName, commonLength, right.IsTree);
+    }
+
+    private static int NextByte(ReadOnlySpan<byte> name, int index, bool isTree)
+    {
+        if (index < name.Length)
+        {
+            return name[index];
+        }
+
+        return isTree ? (byte)'/' : 0;
+    }
+}

--- a/src/GitVersion.Git.Managed/FileHelpers.cs
+++ b/src/GitVersion.Git.Managed/FileHelpers.cs
@@ -1,0 +1,34 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+internal static class FileHelpers
+{
+    /// <summary>
+    /// Opens the file with a given path for reading, if it exists.
+    /// </summary>
+    /// <param name="path">The path to the file.</param>
+    /// <param name="stream">The stream opened over the file, if the file exists.</param>
+    /// <returns><see langword="true"/> if the file exists; otherwise <see langword="false"/>.</returns>
+    public static bool TryOpen(string path, [NotNullWhen(true)] out FileStream? stream)
+    {
+        if (!File.Exists(path))
+        {
+            stream = null;
+            return false;
+        }
+
+        try
+        {
+            stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return true;
+        }
+        catch (IOException)
+        {
+            stream = null;
+            return false;
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitCommit.cs
+++ b/src/GitVersion.Git.Managed/GitCommit.cs
@@ -1,0 +1,95 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git commit, as stored in the Git object database. The signatures and the
+/// message are kept as raw bytes and decoded lazily: history walks load every traversed
+/// commit but only ever need the parents and the committer timestamp.
+/// </summary>
+internal sealed class GitCommit
+{
+    private GitSignature? author;
+    private GitSignature? committer;
+    private string? message;
+
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> which uniquely identifies this commit.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of the root tree of this commit.
+    /// </summary>
+    public required GitObjectId Tree { get; init; }
+
+    /// <summary>
+    /// Gets the parents of this commit, in order.
+    /// </summary>
+    public required IReadOnlyList<GitObjectId> Parents { get; init; }
+
+    /// <summary>
+    /// Gets the committer timestamp. Parsed eagerly: the revision walk orders commits by it
+    /// and must not pay for decoding the full signatures or the message.
+    /// </summary>
+    public required DateTimeOffset CommitterWhen { get; init; }
+
+    /// <summary>
+    /// Gets the raw bytes of the <c>author</c> header value.
+    /// </summary>
+    public required byte[] RawAuthor { get; init; }
+
+    /// <summary>
+    /// Gets the raw bytes of the <c>committer</c> header value.
+    /// </summary>
+    public required byte[] RawCommitter { get; init; }
+
+    /// <summary>
+    /// Gets the raw bytes of the commit message.
+    /// </summary>
+    public required byte[] RawMessage { get; init; }
+
+    /// <summary>
+    /// Gets the value of the commit's <c>encoding</c> header, if present.
+    /// </summary>
+    public string? EncodingName { get; init; }
+
+    /// <summary>
+    /// Gets the author of this commit, decoded on first access.
+    /// </summary>
+    public GitSignature Author => this.author ??= GitSignature.Parse(RawAuthor, EncodingName);
+
+    /// <summary>
+    /// Gets the committer of this commit, decoded on first access.
+    /// </summary>
+    public GitSignature Committer => this.committer ??= GitSignature.Parse(RawCommitter, EncodingName);
+
+    /// <summary>
+    /// Gets the full commit message, decoded on first access honoring the commit's <c>encoding</c> header.
+    /// </summary>
+    public string Message => this.message ??= GitTextDecoder.Decode(RawMessage, EncodingName);
+
+    /// <summary>
+    /// Creates a copy of this commit with no parents. Used to apply shallow-clone grafts:
+    /// commits at the <c>.git/shallow</c> boundary are exposed as parentless the way git and
+    /// libgit2 expose them, regardless of the parent headers stored in the object.
+    /// </summary>
+    /// <returns>The parentless copy, or this instance when it already has no parents.</returns>
+    public GitCommit WithoutParents() =>
+        Parents.Count == 0
+            ? this
+            : new()
+            {
+                Sha = Sha,
+                Tree = Tree,
+                Parents = [],
+                CommitterWhen = CommitterWhen,
+                RawAuthor = RawAuthor,
+                RawCommitter = RawCommitter,
+                RawMessage = RawMessage,
+                EncodingName = EncodingName
+            };
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git Commit: {Sha}";
+}

--- a/src/GitVersion.Git.Managed/GitCommitReader.cs
+++ b/src/GitVersion.Git.Managed/GitCommitReader.cs
@@ -1,0 +1,119 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitCommit"/> object.
+/// </summary>
+internal static class GitCommitReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitCommit"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the commit in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public static GitCommit Read(Stream stream, GitObjectId sha)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var span = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(span);
+
+            return Read(span, sha);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitCommit"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="commit">A <see cref="ReadOnlySpan{T}"/> which contains the commit in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public static GitCommit Read(ReadOnlySpan<byte> commit, GitObjectId sha)
+    {
+        GitObjectId? tree = null;
+        List<GitObjectId> parents = [];
+        ReadOnlySpan<byte> authorLine = default;
+        ReadOnlySpan<byte> committerLine = default;
+        var hasAuthor = false;
+        var hasCommitter = false;
+        string? encodingName = null;
+
+        var buffer = commit;
+
+        while (!buffer.IsEmpty)
+        {
+            var lineEnd = buffer.IndexOf((byte)'\n');
+            if (lineEnd < 0)
+            {
+                lineEnd = buffer.Length;
+            }
+
+            var line = buffer[..lineEnd];
+            buffer = buffer[Math.Min(lineEnd + 1, buffer.Length)..];
+
+            if (line.IsEmpty)
+            {
+                // An empty line separates the headers from the commit message.
+                break;
+            }
+
+            if (line[0] == ' ')
+            {
+                // A continuation of the previous (multi-line) header, such as gpgsig; skip.
+                continue;
+            }
+
+            if (line.StartsWith("tree "u8))
+            {
+                tree = GitObjectId.ParseHex(line["tree "u8.Length..]);
+            }
+            else if (line.StartsWith("parent "u8))
+            {
+                parents.Add(GitObjectId.ParseHex(line["parent "u8.Length..]));
+            }
+            else if (line.StartsWith("author "u8))
+            {
+                authorLine = line["author "u8.Length..];
+                hasAuthor = true;
+            }
+            else if (line.StartsWith("committer "u8))
+            {
+                committerLine = line["committer "u8.Length..];
+                hasCommitter = true;
+            }
+            else if (line.StartsWith("encoding "u8))
+            {
+                encodingName = GitTextDecoder.Decode(line["encoding "u8.Length..]);
+            }
+        }
+
+        if (tree is null || !hasAuthor || !hasCommitter)
+        {
+            throw new GitObjectStoreException($"The commit {sha} is malformed: a tree, author or committer header is missing.");
+        }
+
+        return new()
+        {
+            Sha = sha,
+            Tree = tree.Value,
+            Parents = parents,
+            CommitterWhen = GitSignature.ParseWhen(committerLine),
+            RawAuthor = authorLine.ToArray(),
+            RawCommitter = committerLine.ToArray(),
+            RawMessage = buffer.ToArray(),
+            EncodingName = encodingName
+        };
+    }
+}

--- a/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitMultiPackIndexReader.cs
@@ -1,0 +1,209 @@
+using System.Buffers.Binary;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a Git <c>multi-pack-index</c> file (format version 1), which indexes the objects
+/// of multiple pack files in a single file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitformat-pack#_multi_pack_index_midx_files_have_the_following_format"/>
+internal sealed class GitMultiPackIndexReader : IDisposable
+{
+    private const uint PackNamesChunkId = 0x504E414D;     // "PNAM"
+    private const uint OidFanoutChunkId = 0x4F494446;     // "OIDF"
+    private const uint OidLookupChunkId = 0x4F49444C;     // "OIDL"
+    private const uint ObjectOffsetsChunkId = 0x4F4F4646; // "OOFF"
+
+    private const int HeaderLength = 12;
+    private const int ChunkTableEntryLength = 12;
+
+    private readonly FileStream stream;
+    private readonly int oidLength;
+    private readonly int[] fanoutTable = new int[256];
+    private readonly Dictionary<uint, (long Offset, long Length)> chunks = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitMultiPackIndexReader"/> class.
+    /// </summary>
+    /// <param name="stream">A <see cref="FileStream"/> which points to the multi-pack-index file. Ownership is transferred to the reader.</param>
+    public GitMultiPackIndexReader(FileStream stream)
+    {
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+        try
+        {
+            Span<byte> header = stackalloc byte[HeaderLength];
+            stream.SafeFileHandle.ReadExactlyAt(0, header);
+
+            if (!header[..4].SequenceEqual("MIDX"u8))
+            {
+                throw new GitObjectStoreException("The multi-pack-index file has an invalid signature.");
+            }
+
+            var version = header[4];
+            if (version != 1)
+            {
+                throw new GitObjectStoreException($"Multi-pack-index version {version} is not supported; only version 1 is supported.");
+            }
+
+            this.oidLength = header[5] switch
+            {
+                1 => GitObjectId.Sha1Size,
+                2 => GitObjectId.Sha256Size,
+                _ => throw new GitObjectStoreException($"The multi-pack-index object id version {header[5]} is not supported.")
+            };
+
+            var chunkCount = header[6];
+            var baseFileCount = header[7];
+            var packCount = BinaryPrimitives.ReadUInt32BigEndian(header[8..12]);
+
+            if (baseFileCount != 0)
+            {
+                throw new NotSupportedException("Incremental multi-pack-index chains are not supported.");
+            }
+
+            ReadChunkTable(chunkCount);
+            ReadFanoutTable();
+            PackNames = ReadPackNames((int)packCount);
+        }
+        catch
+        {
+            this.stream.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets the names of the pack files indexed by this multi-pack-index, without their
+    /// file extension, in the order used by <see cref="GetOffset(GitObjectId)"/>.
+    /// </summary>
+    public IReadOnlyList<string> PackNames { get; }
+
+    /// <summary>
+    /// Looks up an object in the multi-pack-index.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to look up.</param>
+    /// <returns>
+    /// If found, the index (into <see cref="PackNames"/>) of the pack which contains the object,
+    /// and the offset of the object within that pack; otherwise, <see langword="null"/>.
+    /// </returns>
+    public (int PackIndex, long Offset)? GetOffset(GitObjectId objectId)
+    {
+        if (objectId.HashLength != this.oidLength)
+        {
+            return null;
+        }
+
+        Span<byte> objectName = stackalloc byte[this.oidLength];
+        objectId.CopyTo(objectName);
+
+        var low = objectName[0] == 0 ? 0 : this.fanoutTable[objectName[0] - 1];
+        var high = this.fanoutTable[objectName[0]] - 1;
+
+        var oidLookupOffset = GetChunk(OidLookupChunkId).Offset;
+
+        Span<byte> current = stackalloc byte[this.oidLength];
+        var order = -1;
+        var i = 0;
+
+        while (low <= high)
+        {
+            i = (low + high) / 2;
+
+            this.stream.SafeFileHandle.ReadExactlyAt(oidLookupOffset + ((long)this.oidLength * i), current);
+            order = current.SequenceCompareTo(objectName);
+
+            if (order < 0)
+            {
+                low = i + 1;
+            }
+            else if (order > 0)
+            {
+                high = i - 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (order != 0)
+        {
+            return null;
+        }
+
+        Span<byte> entry = stackalloc byte[8];
+        this.stream.SafeFileHandle.ReadExactlyAt(GetChunk(ObjectOffsetsChunkId).Offset + (8L * i), entry);
+
+        var packIndex = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
+        var offset = BinaryPrimitives.ReadUInt32BigEndian(entry[4..8]);
+
+        if ((offset & 0x8000_0000) != 0)
+        {
+            throw new NotSupportedException("Multi-pack-index files with large (>= 2 GiB) object offsets are not supported.");
+        }
+
+        return ((int)packIndex, offset);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => this.stream.Dispose();
+
+    private (long Offset, long Length) GetChunk(uint chunkId) =>
+        this.chunks.TryGetValue(chunkId, out var chunk)
+            ? chunk
+            : throw new GitObjectStoreException($"The multi-pack-index file is missing the required 0x{chunkId:X8} chunk.");
+
+    private void ReadChunkTable(int chunkCount)
+    {
+        // The chunk table has chunkCount + 1 entries; the terminating entry (id 0) records
+        // the offset at which the chunks end, which yields each chunk's length.
+        var table = new byte[(chunkCount + 1) * ChunkTableEntryLength];
+        this.stream.SafeFileHandle.ReadExactlyAt(HeaderLength, table);
+
+        for (var i = 0; i < chunkCount; i++)
+        {
+            var entry = table.AsSpan(i * ChunkTableEntryLength, ChunkTableEntryLength);
+            var chunkId = BinaryPrimitives.ReadUInt32BigEndian(entry[..4]);
+            var chunkOffset = BinaryPrimitives.ReadInt64BigEndian(entry[4..12]);
+            var nextChunkOffset = BinaryPrimitives.ReadInt64BigEndian(table.AsSpan(((i + 1) * ChunkTableEntryLength) + 4, 8));
+            this.chunks[chunkId] = (chunkOffset, nextChunkOffset - chunkOffset);
+        }
+    }
+
+    private void ReadFanoutTable()
+    {
+        Span<byte> fanout = stackalloc byte[256 * 4];
+        this.stream.SafeFileHandle.ReadExactlyAt(GetChunk(OidFanoutChunkId).Offset, fanout);
+
+        for (var i = 0; i < 256; i++)
+        {
+            this.fanoutTable[i] = BinaryPrimitives.ReadInt32BigEndian(fanout.Slice(4 * i, 4));
+        }
+    }
+
+    private string[] ReadPackNames(int packCount)
+    {
+        var (chunkOffset, chunkLength) = GetChunk(PackNamesChunkId);
+
+        var contents = new byte[chunkLength];
+        this.stream.SafeFileHandle.ReadExactlyAt(chunkOffset, contents);
+
+        var names = new string[packCount];
+        var span = contents.AsSpan();
+
+        for (var i = 0; i < packCount; i++)
+        {
+            var nameEnd = span.IndexOf((byte)0);
+            if (nameEnd < 0)
+            {
+                throw new GitObjectStoreException("The multi-pack-index pack name chunk is malformed.");
+            }
+
+            names[i] = Path.GetFileNameWithoutExtension(Encoding.UTF8.GetString(span[..nameEnd]));
+            span = span[(nameEnd + 1)..];
+        }
+
+        return names;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectId.cs
+++ b/src/GitVersion.Git.Managed/GitObjectId.cs
@@ -1,0 +1,232 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Identifies an object stored in the Git object database. The id of an object is the hash
+/// of its contents. This type is hash-agnostic: it stores up to 32 bytes together with the
+/// hash length, supporting both SHA-1 (20 bytes) and SHA-256 (32 bytes) repositories.
+/// </summary>
+/// <seealso href="https://git-scm.com/book/en/v2/Git-Internals-Git-Objects"/>
+internal struct GitObjectId : IEquatable<GitObjectId>
+{
+    /// <summary>The length, in bytes, of a SHA-1 object id.</summary>
+    public const int Sha1Size = 20;
+
+    /// <summary>The length, in bytes, of a SHA-256 object id.</summary>
+    public const int Sha256Size = 32;
+
+    private const string HexDigits = "0123456789abcdef";
+    private static readonly byte[] ReverseHexDigits = BuildReverseHexDigits();
+
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "The inline array is written through its span conversion.")]
+    private HashBuffer value;
+    private byte length;
+    private string? sha;
+
+    [InlineArray(Sha256Size)]
+    private struct HashBuffer
+    {
+        private byte element;
+    }
+
+    /// <summary>
+    /// Gets a <see cref="GitObjectId"/> which represents an empty <see cref="GitObjectId"/>.
+    /// </summary>
+    public static GitObjectId Empty => default;
+
+    /// <summary>
+    /// Gets the length, in bytes, of the hash represented by this object id. Zero for <see cref="Empty"/>.
+    /// </summary>
+    public readonly int HashLength => this.length;
+
+    public static bool operator ==(GitObjectId left, GitObjectId right) => left.Equals(right);
+
+    public static bool operator !=(GitObjectId left, GitObjectId right) => !left.Equals(right);
+
+    /// <summary>
+    /// Parses a sequence of byte values as a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The raw hash bytes. Must be exactly 20 (SHA-1) or 32 (SHA-256) bytes in length.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(ReadOnlySpan<byte> value)
+    {
+        if (value.Length is not (Sha1Size or Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {Sha1Size} or {Sha256Size} bytes, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+        value.CopyTo(bytes);
+        objectId.length = (byte)value.Length;
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation. Must be 40 (SHA-1) or 64 (SHA-256) characters long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(ReadOnlySpan<char> value)
+    {
+        if (value.Length is not (2 * Sha1Size or 2 * Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {2 * Sha1Size} or {2 * Sha256Size} characters, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+        var byteCount = value.Length / 2;
+
+        for (var i = 0; i < byteCount; i++)
+        {
+            var high = GetHexValue(value[2 * i]);
+            var low = GetHexValue(value[(2 * i) + 1]);
+
+            bytes[i] = (byte)((high << 4) + low);
+        }
+
+        objectId.length = (byte)byteCount;
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation. Must be 40 (SHA-1) or 64 (SHA-256) characters long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId Parse(string value)
+    {
+        var objectId = Parse(value.AsSpan());
+        objectId.sha = value.ToLowerInvariant();
+        return objectId;
+    }
+
+    /// <summary>
+    /// Parses the ASCII-encoded hexadecimal representation of a <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <param name="value">The hexadecimal representation, encoded in ASCII. Must be 40 (SHA-1) or 64 (SHA-256) bytes long.</param>
+    /// <returns>A <see cref="GitObjectId"/>.</returns>
+    public static GitObjectId ParseHex(ReadOnlySpan<byte> value)
+    {
+        if (value.Length is not (2 * Sha1Size or 2 * Sha256Size))
+        {
+            throw new ArgumentException($"The length should be {2 * Sha1Size} or {2 * Sha256Size} characters, but was {value.Length}.", nameof(value));
+        }
+
+        var objectId = default(GitObjectId);
+        Span<byte> bytes = objectId.value;
+        var byteCount = value.Length / 2;
+
+        for (var i = 0; i < byteCount; i++)
+        {
+            var high = GetHexValue((char)value[2 * i]);
+            var low = GetHexValue((char)value[(2 * i) + 1]);
+
+            bytes[i] = (byte)((high << 4) + low);
+        }
+
+        objectId.length = (byte)byteCount;
+        return objectId;
+    }
+
+    /// <inheritdoc/>
+    public override readonly bool Equals(object? obj) => obj is GitObjectId other && Equals(other);
+
+    /// <inheritdoc/>
+    public readonly bool Equals(GitObjectId other)
+    {
+        ReadOnlySpan<byte> mine = this.value;
+        ReadOnlySpan<byte> theirs = other.value;
+        return this.length == other.length && mine.SequenceEqual(theirs);
+    }
+
+    /// <inheritdoc/>
+    public override readonly int GetHashCode()
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        return BinaryPrimitives.ReadInt32LittleEndian(bytes);
+    }
+
+    /// <summary>
+    /// Gets a <see cref="ushort"/> which represents the first two bytes of this <see cref="GitObjectId"/>.
+    /// </summary>
+    /// <returns>The first two bytes of this <see cref="GitObjectId"/>, in big-endian order.</returns>
+    public readonly ushort AsUInt16()
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        return BinaryPrimitives.ReadUInt16BigEndian(bytes);
+    }
+
+    /// <summary>
+    /// Copies the byte representation of this <see cref="GitObjectId"/> to a <see cref="Span{T}"/>.
+    /// </summary>
+    /// <param name="destination">The memory to which to copy this <see cref="GitObjectId"/>. Must be at least <see cref="HashLength"/> bytes long.</param>
+    public readonly void CopyTo(Span<byte> destination)
+    {
+        ReadOnlySpan<byte> bytes = this.value;
+        bytes[..this.length].CopyTo(destination);
+    }
+
+    /// <summary>
+    /// Returns the hexadecimal representation of this object id.
+    /// </summary>
+    /// <inheritdoc/>
+    public override string ToString() => this.sha ??= ToString(this.length * 2);
+
+    /// <summary>
+    /// Returns the first <paramref name="length"/> hexadecimal characters of this object id.
+    /// </summary>
+    /// <param name="length">The number of hexadecimal characters to return.</param>
+    /// <returns>A hexadecimal prefix of this object id.</returns>
+    public readonly string ToString(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, this.length * 2);
+
+        Span<char> chars = stackalloc char[length];
+        ReadOnlySpan<byte> bytes = this.value;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var b = bytes[i >> 1];
+            chars[i] = HexDigits[(i & 1) == 0 ? b >> 4 : b & 0x0F];
+        }
+
+        return new string(chars);
+    }
+
+    private static int GetHexValue(char c)
+    {
+        var index = c - '0';
+        if (index < 0 || index >= ReverseHexDigits.Length || (index != 0 && ReverseHexDigits[index] == 0 && c != '0'))
+        {
+            throw new FormatException($"The character '{c}' is not a valid hexadecimal digit.");
+        }
+
+        return ReverseHexDigits[index];
+    }
+
+    private static byte[] BuildReverseHexDigits()
+    {
+        var bytes = new byte['f' - '0' + 1];
+
+        for (var i = 0; i < 10; i++)
+        {
+            bytes[i] = (byte)i;
+        }
+
+        for (var i = 10; i < 16; i++)
+        {
+            bytes[i + 'a' - '0' - 0x0a] = (byte)i;
+            bytes[i + 'A' - '0' - 0x0a] = (byte)i;
+        }
+
+        return bytes;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectStore.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStore.cs
@@ -1,0 +1,284 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only access to the objects stored in a Git object database
+/// (a <c>.git/objects</c> directory), without relying on native libraries or
+/// the <c>git</c> executable.
+/// </summary>
+/// <remarks>
+/// Objects are looked up in the <c>multi-pack-index</c> (when present), in the
+/// individual pack files, among the loose objects, and finally in the alternate
+/// object databases listed in <c>objects/info/alternates</c> (one level deep).
+/// </remarks>
+internal sealed class GitObjectStore : IDisposable
+{
+    private readonly List<GitObjectStore> alternates = [];
+    private readonly Dictionary<string, GitPack> packsByName = new(StringComparer.Ordinal);
+    private readonly Lazy<string[]> packNames;
+    private readonly Lazy<GitMultiPackIndexReader?> multiPackIndex;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitObjectStore"/> class.
+    /// </summary>
+    /// <param name="objectDirectory">The path to the Git object directory (usually <c>.git/objects</c>).</param>
+    public GitObjectStore(string objectDirectory) : this(objectDirectory, followAlternates: true)
+    {
+    }
+
+    private GitObjectStore(string objectDirectory, bool followAlternates)
+    {
+        ArgumentNullException.ThrowIfNull(objectDirectory);
+
+        ObjectDirectory = Path.GetFullPath(objectDirectory);
+        this.packNames = new(LoadPackNames);
+        this.multiPackIndex = new(LoadMultiPackIndex);
+
+        if (followAlternates)
+        {
+            LoadAlternates();
+        }
+    }
+
+    /// <summary>
+    /// Gets the full path to the Git object directory.
+    /// </summary>
+    public string ObjectDirectory { get; }
+
+    /// <summary>
+    /// Reads the commit with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the commit.</param>
+    /// <returns>The <see cref="GitCommit"/>.</returns>
+    public GitCommit GetCommit(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Commit);
+        return GitCommitReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Reads the tree with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public GitTree GetTree(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Tree);
+        return GitTreeReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Reads the annotated tag with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the annotated tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public GitTag GetTag(GitObjectId objectId)
+    {
+        using var stream = GetObject(objectId, GitObjectTypes.Tag);
+        return GitTagReader.Read(stream, objectId);
+    }
+
+    /// <summary>
+    /// Opens a stream over the contents of the blob with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the blob.</param>
+    /// <returns>A <see cref="Stream"/> over the blob contents.</returns>
+    public Stream GetBlob(GitObjectId objectId) => GetObject(objectId, GitObjectTypes.Blob);
+
+    /// <summary>
+    /// Opens a stream over the contents of the object with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <returns>A <see cref="Stream"/> over the object contents.</returns>
+    /// <exception cref="GitObjectStoreException">The object could not be found.</exception>
+    public Stream GetObject(GitObjectId objectId, string objectType) =>
+        TryGetObjectCore(objectId, objectType)?.Stream
+            ?? throw new GitObjectStoreException($"An object of type '{objectType}' with id '{objectId}' could not be found.") { ObjectNotFound = true };
+
+    /// <summary>
+    /// Attempts to open a stream over the contents of the object with the given object id.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> over the object contents.</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, string objectType, [NotNullWhen(true)] out Stream? stream)
+    {
+        stream = TryGetObjectCore(objectId, objectType)?.Stream;
+        return stream is not null;
+    }
+
+    /// <summary>
+    /// Attempts to open a stream over the contents of the object with the given object id,
+    /// without knowing its object type up front.
+    /// </summary>
+    /// <param name="objectId">The object id of the object to retrieve.</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> over the object contents.</param>
+    /// <param name="objectType">If found, receives the object type (<c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>).</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType)
+    {
+        (stream, objectType) = TryGetObjectCore(objectId, objectType: null) is { } result
+            ? (result.Stream, result.ObjectType)
+            : (null, null);
+        return stream is not null;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        foreach (var pack in this.packsByName.Values)
+        {
+            pack.Dispose();
+        }
+
+        this.packsByName.Clear();
+
+        if (this.multiPackIndex.IsValueCreated)
+        {
+            this.multiPackIndex.Value?.Dispose();
+        }
+
+        foreach (var alternate in this.alternates)
+        {
+            alternate.Dispose();
+        }
+    }
+
+    private (Stream Stream, string ObjectType)? TryGetObjectCore(GitObjectId objectId, string? objectType)
+    {
+        // Prefer the multi-pack-index when present.
+        if (this.multiPackIndex.Value is { } midx && midx.GetOffset(objectId) is { } location)
+        {
+            var pack = GetPack(midx.PackNames[location.PackIndex]);
+
+            try
+            {
+                return pack.GetObject(location.Offset, objectType);
+            }
+            catch (GitObjectStoreException exception) when (exception.ObjectNotFound)
+            {
+                // The object exists, but with a different type than requested.
+                return null;
+            }
+        }
+
+        // Fall back to the per-pack .idx files (also covers packs newer than the multi-pack-index).
+        foreach (var packName in this.packNames.Value)
+        {
+            if (GetPack(packName).TryGetObject(objectId, objectType, out var stream, out var actualType))
+            {
+                return (stream, actualType);
+            }
+        }
+
+        if (TryGetLooseObject(objectId, objectType) is { } looseObject)
+        {
+            return looseObject;
+        }
+
+        foreach (var alternate in this.alternates)
+        {
+            if (alternate.TryGetObjectCore(objectId, objectType) is { } fromAlternate)
+            {
+                return fromAlternate;
+            }
+        }
+
+        return null;
+    }
+
+    private (Stream Stream, string ObjectType)? TryGetLooseObject(GitObjectId objectId, string? objectType)
+    {
+        var sha = objectId.ToString();
+        var path = Path.Combine(ObjectDirectory, sha[..2], sha[2..]);
+
+        if (!FileHelpers.TryOpen(path, out var fileStream))
+        {
+            return null;
+        }
+
+        var objectStream = new GitObjectStream(fileStream);
+
+        if (objectType is not null && objectStream.ObjectType != objectType)
+        {
+            objectStream.Dispose();
+            return null;
+        }
+
+        return (objectStream, objectStream.ObjectType);
+    }
+
+    private GitPack GetPack(string packName)
+    {
+        if (!this.packsByName.TryGetValue(packName, out var pack))
+        {
+            var packDirectory = Path.Combine(ObjectDirectory, "pack");
+            pack = new(
+                (id, type) => TryGetObjectCore(id, type),
+                Path.Combine(packDirectory, packName + ".idx"),
+                Path.Combine(packDirectory, packName + ".pack"));
+            this.packsByName.Add(packName, pack);
+        }
+
+        return pack;
+    }
+
+    private string[] LoadPackNames()
+    {
+        var packDirectory = Path.Combine(ObjectDirectory, "pack");
+
+        if (!Directory.Exists(packDirectory))
+        {
+            return [];
+        }
+
+        return [.. Directory.GetFiles(packDirectory, "*.idx")
+            .Where(indexPath => File.Exists(Path.ChangeExtension(indexPath, ".pack")))
+            .Select(Path.GetFileNameWithoutExtension)
+            .OfType<string>()
+            .Order(StringComparer.Ordinal)];
+    }
+
+    private GitMultiPackIndexReader? LoadMultiPackIndex()
+    {
+        var multiPackIndexPath = Path.Combine(ObjectDirectory, "pack", "multi-pack-index");
+
+        return FileHelpers.TryOpen(multiPackIndexPath, out var stream)
+            ? new GitMultiPackIndexReader(stream)
+            : null;
+    }
+
+    private void LoadAlternates()
+    {
+        var alternatesPath = Path.Combine(ObjectDirectory, "info", "alternates");
+
+        if (!File.Exists(alternatesPath))
+        {
+            return;
+        }
+
+        foreach (var line in File.ReadLines(alternatesPath))
+        {
+            var alternatePath = line.Trim();
+
+            if (alternatePath.Length == 0 || alternatePath.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (!Path.IsPathRooted(alternatePath))
+            {
+                alternatePath = Path.Combine(ObjectDirectory, alternatePath);
+            }
+
+            if (Directory.Exists(alternatePath))
+            {
+                // Alternates are followed one level deep only.
+                this.alternates.Add(new(alternatePath, followAlternates: false));
+            }
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectStoreException.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStoreException.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// The exception thrown by the managed Git object store when the object database
+/// is malformed or a requested object cannot be found.
+/// </summary>
+[SuppressMessage("Critical Code Smell", "S3871:Exception types should be \"public\"", Justification = "Every type in this vendored library is internal by design (Phase B.1); the exception never crosses the assembly boundary.")]
+internal sealed class GitObjectStoreException : Exception
+{
+    public GitObjectStoreException()
+    {
+    }
+
+    public GitObjectStoreException(string message) : base(message)
+    {
+    }
+
+    public GitObjectStoreException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this exception represents a missing object
+    /// (as opposed to a malformed object database).
+    /// </summary>
+    public bool ObjectNotFound { get; init; }
+}

--- a/src/GitVersion.Git.Managed/GitObjectStream.cs
+++ b/src/GitVersion.Git.Managed/GitObjectStream.cs
@@ -1,0 +1,75 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A <see cref="Stream"/> which reads data stored as a loose object in the Git object store.
+/// The data is stored as a zlib-compressed stream prefixed with the object type and data length.
+/// </summary>
+internal sealed class GitObjectStream : GitZLibStream
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitObjectStream"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> from which to read data.</param>
+    public GitObjectStream(Stream stream)
+        : base(stream) => ObjectType = ReadObjectTypeAndLength();
+
+    /// <summary>
+    /// Gets the object type of this Git object, such as <c>commit</c>, <c>tree</c>, <c>blob</c> or <c>tag</c>.
+    /// </summary>
+    public string ObjectType { get; }
+
+    private string ReadObjectTypeAndLength()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var typeLength = 0;
+
+        while (true)
+        {
+            var read = ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (read == ' ')
+            {
+                break;
+            }
+
+            if (typeLength >= buffer.Length)
+            {
+                throw new GitObjectStoreException("Invalid loose object header: the object type is too long.");
+            }
+
+            buffer[typeLength++] = (byte)read;
+        }
+
+        long length = 0;
+
+        while (true)
+        {
+            var read = ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (read == 0)
+            {
+                break;
+            }
+
+            if (read is < '0' or > '9')
+            {
+                throw new GitObjectStoreException("Invalid loose object header: the object length is malformed.");
+            }
+
+            length = (10 * length) + (read - '0');
+        }
+
+        Initialize(length);
+        return GitObjectTypes.Canonicalize(buffer[..typeLength]);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitObjectTypes.cs
+++ b/src/GitVersion.Git.Managed/GitObjectTypes.cs
@@ -1,0 +1,42 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Well-known Git object type names.
+/// </summary>
+internal static class GitObjectTypes
+{
+    public const string Commit = "commit";
+    public const string Tree = "tree";
+    public const string Blob = "blob";
+    public const string Tag = "tag";
+
+    /// <summary>
+    /// Returns the canonical (interned) object type name for the given UTF-8 encoded type.
+    /// </summary>
+    /// <param name="type">The UTF-8 encoded object type name.</param>
+    /// <returns>The canonical object type name.</returns>
+    public static string Canonicalize(ReadOnlySpan<byte> type)
+    {
+        if (type.SequenceEqual("commit"u8))
+        {
+            return Commit;
+        }
+
+        if (type.SequenceEqual("tree"u8))
+        {
+            return Tree;
+        }
+
+        if (type.SequenceEqual("blob"u8))
+        {
+            return Blob;
+        }
+
+        if (type.SequenceEqual("tag"u8))
+        {
+            return Tag;
+        }
+
+        throw new GitObjectStoreException($"Unknown git object type '{Encoding.UTF8.GetString(type)}'.");
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPack.cs
+++ b/src/GitVersion.Git.Managed/GitPack.cs
@@ -1,0 +1,162 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A delegate which resolves a Git object across the whole object store (used to resolve
+/// the base object of <c>ref-delta</c> deltified objects, which may live outside the pack).
+/// </summary>
+/// <param name="objectId">The Git object id of the object to fetch.</param>
+/// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+/// <returns>A stream over the object data and its actual object type, or <see langword="null"/> if not found.</returns>
+internal delegate (Stream Stream, string ObjectType)? ResolveGitObject(GitObjectId objectId, string? objectType);
+
+/// <summary>
+/// Supports retrieving objects from a Git pack file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal sealed class GitPack : IDisposable
+{
+    private readonly ResolveGitObject resolveGitObject;
+    private readonly Lazy<FileStream> packStream;
+    private readonly GitPackCache cache;
+
+    // Maps GitObjectIds to offsets in the git pack.
+    private readonly Dictionary<GitObjectId, long> offsets = [];
+
+    private readonly Lazy<GitPackIndexReader> indexReader;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPack"/> class.
+    /// </summary>
+    /// <param name="resolveGitObject">A delegate which fetches objects from the Git object store.</param>
+    /// <param name="indexPath">The full path to the index (<c>.idx</c>) file.</param>
+    /// <param name="packPath">The full path to the pack file.</param>
+    /// <param name="cache">A <see cref="GitPackCache"/> which is used to cache <see cref="Stream"/> objects which operate on the pack file.</param>
+    public GitPack(ResolveGitObject resolveGitObject, string indexPath, string packPath, GitPackCache? cache = null)
+    {
+        this.resolveGitObject = resolveGitObject ?? throw new ArgumentNullException(nameof(resolveGitObject));
+        this.indexReader = new(() => new GitPackIndexReader(File.OpenRead(indexPath)));
+        this.packStream = new(() => File.OpenRead(packPath));
+        this.cache = cache ?? new GitPackMemoryCache();
+    }
+
+    /// <summary>
+    /// Resolves a Git object across the whole object store. Used to resolve the base
+    /// object of <c>ref-delta</c> deltified objects.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to fetch.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A stream over the object data and its actual object type, or <see langword="null"/> if not found.</returns>
+    public (Stream Stream, string ObjectType)? ResolveBaseObject(GitObjectId objectId, string? objectType) =>
+        this.resolveGitObject(objectId, objectType);
+
+    /// <summary>
+    /// Attempts to retrieve a Git object from this Git pack.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the object to retrieve.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <param name="stream">If found, receives a <see cref="Stream"/> which represents the object.</param>
+    /// <param name="actualType">If found, receives the actual object type.</param>
+    /// <returns><see langword="true"/> if the object was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetObject(GitObjectId objectId, string? objectType, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? actualType)
+    {
+        var offset = GetOffset(objectId);
+
+        if (offset is null)
+        {
+            stream = null;
+            actualType = null;
+            return false;
+        }
+
+        try
+        {
+            (stream, actualType) = GetObject(offset.Value, objectType);
+            return true;
+        }
+        catch (GitObjectStoreException exception) when (exception.ObjectNotFound)
+        {
+            stream = null;
+            actualType = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets a Git object at a specific offset.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object, relative to the pack file.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A <see cref="Stream"/> which represents the object, and the actual object type.</returns>
+    public (Stream Stream, string ObjectType) GetObject(long offset, string? objectType)
+    {
+        if (this.cache.TryOpen(offset, out var cachedStream, out var cachedType))
+        {
+            if (objectType is not null && cachedType != objectType)
+            {
+                cachedStream.Dispose();
+                throw new GitObjectStoreException($"An object of type {objectType} could not be located at offset {offset}.") { ObjectNotFound = true };
+            }
+
+            return (cachedStream, cachedType);
+        }
+
+        var packDataStream = GetPackStream();
+        Stream objectStream;
+        string actualType;
+
+        try
+        {
+            (objectStream, actualType) = GitPackReader.GetObject(this, packDataStream, offset, objectType);
+        }
+        catch
+        {
+            packDataStream.Dispose();
+            throw;
+        }
+
+        return (this.cache.Add(offset, objectStream, actualType), actualType);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.indexReader.IsValueCreated)
+        {
+            this.indexReader.Value.Dispose();
+        }
+
+        if (this.packStream.IsValueCreated)
+        {
+            this.packStream.Value.Dispose();
+        }
+
+        this.cache.Dispose();
+    }
+
+    private long? GetOffset(GitObjectId objectId)
+    {
+        if (this.offsets.TryGetValue(objectId, out var cachedOffset))
+        {
+            return cachedOffset;
+        }
+
+        var offset = this.indexReader.Value.GetOffset(objectId);
+
+        if (offset is not null)
+        {
+            this.offsets.Add(objectId, offset.Value);
+        }
+
+        return offset;
+    }
+
+    private Stream GetPackStream()
+    {
+        var file = this.packStream.Value;
+        return new RandomAccessStream(file.SafeFileHandle, file.Length);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackCache.cs
+++ b/src/GitVersion.Git.Managed/GitPackCache.cs
@@ -1,0 +1,46 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a cache in which objects retrieved from a <see cref="GitPack"/> are cached.
+/// Caching these objects can be of interest, because retrieving data from a <see cref="GitPack"/>
+/// can be potentially expensive: the data is compressed and can be deltified.
+/// </summary>
+internal abstract class GitPackCache : IDisposable
+{
+    /// <summary>
+    /// Attempts to retrieve a Git object from cache.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object in the Git pack.</param>
+    /// <param name="stream">A <see cref="Stream"/> which will be set to the cached data, if found.</param>
+    /// <param name="objectType">The object type of the cached object, if found.</param>
+    /// <returns><see langword="true"/> if the object was found in cache; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType);
+
+    /// <summary>
+    /// Adds a Git object to this cache.
+    /// </summary>
+    /// <param name="offset">The offset of the Git object in the Git pack.</param>
+    /// <param name="stream">A <see cref="Stream"/> which represents the object to add.</param>
+    /// <param name="objectType">The object type of the object to add to the cache.</param>
+    /// <returns>A <see cref="Stream"/> which represents the cached entry.</returns>
+    public abstract Stream Add(long offset, Stream stream, string objectType);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes of native and managed resources associated by this object.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> to dispose managed and native resources; <see langword="false"/> to only dispose of native resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackDeltafiedStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackDeltafiedStream.cs
@@ -1,0 +1,159 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads data from a deltified object.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format#_deltified_representation"/>
+internal sealed class GitPackDeltafiedStream : Stream
+{
+    private readonly long length;
+
+    private readonly Stream baseStream;
+    private readonly Stream deltaStream;
+
+    private long position;
+    private DeltaInstruction? current;
+    private int offset;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPackDeltafiedStream"/> class.
+    /// </summary>
+    /// <param name="baseStream">The base stream to which the deltas are applied.</param>
+    /// <param name="deltaStream">A <see cref="Stream"/> which contains a sequence of <see cref="DeltaInstruction"/>s.</param>
+    public GitPackDeltafiedStream(Stream baseStream, Stream deltaStream)
+    {
+        this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+        this.deltaStream = deltaStream ?? throw new ArgumentNullException(nameof(deltaStream));
+
+        _ = this.deltaStream.ReadMbsInt(); // base object length
+        this.length = this.deltaStream.ReadMbsInt();
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => false;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        var read = 0;
+
+        while (read < buffer.Length && TryGetInstruction(out var instruction))
+        {
+            var source = instruction.InstructionType == DeltaInstructionType.Copy ? this.baseStream : this.deltaStream;
+
+            var canRead = Math.Min(buffer.Length - read, instruction.Size - this.offset);
+            var didRead = source.Read(buffer.Slice(read, canRead));
+
+            if (didRead == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            read += didRead;
+            this.offset += didRead;
+        }
+
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin == SeekOrigin.Begin && offset == this.position)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Current && offset == 0)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Begin && offset > this.position)
+        {
+            this.ReadBytes(checked((int)(offset - this.position)));
+            return this.position;
+        }
+
+        throw new NotSupportedException("Only forward seeks are supported.");
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.deltaStream.Dispose();
+            this.baseStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private bool TryGetInstruction(out DeltaInstruction instruction)
+    {
+        if (this.current is not null && this.offset < this.current.Value.Size)
+        {
+            instruction = this.current.Value;
+            return true;
+        }
+
+        this.current = DeltaStreamReader.Read(this.deltaStream);
+
+        if (this.current is null)
+        {
+            instruction = default;
+            return false;
+        }
+
+        instruction = this.current.Value;
+
+        switch (instruction.InstructionType)
+        {
+            case DeltaInstructionType.Copy:
+                this.baseStream.Seek(instruction.Offset, SeekOrigin.Begin);
+                this.offset = 0;
+                break;
+
+            case DeltaInstructionType.Insert:
+                this.offset = 0;
+                break;
+
+            default:
+                throw new GitObjectStoreException($"Invalid delta instruction type '{instruction.InstructionType}'.");
+        }
+
+        return true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackIndexReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackIndexReader.cs
@@ -1,0 +1,147 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Binary;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a Git pack index (<c>.idx</c>) file, version 2.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal sealed class GitPackIndexReader : IDisposable
+{
+    private static readonly byte[] Header = [0xff, 0x74, 0x4f, 0x63];
+
+    // The object name table starts at: 4 (header) + 4 (version) + 256 * 4 (fanout table).
+    private const int NameTableStart = 4 + 4 + (256 * 4);
+
+    private readonly FileStream stream;
+
+    // The fanout table consists of 256 4-byte network byte order integers.
+    // The N-th entry of this table records the number of objects in the corresponding pack,
+    // the first byte of whose object name is less than or equal to N.
+    private readonly int[] fanoutTable = new int[257];
+
+    private bool initialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitPackIndexReader"/> class.
+    /// </summary>
+    /// <param name="stream">A <see cref="FileStream"/> which points to the index file. Ownership is transferred to the reader.</param>
+    public GitPackIndexReader(FileStream stream) => this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+    /// <summary>
+    /// Gets the offset of a Git object in the pack file.
+    /// </summary>
+    /// <param name="objectId">The Git object id of the Git object for which to get the offset.</param>
+    /// <returns>If found, the offset of the Git object in the pack file; otherwise, <see langword="null"/>.</returns>
+    public long? GetOffset(GitObjectId objectId)
+    {
+        const int hashLength = GitObjectId.Sha1Size;
+
+        Initialize();
+
+        Span<byte> objectName = stackalloc byte[hashLength];
+        objectId.CopyTo(objectName);
+
+        var objectCount = this.fanoutTable[256];
+
+        // The fanout table is followed by a table of sorted 20-byte SHA-1 object names.
+        var low = this.fanoutTable[objectName[0]];
+        var high = this.fanoutTable[objectName[0] + 1] - 1;
+
+        Span<byte> current = stackalloc byte[hashLength];
+        var order = -1;
+        var i = 0;
+
+        while (low <= high)
+        {
+            i = (low + high) / 2;
+
+            this.stream.SafeFileHandle.ReadExactlyAt(NameTableStart + ((long)hashLength * i), current);
+            order = current.SequenceCompareTo(objectName);
+
+            if (order < 0)
+            {
+                low = i + 1;
+            }
+            else if (order > 0)
+            {
+                high = i - 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (order != 0)
+        {
+            return null;
+        }
+
+        // Get the offset value. It's located at:
+        // 4 (header) + 4 (version) + 256 * 4 (fanout table) + 20 * objectCount (name table) + 4 * objectCount (CRC32) + 4 * i (offset values)
+        var offsetTableStart = NameTableStart + (((long)hashLength + 4) * objectCount);
+        Span<byte> offsetBuffer = stackalloc byte[8];
+
+        this.stream.SafeFileHandle.ReadExactlyAt(offsetTableStart + (4L * i), offsetBuffer[..4]);
+        var offset = BinaryPrimitives.ReadUInt32BigEndian(offsetBuffer[..4]);
+
+        if ((offset & 0x8000_0000) == 0)
+        {
+            return offset;
+        }
+
+        // If the first bit of the offset address is set, the offset is stored as a 64-bit value in the table
+        // of 8-byte offset entries, which follows the table of 4-byte offset entries:
+        // "large offsets are encoded as an index into the next table with the msbit set."
+        offset &= 0x7FFFFFFF;
+
+        this.stream.SafeFileHandle.ReadExactlyAt(offsetTableStart + (4L * objectCount) + (8L * offset), offsetBuffer);
+        return BinaryPrimitives.ReadInt64BigEndian(offsetBuffer);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => this.stream.Dispose();
+
+    private void Initialize()
+    {
+        if (this.initialized)
+        {
+            return;
+        }
+
+        const int fanoutTableLength = 256;
+        Span<byte> value = stackalloc byte[4 + 4 + (4 * fanoutTableLength)];
+        this.stream.SafeFileHandle.ReadExactlyAt(0, value);
+
+        var header = value[..4];
+        var version = BinaryPrimitives.ReadInt32BigEndian(value.Slice(4, 4));
+
+        if (!header.SequenceEqual(Header))
+        {
+            throw new GitObjectStoreException("The pack index file has an invalid header.");
+        }
+
+        if (version != 2)
+        {
+            throw new GitObjectStoreException($"Pack index version {version} is not supported; only version 2 is supported.");
+        }
+
+        for (var i = 1; i <= fanoutTableLength; i++)
+        {
+            // The on-disk fanout entries are unsigned 32-bit integers.
+            var entry = BinaryPrimitives.ReadUInt32BigEndian(value.Slice(4 + (4 * i), 4));
+
+            if (entry > int.MaxValue)
+            {
+                throw new GitObjectStoreException($"The pack index file has a fanout entry of {entry} objects, which exceeds the supported maximum of {int.MaxValue}.");
+            }
+
+            this.fanoutTable[i] = (int)entry;
+        }
+
+        this.initialized = true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCache.cs
@@ -1,0 +1,115 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// <para>
+/// When a <see cref="Stream"/> is added to the <see cref="GitPackMemoryCache"/>, it is wrapped
+/// in a <see cref="GitPackMemoryCacheStream"/>. This stream allows for just-in-time, random,
+/// read-only access to the underlying data (which may be deltified and/or compressed).
+/// </para>
+/// <para>
+/// Whenever data is read from a <see cref="GitPackMemoryCacheStream"/>, the call is forwarded to the
+/// underlying <see cref="Stream"/> and cached in a <see cref="MemoryStream"/>. If the same data is read
+/// twice, it is read from the <see cref="MemoryStream"/>, rather than the underlying <see cref="Stream"/>.
+/// </para>
+/// <para>
+/// The cache is bounded: when the decompressed size of the retained entries exceeds the budget,
+/// the least recently used entries are evicted (and disposed once no view is reading them),
+/// so full-history walks over large repositories do not retain every object in memory.
+/// </para>
+/// </summary>
+internal sealed class GitPackMemoryCache : GitPackCache
+{
+    // libgit2 caps its object cache at 256 MB by default; the same budget keeps the
+    // hot delta-base entries while releasing objects no walk will read again.
+    private const long MaxTotalSize = 256 * 1024 * 1024;
+
+    private readonly object syncRoot = new();
+    private readonly Dictionary<long, LinkedListNode<CacheEntry>> cache = [];
+    private readonly LinkedList<CacheEntry> recency = new();
+    private long totalSize;
+
+    private sealed record CacheEntry(long Offset, GitPackMemoryCacheStream Stream, string ObjectType);
+
+    /// <inheritdoc/>
+    public override Stream Add(long offset, Stream stream, string objectType)
+    {
+        lock (this.syncRoot)
+        {
+            if (this.cache.TryGetValue(offset, out var existing))
+            {
+                // Someone cached this offset between the caller's TryOpen and this Add:
+                // serve the existing entry (refreshing its recency) and discard the source
+                // so hot objects are decompressed and held in memory only once.
+                stream.Dispose();
+                this.recency.Remove(existing);
+                this.recency.AddFirst(existing);
+                return new GitPackMemoryCacheViewStream(existing.Value.Stream);
+            }
+
+            var cacheStream = new GitPackMemoryCacheStream(stream);
+            var node = this.recency.AddFirst(new CacheEntry(offset, cacheStream, objectType));
+            this.cache.Add(offset, node);
+            this.totalSize += cacheStream.Length;
+            EvictWhileOverBudget();
+            return new GitPackMemoryCacheViewStream(cacheStream);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override bool TryOpen(long offset, [NotNullWhen(true)] out Stream? stream, [NotNullWhen(true)] out string? objectType)
+    {
+        lock (this.syncRoot)
+        {
+            if (this.cache.TryGetValue(offset, out var node))
+            {
+                this.recency.Remove(node);
+                this.recency.AddFirst(node);
+                stream = new GitPackMemoryCacheViewStream(node.Value.Stream);
+                objectType = node.Value.ObjectType;
+                return true;
+            }
+        }
+
+        stream = null;
+        objectType = null;
+        return false;
+    }
+
+    private void EvictWhileOverBudget()
+    {
+        // Never evict the most recent entry: a single object larger than the whole
+        // budget must still be readable through the entry just added.
+        while (this.totalSize > MaxTotalSize && this.recency.Count > 1 && this.recency.Last is { } tail)
+        {
+            this.recency.RemoveLast();
+            this.cache.Remove(tail.Value.Offset);
+            this.totalSize -= tail.Value.Stream.Length;
+            tail.Value.Stream.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            lock (this.syncRoot)
+            {
+                foreach (var entry in this.recency)
+                {
+                    entry.Stream.Release();
+                }
+
+                this.recency.Clear();
+                this.cache.Clear();
+                this.totalSize = 0;
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheStream.cs
@@ -1,0 +1,136 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A stream which caches the data read from an underlying (non-seekable) stream in memory,
+/// providing random read-only access to that data.
+/// </summary>
+internal sealed class GitPackMemoryCacheStream : Stream
+{
+    private readonly Stream stream;
+    private readonly MemoryStream cacheStream = new();
+    private readonly long length;
+    private int referenceCount = 1;
+    private bool released;
+
+    public GitPackMemoryCacheStream(Stream stream)
+    {
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        this.length = this.stream.Length;
+    }
+
+    /// <summary>
+    /// Registers an additional consumer (a <see cref="GitPackMemoryCacheViewStream"/>) of
+    /// this stream. The underlying data is only disposed once the cache has evicted the
+    /// entry and the last consumer has released it.
+    /// </summary>
+    public void AddReference() => Interlocked.Increment(ref this.referenceCount);
+
+    /// <summary>
+    /// Releases one consumer's reference, disposing the underlying streams when none remain.
+    /// </summary>
+    public void Release()
+    {
+        if (Interlocked.Decrement(ref this.referenceCount) == 0)
+        {
+            this.stream.Dispose();
+            this.cacheStream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Gets the object on which <see cref="GitPackMemoryCacheViewStream"/> instances synchronize
+    /// their access to this shared stream.
+    /// </summary>
+    public object SyncRoot { get; } = new();
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.cacheStream.Position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        if (this.cacheStream.Length < this.length
+            && this.cacheStream.Position + buffer.Length > this.cacheStream.Length)
+        {
+            var currentPosition = this.cacheStream.Position;
+            var toRead = (int)(buffer.Length - this.cacheStream.Length + this.cacheStream.Position);
+            var actualRead = this.stream.Read(buffer[..toRead]);
+            this.cacheStream.Seek(0, SeekOrigin.End);
+            this.cacheStream.Write(buffer[..actualRead]);
+            this.cacheStream.Seek(currentPosition, SeekOrigin.Begin);
+            DisposeStreamIfRead();
+        }
+
+        return this.cacheStream.Read(buffer);
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Begin)
+        {
+            throw new NotSupportedException();
+        }
+
+        if (offset > this.cacheStream.Length)
+        {
+            this.cacheStream.Seek(0, SeekOrigin.End);
+            var toRead = (int)(offset - this.cacheStream.Length);
+            this.stream.ReadBytes(toRead, this.cacheStream);
+            DisposeStreamIfRead();
+            return this.cacheStream.Position;
+        }
+
+        return this.cacheStream.Seek(offset, origin);
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !this.released)
+        {
+            this.released = true;
+            Release();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void DisposeStreamIfRead()
+    {
+        if (this.cacheStream.Length == this.stream.Length)
+        {
+            this.stream.Dispose();
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
+++ b/src/GitVersion.Git.Managed/GitPackMemoryCacheViewStream.cs
@@ -1,0 +1,95 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A read-only view over a shared <see cref="GitPackMemoryCacheStream"/> which maintains
+/// its own position, so multiple readers can independently consume the same cached object.
+/// </summary>
+internal sealed class GitPackMemoryCacheViewStream : Stream
+{
+    private readonly GitPackMemoryCacheStream baseStream;
+
+    private long position;
+    private bool disposed;
+
+    public GitPackMemoryCacheViewStream(GitPackMemoryCacheStream baseStream)
+    {
+        this.baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+        this.baseStream.AddReference();
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.baseStream.Length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        int read;
+
+        lock (this.baseStream.SyncRoot)
+        {
+            if (this.baseStream.Position != this.position)
+            {
+                this.baseStream.Seek(this.position, SeekOrigin.Begin);
+            }
+
+            read = this.baseStream.Read(buffer);
+        }
+
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Begin)
+        {
+            throw new NotSupportedException();
+        }
+
+        this.position = Math.Min(offset, Length);
+        return this.position;
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !this.disposed)
+        {
+            this.disposed = true;
+            this.baseStream.Release();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitPackObjectType.cs
+++ b/src/GitVersion.Git.Managed/GitPackObjectType.cs
@@ -1,0 +1,31 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Enumerates the object types which can be stored in a Git pack file.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/pack-format"/>
+internal enum GitPackObjectType
+{
+    /// <summary>Invalid.</summary>
+    Invalid = 0,
+
+    /// <summary>A commit.</summary>
+    Commit = 1,
+
+    /// <summary>A tree.</summary>
+    Tree = 2,
+
+    /// <summary>A blob.</summary>
+    Blob = 3,
+
+    /// <summary>A tag.</summary>
+    Tag = 4,
+
+    /// <summary>A deltified object whose base object is referenced by a relative offset in the same pack.</summary>
+    OfsDelta = 6,
+
+    /// <summary>A deltified object whose base object is referenced by object id.</summary>
+    RefDelta = 7
+}

--- a/src/GitVersion.Git.Managed/GitPackReader.cs
+++ b/src/GitVersion.Git.Managed/GitPackReader.cs
@@ -1,0 +1,133 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+internal static class GitPackReader
+{
+    /// <summary>
+    /// Reads a Git object which is stored at a given offset in a Git pack file.
+    /// </summary>
+    /// <param name="pack">The pack from which to read the object.</param>
+    /// <param name="stream">A (seekable) stream over the pack file. Ownership is transferred to the returned stream.</param>
+    /// <param name="offset">The offset of the object in the pack file.</param>
+    /// <param name="objectType">The expected object type, or <see langword="null"/> to accept any type.</param>
+    /// <returns>A stream over the object data, and the actual object type.</returns>
+    public static (Stream Stream, string ObjectType) GetObject(GitPack pack, Stream stream, long offset, string? objectType)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        ArgumentNullException.ThrowIfNull(stream);
+
+        try
+        {
+            stream.Seek(offset, SeekOrigin.Begin);
+
+            var (type, decompressedSize) = ReadObjectHeader(stream);
+
+            switch (type)
+            {
+                case GitPackObjectType.OfsDelta:
+                    {
+                        var baseObjectRelativeOffset = ReadVariableLengthInteger(stream);
+                        var baseObjectOffset = offset - baseObjectRelativeOffset;
+
+                        // The base of an ofs-delta always precedes the delta in the pack; a zero
+                        // relative offset would recurse into this same object until the stack
+                        // overflows, and a negative target would seek outside the pack.
+                        if (baseObjectOffset <= 0 || baseObjectOffset >= offset)
+                        {
+                            throw new GitObjectStoreException($"The deltified object at offset {offset} has an invalid base object offset {baseObjectOffset}.");
+                        }
+
+                        var deltaStream = new GitZLibStream(stream, decompressedSize);
+                        var (baseStream, baseType) = pack.GetObject(baseObjectOffset, objectType);
+
+                        return (new GitPackDeltafiedStream(baseStream, deltaStream), baseType);
+                    }
+
+                case GitPackObjectType.RefDelta:
+                    {
+                        Span<byte> baseObjectId = stackalloc byte[GitObjectId.Sha1Size];
+                        stream.ReadExactly(baseObjectId);
+
+                        var baseObject = pack.ResolveBaseObject(GitObjectId.Parse(baseObjectId), objectType)
+                            ?? throw new GitObjectStoreException($"The base object of the deltified object at offset {offset} could not be found.") { ObjectNotFound = true };
+
+                        var seekableBaseObject = new GitPackMemoryCacheStream(baseObject.Stream);
+                        var deltaStream = new GitZLibStream(stream, decompressedSize);
+
+                        return (new GitPackDeltafiedStream(seekableBaseObject, deltaStream), baseObject.ObjectType);
+                    }
+
+                default:
+                    {
+                        var actualType = type switch
+                        {
+                            GitPackObjectType.Commit => GitObjectTypes.Commit,
+                            GitPackObjectType.Tree => GitObjectTypes.Tree,
+                            GitPackObjectType.Blob => GitObjectTypes.Blob,
+                            GitPackObjectType.Tag => GitObjectTypes.Tag,
+                            _ => throw new GitObjectStoreException($"The object at offset {offset} has an unsupported pack object type '{type}'.")
+                        };
+
+                        if (objectType is not null && actualType != objectType)
+                        {
+                            throw new GitObjectStoreException($"An object of type {objectType} could not be located at offset {offset}.") { ObjectNotFound = true };
+                        }
+
+                        return (new GitZLibStream(stream, decompressedSize), actualType);
+                    }
+            }
+        }
+        catch (EndOfStreamException eof)
+        {
+            throw new GitObjectStoreException($"An object could not be located at offset {offset}.", eof) { ObjectNotFound = true };
+        }
+    }
+
+    private static (GitPackObjectType ObjectType, long Length) ReadObjectHeader(Stream stream)
+    {
+        Span<byte> value = stackalloc byte[1];
+        stream.ReadExactly(value);
+
+        var type = (GitPackObjectType)((value[0] & 0b0111_0000) >> 4);
+        long length = value[0] & 0b_1111;
+
+        if ((value[0] & 0b1000_0000) == 0)
+        {
+            return (type, length);
+        }
+
+        var shift = 4;
+
+        do
+        {
+            stream.ReadExactly(value);
+            length |= (value[0] & 0b0111_1111L) << shift;
+            shift += 7;
+        }
+        while ((value[0] & 0b1000_0000) != 0);
+
+        return (type, length);
+    }
+
+    private static long ReadVariableLengthInteger(Stream stream)
+    {
+        long offset = -1;
+        int b;
+
+        do
+        {
+            offset++;
+            b = stream.ReadByte();
+            if (b == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            offset = (offset << 7) + (b & 127);
+        }
+        while ((b & 128) != 0);
+
+        return offset;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitSignature.cs
+++ b/src/GitVersion.Git.Managed/GitSignature.cs
@@ -1,0 +1,107 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers.Text;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents the signature of a Git committer, author or tagger.
+/// </summary>
+/// <param name="Name">The name of the person.</param>
+/// <param name="Email">The e-mail address of the person.</param>
+/// <param name="When">The date and time of the action, including the recorded UTC offset.</param>
+internal readonly record struct GitSignature(string Name, string Email, DateTimeOffset When)
+{
+    /// <summary>
+    /// Parses a signature line value in the format <c>Name &lt;email&gt; timestamp offset</c>,
+    /// for example <c>Jane Doe &lt;jane@example.com&gt; 1580753429 +0100</c>.
+    /// </summary>
+    /// <param name="value">The signature value (excluding the <c>author</c>/<c>committer</c>/<c>tagger</c> prefix).</param>
+    /// <param name="encodingName">The value of the containing object's <c>encoding</c> header, if present.</param>
+    /// <returns>The parsed <see cref="GitSignature"/>.</returns>
+    public static GitSignature Parse(ReadOnlySpan<byte> value, string? encodingName = null)
+    {
+        var (emailStart, emailEnd) = FindEmailDelimiters(value);
+
+        var name = value[..Math.Max(emailStart - 1, 0)];
+        var email = value[(emailStart + 1)..emailEnd];
+        var when = ParseTime(value[Math.Min(emailEnd + 2, value.Length)..]);
+
+        return new(GitTextDecoder.Decode(name, encodingName), GitTextDecoder.Decode(email, encodingName), when);
+    }
+
+    /// <summary>
+    /// Parses only the timestamp of a signature line value, without decoding the name
+    /// or the e-mail address into strings.
+    /// </summary>
+    /// <param name="value">The signature value (excluding the <c>author</c>/<c>committer</c>/<c>tagger</c> prefix).</param>
+    /// <returns>The date and time of the action, including the recorded UTC offset.</returns>
+    public static DateTimeOffset ParseWhen(ReadOnlySpan<byte> value)
+    {
+        var (_, emailEnd) = FindEmailDelimiters(value);
+        return ParseTime(value[Math.Min(emailEnd + 2, value.Length)..]);
+    }
+
+    private static (int EmailStart, int EmailEnd) FindEmailDelimiters(ReadOnlySpan<byte> value)
+    {
+        var emailStart = value.IndexOf((byte)'<');
+        var emailEnd = value.IndexOf((byte)'>');
+
+        if (emailStart < 0 || emailEnd < emailStart)
+        {
+            throw new GitObjectStoreException("A signature line is malformed: no e-mail address found.");
+        }
+
+        return (emailStart, emailEnd);
+    }
+
+    private static DateTimeOffset ParseTime(ReadOnlySpan<byte> time)
+    {
+        var offsetStart = time.IndexOf((byte)' ');
+        if (offsetStart < 0)
+        {
+            offsetStart = time.Length;
+        }
+
+        if (!Utf8Parser.TryParse(time[..offsetStart], out long seconds, out _))
+        {
+            throw new GitObjectStoreException("A signature line is malformed: no timestamp found.");
+        }
+
+        var when = DateTimeOffset.FromUnixTimeSeconds(seconds);
+
+        if (TryParseOffset(time[Math.Min(offsetStart + 1, time.Length)..], out var offset))
+        {
+            when = when.ToOffset(offset);
+        }
+
+        return when;
+    }
+
+    private static bool TryParseOffset(ReadOnlySpan<byte> value, out TimeSpan offset)
+    {
+        offset = TimeSpan.Zero;
+
+        if (value.Length < 5 || (value[0] != '+' && value[0] != '-'))
+        {
+            return false;
+        }
+
+        var hours = ((value[1] - '0') * 10) + (value[2] - '0');
+        var minutes = ((value[3] - '0') * 10) + (value[4] - '0');
+
+        if (hours is < 0 or > 14 || minutes is < 0 or > 59)
+        {
+            return false;
+        }
+
+        offset = new TimeSpan(hours, minutes, 0);
+
+        if (value[0] == '-')
+        {
+            offset = offset.Negate();
+        }
+
+        return true;
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTag.cs
+++ b/src/GitVersion.Git.Managed/GitTag.cs
@@ -1,0 +1,42 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git annotated tag, as stored in the Git object database.
+/// </summary>
+internal sealed class GitTag
+{
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> which uniquely identifies this annotated tag.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of the object this tag points at.
+    /// </summary>
+    public required GitObjectId Target { get; init; }
+
+    /// <summary>
+    /// Gets the type of the object this tag points at, e.g. <c>commit</c> or, for nested tags, <c>tag</c>.
+    /// </summary>
+    public required string TargetType { get; init; }
+
+    /// <summary>
+    /// Gets the name of this tag.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the tagger of this tag, or <see langword="null"/> when the tag has no <c>tagger</c> header.
+    /// </summary>
+    public GitSignature? Tagger { get; init; }
+
+    /// <summary>
+    /// Gets the tag message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git Tag: {Name} with id {Sha}";
+}

--- a/src/GitVersion.Git.Managed/GitTagReader.cs
+++ b/src/GitVersion.Git.Managed/GitTagReader.cs
@@ -1,0 +1,108 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitTag"/> (annotated tag) object.
+/// </summary>
+internal static class GitTagReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitTag"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the tag in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public static GitTag Read(Stream stream, GitObjectId sha)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var span = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(span);
+
+            return Read(span, sha);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitTag"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="tag">A <see cref="ReadOnlySpan{T}"/> which contains the tag in its text representation.</param>
+    /// <param name="sha">The <see cref="GitObjectId"/> of the tag.</param>
+    /// <returns>The <see cref="GitTag"/>.</returns>
+    public static GitTag Read(ReadOnlySpan<byte> tag, GitObjectId sha)
+    {
+        GitObjectId? target = null;
+        string? targetType = null;
+        string? name = null;
+        GitSignature? tagger = null;
+
+        var buffer = tag;
+
+        while (!buffer.IsEmpty)
+        {
+            var lineEnd = buffer.IndexOf((byte)'\n');
+            if (lineEnd < 0)
+            {
+                lineEnd = buffer.Length;
+            }
+
+            var line = buffer[..lineEnd];
+            buffer = buffer[Math.Min(lineEnd + 1, buffer.Length)..];
+
+            if (line.IsEmpty)
+            {
+                // An empty line separates the headers from the tag message.
+                break;
+            }
+
+            if (line[0] == ' ')
+            {
+                // A continuation of the previous (multi-line) header; skip.
+                continue;
+            }
+
+            if (line.StartsWith("object "u8))
+            {
+                target = GitObjectId.ParseHex(line["object "u8.Length..]);
+            }
+            else if (line.StartsWith("type "u8))
+            {
+                targetType = GitObjectTypes.Canonicalize(line["type "u8.Length..]);
+            }
+            else if (line.StartsWith("tag "u8))
+            {
+                name = GitTextDecoder.Decode(line["tag "u8.Length..]);
+            }
+            else if (line.StartsWith("tagger "u8))
+            {
+                tagger = GitSignature.Parse(line["tagger "u8.Length..]);
+            }
+        }
+
+        if (target is null || targetType is null || name is null)
+        {
+            throw new GitObjectStoreException($"The tag {sha} is malformed: an object, type or tag header is missing.");
+        }
+
+        return new()
+        {
+            Sha = sha,
+            Target = target.Value,
+            TargetType = targetType,
+            Name = name,
+            Tagger = tagger,
+            Message = GitTextDecoder.Decode(buffer)
+        };
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTextDecoder.cs
+++ b/src/GitVersion.Git.Managed/GitTextDecoder.cs
@@ -1,0 +1,52 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Decodes text stored in Git objects, matching git's behavior: content is assumed to be
+/// UTF-8 (or the encoding named by the commit's <c>encoding</c> header), falling back to
+/// Latin-1 when the bytes are not valid UTF-8.
+/// </summary>
+internal static class GitTextDecoder
+{
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// Decodes the given bytes as UTF-8, falling back to Latin-1 when the bytes are not valid UTF-8.
+    /// </summary>
+    /// <param name="bytes">The bytes to decode.</param>
+    /// <returns>The decoded string.</returns>
+    public static string Decode(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            return StrictUtf8.GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return Encoding.Latin1.GetString(bytes);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the given bytes using the named encoding when available, otherwise
+    /// falling back to <see cref="Decode(ReadOnlySpan{byte})"/>.
+    /// </summary>
+    /// <param name="bytes">The bytes to decode.</param>
+    /// <param name="encodingName">The value of the object's <c>encoding</c> header, if present.</param>
+    /// <returns>The decoded string.</returns>
+    public static string Decode(ReadOnlySpan<byte> bytes, string? encodingName)
+    {
+        if (encodingName is not null && !encodingName.Equals("UTF-8", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                return Encoding.GetEncoding(encodingName).GetString(bytes);
+            }
+            catch (ArgumentException)
+            {
+                // Unknown or unsupported encoding: fall back to git's default behavior.
+            }
+        }
+
+        return Decode(bytes);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTree.cs
+++ b/src/GitVersion.Git.Managed/GitTree.cs
@@ -1,0 +1,72 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git tree, as stored in the Git object database.
+/// </summary>
+internal sealed class GitTree
+{
+    /// <summary>
+    /// Gets the <see cref="GitObjectId"/> of this tree.
+    /// </summary>
+    public required GitObjectId Sha { get; init; }
+
+    /// <summary>
+    /// Gets the entries in this tree, in the order in which they are stored.
+    /// </summary>
+    public required IReadOnlyList<GitTreeEntry> Entries { get; init; }
+
+    /// <summary>
+    /// Gets the entry with the given name, or <see langword="null"/> if no such entry exists.
+    /// </summary>
+    /// <param name="name">The name of the entry to find.</param>
+    /// <returns>The matching entry, if found.</returns>
+    public GitTreeEntry? FindEntry(string name) => Entries.FirstOrDefault(entry => entry.Name == name);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Git tree: {Sha}";
+}
+
+/// <summary>
+/// Represents an individual entry in a Git tree.
+/// </summary>
+/// <param name="name">The name of the entry.</param>
+/// <param name="nameBytes">The raw name bytes of the entry, exactly as stored in the tree object.</param>
+/// <param name="mode">The file mode of the entry, as stored in the tree object (octal, without leading zeros), e.g. <c>100644</c> or <c>40000</c>.</param>
+/// <param name="sha">The Git object id of the blob or tree of the entry.</param>
+internal sealed class GitTreeEntry(string name, ReadOnlyMemory<byte> nameBytes, string mode, GitObjectId sha)
+{
+    private const string TreeMode = "40000";
+
+    /// <summary>
+    /// Gets the name of the entry.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the raw name bytes of the entry, exactly as stored in the tree object.
+    /// Git sorts and aligns tree entries by these bytes; <see cref="Name"/> is a decoded
+    /// form (UTF-8 with a Latin-1 fallback) which does not always round-trip to them.
+    /// </summary>
+    public ReadOnlyMemory<byte> NameBytes { get; } = nameBytes;
+
+    /// <summary>
+    /// Gets the file mode of the entry, as stored in the tree object (octal, without leading zeros),
+    /// e.g. <c>100644</c> for a regular file or <c>40000</c> for a directory.
+    /// </summary>
+    public string Mode { get; } = mode;
+
+    /// <summary>
+    /// Gets the Git object id of the blob or tree of the entry.
+    /// </summary>
+    public GitObjectId Sha { get; } = sha;
+
+    /// <summary>
+    /// Gets a value indicating whether this entry points to a tree (directory).
+    /// </summary>
+    public bool IsTree => Mode == TreeMode;
+
+    /// <inheritdoc/>
+    public override string ToString() => Name;
+}

--- a/src/GitVersion.Git.Managed/GitTreeReader.cs
+++ b/src/GitVersion.Git.Managed/GitTreeReader.cs
@@ -1,0 +1,86 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Reads a <see cref="GitTree"/> object.
+/// </summary>
+internal static class GitTreeReader
+{
+    /// <summary>
+    /// Reads a <see cref="GitTree"/> object from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which contains the tree in its binary representation.</param>
+    /// <param name="objectId">The <see cref="GitObjectId"/> of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public static GitTree Read(Stream stream, GitObjectId objectId)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var contents = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(contents);
+
+            return Read(contents, objectId);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a <see cref="GitTree"/> object from a <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    /// <param name="tree">A <see cref="ReadOnlySpan{T}"/> which contains the tree in its binary representation.</param>
+    /// <param name="objectId">The <see cref="GitObjectId"/> of the tree.</param>
+    /// <returns>The <see cref="GitTree"/>.</returns>
+    public static GitTree Read(ReadOnlySpan<byte> tree, GitObjectId objectId)
+    {
+        List<GitTreeEntry> entries = [];
+
+        var contents = tree;
+
+        while (!contents.IsEmpty)
+        {
+            // Format: [mode] [file/folder name]\0[object id of the referenced blob or tree]
+            var (name, nameBytes, mode, sha, entryLength) = ReadEntry(contents);
+            entries.Add(new(name, nameBytes, mode, sha));
+            contents = contents[entryLength..];
+        }
+
+        return new()
+        {
+            Sha = objectId,
+            Entries = entries
+        };
+    }
+
+    internal static (string Name, byte[] NameBytes, string Mode, GitObjectId Sha, int EntryLength) ReadEntry(ReadOnlySpan<byte> contents)
+    {
+        const int hashLength = GitObjectId.Sha1Size;
+
+        var modeEnd = contents.IndexOf((byte)' ');
+        var nameEnd = contents.IndexOf((byte)0);
+
+        if (modeEnd < 0 || nameEnd < modeEnd || contents.Length < nameEnd + 1 + hashLength)
+        {
+            throw new GitObjectStoreException("The tree object is malformed.");
+        }
+
+        var mode = Encoding.UTF8.GetString(contents[..modeEnd]);
+        // Keep a stable copy of the raw name bytes: the source span may be backed by a
+        // pooled buffer, and the decoded name (UTF-8 with a Latin-1 fallback) does not
+        // always round-trip back to the on-disk bytes git sorts entries by.
+        var nameBytes = contents[(modeEnd + 1)..nameEnd].ToArray();
+        var name = GitTextDecoder.Decode(nameBytes);
+        var sha = GitObjectId.Parse(contents.Slice(nameEnd + 1, hashLength));
+
+        return (name, nameBytes, mode, sha, nameEnd + 1 + hashLength);
+    }
+}

--- a/src/GitVersion.Git.Managed/GitTreeStreamingReader.cs
+++ b/src/GitVersion.Git.Managed/GitTreeStreamingReader.cs
@@ -1,0 +1,61 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Finds entries in Git tree objects by scanning the raw tree bytes directly,
+/// without parsing every entry into a <see cref="GitTree"/> model.
+/// </summary>
+internal static class GitTreeStreamingReader
+{
+    /// <summary>
+    /// Finds a specific node in a git tree.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> which represents the git tree.</param>
+    /// <param name="name">The name of the node to find, in its UTF-8 representation.</param>
+    /// <returns>
+    /// The <see cref="GitObjectId"/> of the requested node, or <see cref="GitObjectId.Empty"/> if not found.
+    /// </returns>
+    public static GitObjectId FindNode(Stream stream, ReadOnlySpan<byte> name)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        const int hashLength = GitObjectId.Sha1Size;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(checked((int)stream.Length));
+
+        try
+        {
+            var contents = buffer.AsSpan(0, (int)stream.Length);
+            stream.ReadExactly(contents);
+
+            while (!contents.IsEmpty)
+            {
+                var modeEnd = contents.IndexOf((byte)' ');
+                var nameEnd = contents.IndexOf((byte)0);
+
+                if (modeEnd < 0 || nameEnd < modeEnd || contents.Length < nameEnd + 1 + hashLength)
+                {
+                    throw new GitObjectStoreException("The tree object is malformed.");
+                }
+
+                var currentName = contents[(modeEnd + 1)..nameEnd];
+
+                if (currentName.SequenceEqual(name))
+                {
+                    return GitObjectId.Parse(contents.Slice(nameEnd + 1, hashLength));
+                }
+
+                contents = contents[(nameEnd + 1 + hashLength)..];
+            }
+
+            return GitObjectId.Empty;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
+++ b/src/GitVersion.Git.Managed/GitVersion.Git.Managed.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="GitVersion.Git.Managed.Tests" />
+        <InternalsVisibleTo Include="GitVersion.Core.Tests" />
+    </ItemGroup>
+
+</Project>

--- a/src/GitVersion.Git.Managed/GitVersionManagedGitModule.cs
+++ b/src/GitVersion.Git.Managed/GitVersionManagedGitModule.cs
@@ -1,0 +1,20 @@
+using GitVersion.Git;
+
+namespace GitVersion;
+
+/// <summary>
+/// Registers the managed Git backend: all repository reads are served by the managed
+/// object/reference readers, while mutating and network operations go through the git CLI.
+/// </summary>
+public class GitVersionManagedGitModule : IGitVersionModule
+{
+    /// <summary>Registers the services provided by this module into <paramref name="services"/>.</summary>
+    public void RegisterTypes(IServiceCollection services)
+    {
+        services.AddSingleton<IGitCliExecutor, GitCliExecutor>();
+        services.AddSingleton<IGitCliMutator, GitCliMutator>();
+        services.AddSingleton<IGitRepository, ManagedGitRepository>();
+        services.AddSingleton<IMutatingGitRepository>(sp => (IMutatingGitRepository)sp.GetRequiredService<IGitRepository>());
+        services.AddSingleton<IGitRepositoryInfo, ManagedGitRepositoryInfo>();
+    }
+}

--- a/src/GitVersion.Git.Managed/GitZLibStream.cs
+++ b/src/GitVersion.Git.Managed/GitZLibStream.cs
@@ -1,0 +1,146 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.IO.Compression;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A <see cref="Stream"/> which reads zlib-compressed data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This stream parses but ignores the two-byte zlib header at the start of the compressed
+/// stream. It keeps track of the current position and, if provided, the length, and supports
+/// forward-only seeking.
+/// </para>
+/// <para>
+/// This class wraps a <see cref="DeflateStream"/> rather than inheriting from it, because
+/// <see cref="DeflateStream"/> detects whether <c>Read(Span{byte})</c> is being overridden
+/// and behaves differently when it is.
+/// </para>
+/// </remarks>
+internal class GitZLibStream : Stream
+{
+    private readonly DeflateStream stream;
+    private long length;
+    private long position;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitZLibStream"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> from which to read data.</param>
+    /// <param name="length">The size of the uncompressed data.</param>
+    public GitZLibStream(Stream stream, long length = -1)
+    {
+        this.stream = new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: false);
+        this.length = length;
+
+        Span<byte> zlibHeader = stackalloc byte[2];
+        stream.ReadExactly(zlibHeader);
+
+        if (zlibHeader[0] != 0x78 || (zlibHeader[1] != 0x01 && zlibHeader[1] != 0x9C && zlibHeader[1] != 0x5E && zlibHeader[1] != 0xDA))
+        {
+            throw new GitObjectStoreException($"Invalid zlib header {zlibHeader[0]:X2} {zlibHeader[1]:X2}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => this.position;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var read = this.stream.Read(buffer, offset, count);
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        var read = this.stream.Read(buffer);
+        this.position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override int ReadByte()
+    {
+        var value = this.stream.ReadByte();
+
+        if (value != -1)
+        {
+            this.position += 1;
+        }
+
+        return value;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin == SeekOrigin.Begin && offset == this.position)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Current && offset == 0)
+        {
+            return this.position;
+        }
+
+        if (origin == SeekOrigin.Begin && offset > this.position)
+        {
+            this.ReadBytes(checked((int)(offset - this.position)));
+            return this.position;
+        }
+
+        throw new NotSupportedException("Only forward seeks are supported.");
+    }
+
+    /// <inheritdoc/>
+    public override void Flush() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.stream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Initializes the length and position properties.
+    /// </summary>
+    /// <param name="length">The length of the uncompressed data.</param>
+    protected void Initialize(long length)
+    {
+        this.position = 0;
+        this.length = length;
+    }
+}

--- a/src/GitVersion.Git.Managed/History/GitRevisionSortStrategies.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionSortStrategies.cs
@@ -1,0 +1,30 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// The sort orders supported by <see cref="GitRevisionWalker"/>, mirroring the strategies
+/// GitVersion uses when querying commit history.
+/// </summary>
+[Flags]
+internal enum GitRevisionSortStrategies
+{
+    /// <summary>
+    /// Git's default ordering: reverse chronological by committer date.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Topological ordering: a commit is only emitted after all of the emitted
+    /// commits which list it as a parent.
+    /// </summary>
+    Topological = 1,
+
+    /// <summary>
+    /// Reverse chronological ordering by committer date.
+    /// </summary>
+    Time = 2,
+
+    /// <summary>
+    /// Reverses the selected ordering.
+    /// </summary>
+    Reverse = 4
+}

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalkOptions.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Describes a revision walk: which commits to start from, which histories to exclude,
+/// the sort order, and whether to follow only first parents.
+/// </summary>
+internal sealed class GitRevisionWalkOptions
+{
+    /// <summary>
+    /// Gets the commits whose histories are included in the walk.
+    /// </summary>
+    public IList<GitObjectId> Include { get; } = [];
+
+    /// <summary>
+    /// Gets the commits whose histories (including the commits themselves) are excluded from the walk.
+    /// </summary>
+    public IList<GitObjectId> Exclude { get; } = [];
+
+    /// <summary>
+    /// Gets the sort order of the walk.
+    /// </summary>
+    public GitRevisionSortStrategies Sort { get; init; } = GitRevisionSortStrategies.None;
+
+    /// <summary>
+    /// Gets a value indicating whether only the first parent of each commit is followed.
+    /// </summary>
+    public bool FirstParentOnly { get; init; }
+}

--- a/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
+++ b/src/GitVersion.Git.Managed/History/GitRevisionWalker.cs
@@ -1,0 +1,831 @@
+using System.Collections.Concurrent;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Walks commit history in the orders GitVersion depends on (chronological, topological,
+/// reversed, first-parent-only, with include/exclude reachability sets) and computes merge
+/// bases. The walk replicates libgit2's revision-walk behavior — including its date-directed
+/// limiting pass and its tie-breaking on equal committer timestamps — because GitVersion's
+/// version output depends on the exact commit ordering. Parity is validated against libgit2
+/// by the test suite.
+/// </summary>
+/// <remarks>
+/// Shallow-clone boundaries are honored the way git and libgit2 honor the <c>.git/shallow</c>
+/// grafts: commits in <paramref name="shallowCommits"/> are treated as parentless, even when
+/// their parent objects happen to be reachable through the object store. A parent that fails
+/// to load and is not explained by a shallow boundary indicates a corrupt or incomplete
+/// repository and fails the walk with a <see cref="GitObjectStoreException"/>, matching
+/// libgit2, instead of silently truncating history.
+/// </remarks>
+internal sealed class GitRevisionWalker(GitObjectStore objectStore, IReadOnlySet<GitObjectId>? shallowCommits = null)
+{
+    // The number of uninteresting commits to look at after running out of interesting ones,
+    // matching git's slop heuristic for clock-skewed histories.
+    private const int Slop = 5;
+
+    private readonly GitObjectStore objectStore = objectStore ?? throw new ArgumentNullException(nameof(objectStore));
+    private readonly IReadOnlySet<GitObjectId> shallowCommits = shallowCommits ?? new HashSet<GitObjectId>();
+    private readonly ConcurrentDictionary<GitObjectId, GitCommit?> commitCache = new();
+
+    /// <summary>
+    /// Walks the commits described by <paramref name="options"/> and returns them in order.
+    /// </summary>
+    /// <param name="options">The walk description.</param>
+    /// <returns>The commits, in the requested order.</returns>
+    public IReadOnlyList<GitCommit> Walk(GitRevisionWalkOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var walk = new WalkState(this, options);
+        var result = walk.Run();
+
+        if (options.Sort.HasFlag(GitRevisionSortStrategies.Reverse))
+        {
+            result.Reverse();
+        }
+
+        return [.. result.Select(node => node.Commit)];
+    }
+
+    /// <summary>
+    /// Finds the best common ancestor of two commits, the way <c>git merge-base</c> does:
+    /// paint-down-to-common followed by elimination of redundant candidates.
+    /// </summary>
+    /// <param name="first">The first commit.</param>
+    /// <param name="second">The second commit.</param>
+    /// <returns>The merge base, or <see langword="null"/> when the histories are unrelated.</returns>
+    public GitObjectId? FindMergeBase(GitObjectId first, GitObjectId second)
+    {
+        if (first == second)
+        {
+            return TryLoad(first) is null ? null : first;
+        }
+
+        var candidates = PaintDownToCommon(first, second);
+
+        return candidates.Count switch
+        {
+            0 => null,
+            1 => candidates[0],
+            _ => RemoveRedundantCandidates(candidates)
+        };
+    }
+
+    private HashSet<GitObjectId> CollectReachable(IEnumerable<GitObjectId> roots, bool firstParentOnly)
+    {
+        var reachable = new HashSet<GitObjectId>();
+        var stack = new Stack<GitObjectId>();
+
+        foreach (var root in roots)
+        {
+            stack.Push(root);
+        }
+
+        while (stack.Count > 0)
+        {
+            var id = stack.Pop();
+
+            if (!reachable.Add(id))
+            {
+                continue;
+            }
+
+            var commit = LoadParent(id);
+
+            foreach (var parentId in firstParentOnly ? commit.Parents.Take(1) : commit.Parents)
+            {
+                stack.Push(parentId);
+            }
+        }
+
+        return reachable;
+    }
+
+    private List<GitObjectId> PaintDownToCommon(GitObjectId first, GitObjectId second)
+    {
+        var walk = new PaintDownWalk(this);
+        walk.Enqueue(first, PaintDownWalk.FlagFirst);
+        walk.Enqueue(second, PaintDownWalk.FlagSecond);
+        return walk.Run();
+    }
+
+    /// <summary>
+    /// The paint-down-to-common walk of <c>git merge-base</c>: descend from both tips in
+    /// date order, painting each commit with the tips that reach it; commits reached by
+    /// both are candidates, and everything below a candidate is stale. The number of
+    /// queued non-stale entries is tracked incrementally: libgit2 rescans its whole queue
+    /// per iteration to decide whether anything interesting remains, which is quadratic
+    /// on the hottest path of version calculation. The count is equivalent to that scan.
+    /// </summary>
+    private sealed class PaintDownWalk(GitRevisionWalker walker)
+    {
+        public const int FlagFirst = 1;
+        public const int FlagSecond = 2;
+        private const int FlagStale = 4;
+        private const int FlagBoth = FlagFirst | FlagSecond;
+
+        private readonly Dictionary<GitObjectId, int> flags = [];
+        private readonly Dictionary<GitObjectId, int> queuedCounts = [];
+        private readonly List<GitObjectId> candidates = [];
+        private readonly PriorityQueue<GitCommit, (long Time, long Sequence)> queue = new(TimeDescendingComparer.Instance);
+        private long sequence;
+        private int interesting;
+
+        public List<GitObjectId> Run()
+        {
+            while (this.interesting > 0)
+            {
+                Process(this.queue.Dequeue());
+            }
+
+            return this.candidates;
+        }
+
+        public void Enqueue(GitObjectId id, int newFlags)
+        {
+            var current = this.flags.GetValueOrDefault(id);
+            var updated = current | newFlags;
+
+            if (updated == current)
+            {
+                return;
+            }
+
+            this.flags[id] = updated;
+
+            if ((current & FlagStale) == 0 && (updated & FlagStale) != 0)
+            {
+                MarkQueuedEntriesStale(id);
+            }
+
+            if (walker.TryLoad(id) is { } commit)
+            {
+                this.queue.Enqueue(commit, (commit.CommitterWhen.ToUnixTimeSeconds(), this.sequence++));
+                this.queuedCounts[id] = this.queuedCounts.GetValueOrDefault(id) + 1;
+
+                if ((updated & FlagStale) == 0)
+                {
+                    this.interesting++;
+                }
+            }
+        }
+
+        private void Process(GitCommit commit)
+        {
+            var commitFlags = this.flags[commit.Sha];
+            this.queuedCounts[commit.Sha]--;
+
+            if ((commitFlags & FlagStale) == 0)
+            {
+                this.interesting--;
+            }
+
+            var paint = commitFlags & FlagBoth;
+
+            if (paint == FlagBoth)
+            {
+                if ((commitFlags & FlagStale) == 0)
+                {
+                    this.candidates.Add(commit.Sha);
+                    this.flags[commit.Sha] = commitFlags | FlagStale;
+                    MarkQueuedEntriesStale(commit.Sha);
+                }
+
+                // Everything below a common commit is stale: it cannot be a better candidate.
+                paint |= FlagStale;
+            }
+
+            foreach (var parentId in commit.Parents)
+            {
+                walker.LoadParent(parentId);
+                Enqueue(parentId, paint);
+            }
+        }
+
+        private void MarkQueuedEntriesStale(GitObjectId id) => this.interesting -= this.queuedCounts.GetValueOrDefault(id);
+    }
+
+    private GitObjectId? RemoveRedundantCandidates(List<GitObjectId> candidates)
+    {
+        // A candidate which is an ancestor of another candidate is redundant. Candidates are
+        // in discovery order (most recent first), so return the first independent one.
+        foreach (var candidate in candidates)
+        {
+            var others = candidates.Where(other => other != candidate).ToList();
+
+            if (!IsAncestorOfAny(candidate, others))
+            {
+                return candidate;
+            }
+        }
+
+        return candidates[0];
+    }
+
+    private bool IsAncestorOfAny(GitObjectId candidate, List<GitObjectId> others)
+    {
+        foreach (var other in others)
+        {
+            if (TryLoad(other) is not { } commit)
+            {
+                continue;
+            }
+
+            if (CollectReachable(commit.Parents, firstParentOnly: false).Contains(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Loads a commit through the walker's parsed-commit cache, or returns
+    /// <see langword="null"/> when the object does not exist. The cache is shared with the
+    /// adapter layer so each commit is read and parsed at most once per session.
+    /// </summary>
+    /// <param name="id">The id of the commit.</param>
+    /// <returns>The commit, or <see langword="null"/>.</returns>
+    public GitCommit? TryLoadCommit(GitObjectId id) => TryLoad(id);
+
+    private GitCommit? TryLoad(GitObjectId id)
+    {
+        if (this.commitCache.TryGetValue(id, out var cached))
+        {
+            return cached;
+        }
+
+        GitCommit? commit = null;
+
+        if (this.objectStore.TryGetObject(id, GitObjectTypes.Commit, out var stream))
+        {
+            using (stream)
+            {
+                commit = GitCommitReader.Read(stream, id);
+            }
+
+            if (this.shallowCommits.Contains(id))
+            {
+                // Apply the shallow graft: the boundary commit is parentless even when its
+                // parent objects are present (e.g. via alternates), matching git and libgit2.
+                commit = commit.WithoutParents();
+            }
+        }
+
+        return this.commitCache.GetOrAdd(id, commit);
+    }
+
+    /// <summary>
+    /// Loads a parent commit, failing the walk when the object is missing: with shallow
+    /// boundaries grafted away in <see cref="TryLoad"/>, a missing parent means the
+    /// repository is corrupt or incomplete, and truncating history there would silently
+    /// produce a wrong version.
+    /// </summary>
+    /// <param name="id">The id of the parent commit.</param>
+    /// <returns>The parent commit.</returns>
+    /// <exception cref="GitObjectStoreException">The parent object does not exist.</exception>
+    private GitCommit LoadParent(GitObjectId id) =>
+        TryLoad(id)
+            ?? throw new GitObjectStoreException($"The parent commit '{id}' could not be found in the repository; the object database is corrupt or incomplete.") { ObjectNotFound = true };
+
+    /// <summary>
+    /// The per-walk engine. Mirrors libgit2's revwalk phases: seed preparation, the
+    /// date-directed limiting pass, and the per-sort emission disciplines.
+    /// </summary>
+    private sealed class WalkState(GitRevisionWalker walker, GitRevisionWalkOptions options)
+    {
+        private readonly Dictionary<GitObjectId, WalkNode> nodes = [];
+
+        private bool FirstParentOnly => options.FirstParentOnly;
+
+        public List<WalkNode> Run()
+        {
+            var (seeds, limited) = PrepareSeeds();
+
+            if (limited)
+            {
+                seeds = LimitList(seeds);
+            }
+
+            if (options.Sort.HasFlag(GitRevisionSortStrategies.Topological))
+            {
+                return SortInTopologicalOrder(seeds, byTime: options.Sort.HasFlag(GitRevisionSortStrategies.Time));
+            }
+
+            if (options.Sort.HasFlag(GitRevisionSortStrategies.Time))
+            {
+                return EmitByTime(seeds);
+            }
+
+            return limited ? [.. seeds.Where(node => !node.Uninteresting)] : EmitUnsorted(seeds);
+        }
+
+        private (List<WalkNode> Seeds, bool Limited) PrepareSeeds()
+        {
+            var limited = options.Sort != GitRevisionSortStrategies.None;
+
+            // Pushes prepend to the input list; includes are pushed before hides,
+            // and a hide overrides an earlier push of the same commit.
+            var userInput = new List<WalkNode>();
+
+            foreach (var (id, uninteresting) in
+                     options.Include.Select(id => (id, false)).Concat(options.Exclude.Select(id => (id, true))))
+            {
+                var node = LookupNode(id);
+
+                if (node.Uninteresting && !uninteresting)
+                {
+                    continue;
+                }
+
+                node.Uninteresting = uninteresting;
+                limited |= uninteresting;
+                userInput.Insert(0, node);
+            }
+
+            var seeds = new List<WalkNode>();
+
+            foreach (var node in userInput)
+            {
+                Parse(node);
+
+                // A pushed or hidden commit whose object cannot be looked up fails the
+                // walk in libgit2, too; an unparsed seed would be emitted as a null commit.
+                if (!node.Parsed)
+                {
+                    throw new GitObjectStoreException($"The commit '{node.Id}' could not be found in the repository.") { ObjectNotFound = true };
+                }
+
+                if (node.Uninteresting)
+                {
+                    MarkParentsUninteresting(node);
+                }
+
+                if (!node.Seen)
+                {
+                    node.Seen = true;
+                    seeds.Add(node);
+                }
+            }
+
+            return (seeds, limited);
+        }
+
+        /// <summary>
+        /// The date-directed limiting pass: traverses from the seeds in descending date order,
+        /// propagating "uninteresting" and stopping a few commits (the slop) after only
+        /// uninteresting commits remain. Returns the interesting commits in traversal order.
+        /// </summary>
+        private List<WalkNode> LimitList(List<WalkNode> seeds)
+        {
+            var list = new LinkedList<WalkNode>(seeds);
+            var newList = new List<WalkNode>();
+            var slop = Slop;
+            var time = long.MaxValue;
+
+            while (list.First is { } head)
+            {
+                list.RemoveFirst();
+                var commit = head.Value;
+
+                AddParentsToList(commit, list);
+
+                if (commit.Uninteresting)
+                {
+                    MarkParentsUninteresting(commit);
+
+                    slop = StillInteresting(list, time, slop);
+
+                    if (slop > 0)
+                    {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                time = commit.Time;
+                newList.Add(commit);
+            }
+
+            return newList;
+        }
+
+        private void AddParentsToList(WalkNode commit, LinkedList<WalkNode> list)
+        {
+            if (commit.Added)
+            {
+                return;
+            }
+
+            commit.Added = true;
+
+            if (commit.Uninteresting)
+            {
+                // Hidden histories ignore first-parent simplification: hide as much as possible.
+                foreach (var parent in ParsedParents(commit))
+                {
+                    parent.Uninteresting = true;
+                    ParseParent(parent);
+
+                    if (parent.Parents.Count > 0)
+                    {
+                        MarkParentsUninteresting(parent);
+                    }
+
+                    parent.Seen = true;
+                    InsertByDate(list, parent);
+                }
+
+                return;
+            }
+
+            foreach (var parent in ParsedParents(commit))
+            {
+                ParseParent(parent);
+
+                if (!parent.Seen)
+                {
+                    parent.Seen = true;
+                    InsertByDate(list, parent);
+                }
+
+                if (FirstParentOnly)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static int StillInteresting(LinkedList<WalkNode> list, long time, int slop)
+        {
+            if (list.Count == 0)
+            {
+                return 0;
+            }
+
+            // A destination commit later than our current date means we are not done.
+            if (time <= list.First!.Value.Time)
+            {
+                return Slop;
+            }
+
+            foreach (var item in list)
+            {
+                if (!item.Uninteresting || item.Time > time)
+                {
+                    return Slop;
+                }
+            }
+
+            return slop - 1;
+        }
+
+        private static void InsertByDate(LinkedList<WalkNode> list, WalkNode item)
+        {
+            // Keep the list in descending date order; equal dates go after existing entries.
+            var current = list.First;
+
+            while (current is not null && current.Value.Time >= item.Time)
+            {
+                current = current.Next;
+            }
+
+            if (current is null)
+            {
+                list.AddLast(item);
+            }
+            else
+            {
+                list.AddBefore(current, item);
+            }
+        }
+
+        private static void MarkParentsUninteresting(WalkNode node)
+        {
+            // Mark all (currently parsed) ancestors uninteresting, chasing first-parent
+            // chains and stopping at commits which have not been parsed yet — the limiting
+            // pass will pick those up as it reaches them.
+            var pending = new Stack<WalkNode>();
+
+            foreach (var parent in ParsedParents(node))
+            {
+                pending.Push(parent);
+            }
+
+            while (pending.Count > 0)
+            {
+                var commit = pending.Pop();
+
+                while (true)
+                {
+                    if (commit.Uninteresting)
+                    {
+                        break;
+                    }
+
+                    commit.Uninteresting = true;
+
+                    if (!commit.Parsed || commit.Parents.Count == 0)
+                    {
+                        break;
+                    }
+
+                    foreach (var parent in commit.Parents)
+                    {
+                        pending.Push(parent);
+                    }
+
+                    commit = commit.Parents[0];
+                }
+            }
+        }
+
+        private static List<WalkNode> EmitByTime(List<WalkNode> seeds)
+        {
+            var queue = new BinaryHeap(byTime: true);
+
+            foreach (var node in seeds)
+            {
+                queue.Insert(node);
+            }
+
+            var result = new List<WalkNode>();
+
+            while (queue.Pop() is { } next)
+            {
+                if (!next.Uninteresting)
+                {
+                    result.Add(next);
+                }
+            }
+
+            return result;
+        }
+
+        private List<WalkNode> EmitUnsorted(List<WalkNode> seeds)
+        {
+            // The default walk: pop the head of a date-sorted list, lazily inserting parents.
+            var list = new LinkedList<WalkNode>(seeds);
+            var result = new List<WalkNode>();
+
+            while (list.First is { } head)
+            {
+                list.RemoveFirst();
+                var commit = head.Value;
+
+                AddParentsToList(commit, list);
+
+                if (!commit.Uninteresting)
+                {
+                    result.Add(commit);
+                }
+            }
+
+            return result;
+        }
+
+        private static List<WalkNode> SortInTopologicalOrder(List<WalkNode> list, bool byTime)
+        {
+            // A commit may only be emitted after all commits in the list which have it as a
+            // parent. Ready commits are emitted chronologically when time-sorting, otherwise
+            // in the order the limiting pass produced them.
+            ComputeChildCounts(list);
+
+            var queue = CreateReadyQueue(list, byTime);
+            var result = new List<WalkNode>();
+
+            while (queue.Pop() is { } next)
+            {
+                foreach (var parent in next.Parents.Where(parent => parent.InDegree > 0))
+                {
+                    if (--parent.InDegree == 1)
+                    {
+                        queue.Insert(parent);
+                    }
+                }
+
+                next.InDegree = 0;
+
+                if (!next.Uninteresting)
+                {
+                    result.Add(next);
+                }
+            }
+
+            return result;
+        }
+
+        private static void ComputeChildCounts(List<WalkNode> list)
+        {
+            foreach (var node in list)
+            {
+                node.InDegree = 1;
+            }
+
+            foreach (var parent in list.SelectMany(node => node.Parents).Where(parent => parent.InDegree > 0))
+            {
+                parent.InDegree++;
+            }
+        }
+
+        private static BinaryHeap CreateReadyQueue(List<WalkNode> list, bool byTime)
+        {
+            var queue = new BinaryHeap(byTime);
+
+            foreach (var node in list.Where(node => node.InDegree == 1))
+            {
+                queue.Insert(node);
+            }
+
+            // The tips must come out in traversal order; without time-sorting the plain
+            // vector pops from the end, so reverse it to preserve the insertion order.
+            if (!byTime)
+            {
+                queue.Reverse();
+            }
+
+            return queue;
+        }
+
+        private static IEnumerable<WalkNode> ParsedParents(WalkNode node)
+        {
+            if (!node.Parsed)
+            {
+                yield break;
+            }
+
+            foreach (var parent in node.Parents)
+            {
+                yield return parent;
+            }
+        }
+
+        private WalkNode LookupNode(GitObjectId id)
+        {
+            if (!this.nodes.TryGetValue(id, out var node))
+            {
+                node = new(id);
+                this.nodes.Add(id, node);
+            }
+
+            return node;
+        }
+
+        private void Parse(WalkNode node)
+        {
+            if (!node.Parsed && walker.TryLoad(node.Id) is { } commit)
+            {
+                Populate(node, commit);
+            }
+        }
+
+        private void ParseParent(WalkNode node)
+        {
+            if (!node.Parsed)
+            {
+                Populate(node, walker.LoadParent(node.Id));
+            }
+        }
+
+        private void Populate(WalkNode node, GitCommit commit)
+        {
+            node.Commit = commit;
+            node.Time = commit.CommitterWhen.ToUnixTimeSeconds();
+            node.Parents.AddRange(commit.Parents.Select(LookupNode));
+            node.Parsed = true;
+        }
+    }
+
+    private sealed class WalkNode(GitObjectId id)
+    {
+        public GitObjectId Id { get; } = id;
+        public GitCommit Commit { get; set; } = null!;
+        public long Time { get; set; }
+        public List<WalkNode> Parents { get; } = [];
+        public bool Parsed { get; set; }
+        public bool Seen { get; set; }
+        public bool Uninteresting { get; set; }
+        public bool Added { get; set; }
+        public int InDegree { get; set; }
+    }
+
+    /// <summary>
+    /// A binary min-heap over descending commit time, replicating the classic array-heap
+    /// mechanics (append + sift-up on insert; move-last-to-root + sift-down on pop, with
+    /// strict comparisons) so that the emission order of equal-timestamp commits matches
+    /// libgit2's. Without time ordering it degrades to a plain vector popped from the end.
+    /// </summary>
+    private sealed class BinaryHeap(bool byTime)
+    {
+        private readonly List<WalkNode> items = [];
+
+        public void Insert(WalkNode item)
+        {
+            this.items.Add(item);
+
+            if (byTime)
+            {
+                SiftUp(this.items.Count - 1);
+            }
+        }
+
+        public void Reverse() => this.items.Reverse();
+
+        public WalkNode? Pop()
+        {
+            if (this.items.Count == 0)
+            {
+                return null;
+            }
+
+            if (!byTime)
+            {
+                var last = this.items[^1];
+                this.items.RemoveAt(this.items.Count - 1);
+                return last;
+            }
+
+            var result = this.items[0];
+
+            if (this.items.Count > 1)
+            {
+                this.items[0] = this.items[^1];
+                this.items.RemoveAt(this.items.Count - 1);
+                SiftDown(0);
+            }
+            else
+            {
+                this.items.RemoveAt(0);
+            }
+
+            return result;
+        }
+
+        private static int Compare(WalkNode left, WalkNode right) => right.Time.CompareTo(left.Time);
+
+        private void SiftUp(int index)
+        {
+            var item = this.items[index];
+
+            while (index > 0)
+            {
+                var parentIndex = (index - 1) >> 1;
+                var parent = this.items[parentIndex];
+
+                if (Compare(parent, item) <= 0)
+                {
+                    break;
+                }
+
+                this.items[index] = parent;
+                index = parentIndex;
+            }
+
+            this.items[index] = item;
+        }
+
+        private void SiftDown(int index)
+        {
+            var item = this.items[index];
+
+            while (true)
+            {
+                var childIndex = (index << 1) + 1;
+
+                if (childIndex >= this.items.Count)
+                {
+                    break;
+                }
+
+                if (childIndex + 1 < this.items.Count && Compare(this.items[childIndex], this.items[childIndex + 1]) > 0)
+                {
+                    childIndex++;
+                }
+
+                if (Compare(item, this.items[childIndex]) <= 0)
+                {
+                    break;
+                }
+
+                this.items[index] = this.items[childIndex];
+                index = childIndex;
+            }
+
+            this.items[index] = item;
+        }
+    }
+
+    private sealed class TimeDescendingComparer : IComparer<(long Time, long Sequence)>
+    {
+        public static TimeDescendingComparer Instance { get; } = new();
+
+        public int Compare((long Time, long Sequence) x, (long Time, long Sequence) y)
+        {
+            var byTime = y.Time.CompareTo(x.Time);
+            return byTime != 0 ? byTime : x.Sequence.CompareTo(y.Sequence);
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/NOTICE.md
+++ b/src/GitVersion.Git.Managed/NOTICE.md
@@ -1,0 +1,35 @@
+# Third-party notices
+
+## Nerdbank.GitVersioning
+
+Portions of the code in this project (the managed Git object store reader) are derived from
+[Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning), specifically its
+`ManagedGit` implementation.
+
+Nerdbank.GitVersioning is licensed under the MIT License:
+
+```
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/src/GitVersion.Git.Managed/PublicAPI.Shipped.txt
+++ b/src/GitVersion.Git.Managed/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GitVersion.Git.Managed/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Git.Managed/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+GitVersion.GitVersionManagedGitModule
+GitVersion.GitVersionManagedGitModule.GitVersionManagedGitModule() -> void
+GitVersion.GitVersionManagedGitModule.RegisterTypes(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void

--- a/src/GitVersion.Git.Managed/RandomAccessStream.cs
+++ b/src/GitVersion.Git.Managed/RandomAccessStream.cs
@@ -1,0 +1,98 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only, seekable access to a file through a shared <see cref="SafeFileHandle"/>.
+/// Each instance maintains its own position, so multiple streams can read the same file
+/// concurrently without interfering with each other. The handle is not owned by this stream.
+/// </summary>
+internal sealed class RandomAccessStream : Stream
+{
+    private readonly SafeFileHandle handle;
+    private readonly long length;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RandomAccessStream"/> class.
+    /// </summary>
+    /// <param name="handle">The handle of the file to read. Remains owned by the caller.</param>
+    /// <param name="length">The length of the file.</param>
+    public RandomAccessStream(SafeFileHandle handle, long length)
+    {
+        this.handle = handle ?? throw new ArgumentNullException(nameof(handle));
+        this.length = length;
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => true;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => true;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => false;
+
+    /// <inheritdoc/>
+    public override long Length => this.length;
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get;
+        set => field = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), value, "A stream position cannot be negative.");
+    }
+
+    /// <inheritdoc/>
+    public override void Flush()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc/>
+    public override int Read(Span<byte> buffer)
+    {
+        var toRead = (int)Math.Min(buffer.Length, this.length - Position);
+        if (toRead <= 0)
+        {
+            return 0;
+        }
+
+        var read = RandomAccess.Read(this.handle, buffer[..toRead], Position);
+        Position += read;
+        return read;
+    }
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        var newPosition = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => Position + offset,
+            _ => throw new NotSupportedException()
+        };
+
+        if (newPosition > this.length)
+        {
+            newPosition = this.length;
+        }
+
+        if (newPosition < 0)
+        {
+            throw new IOException("Attempted to seek before the start or beyond the end of the stream.");
+        }
+
+        Position = newPosition;
+        return Position;
+    }
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/GitVersion.Git.Managed/Refs/GitReference.cs
+++ b/src/GitVersion.Git.Managed/Refs/GitReference.cs
@@ -1,0 +1,46 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Represents a Git reference: either a direct reference pointing at an object,
+/// or a symbolic reference pointing at another reference.
+/// </summary>
+internal sealed class GitReference
+{
+    /// <summary>
+    /// Gets the canonical name of the reference, e.g. <c>refs/heads/main</c> or <c>HEAD</c>.
+    /// </summary>
+    public required string CanonicalName { get; init; }
+
+    /// <summary>
+    /// Gets the object id the reference points at, for direct references.
+    /// </summary>
+    public GitObjectId? ObjectId { get; init; }
+
+    /// <summary>
+    /// Gets the canonical name of the reference this reference points at, for symbolic references.
+    /// </summary>
+    public string? SymbolicTargetName { get; init; }
+
+    /// <summary>
+    /// Gets the fully peeled target of the reference (the commit an annotated tag ultimately
+    /// points at), when known from the <c>packed-refs</c> file; otherwise <see langword="null"/>.
+    /// </summary>
+    public GitObjectId? PeeledObjectId { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this reference was read from the <c>packed-refs</c>
+    /// file (as opposed to a loose reference file).
+    /// </summary>
+    public bool IsPacked { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a symbolic reference.
+    /// </summary>
+    public bool IsSymbolic => SymbolicTargetName is not null;
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        IsSymbolic
+            ? $"{CanonicalName} -> {SymbolicTargetName}"
+            : $"{CanonicalName} -> {ObjectId}";
+}

--- a/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
+++ b/src/GitVersion.Git.Managed/Refs/GitReferenceStore.cs
@@ -1,0 +1,242 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides read-only access to the references of a Git repository: loose refs under
+/// <c>refs/</c>, the <c>packed-refs</c> file (including peeled targets), and per-worktree
+/// refs such as <c>HEAD</c>.
+/// </summary>
+/// <remarks>
+/// Loose references take precedence over entries in <c>packed-refs</c>, matching git.
+/// </remarks>
+internal sealed class GitReferenceStore
+{
+    private const string RefsPrefix = "refs/";
+
+    // Matches git's limit on the depth of nested symbolic references (MAXDEPTH in refs.c).
+    private const int MaxSymbolicReferenceDepth = 5;
+
+    private readonly string gitDirectory;
+    private readonly string commonDirectory;
+    private readonly Lazy<Dictionary<string, GitReference>> packedReferences;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitReferenceStore"/> class.
+    /// </summary>
+    /// <param name="gitDirectory">The (per-worktree) git directory, which contains <c>HEAD</c>.</param>
+    /// <param name="commonDirectory">
+    /// The common git directory, which contains <c>refs/</c> and <c>packed-refs</c>.
+    /// Defaults to <paramref name="gitDirectory"/>.
+    /// </param>
+    public GitReferenceStore(string gitDirectory, string? commonDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(gitDirectory);
+
+        this.gitDirectory = Path.GetFullPath(gitDirectory);
+        this.commonDirectory = commonDirectory is null ? this.gitDirectory : Path.GetFullPath(commonDirectory);
+        this.packedReferences = new(ReadPackedReferences);
+    }
+
+    /// <summary>
+    /// Reads a single reference by its canonical name, without following symbolic references.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>refs/heads/main</c> or <c>HEAD</c>.</param>
+    /// <returns>The reference, or <see langword="null"/> if it does not exist.</returns>
+    public GitReference? GetReference(string canonicalName)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalName);
+
+        return ReadLooseReference(canonicalName)
+            ?? (this.packedReferences.Value.TryGetValue(canonicalName, out var packed) ? packed : null);
+    }
+
+    /// <summary>
+    /// Reads the <c>HEAD</c> reference of the (worktree's) repository.
+    /// </summary>
+    /// <returns>The <c>HEAD</c> reference, or <see langword="null"/> if it does not exist.</returns>
+    public GitReference? GetHead() => GetReference("HEAD");
+
+    /// <summary>
+    /// Resolves a reference to a direct reference, following symbolic references.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>HEAD</c> or <c>refs/heads/main</c>.</param>
+    /// <returns>
+    /// The direct reference at the end of the symbolic chain, or <see langword="null"/> when the
+    /// reference does not exist (e.g. <c>HEAD</c> pointing at an unborn branch).
+    /// </returns>
+    public GitReference? Resolve(string canonicalName)
+    {
+        var current = GetReference(canonicalName);
+        var depth = 0;
+
+        while (current is { IsSymbolic: true })
+        {
+            if (++depth > MaxSymbolicReferenceDepth)
+            {
+                throw new GitObjectStoreException($"The symbolic reference '{canonicalName}' is nested more than {MaxSymbolicReferenceDepth} levels deep.");
+            }
+
+            current = GetReference(current.SymbolicTargetName!);
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Resolves a reference to the object id it (ultimately) points at.
+    /// </summary>
+    /// <param name="canonicalName">The canonical name, e.g. <c>HEAD</c> or <c>refs/tags/v1.0.0</c>.</param>
+    /// <returns>The object id, or <see langword="null"/> when the reference does not exist.</returns>
+    public GitObjectId? ResolveToObjectId(string canonicalName) => Resolve(canonicalName)?.ObjectId;
+
+    /// <summary>
+    /// Enumerates the references whose canonical name starts with the given prefix,
+    /// in ordinal name order. Loose references shadow packed references of the same name.
+    /// </summary>
+    /// <param name="prefix">The prefix to filter by, e.g. <c>refs/</c>, <c>refs/heads/</c> or <c>refs/tags/</c>.</param>
+    /// <returns>The matching references.</returns>
+    public IEnumerable<GitReference> EnumerateReferences(string prefix = RefsPrefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        var references = new SortedDictionary<string, GitReference>(StringComparer.Ordinal);
+
+        foreach (var packed in this.packedReferences.Value.Values
+                     .Where(reference => reference.CanonicalName.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            references[packed.CanonicalName] = packed;
+        }
+
+        var refsRoot = Path.Combine(this.commonDirectory, "refs");
+
+        if (Directory.Exists(refsRoot))
+        {
+            foreach (var file in Directory.EnumerateFiles(refsRoot, "*", SearchOption.AllDirectories))
+            {
+                // Skip transient lock files created while git updates a reference, matching git/libgit2.
+                if (file.EndsWith(".lock", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var canonicalName = RefsPrefix + Path.GetRelativePath(refsRoot, file).Replace(Path.DirectorySeparatorChar, '/');
+
+                if (!canonicalName.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (ReadLooseReference(canonicalName) is { } reference)
+                {
+                    references[canonicalName] = reference;
+                }
+            }
+        }
+
+        return references.Values;
+    }
+
+    private GitReference? ReadLooseReference(string canonicalName)
+    {
+        // HEAD and other pseudo-refs (ORIG_HEAD, FETCH_HEAD, ...) are per-worktree and live in
+        // the git directory; everything under refs/ is shared and lives in the common directory.
+        var directory = canonicalName.StartsWith(RefsPrefix, StringComparison.Ordinal)
+            ? this.commonDirectory
+            : this.gitDirectory;
+
+        var path = Path.Combine(directory, canonicalName.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        string? line;
+
+        using (var reader = new StreamReader(path, Encoding.UTF8))
+        {
+            line = reader.ReadLine();
+        }
+
+        line = line?.Trim();
+
+        if (string.IsNullOrEmpty(line))
+        {
+            return null;
+        }
+
+        if (line.StartsWith("ref: ", StringComparison.Ordinal))
+        {
+            return new()
+            {
+                CanonicalName = canonicalName,
+                SymbolicTargetName = line["ref: ".Length..].Trim()
+            };
+        }
+
+        return new()
+        {
+            CanonicalName = canonicalName,
+            ObjectId = GitObjectId.Parse(line)
+        };
+    }
+
+    private Dictionary<string, GitReference> ReadPackedReferences()
+    {
+        var references = new Dictionary<string, GitReference>(StringComparer.Ordinal);
+        var packedRefsPath = Path.Combine(this.commonDirectory, "packed-refs");
+
+        if (!File.Exists(packedRefsPath))
+        {
+            return references;
+        }
+
+        string? previousName = null;
+
+        foreach (var rawLine in File.ReadLines(packedRefsPath, Encoding.UTF8))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0 || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('^'))
+            {
+                // A peeled line holds the fully-peeled target of the preceding annotated tag.
+                if (previousName is null)
+                {
+                    throw new GitObjectStoreException("The packed-refs file is malformed: a peeled line has no preceding reference.");
+                }
+
+                var peeled = references[previousName];
+                references[previousName] = new()
+                {
+                    CanonicalName = peeled.CanonicalName,
+                    ObjectId = peeled.ObjectId,
+                    PeeledObjectId = GitObjectId.Parse(line[1..]),
+                    IsPacked = true
+                };
+                continue;
+            }
+
+            var separator = line.IndexOf(' ');
+
+            if (separator <= 0 || separator == line.Length - 1)
+            {
+                throw new GitObjectStoreException("The packed-refs file is malformed: a line does not contain an object id and a reference name.");
+            }
+
+            var name = line[(separator + 1)..];
+            references[name] = new()
+            {
+                CanonicalName = name,
+                ObjectId = GitObjectId.Parse(line[..separator]),
+                IsPacked = true
+            };
+            previousName = name;
+        }
+
+        return references;
+    }
+}

--- a/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitConfigurationFile.cs
@@ -1,0 +1,241 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// A minimal parser for the repository-local <c>.git/config</c> file, covering the entries
+/// GitVersion needs: <c>[remote "name"]</c> (url/fetch/push) and <c>[branch "name"]</c>
+/// (remote/merge). Section names and keys are case-insensitive, subsection names are
+/// case-sensitive, and later values override earlier ones (git's last-one-wins semantics).
+/// </summary>
+internal sealed class GitConfigurationFile
+{
+    private readonly List<(string Section, string? Subsection, string Key, string Value)> entries;
+
+    private GitConfigurationFile(List<(string Section, string? Subsection, string Key, string Value)> entries) => this.entries = entries;
+
+    /// <summary>
+    /// Loads a configuration file, returning an empty configuration when the file does not exist.
+    /// </summary>
+    /// <param name="path">The path of the configuration file.</param>
+    /// <returns>The parsed configuration.</returns>
+    public static GitConfigurationFile Load(string path)
+    {
+        var entries = new List<(string, string?, string, string)>();
+
+        if (!File.Exists(path))
+        {
+            return new(entries);
+        }
+
+        string? section = null;
+        string? subsection = null;
+
+        foreach (var rawLine in File.ReadLines(path, Encoding.UTF8))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0 || line.StartsWith('#') || line.StartsWith(';'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('['))
+            {
+                (section, subsection) = ParseSectionHeader(line);
+                continue;
+            }
+
+            if (section is null)
+            {
+                continue;
+            }
+
+            var separator = line.IndexOf('=');
+            string key;
+            string value;
+
+            if (separator < 0)
+            {
+                // A key without '=' is a boolean true.
+                key = StripComment(line).Trim();
+                value = "true";
+            }
+            else
+            {
+                key = line[..separator].Trim();
+                value = ParseValue(line[(separator + 1)..]);
+            }
+
+            if (key.Length > 0)
+            {
+                entries.Add((section, subsection, key.ToLowerInvariant(), value));
+            }
+        }
+
+        return new(entries);
+    }
+
+    /// <summary>
+    /// Gets the effective (last) value of a key, or <see langword="null"/> when not present.
+    /// </summary>
+    public string? GetString(string section, string? subsection, string key)
+    {
+        var values = GetAll(section, subsection, key);
+        return values.Count > 0 ? values[^1] : null;
+    }
+
+    /// <summary>
+    /// Gets the effective value of a boolean key using git's boolean semantics,
+    /// or <see langword="null"/> when the key is not present or not a valid boolean.
+    /// </summary>
+    public bool? GetBoolean(string section, string? subsection, string key) =>
+        GetString(section, subsection, key) switch
+        {
+            null => null,
+            "" => false,
+            var value when value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("on", StringComparison.OrdinalIgnoreCase) => true,
+            var value when value.Equals("false", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("no", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("off", StringComparison.OrdinalIgnoreCase) => false,
+            var value when long.TryParse(value, out var number) => number != 0,
+            _ => null
+        };
+
+    /// <summary>
+    /// Gets all values of a multi-valued key, in file order.
+    /// </summary>
+    public IReadOnlyList<string> GetAll(string section, string? subsection, string key) =>
+        [.. this.entries
+            .Where(entry => entry.Section.Equals(section, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(entry.Subsection, subsection, StringComparison.Ordinal)
+                            && entry.Key.Equals(key, StringComparison.OrdinalIgnoreCase))
+            .Select(entry => entry.Value)];
+
+    /// <summary>
+    /// Gets the distinct subsection names of a section, in file order.
+    /// </summary>
+    public IReadOnlyList<string> GetSubsections(string section) =>
+        [.. this.entries
+            .Where(entry => entry.Section.Equals(section, StringComparison.OrdinalIgnoreCase) && entry.Subsection is not null)
+            .Select(entry => entry.Subsection!)
+            .Distinct(StringComparer.Ordinal)];
+
+    private static (string Section, string? Subsection) ParseSectionHeader(string line)
+    {
+        var end = line.IndexOf(']');
+        var header = end > 0 ? line[1..end] : line[1..];
+        var space = header.IndexOf(' ');
+
+        if (space < 0)
+        {
+            // Handle the deprecated [section.subsection] form as a plain section name.
+            return (header.Trim().ToLowerInvariant(), null);
+        }
+
+        var section = header[..space].Trim().ToLowerInvariant();
+        var subsection = header[space..].Trim();
+
+        if (subsection.StartsWith('"') && subsection.EndsWith('"') && subsection.Length >= 2)
+        {
+            subsection = subsection[1..^1].Replace("\\\\", "\\").Replace("\\\"", "\"");
+        }
+
+        return (section, subsection);
+    }
+
+    private static string ParseValue(string raw)
+    {
+        // git config values are unescaped regardless of whether they are quoted: backslash
+        // escapes (\\, \", \n, \t, \b) and double-quoted spans are processed inline, so an
+        // unquoted Windows path stored as D:\\a\\repo decodes back to D:\a\repo. Comments
+        // (# or ;) and trailing whitespace are only significant outside quotes.
+        var index = SkipLeadingWhitespace(raw);
+        var result = new StringBuilder(raw.Length - index);
+        var inQuotes = false;
+        var contentEnd = 0;
+
+        while (index < raw.Length)
+        {
+            var current = raw[index];
+
+            if (current == '\\')
+            {
+                if (index + 1 >= raw.Length)
+                {
+                    break;
+                }
+
+                result.Append(DecodeEscape(raw[index + 1]));
+                contentEnd = result.Length;
+                index += 2;
+                continue;
+            }
+
+            index++;
+
+            if (current == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && IsCommentStart(current))
+            {
+                break;
+            }
+
+            result.Append(current);
+            if (inQuotes || !IsWhitespace(current))
+            {
+                contentEnd = result.Length;
+            }
+        }
+
+        return result.ToString(0, contentEnd);
+    }
+
+    private static int SkipLeadingWhitespace(string raw)
+    {
+        var index = 0;
+        while (index < raw.Length && IsWhitespace(raw[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static bool IsWhitespace(char value) => value is ' ' or '\t';
+
+    private static bool IsCommentStart(char value) => value is '#' or ';';
+
+    private static char DecodeEscape(char escaped) => escaped switch
+    {
+        'n' => '\n',
+        't' => '\t',
+        'b' => '\b',
+        _ => escaped // covers \\ and \" and is lenient for any other escape
+    };
+
+    private static string StripComment(string value)
+    {
+        var inQuotes = false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var current = value[i];
+
+            if (current == '"' && (i == 0 || value[i - 1] != '\\'))
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (current is '#' or ';' && !inQuotes)
+            {
+                return value[..i];
+            }
+        }
+
+        return value;
+    }
+}

--- a/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
+++ b/src/GitVersion.Git.Managed/Repository/GitRepositoryLayout.cs
@@ -1,0 +1,211 @@
+namespace GitVersion.Git;
+
+/// <summary>
+/// Describes the on-disk layout of a Git repository: where its git directory, common
+/// directory and working directory are, and how to open its object and reference stores.
+/// Handles regular repositories, bare repositories, linked worktrees (<c>.git</c> files
+/// and <c>commondir</c> indirection) and shallow clones.
+/// </summary>
+internal sealed class GitRepositoryLayout
+{
+    private const string GitDirectoryOrFileName = ".git";
+    private const string GitDirFilePrefix = "gitdir:";
+
+    /// <summary>
+    /// Gets the (per-worktree) git directory, which contains <c>HEAD</c>.
+    /// </summary>
+    public required string GitDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the common git directory, which contains <c>objects/</c>, <c>refs/</c> and
+    /// <c>packed-refs</c>. Equal to <see cref="GitDirectory"/> except for linked worktrees.
+    /// </summary>
+    public required string CommonDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the root of the working directory, or <see langword="null"/> for bare repositories.
+    /// </summary>
+    public string? WorkingDirectory { get; init; }
+
+    /// <summary>
+    /// Gets the path to the object database of the repository.
+    /// </summary>
+    public string ObjectsDirectory => Path.Combine(CommonDirectory, "objects");
+
+    /// <summary>
+    /// Gets a value indicating whether the repository is a shallow clone.
+    /// </summary>
+    public bool IsShallow => File.Exists(ShallowFilePath);
+
+    private string ShallowFilePath => Path.Combine(CommonDirectory, "shallow");
+
+    /// <summary>
+    /// Discovers the repository containing <paramref name="startPath"/> by walking up the
+    /// directory hierarchy, resolving <c>.git</c> files (linked worktrees, submodules) and
+    /// the <c>commondir</c> indirection.
+    /// </summary>
+    /// <param name="startPath">The path at which to start the discovery.</param>
+    /// <returns>The layout of the discovered repository.</returns>
+    /// <exception cref="GitObjectStoreException">No repository was found.</exception>
+    public static GitRepositoryLayout Discover(string startPath) =>
+        TryDiscover(startPath)
+            ?? throw new GitObjectStoreException($"No git repository was found at or above '{startPath}'.");
+
+    /// <summary>
+    /// Discovers the repository containing <paramref name="startPath"/> by walking up the
+    /// directory hierarchy, resolving <c>.git</c> files (linked worktrees, submodules) and
+    /// the <c>commondir</c> indirection.
+    /// </summary>
+    /// <param name="startPath">The path at which to start the discovery.</param>
+    /// <returns>The layout of the discovered repository, or <see langword="null"/> if none was found.</returns>
+    public static GitRepositoryLayout? TryDiscover(string startPath)
+    {
+        ArgumentNullException.ThrowIfNull(startPath);
+
+        for (var current = Path.GetFullPath(startPath); current is not null; current = Path.GetDirectoryName(current))
+        {
+            if (TryOpenExact(current) is { } layout)
+            {
+                return layout;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Opens the repository at exactly <paramref name="path"/> (a working directory with a
+    /// <c>.git</c> entry, or a git directory itself) without walking up the hierarchy —
+    /// the equivalent of libgit2's <c>new Repository(path)</c> as opposed to its discovery.
+    /// </summary>
+    /// <param name="path">The path of the repository.</param>
+    /// <returns>The layout of the repository, or <see langword="null"/> when the path is not itself a repository.</returns>
+    public static GitRepositoryLayout? TryOpen(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return TryOpenExact(Path.GetFullPath(path));
+    }
+
+    private static GitRepositoryLayout? TryOpenExact(string current)
+    {
+        var dotGit = Path.Combine(current, GitDirectoryOrFileName);
+
+        if (Directory.Exists(dotGit))
+        {
+            return FromGitDirectory(dotGit, current);
+        }
+
+        if (File.Exists(dotGit))
+        {
+            return FromGitDirectory(ResolveGitDirFile(dotGit), current);
+        }
+
+        if (IsGitDirectory(current))
+        {
+            // A bare repository, or the .git directory itself.
+            return FromGitDirectory(current, workingDirectory: null);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates the layout for a known git directory, resolving the <c>commondir</c> indirection
+    /// used by linked worktrees.
+    /// </summary>
+    /// <param name="gitDirectory">The git directory.</param>
+    /// <param name="workingDirectory">The root of the working directory, or <see langword="null"/> for bare repositories.</param>
+    /// <returns>The layout of the repository.</returns>
+    public static GitRepositoryLayout FromGitDirectory(string gitDirectory, string? workingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(gitDirectory);
+
+        gitDirectory = Path.GetFullPath(gitDirectory);
+        var commonDirectory = gitDirectory;
+
+        // Linked worktrees store the path of the main repository's git directory in a 'commondir' file.
+        var commonDirFile = Path.Combine(gitDirectory, "commondir");
+
+        if (File.Exists(commonDirFile))
+        {
+            var target = File.ReadAllText(commonDirFile).Trim();
+
+            commonDirectory = Path.IsPathRooted(target)
+                ? Path.GetFullPath(target)
+                : Path.GetFullPath(Path.Combine(gitDirectory, target));
+        }
+
+        if (Directory.Exists(Path.Combine(commonDirectory, "reftable")))
+        {
+            throw new NotSupportedException("Repositories using the reftable reference storage format are not supported yet.");
+        }
+
+        // SHA-256 repositories declare extensions.objectformat in their config. The managed
+        // reader only implements SHA-1 pack indexes so far; fail clearly at open instead of
+        // deep inside an object lookup (parity: libgit2 cannot read them either).
+        var objectFormat = GitConfigurationFile.Load(Path.Combine(commonDirectory, "config"))
+            .GetString("extensions", null, "objectformat");
+        if (objectFormat is not null && !objectFormat.Equals("sha1", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException($"Repositories using the '{objectFormat}' object format are not supported yet.");
+        }
+
+        return new()
+        {
+            GitDirectory = gitDirectory,
+            CommonDirectory = commonDirectory,
+            WorkingDirectory = workingDirectory
+        };
+    }
+
+    /// <summary>
+    /// Opens the object store of the repository.
+    /// </summary>
+    /// <returns>A new <see cref="GitObjectStore"/> over the repository's object database.</returns>
+    public GitObjectStore CreateObjectStore() => new(ObjectsDirectory);
+
+    /// <summary>
+    /// Opens the reference store of the repository.
+    /// </summary>
+    /// <returns>A new <see cref="GitReferenceStore"/> over the repository's references.</returns>
+    public GitReferenceStore CreateReferenceStore() => new(GitDirectory, CommonDirectory);
+
+    /// <summary>
+    /// Reads the commit ids at the boundary of a shallow clone from the <c>shallow</c> file.
+    /// </summary>
+    /// <returns>The shallow boundary commits, or an empty list when the repository is not shallow.</returns>
+    public IReadOnlyList<GitObjectId> ReadShallowCommits()
+    {
+        if (!IsShallow)
+        {
+            return [];
+        }
+
+        return [.. File.ReadLines(ShallowFilePath, Encoding.UTF8)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .Select(GitObjectId.Parse)];
+    }
+
+    private static bool IsGitDirectory(string path) =>
+        File.Exists(Path.Combine(path, "HEAD"))
+        && Directory.Exists(Path.Combine(path, "objects"))
+        && Directory.Exists(Path.Combine(path, "refs"));
+
+    private static string ResolveGitDirFile(string dotGitFile)
+    {
+        // Format: "gitdir: <path>", where the path may be relative to the file's directory.
+        var content = File.ReadAllText(dotGitFile).Trim();
+
+        if (!content.StartsWith(GitDirFilePrefix, StringComparison.Ordinal))
+        {
+            throw new GitObjectStoreException($"The .git file '{dotGitFile}' is malformed: it does not start with '{GitDirFilePrefix}'.");
+        }
+
+        var target = content[GitDirFilePrefix.Length..].Trim();
+
+        return Path.IsPathRooted(target)
+            ? Path.GetFullPath(target)
+            : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(dotGitFile)!, target));
+    }
+}

--- a/src/GitVersion.Git.Managed/SafeFileHandleExtensions.cs
+++ b/src/GitVersion.Git.Managed/SafeFileHandleExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides extension methods for reading files through a <see cref="SafeFileHandle"/>.
+/// </summary>
+internal static class SafeFileHandleExtensions
+{
+    /// <summary>
+    /// Fills <paramref name="buffer"/> with the bytes stored at <paramref name="offset"/> in the file,
+    /// without affecting any stream position.
+    /// </summary>
+    /// <param name="handle">The handle of the file to read from.</param>
+    /// <param name="offset">The offset in the file at which to start reading.</param>
+    /// <param name="buffer">The buffer to fill.</param>
+    /// <exception cref="EndOfStreamException">Thrown when the file ends before <paramref name="buffer"/> could be filled.</exception>
+    public static void ReadExactlyAt(this SafeFileHandle handle, long offset, Span<byte> buffer)
+    {
+        var totalRead = 0;
+
+        while (totalRead < buffer.Length)
+        {
+            var read = RandomAccess.Read(handle, buffer[totalRead..], offset + totalRead);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += read;
+        }
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIgnoreRules.cs
@@ -1,0 +1,215 @@
+using System.Text.RegularExpressions;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// The parsed rules of a single ignore source (a <c>.gitignore</c> file or
+/// <c>.git/info/exclude</c>), matched against paths relative to the source's directory.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitignore"/>
+internal sealed class GitIgnoreRules
+{
+    private readonly List<(Regex Pattern, bool DirectoryOnly, bool Negated)> rules = [];
+
+    private GitIgnoreRules(IEnumerable<string> lines, bool ignoreCase)
+    {
+        foreach (var line in lines)
+        {
+            if (ParseLine(line, ignoreCase) is { } rule)
+            {
+                this.rules.Add(rule);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads the rules from an ignore file, or returns <see langword="null"/> when the file does not exist.
+    /// </summary>
+    /// <param name="path">The path of the ignore file.</param>
+    /// <param name="ignoreCase">Whether patterns match case-insensitively (<c>core.ignorecase</c>).</param>
+    /// <returns>The parsed rules, if the file exists.</returns>
+    public static GitIgnoreRules? Load(string path, bool ignoreCase) => File.Exists(path) ? new(File.ReadLines(path), ignoreCase) : null;
+
+    /// <summary>
+    /// Parses ignore rules from text lines.
+    /// </summary>
+    /// <param name="lines">The lines of an ignore file.</param>
+    /// <param name="ignoreCase">Whether patterns match case-insensitively (<c>core.ignorecase</c>).</param>
+    /// <returns>The parsed rules.</returns>
+    public static GitIgnoreRules Parse(IEnumerable<string> lines, bool ignoreCase) => new(lines, ignoreCase);
+
+    /// <summary>
+    /// Determines whether this source decides the ignored state of the given path.
+    /// The last matching rule wins, per gitignore semantics.
+    /// </summary>
+    /// <param name="relativePath">The path, relative to this source's directory, using forward slashes.</param>
+    /// <param name="isDirectory">Whether the path refers to a directory.</param>
+    /// <returns>
+    /// <see langword="true"/> (ignored), <see langword="false"/> (explicitly re-included),
+    /// or <see langword="null"/> when no rule matches.
+    /// </returns>
+    public bool? IsIgnored(string relativePath, bool isDirectory)
+    {
+        for (var i = this.rules.Count - 1; i >= 0; i--)
+        {
+            var (pattern, directoryOnly, negated) = this.rules[i];
+
+            if (directoryOnly && !isDirectory)
+            {
+                continue;
+            }
+
+            if (pattern.IsMatch(relativePath))
+            {
+                return !negated;
+            }
+        }
+
+        return null;
+    }
+
+    private static (Regex Pattern, bool DirectoryOnly, bool Negated)? ParseLine(string line, bool ignoreCase)
+    {
+        var pattern = TrimTrailingSpaces(line);
+
+        if (pattern.Length == 0 || pattern[0] == '#')
+        {
+            return null;
+        }
+
+        var negated = pattern[0] == '!';
+
+        if (negated)
+        {
+            pattern = pattern[1..];
+        }
+
+        var directoryOnly = pattern.EndsWith('/');
+
+        if (directoryOnly)
+        {
+            pattern = pattern[..^1];
+        }
+
+        if (pattern.Length == 0)
+        {
+            return null;
+        }
+
+        // Patterns containing a slash are anchored to the directory of the ignore file,
+        // while all other patterns match at any depth below it.
+        if (!pattern.Contains('/'))
+        {
+            pattern = "**/" + pattern;
+        }
+
+        pattern = pattern.TrimStart('/');
+
+        // git matches ignore patterns case-insensitively when core.ignorecase is set
+        // (the default in repositories created on case-insensitive filesystems).
+        var regexOptions = RegexOptions.CultureInvariant | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
+        var regex = new Regex(
+            "^" + TranslateToRegex(pattern) + "$",
+            regexOptions,
+            TimeSpan.FromSeconds(1));
+
+        return (regex, directoryOnly, negated);
+    }
+
+    private static string TrimTrailingSpaces(string line)
+    {
+        var end = line.Length;
+
+        while (end > 0 && line[end - 1] == ' ' && (end < 2 || line[end - 2] != '\\'))
+        {
+            end--;
+        }
+
+        return line[..end];
+    }
+
+    private static string TranslateToRegex(string pattern)
+    {
+        var regex = new StringBuilder();
+        var i = 0;
+
+        while (i < pattern.Length)
+        {
+            var atSegmentStart = i == 0 || pattern[i - 1] == '/';
+
+            if (atSegmentStart && pattern.AsSpan(i).StartsWith("**/", StringComparison.Ordinal))
+            {
+                regex.Append("(?:[^/]+/)*");
+                i += 3;
+                continue;
+            }
+
+            if (atSegmentStart && pattern.AsSpan(i).SequenceEqual("**"))
+            {
+                regex.Append(".*");
+                i += 2;
+                continue;
+            }
+
+            var current = pattern[i];
+
+            switch (current)
+            {
+                case '*' when i + 1 < pattern.Length && pattern[i + 1] == '*':
+                    // Consecutive asterisks that are not at a path boundary act as
+                    // regular asterisks, per the gitignore specification.
+                    regex.Append("[^/]*");
+                    i += 2;
+                    break;
+
+                case '*':
+                    regex.Append("[^/]*");
+                    i++;
+                    break;
+
+                case '?':
+                    regex.Append("[^/]");
+                    i++;
+                    break;
+
+                case '[':
+                    i = AppendCharacterClass(pattern, i, regex);
+                    break;
+
+                case '\\' when i + 1 < pattern.Length:
+                    regex.Append(Regex.Escape(pattern[i + 1].ToString()));
+                    i += 2;
+                    break;
+
+                default:
+                    regex.Append(Regex.Escape(current.ToString()));
+                    i++;
+                    break;
+            }
+        }
+
+        return regex.ToString();
+    }
+
+    private static int AppendCharacterClass(string pattern, int start, StringBuilder regex)
+    {
+        var end = pattern.IndexOf(']', start + 1);
+
+        if (end < 0)
+        {
+            // An unterminated class matches a literal bracket.
+            regex.Append(Regex.Escape("["));
+            return start + 1;
+        }
+
+        var body = pattern[(start + 1)..end];
+
+        if (body.StartsWith('!'))
+        {
+            body = "^" + body[1..];
+        }
+
+        regex.Append('[').Append(body).Append(']');
+        return end + 1;
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitIndex.cs
+++ b/src/GitVersion.Git.Managed/Status/GitIndex.cs
@@ -1,0 +1,203 @@
+using System.Buffers.Binary;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// A single entry of the <c>.git/index</c> file.
+/// </summary>
+/// <param name="Path">The repository-relative path, using forward slashes.</param>
+/// <param name="Mode">The file mode, e.g. <c>0b1000_000_110_100_100</c> (100644 octal) for a regular file.</param>
+/// <param name="ObjectId">The object id of the staged blob.</param>
+/// <param name="Stage">The merge stage: 0 for a normal entry, 1–3 during conflicts.</param>
+/// <param name="Size">The cached on-disk file size (truncated to 32 bits).</param>
+/// <param name="ModificationTimeSeconds">The cached modification time, in seconds since the epoch.</param>
+/// <param name="ModificationTimeNanoseconds">The nanosecond fraction of the cached modification time.</param>
+/// <param name="AssumeValid">Whether the assume-unchanged bit is set.</param>
+/// <param name="SkipWorktree">Whether the skip-worktree bit is set (sparse checkout).</param>
+/// <param name="IntentToAdd">Whether the intent-to-add bit is set (<c>git add -N</c>).</param>
+internal sealed record GitIndexEntry(
+    string Path,
+    uint Mode,
+    GitObjectId ObjectId,
+    int Stage,
+    uint Size,
+    uint ModificationTimeSeconds,
+    uint ModificationTimeNanoseconds,
+    bool AssumeValid,
+    bool SkipWorktree,
+    bool IntentToAdd)
+{
+    /// <summary>
+    /// Gets a value indicating whether the entry's file mode has the executable bit set.
+    /// </summary>
+    public bool IsExecutable => (Mode & 0b001_000_000) != 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the entry is a symbolic link (mode <c>120000</c>).
+    /// </summary>
+    public bool IsSymbolicLink => (Mode & 0b1111_000_000_000_000) == 0b1010_000_000_000_000;
+
+    /// <summary>
+    /// Gets a value indicating whether the entry is a gitlink/submodule (mode <c>160000</c>).
+    /// </summary>
+    public bool IsGitLink => (Mode & 0b1111_000_000_000_000) == 0b1110_000_000_000_000;
+}
+
+/// <summary>
+/// Reads the <c>.git/index</c> file (the staging area), versions 2 to 4.
+/// </summary>
+/// <seealso href="https://git-scm.com/docs/gitformat-index"/>
+internal sealed class GitIndex
+{
+    private const int HeaderLength = 12;
+    private const int EntryFixedLength = 62;
+
+    private GitIndex(int version, IReadOnlyList<GitIndexEntry> entries)
+    {
+        Version = version;
+        Entries = entries;
+    }
+
+    /// <summary>
+    /// Gets the format version of the index file: 2, 3 or 4.
+    /// </summary>
+    public int Version { get; }
+
+    /// <summary>
+    /// Gets the entries of the index, in the order stored (sorted by path and stage).
+    /// </summary>
+    public IReadOnlyList<GitIndexEntry> Entries { get; }
+
+    /// <summary>
+    /// Reads an index file from disk. A missing file yields an empty index.
+    /// </summary>
+    /// <param name="path">The path to the index file.</param>
+    /// <returns>The parsed index.</returns>
+    public static GitIndex Read(string path) =>
+        File.Exists(path) ? Parse(File.ReadAllBytes(path)) : new(2, []);
+
+    /// <summary>
+    /// Parses the binary content of an index file.
+    /// </summary>
+    /// <param name="data">The raw bytes of the index file.</param>
+    /// <returns>The parsed index.</returns>
+    public static GitIndex Parse(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < HeaderLength || !data[..4].SequenceEqual("DIRC"u8))
+        {
+            throw new GitObjectStoreException("The index file has an invalid signature.");
+        }
+
+        var version = BinaryPrimitives.ReadInt32BigEndian(data[4..8]);
+
+        if (version is < 2 or > 4)
+        {
+            throw new GitObjectStoreException($"Index version {version} is not supported; only versions 2 to 4 are supported.");
+        }
+
+        var entryCount = BinaryPrimitives.ReadInt32BigEndian(data[8..12]);
+        var entries = new List<GitIndexEntry>(entryCount);
+        var offset = HeaderLength;
+        var previousPath = "";
+
+        for (var i = 0; i < entryCount; i++)
+        {
+            (var entry, offset) = ReadEntry(data, offset, version, previousPath);
+            entries.Add(entry);
+            previousPath = entry.Path;
+        }
+
+        // Extensions and the trailing checksum are not needed and are skipped.
+        return new(version, entries);
+    }
+
+    private static (GitIndexEntry Entry, int Offset) ReadEntry(ReadOnlySpan<byte> data, int offset, int version, string previousPath)
+    {
+        var entryStart = offset;
+        var fixedPart = data.Slice(offset, EntryFixedLength);
+
+        var modificationSeconds = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[8..12]);
+        var modificationNanoseconds = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[12..16]);
+        var mode = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[24..28]);
+        var size = BinaryPrimitives.ReadUInt32BigEndian(fixedPart[36..40]);
+        var objectId = GitObjectId.Parse(fixedPart.Slice(40, GitObjectId.Sha1Size));
+        var flags = BinaryPrimitives.ReadUInt16BigEndian(fixedPart[60..62]);
+
+        var assumeValid = (flags & 0x8000) != 0;
+        var extended = (flags & 0x4000) != 0;
+        var stage = (flags >> 12) & 0x3;
+        var nameLength = flags & 0xFFF;
+
+        offset += EntryFixedLength;
+
+        var skipWorktree = false;
+        var intentToAdd = false;
+
+        if (extended)
+        {
+            if (version < 3)
+            {
+                throw new GitObjectStoreException("The index file is malformed: an extended entry appears in a version 2 index.");
+            }
+
+            var extendedFlags = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+            skipWorktree = (extendedFlags & 0x4000) != 0;
+            intentToAdd = (extendedFlags & 0x2000) != 0;
+            offset += 2;
+        }
+
+        string path;
+
+        if (version < 4)
+        {
+            var nameBytes = nameLength < 0xFFF
+                ? data.Slice(offset, nameLength)
+                : data[offset..(offset + data[offset..].IndexOf((byte)0))];
+            path = Encoding.UTF8.GetString(nameBytes);
+
+            // The entry is zero-padded so its total length is a multiple of eight,
+            // with at least one trailing NUL.
+            var entryLength = ((offset - entryStart) + nameBytes.Length + 8) & ~7;
+            offset = entryStart + entryLength;
+        }
+        else
+        {
+            // Version 4 prefix-compresses the path against the previous entry's path.
+            (var stripCount, offset) = ReadVariableWidthInt(data, offset);
+            var suffixEnd = data[offset..].IndexOf((byte)0);
+            var suffix = Encoding.UTF8.GetString(data.Slice(offset, suffixEnd));
+            path = previousPath[..(previousPath.Length - stripCount)] + suffix;
+            offset += suffixEnd + 1;
+        }
+
+        var entry = new GitIndexEntry(
+            path,
+            mode,
+            objectId,
+            stage,
+            size,
+            modificationSeconds,
+            modificationNanoseconds,
+            assumeValid,
+            skipWorktree,
+            intentToAdd);
+
+        return (entry, offset);
+    }
+
+    private static (int Value, int Offset) ReadVariableWidthInt(ReadOnlySpan<byte> data, int offset)
+    {
+        // Git's offset-encoded variable-width integer: each continuation adds one.
+        int current = data[offset++];
+        var value = current & 0x7F;
+
+        while ((current & 0x80) != 0)
+        {
+            value++;
+            current = data[offset++];
+            value = (value << 7) | (current & 0x7F);
+        }
+
+        return (value, offset);
+    }
+}

--- a/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
+++ b/src/GitVersion.Git.Managed/Status/GitStatusCalculator.cs
@@ -1,0 +1,360 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Computes the number of uncommitted changes in a working directory, matching the
+/// semantics GitVersion has always used with libgit2: the number of distinct paths in
+/// a diff of the HEAD tree against the index and the working directory combined —
+/// untracked files included, ignored files excluded.
+/// </summary>
+internal sealed class GitStatusCalculator(GitRepositoryLayout layout, GitObjectStore objectStore)
+{
+    private readonly GitRepositoryLayout layout = layout ?? throw new ArgumentNullException(nameof(layout));
+    private readonly GitTreeDiff treeDiff = new(objectStore);
+    private readonly Lazy<bool> ignoreCase = new(() =>
+        GitConfigurationFile.Load(Path.Combine(layout.CommonDirectory, "config"))
+            .GetBoolean("core", null, "ignorecase") ?? false);
+
+    /// <summary>
+    /// Counts the paths which differ between the given HEAD tree, the index, and the
+    /// working directory.
+    /// </summary>
+    /// <param name="headTreeId">The root tree of the HEAD commit.</param>
+    /// <returns>The number of changed paths.</returns>
+    public int CountUncommittedChanges(GitObjectId headTreeId)
+    {
+        var workingDirectory = RequireWorkingDirectory();
+        var indexPath = Path.Combine(this.layout.GitDirectory, "index");
+        var index = GitIndex.Read(indexPath);
+        var indexTimestamp = ReadUnixTimestampSeconds(indexPath);
+        var headFiles = this.treeDiff.FlattenTree(headTreeId);
+        var indexEntries = index.Entries.ToDictionary(entry => entry.Path, StringComparer.Ordinal);
+
+        var changed = new HashSet<string>(StringComparer.Ordinal);
+
+        CompareHeadWithIndex(headFiles, indexEntries, changed);
+        CompareIndexWithWorkingDirectory(workingDirectory, indexEntries, indexTimestamp, changed);
+        changed.UnionWith(FindUntrackedFiles(workingDirectory, indexEntries));
+
+        return changed.Count;
+    }
+
+    /// <summary>
+    /// Counts the changes the way GitVersion counts them in a repository whose HEAD is
+    /// unborn (a brand-new repository): the untracked files.
+    /// </summary>
+    /// <returns>The number of changed paths.</returns>
+    public int CountChangesInEmptyRepository()
+    {
+        var workingDirectory = RequireWorkingDirectory();
+        var index = GitIndex.Read(Path.Combine(this.layout.GitDirectory, "index"));
+        var indexEntries = index.Entries.ToDictionary(entry => entry.Path, StringComparer.Ordinal);
+
+        return FindUntrackedFiles(workingDirectory, indexEntries).Count;
+    }
+
+    private string RequireWorkingDirectory() =>
+        this.layout.WorkingDirectory
+            ?? throw new GitObjectStoreException("The repository is bare: it has no working directory to compute uncommitted changes for.");
+
+    private static void CompareHeadWithIndex(
+        Dictionary<string, GitTreeEntry> headFiles,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        HashSet<string> changed)
+    {
+        foreach (var (path, headEntry) in headFiles)
+        {
+            if (!indexEntries.TryGetValue(path, out var indexEntry))
+            {
+                changed.Add(path);
+                continue;
+            }
+
+            if (indexEntry.ObjectId != headEntry.Sha || indexEntry.Mode != Convert.ToUInt32(headEntry.Mode, 8))
+            {
+                changed.Add(path);
+            }
+        }
+
+        foreach (var path in indexEntries.Keys.Where(path => !headFiles.ContainsKey(path)))
+        {
+            changed.Add(path);
+        }
+    }
+
+    private static void CompareIndexWithWorkingDirectory(
+        string workingDirectory,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        long indexTimestamp,
+        HashSet<string> changed)
+    {
+        foreach (var (path, entry) in indexEntries)
+        {
+            if (IsWorkingTreeEntryModified(workingDirectory, path, entry, indexTimestamp))
+            {
+                changed.Add(path);
+            }
+        }
+    }
+
+    private static bool IsWorkingTreeEntryModified(
+        string workingDirectory,
+        string path,
+        GitIndexEntry entry,
+        long indexTimestamp)
+    {
+        if (entry.Stage != 0)
+        {
+            // A conflicted path is always a change.
+            return true;
+        }
+
+        if (entry.AssumeValid || entry.SkipWorktree)
+        {
+            return false;
+        }
+
+        var filePath = Path.Combine(workingDirectory, path.Replace('/', Path.DirectorySeparatorChar));
+
+        if (entry.IsGitLink)
+        {
+            // A submodule: only its presence is checked, matching what the diff exposes.
+            return !Directory.Exists(filePath);
+        }
+
+        if (entry.IsSymbolicLink)
+        {
+            // A symbolic link's blob content is the raw link target, not the target's content.
+            var linkTarget = new FileInfo(filePath).LinkTarget;
+            return linkTarget is null
+                || HashBlob(Encoding.UTF8.GetBytes(linkTarget.Replace(Path.DirectorySeparatorChar, '/'))) != entry.ObjectId;
+        }
+
+        var fileInfo = new FileInfo(filePath);
+
+        if (!fileInfo.Exists)
+        {
+            return true;
+        }
+
+        if ((uint)fileInfo.Length != entry.Size || HasExecutableBitChanged(fileInfo, entry))
+        {
+            return true;
+        }
+
+        // Like git, trust the cached stat data: when size and modification time still match
+        // the index entry, the file is clean without hashing. An entry whose timestamp is not
+        // older than the index file itself is "racily clean" and must be verified by content.
+        var fileTimestamp = new DateTimeOffset(fileInfo.LastWriteTimeUtc).ToUnixTimeSeconds();
+        var racilyClean = entry.ModificationTimeSeconds >= indexTimestamp;
+
+        if (!racilyClean && fileTimestamp == entry.ModificationTimeSeconds)
+        {
+            return false;
+        }
+
+        return !ContentMatchesIndexEntry(fileInfo, entry);
+    }
+
+    /// <summary>
+    /// Verifies a file's content against the staged blob. When the raw content does not match,
+    /// the CRLF-normalized content is tried as well: git's check-in filters strip carriage
+    /// returns for text files, so a checkout with CRLF line endings still counts as clean —
+    /// matching how libgit2 applies filters before comparing blob ids.
+    /// </summary>
+    private static bool ContentMatchesIndexEntry(FileInfo fileInfo, GitIndexEntry entry)
+    {
+        var content = File.ReadAllBytes(fileInfo.FullName);
+
+        if (HashBlob(content) == entry.ObjectId)
+        {
+            return true;
+        }
+
+        var normalized = RemoveCarriageReturnsBeforeLineFeeds(content);
+        return normalized is not null && HashBlob(normalized) == entry.ObjectId;
+    }
+
+    private static byte[]? RemoveCarriageReturnsBeforeLineFeeds(byte[] content)
+    {
+        var result = new byte[content.Length];
+        var length = 0;
+        var removed = false;
+
+        for (var i = 0; i < content.Length; i++)
+        {
+            if (content[i] == (byte)'\r' && i + 1 < content.Length && content[i + 1] == (byte)'\n')
+            {
+                removed = true;
+                continue;
+            }
+
+            result[length++] = content[i];
+        }
+
+        return removed ? result[..length] : null;
+    }
+
+    /// <summary>
+    /// Resolves the user's global excludes file the way git does: <c>core.excludesFile</c>
+    /// from the repository or global configuration, with the XDG default
+    /// (<c>$XDG_CONFIG_HOME/git/ignore</c>, usually <c>~/.config/git/ignore</c>) as fallback.
+    /// </summary>
+    private string? ResolveGlobalExcludesFile()
+    {
+        static string? GetExcludesFile(string configPath) =>
+            File.Exists(configPath)
+                ? GitConfigurationFile.Load(configPath).GetString("core", null, "excludesfile")
+                : null;
+
+        var home = SysEnv.GetEnvironmentVariable("HOME")
+            ?? SysEnv.GetFolderPath(SysEnv.SpecialFolder.UserProfile);
+        var xdgConfigHome = SysEnv.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        var xdgBase = string.IsNullOrEmpty(xdgConfigHome) ? Path.Combine(home, ".config") : xdgConfigHome;
+
+        // Later configuration levels override earlier ones, so the repository config wins.
+        var excludesFile = GetExcludesFile(Path.Combine(this.layout.CommonDirectory, "config"))
+            ?? GetExcludesFile(Path.Combine(home, ".gitconfig"))
+            ?? GetExcludesFile(Path.Combine(xdgBase, "git", "config"));
+
+        if (excludesFile is null)
+        {
+            return Path.Combine(xdgBase, "git", "ignore");
+        }
+
+        return excludesFile.StartsWith("~/", StringComparison.Ordinal)
+            ? Path.Combine(home, excludesFile[2..])
+            : excludesFile;
+    }
+
+    private static long ReadUnixTimestampSeconds(string path) =>
+        File.Exists(path)
+            ? new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds()
+            : 0;
+
+    private List<string> FindUntrackedFiles(string workingDirectory, Dictionary<string, GitIndexEntry> indexEntries)
+    {
+        var untracked = new List<string>();
+        var ignoreSources = new List<(string BasePrefix, GitIgnoreRules Rules)>();
+
+        // Shallowest sources first: the user's global excludes file, then the repository's
+        // info/exclude, then the per-directory .gitignore chain added while walking.
+        if (ResolveGlobalExcludesFile() is { } globalExcludesFile && GitIgnoreRules.Load(globalExcludesFile, this.ignoreCase.Value) is { } globalRules)
+        {
+            ignoreSources.Add(("", globalRules));
+        }
+
+        if (GitIgnoreRules.Load(Path.Combine(this.layout.CommonDirectory, "info", "exclude"), this.ignoreCase.Value) is { } excludeRules)
+        {
+            ignoreSources.Add(("", excludeRules));
+        }
+
+        WalkDirectory(workingDirectory, relativePrefix: "", this.ignoreCase.Value, ignoreSources, indexEntries, untracked);
+        return untracked;
+    }
+
+    private static void WalkDirectory(
+        string directory,
+        string relativePrefix,
+        bool ignoreCase,
+        List<(string BasePrefix, GitIgnoreRules Rules)> ignoreSources,
+        Dictionary<string, GitIndexEntry> indexEntries,
+        List<string> untracked)
+    {
+        var addedSource = false;
+
+        if (GitIgnoreRules.Load(Path.Combine(directory, ".gitignore"), ignoreCase) is { } rules)
+        {
+            ignoreSources.Add((relativePrefix, rules));
+            addedSource = true;
+        }
+
+        try
+        {
+            foreach (var entry in new DirectoryInfo(directory).EnumerateFileSystemInfos().OrderBy(entry => entry.Name, StringComparer.Ordinal))
+            {
+                var name = entry.Name;
+
+                if (relativePrefix.Length == 0 && name == ".git")
+                {
+                    continue;
+                }
+
+                var relativePath = relativePrefix + name;
+
+                // A symbolic link is a single file-like entry whose blob is the link target.
+                // It is never descended into, matching git — and preventing link loops.
+                var isDirectory = entry is DirectoryInfo && (entry.Attributes & FileAttributes.ReparsePoint) == 0;
+
+                if (IsIgnored(ignoreSources, relativePath, isDirectory))
+                {
+                    // Ignored directories are not descended into: nothing below them
+                    // can be re-included, matching git.
+                    continue;
+                }
+
+                if (isDirectory)
+                {
+                    WalkDirectory(entry.FullName, relativePath + "/", ignoreCase, ignoreSources, indexEntries, untracked);
+                }
+                else if (!indexEntries.ContainsKey(relativePath))
+                {
+                    untracked.Add(relativePath);
+                }
+            }
+        }
+        finally
+        {
+            if (addedSource)
+            {
+                ignoreSources.RemoveAt(ignoreSources.Count - 1);
+            }
+        }
+    }
+
+    private static bool IsIgnored(
+        List<(string BasePrefix, GitIgnoreRules Rules)> ignoreSources,
+        string relativePath,
+        bool isDirectory)
+    {
+        // Deeper sources take precedence over shallower ones; .git/info/exclude is the
+        // shallowest of all.
+        for (var i = ignoreSources.Count - 1; i >= 0; i--)
+        {
+            var (basePrefix, rules) = ignoreSources[i];
+
+            if (rules.IsIgnored(relativePath[basePrefix.Length..], isDirectory) is { } decision)
+            {
+                return decision;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasExecutableBitChanged(FileInfo fileInfo, GitIndexEntry entry)
+    {
+        // Windows has no executable bit and git ignores file modes there.
+        if (OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        var isExecutable = (File.GetUnixFileMode(fileInfo.FullName) & UnixFileMode.UserExecute) != 0;
+        return isExecutable != entry.IsExecutable;
+    }
+
+    [SuppressMessage("Critical Security Hotspot", "S4790:Using weak hashing algorithms is security-sensitive", Justification = "Git object ids are SHA-1 by definition; the hash is used for content identity, not security.")]
+    private static GitObjectId HashBlob(byte[] content)
+    {
+        var header = Encoding.ASCII.GetBytes($"blob {content.Length}\0");
+
+        var buffer = new byte[header.Length + content.Length];
+        header.CopyTo(buffer, 0);
+        content.CopyTo(buffer, header.Length);
+
+        return GitObjectId.Parse(SHA1.HashData(buffer));
+    }
+}

--- a/src/GitVersion.Git.Managed/StreamExtensions.cs
+++ b/src/GitVersion.Git.Managed/StreamExtensions.cs
@@ -1,0 +1,81 @@
+// Portions derived from Nerdbank.GitVersioning (https://github.com/dotnet/Nerdbank.GitVersioning), MIT License.
+
+using System.Buffers;
+
+namespace GitVersion.Git;
+
+/// <summary>
+/// Provides extension methods for the <see cref="Stream"/> class.
+/// </summary>
+internal static class StreamExtensions
+{
+    /// <summary>
+    /// Reads a variable-length integer off a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">The stream off which to read the variable-length integer.</param>
+    /// <returns>The requested value.</returns>
+    /// <exception cref="EndOfStreamException">Thrown when the stream runs out of data before the integer could be read.</exception>
+    /// <exception cref="GitObjectStoreException">Thrown when the encoded value does not fit in an <see cref="int"/>.</exception>
+    public static int ReadMbsInt(this Stream stream)
+    {
+        var value = 0L;
+        var currentBit = 0;
+
+        while (true)
+        {
+            var read = stream.ReadByte();
+            if (read == -1)
+            {
+                throw new EndOfStreamException();
+            }
+
+            value |= (long)(read & 0b_0111_1111) << currentBit;
+            currentBit += 7;
+
+            if (currentBit > 35 || value > int.MaxValue)
+            {
+                throw new GitObjectStoreException("The variable-length integer is malformed or too large.");
+            }
+
+            if (read < 128)
+            {
+                break;
+            }
+        }
+
+        return (int)value;
+    }
+
+    /// <summary>
+    /// Reads the specified number of bytes from a stream, or until the end of the stream.
+    /// </summary>
+    /// <param name="readFrom">The stream to read from.</param>
+    /// <param name="length">The number of bytes to be read.</param>
+    /// <param name="copyTo">The stream to copy the read bytes to, if required.</param>
+    /// <returns>The number of bytes actually read. This will be less than <paramref name="length"/> only if the end of <paramref name="readFrom"/> is reached.</returns>
+    public static int ReadBytes(this Stream readFrom, int length, Stream? copyTo = null)
+    {
+        var bytesRemaining = length;
+        var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(50 * 1024, bytesRemaining));
+        try
+        {
+            while (bytesRemaining > 0)
+            {
+                var read = readFrom.Read(buffer, 0, Math.Min(buffer.Length, bytesRemaining));
+                if (read == 0)
+                {
+                    break;
+                }
+
+                copyTo?.Write(buffer, 0, read);
+                bytesRemaining -= read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        return length - bytesRemaining;
+    }
+}

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -22,6 +22,7 @@
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" />
         <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />
+        <ProjectReference Include="..\GitVersion.Git.Managed\GitVersion.Git.Managed.csproj" />
         <ProjectReference Include="..\GitVersion.LibGit2Sharp\GitVersion.LibGit2Sharp.csproj" />
         <ProjectReference Include="..\GitVersion.MsBuild\GitVersion.MsBuild.csproj" />
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />

--- a/src/GitVersion.slnx
+++ b/src/GitVersion.slnx
@@ -8,6 +8,8 @@
     <Project Path="GitVersion.BuildAgents/GitVersion.BuildAgents.csproj" />
     <Project Path="GitVersion.Configuration.Tests/GitVersion.Configuration.Tests.csproj" />
     <Project Path="GitVersion.Configuration/GitVersion.Configuration.csproj" />
+    <Project Path="GitVersion.Git.Managed.Tests/GitVersion.Git.Managed.Tests.csproj" />
+    <Project Path="GitVersion.Git.Managed/GitVersion.Git.Managed.csproj" />
     <Project Path="GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj" />
     <Project Path="GitVersion.Output.Tests/GitVersion.Output.Tests.csproj" />
     <Project Path="GitVersion.Output/GitVersion.Output.csproj" />


### PR DESCRIPTION
Implements the managed Git backend for the v7.0 dual-backend window (#5031, design: `docs/design/managed-git-migration.md`): a vendored, fully managed reader for all read/history operations paired with the `git` CLI for mutations and network, selectable at runtime alongside the existing libgit2 backend.

## What's in the branch

Layered bottom-up, one commit per layer, each with its tests:

- **Object database** — hash-agnostic `GitObjectId`, zlib/random-access streams, pack + idx v2 readers with delta application, bounded pack memory cache, multi-pack-index, loose objects, SHA-256 detection with a clear failure message (NOTICE attribution for code ported from Nerdbank.GitVersioning ManagedGit, MIT).
- **Parsers** — commit (signatures, encoding with Latin-1 fallback), tree (streaming reads), annotated tags.
- **Refs & repository layout** — loose/packed refs (peeled, symrefs, `.lock` skipping), walk-up discovery with `.git`-file indirection, worktrees/commondir, shallow detection, config parsing, reftable rejection.
- **Revision walker** — libgit2-parity time/topo ordering with exact tie-break mechanics, mark-uninteresting limiting, paint-down-to-common merge-base, `.git/shallow` boundaries grafted parentless.
- **Diff & status** — changed-paths tree diff in raw byte order, index v2–v4 reader, gitignore matching, working-tree status matching the libgit2 adapter's uncommitted-changes expression.
- **CLI mutator** — plumbing-only parsing, `ArgumentList` invocation (`LC_ALL=C`, no terminal prompts), per-invocation auth headers, stderr classification mapped to the existing exceptions (Polly `LockedFileException` retry preserved).
- **Adapters & selection** — `Managed*` implementations of the Core git abstractions over an immutable session snapshot (invalidated after mutations); `GITVERSION_GIT_BACKEND=libgit2|managed` resolved once in `GitBackendSelector` (unset ⇒ `libgit2` in v7.0; unknown values fail fast); the resolved backend is logged at startup.

## Behavior

- **v7.0 default is unchanged (`libgit2`)** — the managed backend is opt-in for validation; v7.1 flips the default per the release plan.
- With `managed`, `git` on `PATH` is required **only** for normalization/dynamic-repo scenarios; plain version calculation on a prepared checkout needs no git binary.

## Validation

- CI unit-test matrix runs every leg against **both backends** (`git_backend` dimension) on three OSes — the full integration suites assert exact SemVer strings over complex histories.
- `DualBackendParityTests`: deep-equality on ref enumeration, order-sensitive walks, merge-base over commit pairs (criss-cross, equal timestamps), `DiffPaths`, `UncommittedChangesCount`.
- `build/parity-corpus.ps1` diffs `gitversion /nocache /output json` across backends on real-world repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)