### PR TITLE
chore: prepare 7.0.0 alpha artifacts

### DIFF
--- a/.gitversion.yml
+++ b/.gitversion.yml
@@ -4,6 +4,6 @@ mode: ManualDeployment
 next-version: 7.0.0
 branches:
   main:
-    label: rc
+    label: alpha
   support:
     label: beta

--- a/.gitversion.yml
+++ b/.gitversion.yml
@@ -1,6 +1,7 @@
 # $schema: https://gitversion.net/schemas/6.4/GitVersion.configuration.json
 workflow: GitFlow/v1
 mode: ManualDeployment
+next-version: 7.0.0
 branches:
   main:
     label: rc

--- a/.gitversion.yml
+++ b/.gitversion.yml
@@ -1,4 +1,4 @@
-# $schema: https://gitversion.net/schemas/6.4/GitVersion.configuration.json
+# $schema: https://gitversion.net/schemas/7.0/GitVersion.configuration.json
 workflow: GitFlow/v1
 mode: ManualDeployment
 next-version: 7.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,11 +131,11 @@ We use Cake for our build and deployment process. The way the release process is
 
 1. We build releasable artifacts with GitHub Actions
 2. We create a milestone for the release if it's not already created. Our milestones are named using the semver.
-   For example `7.0.0`
+   For example `5.12.0` or `6.0.0-beta.2`
 3. We move all the closed issues and closed pull requests that are going to be included in the release to the milestone.
 4. We check that all the issues and pull requests that are going to be included in the release have a label assigned,
    otherwise it will fail the release.
-5. We create a release in the GitHub UI, and create a tag and name it using the milestone name. For example `7.0.0`
+5. We create a release in the GitHub UI, and create a tag and name it using the milestone name. For example `5.12.0` or `6.0.0-beta.2`
 6. We specify if the release is a pre-release or latest release in the GitHub UI.
 7. We publish the release.
 8. The GitHub Actions will create a GitHub release and publish the artifacts to NuGet, Chocolatey, Docker, Homebrew

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,11 +131,11 @@ We use Cake for our build and deployment process. The way the release process is
 
 1. We build releasable artifacts with GitHub Actions
 2. We create a milestone for the release if it's not already created. Our milestones are named using the semver.
-   For example `5.12.0` or `6.0.0-beta.2`
+   For example `7.0.0`
 3. We move all the closed issues and closed pull requests that are going to be included in the release to the milestone.
 4. We check that all the issues and pull requests that are going to be included in the release have a label assigned,
    otherwise it will fail the release.
-5. We create a release in the GitHub UI, and create a tag and name it using the milestone name. For example `5.12.0` or `6.0.0-beta.2`
+5. We create a release in the GitHub UI, and create a tag and name it using the milestone name. For example `7.0.0`
 6. We specify if the release is a pre-release or latest release in the GitHub UI.
 7. We publish the release.
 8. The GitHub Actions will create a GitHub release and publish the artifacts to NuGet, Chocolatey, Docker, Homebrew

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG REGISTRY='docker.io'
 ARG DISTRO='debian.12'
-ARG DOTNET_VERSION='8.0'
-ARG VERSION='6.7.0'
+ARG DOTNET_VERSION='10.0'
+ARG VERSION='7.0.0'
 
 FROM $REGISTRY/gittools/build-images:$DISTRO-sdk-$DOTNET_VERSION AS installer
 ARG nugetFolder

--- a/docs/input/docs/usage/cli/installation.md
+++ b/docs/input/docs/usage/cli/installation.md
@@ -17,9 +17,9 @@ dotnet tool install --global GitVersion.Tool
 ```
 
 :::{.alert .alert-info}
-**Hint:** To install an older version of GitVersion.Tool, use the --version flag of dotnet tool install
+**Hint:** To install a specific version of GitVersion.Tool, use the --version flag of dotnet tool install
 
-Example: `dotnet tool install GitVersion.Tool --global --version 6.*`
+Example: `dotnet tool install GitVersion.Tool --global --version 7.0.0`
 :::
 
 If you want to pin to a specific version of GitVersion, you can find the available
@@ -57,7 +57,7 @@ source control.
 :::{.alert .alert-info}
 **Hint:** To install a specific version of GitVersion.Tool as a local tool, use the --version flag
 
-Example: `dotnet tool install GitVersion.Tool --version 6.*`
+Example: `dotnet tool install GitVersion.Tool --version 7.0.0`
 :::
 
 To restore tools specified in the manifest (for example, after cloning the

--- a/docs/input/docs/usage/msbuild.md
+++ b/docs/input/docs/usage/msbuild.md
@@ -39,7 +39,7 @@ If you're using `PackageReference` style NuGet dependencies (VS 2017+), add
 dependency of your package:
 
 ```xml
-<PackageReference Include="GitVersion.MsBuild" Version="6.0.0">
+<PackageReference Include="GitVersion.MsBuild" Version="7.0.0">
   <PrivateAssets>All</PrivateAssets>
 </PackageReference>
 ```

--- a/tests/scripts/test-global-tool.sh
+++ b/tests/scripts/test-global-tool.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
-# sh /scripts/test-global-tool.sh --version 6.0.0 --nugetPath /nuget --repoPath /repo
+# sh /scripts/test-global-tool.sh --version 7.0.0 --nugetPath /nuget --repoPath /repo
 while test "$#" -gt 0
 do
     case $1 in

--- a/tests/scripts/test-msbuild-task.sh
+++ b/tests/scripts/test-msbuild-task.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
-# sh /scripts/test-msbuild-task.sh --version 6.0.0 --nugetPath /nuget --repoPath /repo/tests/integration --targetframework net10.0
+# sh /scripts/test-msbuild-task.sh --version 7.0.0 --nugetPath /nuget --repoPath /repo/tests/integration --targetframework net10.0
 while test "$#" -gt 0
 do
     case $1 in

--- a/tests/scripts/test-native-tool.sh
+++ b/tests/scripts/test-native-tool.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
-# sh /scripts/test-native-tool.sh --version 6.0.0 --runtime linux-musl-x64 /nuget --repoPath /repo
+# sh /scripts/test-native-tool.sh --version 7.0.0 --runtime linux-musl-x64 /nuget --repoPath /repo
 while test "$#" -gt 0
 do
     case $1 in


### PR DESCRIPTION
## Summary
- configure GitVersion to base new artifacts on 7.0.0
- publish alpha builds from main before moving to release candidates
- update active v7 installation, package, Docker, schema, and artifact-test examples

## Verification
- main calculation: 7.0.0-alpha.1
- feature branch calculation: 7.0.0-prepare-7-0-0.1
- changed Markdown files pass remark linting
- artifact test scripts pass shell syntax validation