### PR TITLE
build: remove redundant framework package references

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,11 +47,8 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SharpYaml" Version="3.13.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.2.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.10" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup Condition=" '$(MicrosoftBuildVersion)' != '' ">
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />

--- a/src/GitVersion.App.Tests/GitVersion.App.Tests.csproj
+++ b/src/GitVersion.App.Tests/GitVersion.App.Tests.csproj
@@ -2,7 +2,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />

--- a/src/GitVersion.Configuration/GitVersion.Configuration.csproj
+++ b/src/GitVersion.Configuration/GitVersion.Configuration.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
         <PackageReference Include="SharpYaml" />
-        <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.IO.Redist" />
         <PackageReference Include="MSBuild.ProjectCreation" />
-        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -17,7 +17,6 @@
         <PackageReference Include="Microsoft.Build.Utilities.Core" />
         <PackageReference Include="Microsoft.Win32.Registry" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-        <PackageReference Include="System.Collections.Immutable" />
         <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
         <PackageReference Update="@(PackageReference)" PrivateAssets="All"/>
     </ItemGroup>

--- a/src/GitVersion.Schema/GitVersion.Schema.csproj
+++ b/src/GitVersion.Schema/GitVersion.Schema.csproj
@@ -6,7 +6,6 @@
     <ItemGroup>
         <PackageReference Include="JsonSchema.Net.Generation" />
         <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
-        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Core\GitVersion.Core.csproj" />

--- a/src/GitVersion.Testing/GitVersion.Testing.csproj
+++ b/src/GitVersion.Testing/GitVersion.Testing.csproj
@@ -7,9 +7,7 @@
     <ItemGroup>
         <PackageReference Include="LibGit2Sharp" />
         <PackageReference Include="Shouldly" />
-    <PackageReference Include="System.Collections.Immutable" />
         <PackageReference Include="System.IO.Abstractions" />
-        <PackageReference Include="System.Reflection.Metadata" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="GitVersion.BuildAgents.Tests" />


### PR DESCRIPTION
## Summary
- remove direct references to framework assemblies already provided by .NET 10
- remove their central package-version entries
- eliminate NU1510 restore warnings

## Verification
- from src: dotnet clean
- from src: dotnet restore
- from src: dotnet build
- result: 0 warnings, 0 errors