### PR TITLE
Drop Intel macOS artifacts

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Intel macOS artifacts removed
+
+GitVersion no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-arm64`) is now the only supported macOS target. Intel Mac users should continue using the last GitVersion v6 release that shipped an `osx-x64` artifact.
+
+### `CommitsSinceVersionSource` output variable removed
+
+`CommitsSinceVersionSource` is no longer emitted in JSON output, build-agent environment variables, generated version-information files, or the MSBuild `GetVersion` task. It can no longer be used in custom format strings. Use `VersionSourceDistance` instead; it has the same value.
+
 ### Invalid label formatting is not ignored
 Previously bad label formatting config would be silently accepted. For example `{Branhc}` (when BranchName is misspelled) or even `{BranchName` (missing a closing brace). This is not ignored now and exceptions will be thrown if formatting problems exist in the label config. This brings it into line with how assembly string formatting is treated.
 

--- a/build/build/BuildContext.cs
+++ b/build/build/BuildContext.cs
@@ -11,7 +11,7 @@ public class BuildContext(ICakeContext context) : BuildContextBase(context)
     {
         [PlatformFamily.Windows] = ["win-x64", "win-arm64"],
         [PlatformFamily.Linux] = ["linux-x64", "linux-musl-x64", "linux-arm64", "linux-musl-arm64"],
-        [PlatformFamily.OSX] = ["osx-x64", "osx-arm64"],
+        [PlatformFamily.OSX] = ["osx-arm64"],
     };
 
     public bool EnabledUnitTests { get; set; }

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -6,6 +6,10 @@ Description: Migration guidance for upgrading from GitVersion v6 to GitVersion v
 
 This document summarizes the relevant breaking changes when migrating from GitVersion v6 to v7.
 
+## Intel macOS artifacts removed
+
+GitVersion v7 no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-arm64`) is now the only supported macOS target. Intel Mac users should continue using the last GitVersion v6 release that shipped an `osx-x64` artifact.
+
 ## `CommitsSinceVersionSource` output variable removed
 
 `CommitsSinceVersionSource` is no longer emitted in JSON output, build-agent environment variables, generated version-information files, or the MSBuild `GetVersion` task. It can no longer be used in custom format strings.


### PR DESCRIPTION
## Summary

- Remove `osx-x64` from the native runtime matrix; macOS artifacts are now Apple Silicon only (`osx-arm64`).
- Document the Intel macOS artifact removal and the previously omitted `CommitsSinceVersionSource` breaking change.

## Verification

- `dotnet build ./build/build/build.csproj --no-restore`
- `dotnet build ./build/docs/docs.csproj --no-restore`

Closes #5078