### PR TITLE
fix: inherit pull request configuration from merge target

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -541,6 +541,11 @@ The special value `Inherit` means that GitVersion should find the parent branch
 (i.e. the branch where the current branch was branched from), and use its values
 for [increment](#increment) or other branch related properties.
 
+For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
+captured from the merge commit message as the immediate parent when it matches
+an allowed source branch. If the message has no matching target, GitVersion
+falls back to Git ancestry, as it does for ordinary branches.
+
 ### tag-prefix
 
 A regular expression which is used to trim Git tags before processing (e.g.,

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -142,6 +142,11 @@ The special value `Inherit` means that GitVersion should find the parent branch
 (i.e. the branch where the current branch was branched from), and use its values
 for [increment](#increment) or other branch related properties.
 
+For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
+captured from the merge commit message as the immediate parent when it matches
+an allowed source branch. If the message has no matching target, GitVersion
+falls back to Git ancestry, as it does for ordinary branches.
+
 ### tag-prefix
 
 A regular expression which is used to trim Git tags before processing (e.g.,

--- a/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -1,5 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
+using GitVersion.VersionCalculation;
 using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
@@ -7,6 +8,8 @@ namespace GitVersion.Tests.IntegrationTests;
 [TestFixture]
 public class PullRequestScenarios : TestBase
 {
+    private const string AzureDevOpsMergeMessage = "Merge pull request 2 from hotfix/v1.0.2 into support/v1.0.x";
+
     /// <summary>
     /// GitHubFlow - Pull requests (increment major on main and minor on feature)
     /// </summary>
@@ -137,5 +140,72 @@ public class PullRequestScenarios : TestBase
         fixture.Repository.CreatePullRequestRef("release/2.0.0", MainBranch, normalise: true);
 
         fixture.AssertFullSemver("2.0.0-PullRequest2.4");
+    }
+
+    [Test]
+    public void PullRequestInheritsSupportConfigurationWhenLocalAndRemoteBranchesExist()
+    {
+        var configuration = GetHotfixToSupportConfiguration();
+
+        using var remote = new EmptyRepositoryFixture("master");
+        remote.Repository.MakeATaggedCommit("v1.0.0");
+        remote.BranchTo("support/v1.0.x");
+        remote.Repository.MakeATaggedCommit("v1.0.1");
+        remote.Checkout("master");
+        remote.Repository.MakeACommit("Merged PR 1: new feature");
+        remote.Checkout("support/v1.0.x");
+        remote.BranchTo("hotfix/v1.0.2");
+        remote.Repository.MakeACommit();
+        remote.Checkout("support/v1.0.x");
+        remote.BranchTo("pull/2/merge");
+        remote.Repository.MergeNoFF("hotfix/v1.0.2", AzureDevOpsMergeMessage);
+
+        using var local = remote.CloneRepository();
+        CopyRemoteBranchesToHeads(local.Repository);
+        local.Checkout("pull/2/merge");
+
+        local.AssertFullSemver("1.0.2-alpha-pr2.2", configuration);
+    }
+
+    [Test]
+    public void PullRequestWithoutRemoteBranchesKeepsHotfixToSupportVersion()
+    {
+        var configuration = GetHotfixToSupportConfiguration();
+
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("v1.0.0");
+        fixture.BranchTo("support/v1.0.x");
+        fixture.BranchTo("hotfix/v1.0.1");
+        fixture.Repository.MakeACommit();
+        fixture.Checkout("support/v1.0.x");
+        fixture.BranchTo("pull/2/merge");
+        fixture.Repository.MergeNoFF("hotfix/v1.0.1", "Merge pull request 2 from hotfix/v1.0.1 into support/v1.0.x");
+
+        fixture.AssertFullSemver("1.0.1-alpha-pr2.2", configuration);
+    }
+
+    private static IGitVersionConfiguration GetHotfixToSupportConfiguration() => GitFlowConfigurationBuilder.New
+        .WithDeploymentMode(DeploymentMode.ContinuousDeployment)
+        .WithBranch("main", b => b
+            .WithIncrement(IncrementStrategy.Minor)
+            .WithLabel("beta")
+        ).WithBranch("pull-request", b => b
+            .WithIncrement(IncrementStrategy.Inherit)
+            .WithLabel("alpha-pr{Number}")
+        ).WithBranch("support", b => b
+            .WithIncrement(IncrementStrategy.Patch)
+            .WithLabel("beta")
+        ).Build();
+
+    private static void CopyRemoteBranchesToHeads(Repository repository)
+    {
+        foreach (var branch in repository.Branches.Where(branch => branch.IsRemote).ToArray())
+        {
+            var localName = branch.FriendlyName.Replace($"{branch.RemoteName}/", string.Empty);
+            if (repository.Branches[localName] is null)
+            {
+                repository.CreateBranch(localName, branch.Tip);
+            }
+        }
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/EffectiveBranchConfigurationFinderTests.cs
@@ -370,4 +370,122 @@ public class EffectiveBranchConfigurationFinderTests
         actual[0].Branch.ShouldBe(developBranchMock);
         actual[0].Value.Increment.ShouldBe(developBranchIncrement);
     }
+
+    [Test]
+    public void Pull_request_merge_target_selects_local_support_branch_from_multiple_candidates()
+    {
+        // Arrange
+        var pullRequestBranch = CreatePullRequestBranch("Merge pull request 2 from hotfix/v1.0.2 into support/v1.0.x");
+        var mainBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/main", GitRepositoryTestingExtensions.CreateMockCommit());
+        var localSupportBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/support/v1.0.x", GitRepositoryTestingExtensions.CreateMockCommit());
+        var remoteSupportBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/remotes/origin/support/v1.0.x", GitRepositoryTestingExtensions.CreateMockCommit());
+        remoteSupportBranch.IsRemote.Returns(true);
+        var configuration = GetPullRequestConfiguration();
+        var repositoryStore = Substitute.For<IRepositoryStore>();
+        SetBranches(repositoryStore, mainBranch, remoteSupportBranch, localSupportBranch);
+        repositoryStore.GetSourceBranches(pullRequestBranch, configuration, Arg.Any<HashSet<IBranch>>())
+            .Returns([mainBranch]);
+
+        var unitUnderTest = new EffectiveBranchConfigurationFinder(NullLogger<EffectiveBranchConfigurationFinder>.Instance, repositoryStore);
+
+        // Act
+        var actual = unitUnderTest.GetConfigurations(pullRequestBranch, configuration).ToArray();
+
+        // Assert
+        actual.ShouldHaveSingleItem().Branch.ShouldBe(localSupportBranch);
+        actual[0].Value.Increment.ShouldBe(IncrementStrategy.Patch);
+    }
+
+    [Test]
+    public void Pull_request_merge_target_accepts_remote_only_branch()
+    {
+        // Arrange
+        var pullRequestBranch = CreatePullRequestBranch("Merge pull request 2 from hotfix/v1.0.2 into support/v1.0.x");
+        var mainBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/main", GitRepositoryTestingExtensions.CreateMockCommit());
+        var remoteSupportBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/remotes/origin/support/v1.0.x", GitRepositoryTestingExtensions.CreateMockCommit());
+        remoteSupportBranch.IsRemote.Returns(true);
+        var configuration = GetPullRequestConfiguration();
+        var repositoryStore = Substitute.For<IRepositoryStore>();
+        SetBranches(repositoryStore, mainBranch, remoteSupportBranch);
+        repositoryStore.GetSourceBranches(pullRequestBranch, configuration, Arg.Any<HashSet<IBranch>>())
+            .Returns([mainBranch]);
+
+        var unitUnderTest = new EffectiveBranchConfigurationFinder(NullLogger<EffectiveBranchConfigurationFinder>.Instance, repositoryStore);
+
+        // Act
+        var actual = unitUnderTest.GetConfigurations(pullRequestBranch, configuration).ToArray();
+
+        // Assert
+        actual.ShouldHaveSingleItem().Branch.ShouldBe(remoteSupportBranch);
+    }
+
+    [TestCase("Merge pull request 2 from hotfix/v1.0.2", "refs/pull/2/merge")]
+    [TestCase("Merge pull request 2 from hotfix/v1.0.2 into release/v1.0.x", "refs/pull/2/merge")]
+    [TestCase("Merge pull request 2 from hotfix/v1.0.2 into support/v1.0.x", "refs/heads/feature/foo")]
+    public void Pull_request_target_falls_back_to_all_source_candidates_when_it_cannot_disambiguate(string message, string branchName)
+    {
+        // Arrange
+        var branch = CreateMergeBranch(branchName, message);
+        var mainBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/main", GitRepositoryTestingExtensions.CreateMockCommit());
+        var supportBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/support/v1.0.x", GitRepositoryTestingExtensions.CreateMockCommit());
+        var configuration = GetPullRequestConfiguration();
+        var repositoryStore = Substitute.For<IRepositoryStore>();
+        SetBranches(repositoryStore, mainBranch, supportBranch);
+        repositoryStore.GetSourceBranches(branch, configuration, Arg.Any<HashSet<IBranch>>()).Returns([mainBranch, supportBranch]);
+
+        var unitUnderTest = new EffectiveBranchConfigurationFinder(NullLogger<EffectiveBranchConfigurationFinder>.Instance, repositoryStore);
+
+        // Act
+        var actual = unitUnderTest.GetConfigurations(branch, configuration).ToArray();
+
+        // Assert
+        actual.Select(x => x.Branch).ShouldBe([mainBranch, supportBranch]);
+    }
+
+    [Test]
+    public void Pull_request_target_continues_inheriting_from_selected_branch()
+    {
+        // Arrange
+        var pullRequestBranch = CreatePullRequestBranch("Merge pull request 2 from hotfix/v1.0.2 into support/v1.0.x");
+        var supportBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/support/v1.0.x", GitRepositoryTestingExtensions.CreateMockCommit());
+        var mainBranch = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/main", GitRepositoryTestingExtensions.CreateMockCommit());
+        var configuration = GetPullRequestConfiguration(supportIncrement: IncrementStrategy.Inherit);
+        var repositoryStore = Substitute.For<IRepositoryStore>();
+        SetBranches(repositoryStore, mainBranch, supportBranch);
+        repositoryStore.GetSourceBranches(pullRequestBranch, configuration, Arg.Any<HashSet<IBranch>>()).Returns([mainBranch]);
+        repositoryStore.GetSourceBranches(supportBranch, configuration, Arg.Any<HashSet<IBranch>>()).Returns([mainBranch]);
+
+        var unitUnderTest = new EffectiveBranchConfigurationFinder(NullLogger<EffectiveBranchConfigurationFinder>.Instance, repositoryStore);
+
+        // Act
+        var actual = unitUnderTest.GetConfigurations(pullRequestBranch, configuration).ToArray();
+
+        // Assert
+        actual.ShouldHaveSingleItem().Branch.ShouldBe(mainBranch);
+        actual[0].Value.Increment.ShouldBe(IncrementStrategy.Minor);
+    }
+
+    private static IBranch CreatePullRequestBranch(string message) => CreateMergeBranch("refs/pull/2/merge", message);
+
+    private static void SetBranches(IRepositoryStore repositoryStore, params IBranch[] branches)
+    {
+        var branchCollection = Substitute.For<IBranchCollection>();
+        branchCollection.MockCollectionReturn(branches);
+        repositoryStore.Branches.Returns(branchCollection);
+    }
+
+    private static IBranch CreateMergeBranch(string branchName, string message)
+    {
+        var mergeCommit = GitRepositoryTestingExtensions.CreateMockCommit();
+        mergeCommit.Message.Returns(message);
+        mergeCommit.IsMergeCommit.Returns(true);
+        return GitRepositoryTestingExtensions.CreateMockBranch(branchName, mergeCommit);
+    }
+
+    private static IGitVersionConfiguration GetPullRequestConfiguration(IncrementStrategy supportIncrement = IncrementStrategy.Patch) =>
+        GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder.WithIncrement(IncrementStrategy.Minor))
+            .WithBranch("pull-request", builder => builder.WithIncrement(IncrementStrategy.Inherit))
+            .WithBranch("support", builder => builder.WithIncrement(supportIncrement))
+            .Build();
 }

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -14,11 +14,12 @@ internal sealed class EffectiveBranchConfigurationFinder(ILogger<EffectiveBranch
         branch.NotNull();
         configuration.NotNull();
 
-        return GetEffectiveConfigurationsRecursive(branch, configuration, null, []);
+        return GetEffectiveConfigurationsRecursive(branch, configuration, null, [], resolvePullRequestTarget: true);
     }
 
     private IEnumerable<EffectiveBranchConfiguration> GetEffectiveConfigurationsRecursive(
-        IBranch branch, IGitVersionConfiguration configuration, IBranchConfiguration? childBranchConfiguration, HashSet<IBranch> traversedBranches)
+        IBranch branch, IGitVersionConfiguration configuration, IBranchConfiguration? childBranchConfiguration,
+        HashSet<IBranch> traversedBranches, bool resolvePullRequestTarget)
     {
         if (!traversedBranches.Add(branch))
         {
@@ -39,6 +40,10 @@ internal sealed class EffectiveBranchConfigurationFinder(ILogger<EffectiveBranch
 
         // At this point we need to check if source branches are available.
         IBranch[] sourceBranches = [.. this.repositoryStore.GetSourceBranches(branch, configuration, traversedBranches)];
+        if (resolvePullRequestTarget && GetPullRequestTargetBranch(branch, configuration) is { } targetBranch)
+        {
+            sourceBranches = [targetBranch];
+        }
 
         if (sourceBranches.Length == 0)
         {
@@ -59,10 +64,49 @@ internal sealed class EffectiveBranchConfigurationFinder(ILogger<EffectiveBranch
         foreach (var sourceBranch in sourceBranches)
         {
             foreach (var effectiveConfiguration
-                in GetEffectiveConfigurationsRecursive(sourceBranch, configuration, branchConfiguration, traversedBranches))
+                in GetEffectiveConfigurationsRecursive(sourceBranch, configuration, branchConfiguration, traversedBranches, resolvePullRequestTarget: false))
             {
                 yield return effectiveConfiguration;
             }
         }
     }
+
+    private IBranch? GetPullRequestTargetBranch(IBranch branch, IGitVersionConfiguration configuration)
+    {
+        if (!IsPullRequestBranch(branch, configuration)
+            || branch.Tip is not { } tip
+            || !MergeMessage.TryParse(tip, configuration, out var mergeMessage)
+            || !mergeMessage.IsMergedPullRequest
+            || string.IsNullOrWhiteSpace(mergeMessage.TargetBranch))
+        {
+            return null;
+        }
+
+        var targetBranch = new SourceBranchFinder(this.repositoryStore.Branches, configuration)
+            .FindSourceBranchesOf(branch)
+            .Where(candidate => candidate.Name.EquivalentTo(mergeMessage.TargetBranch))
+            .MinBy(candidate => candidate.IsRemote);
+
+        if (targetBranch is null)
+        {
+            this.logger.LogDebug(
+                "Pull request target branch '{TargetBranch}' was not found among the allowed source branches for '{Branch}'.",
+                mergeMessage.TargetBranch, branch
+            );
+        }
+        else
+        {
+            this.logger.LogDebug(
+                "Using pull request target branch '{TargetBranch}' as the source branch for '{Branch}'.",
+                targetBranch, branch
+            );
+        }
+
+        return targetBranch;
+    }
+
+    private static bool IsPullRequestBranch(IBranch branch, IGitVersionConfiguration configuration) =>
+        branch.Name.IsPullRequest
+        || configuration.Branches.TryGetValue(ConfigurationConstants.PullRequestBranchKey, out var pullRequestConfiguration)
+        && pullRequestConfiguration.IsMatch(branch.Name.WithoutOrigin);
 }

--- a/src/GitVersion.Testing/Extensions/GitTestExtensions.cs
+++ b/src/GitVersion.Testing/Extensions/GitTestExtensions.cs
@@ -13,6 +13,13 @@ public static class GitTestExtensions
         public Commit MakeACommit(string? commitMessage = null) => CreateFileAndCommit(repository, Guid.NewGuid().ToString(), commitMessage);
         public void MergeNoFF(string branch) => MergeNoFF(repository, branch, Generate.SignatureNow());
 
+        public Commit MergeNoFF(string branch, string message)
+        {
+            repository.MergeNoFF(branch);
+            var signature = Generate.SignatureNow();
+            return repository.Commit(message, signature, signature, new CommitOptions { AmendPreviousCommit = true });
+        }
+
         public void MergeNoFF(string branch, Signature sig) => repository.Merge(repository.Branches[branch], sig, new MergeOptions
         {
             FastForwardStrategy = FastForwardStrategy.NoFastForward


### PR DESCRIPTION
## Description

Synthetic pull request merge refs now inherit branch configuration from the TargetBranch captured in the merge commit message when that branch is an allowed source.

The resolver prefers a matching local branch over its origin alias, accepts a remote-only target, and retains the existing ancestry fallback when the target is absent, unmatched, or the current branch is not a pull request. The configuration reference documentation has been updated accordingly.

## Related Issue

Fixes #3020

## Motivation and Context

When a hotfix pull request targets a support branch, the existing ancestry search can also consider main. Its higher Minor increment wins, producing 1.1.0 instead of the expected patch version 1.0.2. Using the explicit merge target removes that unrelated candidate while keeping the general version-selection behavior unchanged.

## How Has This Been Tested?

* Added integration coverage for both local-only and combined local/remote branch layouts.
* Added focused resolver coverage for local preference, remote-only targets, fallback behavior, and recursive inheritance.
* Passed 36,132 functional GitVersion.Core tests.
* Passed the repository performance scenario in isolation.
* Built src/GitVersion.slnx with zero warnings and errors.
* Verified formatting with dotnet format.
* Reproduced the issue through the legacy CLI parser and syntax:
  * remote plus local refs: 1.0.2-alpha-pr2.2
  * local-only refs: 1.0.1-alpha-pr2.2

## Screenshots (if appropriate):

Not applicable.

## Checklist:

* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.