### PR TITLE
Drop .NET 8 and .NET 9 target frameworks

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### .NET 8 and .NET 9 target frameworks removed
+
+GitVersion now targets .NET 10 only. The CLI, global tool, and `GitVersion.MsBuild` require a .NET 10 runtime. The MSBuild integration continues to support projects targeting earlier frameworks through its `dotnet --roll-forward Major` launcher, provided .NET 10 is installed.
+
 ### Intel macOS artifacts removed
 
 GitVersion no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-arm64`) is now the only supported macOS target. Intel Mac users should continue using the last GitVersion v6 release that shipped an `osx-x64` artifact.

--- a/build/common/Utilities/Constants.cs
+++ b/build/common/Utilities/Constants.cs
@@ -7,7 +7,7 @@ public static class Constants
     public const string Repository = "GitVersion";
 
     public const string DotnetLtsLatest = "10.0";
-    public static readonly string[] DotnetVersions = [DotnetLtsLatest, "9.0", "8.0"];
+    public static readonly string[] DotnetVersions = [DotnetLtsLatest];
 
     public const string DefaultBranch = "main";
     public const string DefaultConfiguration = "Release";

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -10,6 +10,10 @@ This document summarizes the relevant breaking changes when migrating from GitVe
 
 GitVersion v7 no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-arm64`) is now the only supported macOS target. Intel Mac users should continue using the last GitVersion v6 release that shipped an `osx-x64` artifact.
 
+## .NET 8 and .NET 9 target frameworks removed
+
+GitVersion v7 targets .NET 10 only. Install the .NET 10 runtime to use the CLI, global tool, or `GitVersion.MsBuild`. The MSBuild integration can still run in projects targeting earlier frameworks through its `dotnet --roll-forward Major` launcher, provided .NET 10 is installed.
+
 ## `CommitsSinceVersionSource` output variable removed
 
 `CommitsSinceVersionSource` is no longer emitted in JSON output, build-agent environment variables, generated version-information files, or the MSBuild `GetVersion` task. It can no longer be used in custom format strings.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
 
         <EndYear>$([System.DateTime]::Today.Year)</EndYear>
         <Authors>GitTools and Contributors</Authors>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,9 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion Condition=" '$(TargetFramework)' == 'net8.0' ">17.11.48</MicrosoftBuildVersion>
-    <MicrosoftBuildVersion Condition=" '$(TargetFramework)' == 'net9.0' ">17.14.28</MicrosoftBuildVersion>
-    <MicrosoftBuildVersion Condition=" '$(TargetFramework)' == 'net10.0' ">18.8.2</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>18.8.2</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>5.6.0</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/GitVersion.Core/Core/RegexPatterns.cs
+++ b/src/GitVersion.Core/Core/RegexPatterns.cs
@@ -37,65 +37,23 @@ internal static partial class RegexPatterns
     [StringSyntax(StringSyntaxAttribute.Regex, Options)]
     internal const string SanitizeLabelRegexPattern = "[^a-zA-Z0-9-.]";
 
-#if NET9_0_OR_GREATER
     [GeneratedRegex(SwitchArgumentRegexPattern, Options)]
     public static partial Regex SwitchArgumentRegex { get; }
-#else
-    [GeneratedRegex(SwitchArgumentRegexPattern, Options)]
-    private static partial Regex SwitchArgumentRegexImpl();
 
-    public static Regex SwitchArgumentRegex { get; } = SwitchArgumentRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
     [GeneratedRegex(ObscurePasswordRegexPattern, Options)]
     public static partial Regex ObscurePasswordRegex { get; }
-#else
-    [GeneratedRegex(ObscurePasswordRegexPattern, Options)]
-    private static partial Regex ObscurePasswordRegexImpl();
 
