### PR TITLE
[build] Use self-repository syntax for same-repository references

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # TODO: Remove when actionlint supports GitHub's $/ self-repository syntax.
+      # https://github.com/rhysd/actionlint/issues/711
+      - 'reusable workflow call "\$/.+" at "uses" is not following the format'
+      - 'specifying action "\$/.+" in invalid format because ref is missing'

--- a/.github/workflows/_artifacts_linux.yml
+++ b/.github/workflows/_artifacts_linux.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: Download nuget packages
@@ -54,7 +54,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts/packages/native
 
       - name: Set up Docker
-        uses: ./.github/actions/docker-setup
+        uses: $/.github/actions/docker-setup # NOSONAR -- $/ resolves to the running commit.
 
       # Run both backends concurrently in the same job (GitHub Actions parallel steps).
       # Each ArtifactsTest sub-test runs in ephemeral --rm containers, so the runs are independent.

--- a/.github/workflows/_artifacts_windows.yml
+++ b/.github/workflows/_artifacts_windows.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: Download nuget packages

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: '[Build]'
         shell: pwsh

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -16,6 +16,9 @@ on:
       publish_images:
         required: true
         type: boolean
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: false
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
@@ -45,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: Download nuget packages
@@ -54,14 +57,14 @@ jobs:
           path: ${{ github.workspace }}/artifacts/packages/nuget
 
       - name: Set up Docker
-        uses: ./.github/actions/docker-setup
+        uses: $/.github/actions/docker-setup # NOSONAR -- $/ resolves to the running commit.
 
       # Run both backends concurrently in the same job (GitHub Actions parallel steps).
       # Each uses an ephemeral --rm container, so the two runs don't interfere.
       - name: Docker Test (libgit2)
         if: success() && inputs.publish_images == false
         background: true
-        uses: ./.github/actions/docker-test
+        uses: $/.github/actions/docker-test # NOSONAR -- $/ resolves to the running commit.
         with:
           arch: ${{ inputs.arch }}
           docker_distro: ${{ matrix.docker_distro }}
@@ -71,7 +74,7 @@ jobs:
       - name: Docker Test (managed)
         if: success() && inputs.publish_images == false
         background: true
-        uses: ./.github/actions/docker-test
+        uses: $/.github/actions/docker-test # NOSONAR -- $/ resolves to the running commit.
         with:
           arch: ${{ inputs.arch }}
           docker_distro: ${{ matrix.docker_distro }}
@@ -90,7 +93,7 @@ jobs:
 
       - name: Docker Publish
         if: success() && inputs.publish_images
-        uses: ./.github/actions/docker-publish
+        uses: $/.github/actions/docker-publish # NOSONAR -- $/ resolves to the running commit.
         with:
           arch: ${{ inputs.arch }}
           docker_distro: ${{ matrix.docker_distro }}

--- a/.github/workflows/_docker_manifests.yml
+++ b/.github/workflows/_docker_manifests.yml
@@ -10,6 +10,9 @@ on:
       publish_manifests:
         required: true
         type: boolean
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: false
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
@@ -39,10 +42,10 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: Set up Docker
-        uses: ./.github/actions/docker-setup
+        uses: $/.github/actions/docker-setup # NOSONAR -- $/ resolves to the running commit.
 
       - name: Load DockerHub credentials
         if: inputs.publish_manifests
@@ -52,7 +55,7 @@ jobs:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Docker Manifests
-        uses: ./.github/actions/docker-manifests
+        uses: $/.github/actions/docker-manifests # NOSONAR -- $/ resolves to the running commit.
         if: inputs.publish_manifests
         with:
           docker_distro: ${{ matrix.docker_distro }}

--- a/.github/workflows/_prepare.yml
+++ b/.github/workflows/_prepare.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: '[Matrix]'
         id: set_matrix

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -4,6 +4,9 @@ on:
       publish_packages:
         required: true
         type: boolean
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: false
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
@@ -37,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: Download nuget packages

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: '[Unit Test]'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/actionlint.yaml'
 
   pull_request:
     branches:
@@ -20,6 +21,7 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/actionlint.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: Prepare
     permissions:
       contents: read
