### PR TITLE
build: make nullable context visible to Sonar

### DIFF
--- a/build/common/common.csproj
+++ b/build/common/common.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <RootNamespace>Common</RootNamespace>
     </PropertyGroup>

--- a/build/docker/docker.csproj
+++ b/build/docker/docker.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <AssemblyName>docker</AssemblyName>
         <RootNamespace>Docker</RootNamespace>
     </PropertyGroup>

--- a/src/GitVersion.App.Tests/GitVersion.App.Tests.csproj
+++ b/src/GitVersion.App.Tests/GitVersion.App.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     </ItemGroup>

--- a/src/GitVersion.BuildAgents.Tests/GitVersion.BuildAgents.Tests.csproj
+++ b/src/GitVersion.BuildAgents.Tests/GitVersion.BuildAgents.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.BuildAgents\GitVersion.BuildAgents.csproj" />
         <ProjectReference Include="..\GitVersion.Core.Tests\GitVersion.Core.Tests.csproj" />

--- a/src/GitVersion.Configuration.Tests/GitVersion.Configuration.Tests.csproj
+++ b/src/GitVersion.Configuration.Tests/GitVersion.Configuration.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Configuration\GitVersion.Configuration.csproj" />
         <ProjectReference Include="..\GitVersion.Core.Tests\GitVersion.Core.Tests.csproj" />

--- a/src/GitVersion.Configuration/GitVersion.Configuration.csproj
+++ b/src/GitVersion.Configuration/GitVersion.Configuration.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <DefineConstants>GITVERSION_CONFIGURATION</DefineConstants>
     </PropertyGroup>
     

--- a/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
+++ b/src/GitVersion.Core.Tests/GitVersion.Core.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
         <DebugSymbols>true</DebugSymbols>

--- a/src/GitVersion.Core/GitVersion.Core.csproj
+++ b/src/GitVersion.Core/GitVersion.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <RootNamespace>GitVersion</RootNamespace>
         <DocumentationFile>bin\$(Configuration)\GitVersionCore.xml</DocumentationFile>
 

--- a/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
+++ b/src/GitVersion.LibGit2Sharp/GitVersion.LibGit2Sharp.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="LibGit2Sharp" />
     </ItemGroup>

--- a/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
+++ b/src/GitVersion.MsBuild.Tests/GitVersion.MsBuild.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);NU1903</NoWarn>
     </PropertyGroup>
 

--- a/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
+++ b/src/GitVersion.MsBuild/GitVersion.MsBuild.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <PackageId>GitVersion.MsBuild</PackageId>
         <Title>GitVersionMsBuild</Title>
         <PackageVersion Condition="$(PackageVersion) == '' Or $(PackageVersion) == '*Undefined*'">0.0.1-alpha-0001</PackageVersion>

--- a/src/GitVersion.Output.Tests/GitVersion.Output.Tests.csproj
+++ b/src/GitVersion.Output.Tests/GitVersion.Output.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\GitVersion.Output\GitVersion.Output.csproj" />
         <ProjectReference Include="..\GitVersion.Core.Tests\GitVersion.Core.Tests.csproj" />

--- a/src/GitVersion.Output/GitVersion.Output.csproj
+++ b/src/GitVersion.Output/GitVersion.Output.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <DefineConstants>GITVERSION_OUTPUT</DefineConstants>
     </PropertyGroup>
 

--- a/src/GitVersion.Schema/GitVersion.Schema.csproj
+++ b/src/GitVersion.Schema/GitVersion.Schema.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
         <AssemblyName>schema</AssemblyName>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

Make nullable context explicit in all 14 projects that contain the 537 current Sonar S8970 findings. This preserves the existing build behavior while giving automatic .NET analysis the nullable metadata that it does not inherit from `Directory.Build.props`.

## Validation

- `dotnet build ./src/GitVersion.slnx --no-restore` (0 warnings, 0 errors)
- `dotnet restore ./build/docker/docker.csproj`
- `dotnet build ./build/common/common.csproj --no-restore` (0 warnings, 0 errors)
- `dotnet build ./build/docker/docker.csproj --no-restore` (0 warnings, 0 errors)

## Note

SonarCloud has not started PR analysis for this draft PR. The GitHub Actions checks still run; the Sonar result will be available when the PR is ready for review.