### PR TITLE
Fix cached commit selection and CLI verbosity

### DIFF
--- a/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
@@ -63,22 +63,64 @@ public class ExecCmdLineArgumentTest
         requestedCommitResult.Output!.Trim().ShouldBe(requestedCommit);
     }
 
-    [Theory]
-    [TestCase("", "INFO")]
-    [TestCase("--verbosity NORMAL", "INFO")]
-    [TestCase("--verbosity quiet", "")]
-    public void CheckBuildServerVerbosityConsole(string verbosityArg, string expectedOutput)
+    [TestCase(false, "", true)]
+    [TestCase(false, "--verbosity NORMAL", true)]
+    [TestCase(false, "--verbosity quiet", false)]
+    [TestCase(true, "", true)]
+    [TestCase(true, "/verbosity NORMAL", true)]
+    [TestCase(true, "/verbosity quiet", false)]
+    public void CheckBuildServerVerbosityConsole(bool useLegacyParser, string verbosityArgument, bool expectInformation)
     {
         using var fixture = new EmptyRepositoryFixture();
         fixture.MakeATaggedCommit("1.2.3");
         fixture.MakeACommit();
 
-        var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath,
-            $""" {verbosityArg} --output buildserver --log-file "/tmp/path" """, false);
+        var environment = new KeyValuePair<string, string?>(
+            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+        var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
+        var targetPathArgument = useLegacyParser ? $" \"{fixture.RepositoryPath}\"" : string.Empty;
+        var outputArguments = useLegacyParser
+            ? "-output buildserver -l console"
+            : "--output buildserver --log-file console";
+
+        var result = GitVersionHelper.ExecuteIn(workingDirectory,
+            $"{targetPathArgument} {verbosityArgument} {outputArguments}", false, environment);
 
         result.ExitCode.ShouldBe(0);
         result.Output.ShouldNotBeNull();
-        result.Output.ShouldContain(expectedOutput);
+        if (expectInformation)
+        {
+            result.Output.ShouldContain("INFO");
+        }
+        else
+        {
+            result.Output.ShouldNotContain("INFO");
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void VerboseVerbosityIncludesDebugOutput(bool useLegacyParser)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.3");
+        fixture.MakeACommit();
+
+        var environment = new KeyValuePair<string, string?>(
+            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+        var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
+        var targetPathArgument = useLegacyParser ? $" \"{fixture.RepositoryPath}\"" : string.Empty;
+        var verbosityArgument = useLegacyParser ? "/verbosity Verbose" : "--verbosity verbose";
+        var outputArguments = useLegacyParser
+            ? "-nocache -output buildserver -l console"
+            : "--no-cache --output buildserver --log-file console";
+
+        var result = GitVersionHelper.ExecuteIn(workingDirectory,
+            $"{targetPathArgument} {verbosityArgument} {outputArguments}", false, environment);
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotBeNull();
+        result.Output.ShouldContain("DBUG");
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
@@ -36,6 +36,33 @@ public class ExecCmdLineArgumentTest
                     """);
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public void CommitArgumentUsesRequestedCommitWhenCacheExists(bool useLegacyParser)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.0.0");
+        var requestedCommit = fixture.MakeACommit();
+        var headCommit = fixture.MakeACommit();
+
+        var environment = new KeyValuePair<string, string?>(
+            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+        var showVariableArgument = useLegacyParser ? "-showvariable" : "--show-variable";
+        var commitArgument = useLegacyParser ? "-c" : "--commit";
+        var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
+        var targetPathArgument = useLegacyParser ? $" \"{fixture.RepositoryPath}\"" : string.Empty;
+
+        var headResult = GitVersionHelper.ExecuteIn(workingDirectory,
+            $"{targetPathArgument} {showVariableArgument} Sha", false, environment);
+        var requestedCommitResult = GitVersionHelper.ExecuteIn(workingDirectory,
+            $"{targetPathArgument} {commitArgument} {requestedCommit} {showVariableArgument} Sha", false, environment);
+
+        headResult.ExitCode.ShouldBe(0);
+        headResult.Output!.Trim().ShouldBe(headCommit);
+        requestedCommitResult.ExitCode.ShouldBe(0);
+        requestedCommitResult.Output!.Trim().ShouldBe(requestedCommit);
+    }
+
     [Theory]
     [TestCase("", "INFO")]
     [TestCase("--verbosity NORMAL", "INFO")]

--- a/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using GitVersion.Logging;
 using Serilog;
+using Serilog.Core;
 
 namespace GitVersion.Extensions;
 
@@ -26,8 +27,9 @@ public static class ServiceCollectionExtensions
             serviceCollection.AddSerilog((services, loggerConfig) =>
             {
                 var options = services.GetRequiredService<IOptions<GitVersionOptions>>().Value;
+                var loggingLevelSwitch = services.GetRequiredService<LoggingLevelSwitch>();
 
-                ConfigureLogger(loggerConfig, options);
+                ConfigureLogger(loggerConfig, options, loggingLevelSwitch);
             });
             return serviceCollection;
         }
@@ -40,13 +42,15 @@ public static class ServiceCollectionExtensions
             serviceProvider.GetServices<TService>().Single(t => t?.GetType() == typeof(TType));
     }
 
-    private static void ConfigureLogger(LoggerConfiguration loggerConfig, GitVersionOptions gitVersionOptions)
+    private static void ConfigureLogger(LoggerConfiguration loggerConfig, GitVersionOptions gitVersionOptions,
+        LoggingLevelSwitch loggingLevelSwitch)
     {
         const string outputTemplate = "{Level:u4} [{Timestamp:yy-MM-dd HH:mm:ss:ff}] {Indent}{Message:lj}{NewLine}{Exception}";
         const string logDestination = "console";
         var formatProvider = CultureInfo.InvariantCulture;
 
         loggerConfig
+            .MinimumLevel.ControlledBy(loggingLevelSwitch)
             .Enrich.With<SensitiveDataEnricher>()
             .Enrich.With<IndentationEnricher>();
 

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -30,9 +30,10 @@ internal class GitVersionCacheKeyFactory(
         var gitSystemHash = GetGitSystemHash();
         var configFileHash = GetConfigFileHash();
         var repositorySnapshotHash = GetRepositorySnapshotHash();
+        var repositoryTargetHash = GetRepositoryTargetHash();
         var overrideConfigHash = GetOverrideConfigHash(overrideConfiguration);
 
-        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, overrideConfigHash);
+        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, repositoryTargetHash, overrideConfigHash);
         return new(compositeHash);
     }
 
@@ -172,6 +173,17 @@ internal class GitVersionCacheKeyFactory(
 
         var hash = string.Join(":", head.Name.Canonical, head.Tip.Sha);
         return GetHash(hash);
+    }
+
+    private string GetRepositoryTargetHash()
+    {
+        var repoInfo = this.options.Value.RepositoryInfo;
+        if (repoInfo.TargetBranch.IsNullOrEmpty() && repoInfo.CommitId.IsNullOrEmpty())
+        {
+            return string.Empty;
+        }
+
+        return GetHash(repoInfo.TargetBranch ?? string.Empty, repoInfo.CommitId ?? string.Empty);
     }
 
     private string GetOverrideConfigHash(IReadOnlyDictionary<object, object?>? overrideConfiguration)


### PR DESCRIPTION
## Summary

- include the requested branch and commit in the GitVersion cache key so a cached HEAD result is not reused for an explicit historical target
- connect the shared `LoggingLevelSwitch` to the final Serilog pipeline so configured verbosity affects runtime logging
- replace the ineffective verbosity assertion and add regression coverage for both the current and legacy argument parsers

Closes #3297.
Closes #2435.

#2853 is already fixed and closed; its legacy and current syntax were reverified as part of this work, but this PR does not change that parser behavior.

## Automated tests

- `dotnet test --project src/GitVersion.App.Tests/GitVersion.App.Tests.csproj --no-restore`
  - 354 passed
- focused existing cache tests in `GitVersion.Core.Tests`
  - 8 passed
- commit-cache regression test runs with both `--commit` and legacy `-c`
- verbosity regression tests cover default, Normal, Quiet, and Verbose levels with both parser generations

## Reporter-style verification

The branch executable was built with:

```shell
dotnet build src/GitVersion.App/GitVersion.App.csproj --no-restore -m:1 -nr:false -p:UseSharedCompilation=false
```

The commit-selection repository contained a `1.0.0` tag, a requested commit, and a newer HEAD. Commit timestamps were deliberately spaced. HEAD was calculated first to populate the cache before requesting the older commit.

### #3297: cached historical commit and diagnostics

Legacy syntax:

```shell
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> -showvariable Sha
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> -c <older-sha> -showvariable Sha
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> -c <older-sha> -diag -showvariable Sha
```

Both historical-commit invocations returned `<older-sha>`, with and without `-diag`, after the HEAD cache had been populated.

Current syntax:

```shell
gitversion --target-path <repo> --commit <older-sha> --show-variable Sha
gitversion --target-path <repo> --commit <older-sha> --diagnose --log-file console --show-variable Sha
```

Both invocations returned `<older-sha>`.

### #2435: /c and /verbosity

Commit selection with the legacy slash syntax:

```shell
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> /c <older-sha> -showvariable Sha
```

This returned `<older-sha>`. The current `--commit` equivalent above returned the same SHA.

Legacy verbosity syntax was exercised in a build-server console logging context:

```shell
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> /verbosity Normal -nocache -output buildserver -l console
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> /verbosity Verbose -nocache -output buildserver -l console
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion <repo> /verbosity Quiet -nocache -output buildserver -l console
```

Observed results:

- Normal: 35 `INFO` lines and 0 `DBUG` lines
- Verbose: 19 `DBUG` lines
- Quiet: 0 `INFO` lines

Current syntax:

```shell
gitversion --target-path <repo> --verbosity normal --no-cache --output buildserver --log-file console
gitversion --target-path <repo> --verbosity verbose --no-cache --output buildserver --log-file console
gitversion --target-path <repo> --verbosity quiet --no-cache --output buildserver --log-file console
```

The current-parser regression cases verify the same Normal, Verbose, and Quiet behavior. The manual Verbose invocation produced 19 `DBUG` lines.

### #2853: diagnostic and config argument order

The reproduction used an intentionally invalid default `GitVersion.yml` and a valid `custom.yml` containing `next-version: 3.2.1`.

Legacy syntax:

```shell
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion -config custom.yml -diag -showvariable MajorMinorPatch
GITVERSION_USE_V6_ARGUMENT_PARSER=true gitversion -diag -config custom.yml -showvariable MajorMinorPatch
```

Both orders exited with code 0 and returned `3.2.1`.

Current syntax:

```shell
gitversion --config custom.yml --diagnose --log-file console --show-variable MajorMinorPatch
gitversion --diagnose --log-file console --config custom.yml --show-variable MajorMinorPatch
```

Both orders exited with code 0 and returned `3.2.1`.