-    uses: ./.github/workflows/_prepare.yml
+    uses: $/.github/workflows/_prepare.yml # NOSONAR -- $/ resolves to the running commit.
 
   publish_flags:
     name: Publish Flags
@@ -69,7 +69,7 @@ jobs:
     needs: [ prepare ]
     permissions:
       contents: read
-    uses: ./.github/workflows/_build.yml
+    uses: $/.github/workflows/_build.yml # NOSONAR -- $/ resolves to the running commit.
 
   unit_test:
     name: Test
@@ -77,18 +77,17 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/_unit_tests.yml
+    uses: $/.github/workflows/_unit_tests.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_coverage: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets: inherit
 
   artifacts_windows_test:
     name: Artifacts Windows
     needs: [ build ]
     permissions:
       contents: read
-    uses: ./.github/workflows/_artifacts_windows.yml
+    uses: $/.github/workflows/_artifacts_windows.yml # NOSONAR -- $/ resolves to the running commit.
 
   artifacts_linux_test:
     needs: [ prepare, build ]
@@ -103,7 +102,7 @@ jobs:
             runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
-    uses: ./.github/workflows/_artifacts_linux.yml
+    uses: $/.github/workflows/_artifacts_linux.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       runner: ${{ matrix.runner }}
       arch: ${{ matrix.arch }}
@@ -125,14 +124,15 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
 
-    uses: ./.github/workflows/_docker.yml
+    uses: $/.github/workflows/_docker.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       runner: ${{ matrix.runner }}
       arch: ${{ matrix.arch }}
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_images: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   docker_linux_manifests:
     needs: [ prepare, docker_linux_images, publish_flags ]
@@ -140,12 +140,13 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: ./.github/workflows/_docker_manifests.yml
+    uses: $/.github/workflows/_docker_manifests.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_manifests: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   publish:
     name: Publish
@@ -154,10 +155,11 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: ./.github/workflows/_publish.yml
+    uses: $/.github/workflows/_publish.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       publish_packages: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   release:
     name: Release
@@ -184,14 +186,14 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: Restore Artifacts
-        uses: ./.github/actions/artifacts-restore
+        uses: $/.github/actions/artifacts-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: Attestation
         if: env.CAN_PUBLISH == 'true'
-        uses: ./.github/actions/artifacts-attest
+        uses: $/.github/actions/artifacts-attest # NOSONAR -- $/ resolves to the running commit.
 
       - name: Load DockerHub credentials
         id: dockerhub-creds

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: Get npm cache directory
         shell: bash
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore State
-        uses: ./.github/actions/cache-restore
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
 
       - name: Get npm cache directory
         shell: bash


### PR DESCRIPTION
## Description

- Replace all same-repository action references with the new `$/` syntax.
- Replace reusable workflow calls with same-commit `$/` references.
- Keep checkout steps that are still required for build scripts, repository files, Docker inputs, or documentation sources.
- Add a narrowly scoped Actionlint workaround for the two diagnostics that do not yet recognize the new syntax.
- Suppress Sonar rule `githubactions:S7637` only on `$/` references, which already resolve to the exact running commit.
- Replace inherited reusable-workflow secrets with explicit least-privilege passing of `OP_SERVICE_ACCOUNT_TOKEN` where required.

## Related Issue

Resolves #5103

## Static-analysis Compatibility

Actionlint 1.7.12 does not yet recognize the `$/` self-repository syntax. The temporary path-scoped ignores in `.github/actionlint.yaml` suppress only the two obsolete diagnostics while keeping all other lint checks active.

Native support is tracked by https://github.com/rhysd/actionlint/issues/711. Remove the workaround once upstream support is released and used by this repository.

Sonar rule `githubactions:S7637` likewise treats `$/` references as unpinned external dependencies. Each self-reference carries a line-level `NOSONAR` explanation because adding an `@ref` would invalidate the self-repository syntax.

## Motivation and Context

Self-repository references resolve actions and reusable workflows from the exact commit running the workflow. This keeps internal composition aligned when callers pin a workflow to a full commit SHA and avoids requiring checkout solely to load an action.

## How Has This Been Tested?

- `actionlint`
- `git diff --check`
- Verified that `.github/workflows` contains no remaining workspace-relative `uses: ./` references.
- Reviewed every neighboring checkout; each remaining checkout has a separate runtime purpose.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
