### PR TITLE
feat: publish RID-specific tool packages

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,7 +2,11 @@
 
 ### .NET 8 and .NET 9 target frameworks removed
 
-GitVersion now targets .NET 10 only. The CLI, global tool, and `GitVersion.MsBuild` require a .NET 10 runtime. The MSBuild integration continues to support projects targeting earlier frameworks through its `dotnet --roll-forward Major` launcher, provided .NET 10 is installed.
+GitVersion now targets .NET 10 only. The CLI, global tool, and `GitVersion.MsBuild` require a .NET 10 runtime. The MSBuild integration continues to support projects targeting earlier frameworks through its `dotnet exec --roll-forward Major` launcher, provided .NET 10 is installed.
+
+### RID-specific global-tool packages
+
+GitVersion now packages `GitVersion.Tool` per runtime identifier. Install it with the .NET 10 SDK as before; NuGet automatically selects the dedicated package for Windows x64 and ARM64, Linux x64 and ARM64 (including musl), or Apple Silicon macOS.
 
 ### Intel macOS artifacts removed
 

--- a/build/build/Tasks/Package/PackageNuget.cs
+++ b/build/build/Tasks/Package/PackageNuget.cs
@@ -1,4 +1,5 @@
 using Cake.Common.Tools.DotNet.Pack;
+using Cake.Common.Tools.DotNet.Publish;
 using Common.Utilities;
 
 namespace Build.Tasks;
@@ -27,6 +28,13 @@ public class PackageNuget : FrostingTask<BuildContext>
 
         settings.ArgumentCustomization = arg => arg.Append("-p:PackAsTool=true").Append("-p:BuildInParallel=false");
         context.DotNetPack("./src/GitVersion.App", settings);
+
+        context.DotNetPublish("./src/GitVersion.App", new DotNetPublishSettings
+        {
+            Configuration = context.MsBuildConfiguration,
+            Framework = $"net{Constants.DotnetLtsLatest}",
+            MSBuildSettings = context.MsBuildSettings
+        });
 
         settings.ArgumentCustomization = arg => arg.Append("-p:IsPackaging=true");
         context.DotNetPack("./src/GitVersion.MsBuild", settings);