-    public static Regex ObscurePasswordRegex { get; } = ObscurePasswordRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
     [GeneratedRegex(ExpandTokensRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
     public static partial Regex ExpandTokensRegex { get; }
-#else
-    [GeneratedRegex(ExpandTokensRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
-    private static partial Regex ExpandTokensRegexImpl();
 
-    public static Regex ExpandTokensRegex { get; } = ExpandTokensRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
     [GeneratedRegex(SanitizeEnvVarNameRegexPattern, Options)]
     public static partial Regex SanitizeEnvVarNameRegex { get; }
-#else
-    [GeneratedRegex(SanitizeEnvVarNameRegexPattern, Options)]
-    private static partial Regex SanitizeEnvVarNameRegexImpl();
 
-    public static Regex SanitizeEnvVarNameRegex { get; } = SanitizeEnvVarNameRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
     [GeneratedRegex(SanitizeMemberNameRegexPattern, Options)]
     public static partial Regex SanitizeMemberNameRegex { get; }
-#else
-    [GeneratedRegex(SanitizeMemberNameRegexPattern, Options)]
-    private static partial Regex SanitizeMemberNameRegexImpl();
 
-    public static Regex SanitizeMemberNameRegex { get; } = SanitizeMemberNameRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
     [GeneratedRegex(SanitizeNameRegexPattern, Options)]
     public static partial Regex SanitizeNameRegex { get; }
-#else
-    [GeneratedRegex(SanitizeNameRegexPattern, Options)]
-    private static partial Regex SanitizeNameRegexImpl();
-
-    public static Regex SanitizeNameRegex { get; } = SanitizeNameRegexImpl();
-#endif
 
     public static class Cache
     {
@@ -203,105 +161,35 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string UnknownBranchRegexPattern = "(?<BranchName>.+)";
 
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultTagPrefixRegexPattern, Options)]
         public static partial Regex DefaultTagPrefixRegex { get; }
-#else
-        [GeneratedRegex(DefaultTagPrefixRegexPattern, Options)]
-        private static partial Regex DefaultTagPrefixRegexImpl();
 
-        public static Regex DefaultTagPrefixRegex { get; } = DefaultTagPrefixRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultVersionInBranchRegexPattern, Options)]
         public static partial Regex DefaultVersionInBranchRegex { get; }
-#else
-        [GeneratedRegex(DefaultVersionInBranchRegexPattern, Options)]
-        private static partial Regex DefaultVersionInBranchRegexImpl();
 
-        public static Regex DefaultVersionInBranchRegex { get; } = DefaultVersionInBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(MainBranchRegexPattern, Options)]
         public static partial Regex MainBranchRegex { get; }
-#else
-        [GeneratedRegex(MainBranchRegexPattern, Options)]
-        private static partial Regex MainBranchRegexImpl();
 
-        public static Regex MainBranchRegex { get; } = MainBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DevelopBranchRegexPattern, Options)]
         public static partial Regex DevelopBranchRegex { get; }
-#else
-        [GeneratedRegex(DevelopBranchRegexPattern, Options)]
-        private static partial Regex DevelopBranchRegexImpl();
 
-        public static Regex DevelopBranchRegex { get; } = DevelopBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(ReleaseBranchRegexPattern, Options)]
         public static partial Regex ReleaseBranchRegex { get; }
-#else
-        [GeneratedRegex(ReleaseBranchRegexPattern, Options)]
-        private static partial Regex ReleaseBranchRegexImpl();
 
-        public static Regex ReleaseBranchRegex { get; } = ReleaseBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(FeatureBranchRegexPattern, Options)]
         public static partial Regex FeatureBranchRegex { get; }
-#else
-        [GeneratedRegex(FeatureBranchRegexPattern, Options)]
-        private static partial Regex FeatureBranchRegexImpl();
 
-        public static Regex FeatureBranchRegex { get; } = FeatureBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(PullRequestBranchRegexPattern, Options)]
         public static partial Regex PullRequestBranchRegex { get; }
-#else
-        [GeneratedRegex(PullRequestBranchRegexPattern, Options)]
-        private static partial Regex PullRequestBranchRegexImpl();
 
-        public static Regex PullRequestBranchRegex { get; } = PullRequestBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(HotfixBranchRegexPattern, Options)]
         public static partial Regex HotfixBranchRegex { get; }
-#else
-        [GeneratedRegex(HotfixBranchRegexPattern, Options)]
-        private static partial Regex HotfixBranchRegexImpl();
 
-        public static Regex HotfixBranchRegex { get; } = HotfixBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(SupportBranchRegexPattern, Options)]
         public static partial Regex SupportBranchRegex { get; }
-#else
-        [GeneratedRegex(SupportBranchRegexPattern, Options)]
-        private static partial Regex SupportBranchRegexImpl();
 
-        public static Regex SupportBranchRegex { get; } = SupportBranchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(UnknownBranchRegexPattern, Options)]
         public static partial Regex UnknownBranchRegex { get; }
-#else
-        [GeneratedRegex(UnknownBranchRegexPattern, Options)]
-        private static partial Regex UnknownBranchRegexImpl();
-
-        public static Regex UnknownBranchRegex { get; } = UnknownBranchRegexImpl();
-#endif
     }
 
     internal static partial class MergeMessage
@@ -330,85 +218,29 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string AzureDevOpsPullMergeMessageRegexPattern = @"^Merge pull request (?<PullRequestNumber>\d+) from (?<SourceBranch>[^\s]*) into (?<TargetBranch>[^\s]*)";
 
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultMergeMessageRegexPattern, Options)]
         public static partial Regex DefaultMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(DefaultMergeMessageRegexPattern, Options)]
-        private static partial Regex DefaultMergeMessageRegexImpl();
 
-        public static Regex DefaultMergeMessageRegex { get; } = DefaultMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(SmartGitMergeMessageRegexPattern, Options)]
         public static partial Regex SmartGitMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(SmartGitMergeMessageRegexPattern, Options)]
-        private static partial Regex SmartGitMergeMessageRegexImpl();
 
-        public static Regex SmartGitMergeMessageRegex { get; } = SmartGitMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(BitBucketPullMergeMessageRegexPattern, Options)]
         public static partial Regex BitBucketPullMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(BitBucketPullMergeMessageRegexPattern, Options)]
-        private static partial Regex BitBucketPullMergeMessageRegexImpl();
 
-        public static Regex BitBucketPullMergeMessageRegex { get; } = BitBucketPullMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(BitBucketPullv7MergeMessageRegexPattern, Options)]
         public static partial Regex BitBucketPullv7MergeMessageRegex { get; }
-#else
-        [GeneratedRegex(BitBucketPullv7MergeMessageRegexPattern, Options)]
-        private static partial Regex BitBucketPullv7MergeMessageRegexImpl();
 
-        public static Regex BitBucketPullv7MergeMessageRegex { get; } = BitBucketPullv7MergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(BitBucketCloudPullMergeMessageRegexPattern, Options)]
         public static partial Regex BitBucketCloudPullMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(BitBucketCloudPullMergeMessageRegexPattern, Options)]
-        private static partial Regex BitBucketCloudPullMergeMessageRegexImpl();
 
-        public static Regex BitBucketCloudPullMergeMessageRegex { get; } = BitBucketCloudPullMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(GitHubPullMergeMessageRegexPattern, Options)]
         public static partial Regex GitHubPullMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(GitHubPullMergeMessageRegexPattern, Options)]
-        private static partial Regex GitHubPullMergeMessageRegexImpl();
 
-        public static Regex GitHubPullMergeMessageRegex { get; } = GitHubPullMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(RemoteTrackingMergeMessageRegexPattern, Options)]
         public static partial Regex RemoteTrackingMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(RemoteTrackingMergeMessageRegexPattern, Options)]
-        private static partial Regex RemoteTrackingMergeMessageRegexImpl();
 
-        public static Regex RemoteTrackingMergeMessageRegex { get; } = RemoteTrackingMergeMessageRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(AzureDevOpsPullMergeMessageRegexPattern, Options)]
         public static partial Regex AzureDevOpsPullMergeMessageRegex { get; }