--- a/build/publish/Tasks/PublishNuget.cs
+++ b/build/publish/Tasks/PublishNuget.cs
@@ -68,7 +68,9 @@ public class PublishNugetInternal : AsyncFrostingTask<BuildContext>
     {
         ArgumentNullException.ThrowIfNull(context.Version);
         var nugetVersion = context.Version.NugetVersion;
-        foreach (var (packageName, filePath, _) in context.Packages.Where(x => !x.IsChocoPackage))
+        foreach (var (packageName, filePath, _) in context.Packages
+                     .Where(x => !x.IsChocoPackage)
+                     .OrderBy(x => x.PackageName.Equals("gitversion.tool", StringComparison.OrdinalIgnoreCase)))
         {
             context.Information($"Package {packageName}, version {nugetVersion} is being published.");
             context.DotNetNuGetPush(filePath.FullPath,

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -12,7 +12,7 @@ GitVersion v7 no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-ar
 
 ## .NET 8 and .NET 9 target frameworks removed
 
-GitVersion v7 targets .NET 10 only. Install the .NET 10 runtime to use the CLI, global tool, or `GitVersion.MsBuild`. The MSBuild integration can still run in projects targeting earlier frameworks through its `dotnet --roll-forward Major` launcher, provided .NET 10 is installed.
+GitVersion v7 targets .NET 10 only. Install the .NET 10 runtime to use the CLI, global tool, or `GitVersion.MsBuild`. The MSBuild integration can still run in projects targeting earlier frameworks through its `dotnet exec --roll-forward Major` launcher, provided .NET 10 is installed.
 
 ## RID-specific global-tool packages
 

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -14,6 +14,13 @@ GitVersion v7 no longer ships native `osx-x64` artifacts. Apple Silicon (`osx-ar
 
 GitVersion v7 targets .NET 10 only. Install the .NET 10 runtime to use the CLI, global tool, or `GitVersion.MsBuild`. The MSBuild integration can still run in projects targeting earlier frameworks through its `dotnet --roll-forward Major` launcher, provided .NET 10 is installed.
 
+## RID-specific global-tool packages
+
+GitVersion v7 packages `GitVersion.Tool` per runtime identifier. Install it with
+the .NET 10 SDK as before; NuGet automatically selects the dedicated package for
+Windows x64 and ARM64, Linux x64 and ARM64 (including musl), or Apple Silicon
+macOS.
+
 ## `CommitsSinceVersionSource` output variable removed
 
 `CommitsSinceVersionSource` is no longer emitted in JSON output, build-agent environment variables, generated version-information files, or the MSBuild `GetVersion` task. It can no longer be used in custom format strings.

--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -25,7 +25,10 @@ Example: `dotnet tool install GitVersion.Tool --global --version 6.*`
 If you want to pin to a specific version of GitVersion, you can find the available
 versions of [`GitVersion.Tool` on NuGet](https://www.nuget.org/packages/GitVersion.Tool/).
 
-This should work on all operating systems supported by .NET Core.
+GitVersion v7 uses .NET 10 RID-specific tool packages. The install command must
+run with the .NET 10 SDK; NuGet then selects the package for the current
+platform automatically. GitVersion ships dedicated packages for Windows x64 and
+ARM64, Linux x64 and ARM64 (including musl), and Apple Silicon macOS.
 
 To run call
 
@@ -90,7 +93,7 @@ When using these commands, you must specify the package name `GitVersion.Tool` r
 Note that local tools use `dotnet gitversion` (without the hyphen), while the
 global tool uses `dotnet-gitversion` (with a hyphen).
 
-This should work on all operating systems supported by .NET Core.
+The same .NET 10 SDK and platform requirements as the global tool apply.
 
 ### Homebrew
 

--- a/src/GitVersion.App/GitVersion.App.csproj
+++ b/src/GitVersion.App/GitVersion.App.csproj
@@ -12,6 +12,8 @@
         <ToolCommandName>dotnet-gitversion</ToolCommandName>
         <PackageId>GitVersion.Tool</PackageId>
         <RollForward>LatestMajor</RollForward>
+        <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-arm64</RuntimeIdentifiers>
+        <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-arm64</ToolPackageRuntimeIdentifiers>
         <PackageDescription>Derives SemVer information from a repository following GitFlow or GitHubFlow. This is the .NET Core Global Tool allowing usage of GitVersion from command line.</PackageDescription>
     </PropertyGroup>
 

--- a/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
+++ b/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.targets
@@ -12,7 +12,7 @@
         <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == '' and $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0')) == 'true'">net10.0</GitVersionTargetFramework>
         <!-- Fall back to net10.0 for older target frameworks; the CLI rolls forward to the installed .NET 10 runtime. -->
         <GitVersionTargetFramework Condition="'$(GitVersionTargetFramework)' == ''">net10.0</GitVersionTargetFramework>
-        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet --roll-forward Major &quot;$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))gitversion.dll&quot;</GitVersionFileExe>
+        <GitVersionFileExe Condition="'$(GitVersionFileExe)' == ''">dotnet exec --roll-forward Major &quot;$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))gitversion.dll&quot;</GitVersionFileExe>
         <GitVersionAssemblyFile Condition="'$(GitVersionAssemblyFile)' == ''">$([MSBuild]::EnsureTrailingSlash($(MSBuildThisFileDirectory)$(GitVersionTargetFramework)))GitVersion.MsBuild.dll</GitVersionAssemblyFile>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- package the .NET global tool per supported runtime identifier
- publish RID-specific packages before the root pointer package
- document supported global-tool platforms for v7

## Verification
- `dotnet pack src/GitVersion.App/GitVersion.App.csproj --configuration Release -p:PackAsTool=true`
- local-feed install and execution on Apple Silicon macOS
- `dotnet build build/publish/ --configuration Release --no-restore`
- `dotnet build src/GitVersion.slnx --configuration Release --no-restore`

Closes #4899