-#else
-        [GeneratedRegex(AzureDevOpsPullMergeMessageRegexPattern, Options)]
-        private static partial Regex AzureDevOpsPullMergeMessageRegexImpl();
-
-        public static Regex AzureDevOpsPullMergeMessageRegex { get; } = AzureDevOpsPullMergeMessageRegexImpl();
-#endif
     }
 
     internal static partial class Output
@@ -437,85 +269,29 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string SanitizeAssemblyInfoRegexPattern = "[^0-9A-Za-z-.+]";
 
-#if NET9_0_OR_GREATER
         [GeneratedRegex(AssemblyVersionRegexPattern, Options)]
         public static partial Regex AssemblyVersionRegex { get; }
-#else
-        [GeneratedRegex(AssemblyVersionRegexPattern, Options)]
-        private static partial Regex AssemblyVersionRegexImpl();
 
-        public static Regex AssemblyVersionRegex { get; } = AssemblyVersionRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(AssemblyInfoVersionRegexPattern, Options)]
         public static partial Regex AssemblyInfoVersionRegex { get; }
-#else
-        [GeneratedRegex(AssemblyInfoVersionRegexPattern, Options)]
-        private static partial Regex AssemblyInfoVersionRegexImpl();
 
-        public static Regex AssemblyInfoVersionRegex { get; } = AssemblyInfoVersionRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(AssemblyFileVersionRegexPattern, Options)]
         public static partial Regex AssemblyFileVersionRegex { get; }
-#else
-        [GeneratedRegex(AssemblyFileVersionRegexPattern, Options)]
-        private static partial Regex AssemblyFileVersionRegexImpl();
 
-        public static Regex AssemblyFileVersionRegex { get; } = AssemblyFileVersionRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(CsharpAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
         public static partial Regex CsharpAssemblyAttributeRegex { get; }
-#else
-        [GeneratedRegex(CsharpAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
-        private static partial Regex CsharpAssemblyAttributeRegexImpl();
 
-        public static Regex CsharpAssemblyAttributeRegex { get; } = CsharpAssemblyAttributeRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(FsharpAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
         public static partial Regex FsharpAssemblyAttributeRegex { get; }
-#else
-        [GeneratedRegex(FsharpAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
-        private static partial Regex FsharpAssemblyAttributeRegexImpl();
 
-        public static Regex FsharpAssemblyAttributeRegex { get; } = FsharpAssemblyAttributeRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(VisualBasicAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
         public static partial Regex VisualBasicAssemblyAttributeRegex { get; }
-#else
-        [GeneratedRegex(VisualBasicAssemblyAttributeRegexPattern, Options | RegexOptions.Multiline)]
-        private static partial Regex VisualBasicAssemblyAttributeRegexImpl();
 
-        public static Regex VisualBasicAssemblyAttributeRegex { get; } = VisualBasicAssemblyAttributeRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(SanitizeParticipantRegexPattern, Options)]
         public static partial Regex SanitizeParticipantRegex { get; }
-#else
-        [GeneratedRegex(SanitizeParticipantRegexPattern, Options)]
-        private static partial Regex SanitizeParticipantRegexImpl();
 
-        public static Regex SanitizeParticipantRegex { get; } = SanitizeParticipantRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(SanitizeAssemblyInfoRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
         public static partial Regex SanitizeAssemblyInfoRegex { get; }
-#else
-        [GeneratedRegex(SanitizeAssemblyInfoRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
-        private static partial Regex SanitizeAssemblyInfoRegexImpl();
-
-        public static Regex SanitizeAssemblyInfoRegex { get; } = SanitizeAssemblyInfoRegexImpl();
-#endif
     }
 
     internal static partial class VersionCalculation
@@ -532,45 +308,17 @@ internal static partial class RegexPatterns
         [StringSyntax(StringSyntaxAttribute.Regex)]
         internal const string DefaultNoBumpRegexPattern = @"\+semver:\s?(none|skip)";
 
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultMajorRegexPattern, Options)]
         public static partial Regex DefaultMajorRegex { get; }
-#else
-        [GeneratedRegex(DefaultMajorRegexPattern, Options)]
-        private static partial Regex DefaultMajorRegexImpl();
 
-        public static Regex DefaultMajorRegex { get; } = DefaultMajorRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultMinorRegexPattern, Options)]
         public static partial Regex DefaultMinorRegex { get; }
-#else
-        [GeneratedRegex(DefaultMinorRegexPattern, Options)]
-        private static partial Regex DefaultMinorRegexImpl();
 
-        public static Regex DefaultMinorRegex { get; } = DefaultMinorRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultPatchRegexPattern, Options)]
         public static partial Regex DefaultPatchRegex { get; }
-#else
-        [GeneratedRegex(DefaultPatchRegexPattern, Options)]
-        private static partial Regex DefaultPatchRegexImpl();
 
-        public static Regex DefaultPatchRegex { get; } = DefaultPatchRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(DefaultNoBumpRegexPattern, Options)]
         public static partial Regex DefaultNoBumpRegex { get; }
-#else
-        [GeneratedRegex(DefaultNoBumpRegexPattern, Options)]
-        private static partial Regex DefaultNoBumpRegexImpl();
-
-        public static Regex DefaultNoBumpRegex { get; } = DefaultNoBumpRegexImpl();
-#endif
     }
 
     internal static partial class SemanticVersion
@@ -591,55 +339,20 @@ internal static partial class RegexPatterns
         internal const string ParsePreReleaseTagRegexPattern = @"(?<name>.*?)\.?(?<number>\d+)?$";
 
         // uses the git-semver spec https://github.com/semver/semver/blob/master/semver.md
-#if NET9_0_OR_GREATER
         [GeneratedRegex(ParseStrictRegexPattern, Options)]
         public static partial Regex ParseStrictRegex { get; }
-#else
-        [GeneratedRegex(ParseStrictRegexPattern, Options)]
-        private static partial Regex ParseStrictRegexImpl();
 
-        public static Regex ParseStrictRegex { get; } = ParseStrictRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(ParseLooseRegexPattern, Options)]
         public static partial Regex ParseLooseRegex { get; }
-#else
-        [GeneratedRegex(ParseLooseRegexPattern, Options)]
-        private static partial Regex ParseLooseRegexImpl();
 
-        public static Regex ParseLooseRegex { get; } = ParseLooseRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(ParseBuildMetaDataRegexPattern, Options)]
         public static partial Regex ParseBuildMetaDataRegex { get; }
-#else
-        [GeneratedRegex(ParseBuildMetaDataRegexPattern, Options)]
-        private static partial Regex ParseBuildMetaDataRegexImpl();
 
-        public static Regex ParseBuildMetaDataRegex { get; } = ParseBuildMetaDataRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(FormatBuildMetaDataRegexPattern, Options)]
         public static partial Regex FormatBuildMetaDataRegex { get; }
-#else
-        [GeneratedRegex(FormatBuildMetaDataRegexPattern, Options)]
-        private static partial Regex FormatBuildMetaDataRegexImpl();
 
-        public static Regex FormatBuildMetaDataRegex { get; } = FormatBuildMetaDataRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
         [GeneratedRegex(ParsePreReleaseTagRegexPattern, Options)]
         public static partial Regex ParsePreReleaseTagRegex { get; }
-#else
-        [GeneratedRegex(ParsePreReleaseTagRegexPattern, Options)]
-        private static partial Regex ParsePreReleaseTagRegexImpl();
-
-        public static Regex ParsePreReleaseTagRegex { get; } = ParsePreReleaseTagRegexImpl();
-#endif
     }
 
     internal static partial class AssemblyVersion
@@ -664,25 +377,11 @@ internal static partial class RegexPatterns
                 \s*\(\s*\)\s*\]                       # End brackets ()]
                 """;
 
-#if NET9_0_OR_GREATER
             [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex TriviaRegex { get; }
-#else
-            [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex TriviaRegexImpl();
 
-            public static Regex TriviaRegex { get; } = TriviaRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
             [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex AttributeRegex { get; }
-#else
-            [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex AttributeRegexImpl();
-
-            public static Regex AttributeRegex { get; } = AttributeRegexImpl();
-#endif
         }
 
         internal static partial class FSharp
@@ -704,25 +403,11 @@ internal static partial class RegexPatterns
             /// Note that while available to call direct, as the C# TriviaRegex is the same it will handle any calls through the cache for F# too.
             /// </summary>
             /// <returns></returns>
-#if NET9_0_OR_GREATER
             [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex TriviaRegex { get; }
-#else
-            [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex TriviaRegexImpl();
 
-            public static Regex TriviaRegex { get; } = TriviaRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
             [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex AttributeRegex { get; }
-#else
-            [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex AttributeRegexImpl();
-
-            public static Regex AttributeRegex { get; } = AttributeRegexImpl();
-#endif
         }
 
         internal static partial class VisualBasic
@@ -744,25 +429,11 @@ internal static partial class RegexPatterns
                 \s*\(\s*\)\s*\>                       # End brackets ()>
                 """;
 
-#if NET9_0_OR_GREATER
             [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex TriviaRegex { get; }
-#else
-            [GeneratedRegex(TriviaRegexPattern, RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex TriviaRegexImpl();
 
-            public static Regex TriviaRegex { get; } = TriviaRegexImpl();
-#endif
-
-#if NET9_0_OR_GREATER
             [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
             public static partial Regex AttributeRegex { get; }
-#else
-            [GeneratedRegex(AttributeRegexPattern, RegexOptions.IgnorePatternWhitespace | Options)]
-            private static partial Regex AttributeRegexImpl();
-
-            public static Regex AttributeRegex { get; } = AttributeRegexImpl();
-#endif
         }
     }
 }

--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -39,8 +39,6 @@
         <None Include="msbuild/build/*.*" Pack="true" PackagePath="build" />
         <None Include="msbuild/buildMultiTargeting/*.*" Pack="true" PackagePath="buildMultiTargeting" />
 
-        <None Include="$(ExePublishPath)/net8.0/publish/**/*;$(BinPath)/net8.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net8.0" />
-        <None Include="$(ExePublishPath)/net9.0/publish/**/*;$(BinPath)/net9.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net9.0" />
         <None Include="$(ExePublishPath)/net10.0/publish/**/*;$(BinPath)/net10.0/GitVersion.MsBuild.*" Pack="true" PackagePath="tools/net10.0" />
     </ItemGroup>
 

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -9,11 +9,9 @@
         <GenerateGitVersionInformation Condition=" '$(GenerateGitVersionInformation)' == '' And '$(GenerateGitVersionFiles)' == 'true' ">true</GenerateGitVersionInformation>
 
         <!-- Validates the target framework and sets the GitVersionTargetFramework property to the target framework that is compatible with the target framework of the project -->
-        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0')) == 'true'">net8.0</GitVersionTargetFramework>
-        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0')) == 'true'">net9.0</GitVersionTargetFramework>
         <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0')) == 'true'">net10.0</GitVersionTargetFramework>
-        <!-- Fall back to net8.0 if the target framework is not compatible with net10.0, net9.0 and net8.0 -->
-        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == ''">net8.0</GitVersionTargetFramework>
+        <!-- Fall back to net10.0 for older target frameworks; the CLI rolls forward to the installed .NET 10 runtime. -->
+        <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == ''">net10.0</GitVersionTargetFramework>
         <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))gitversion.dll&quot;</GitVersionFileExe>
         <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- Consolidate GitVersion on .NET 10 and remove .NET 8/.NET 9 package, MSBuild packaging, CI, and Docker matrix paths.
- Simplify generated regexes now that the legacy target frameworks are gone.
- Document the .NET 10 runtime requirement and MSBuild roll-forward behavior.

## Verification

- `dotnet build ./src/GitVersion.slnx --no-restore`
- `dotnet build ./new-cli/GitVersion.slnx --no-restore`
- `dotnet format --verify-no-changes ./src/GitVersion.slnx --no-restore`
- Temporary `net8.0` MSBuild consumer selects `GitVersionTargetFramework=net10.0`.

Closes #4997