### PR TITLE
(ci) Use Docker Hub OIDC for image publishing

### DIFF
--- a/.github/actions/docker-manifests/action.yml
+++ b/.github/actions/docker-manifests/action.yml
@@ -7,11 +7,11 @@ inputs:
   dotnet_version:
     description: '.net version'
     required: true
-  docker_registry_username:
-    description: 'DockerHub Registry Username'
+  dockerhub_organization:
+    description: 'Docker Hub organization'
     required: true
-  docker_registry_password:
-    description: 'DockerHub Registry Password'
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
     required: true
   github_registry_username:
     description: 'GitHub Registry Username'
@@ -24,10 +24,11 @@ runs:
   using: 'composite'
   steps:
     - name: Login to DockerHub
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
       with:
-        username: ${{ inputs.docker_registry_username }}
-        password: ${{ inputs.docker_registry_password }}
+        username: ${{ inputs.dockerhub_organization }}
 
     - name: '[Docker Publish Manifests] DockerHub'
       shell: pwsh
@@ -40,7 +41,7 @@ runs:
               --docker_distro=$env:DOCKER_DISTRO --docker_registry dockerhub
 
     - name: Login to GitHub
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ghcr.io
         username: ${{ inputs.github_registry_username }}

--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -10,11 +10,11 @@ inputs:
   dotnet_version:
     description: '.net version'
     required: true
-  docker_registry_username:
-    description: 'DockerHub Registry Username'
+  dockerhub_organization:
+    description: 'Docker Hub organization'
     required: true
-  docker_registry_password:
-    description: 'DockerHub Registry Password'
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
     required: true
   github_registry_username:
     description: 'GitHub Registry Username'
@@ -27,10 +27,11 @@ runs:
   using: 'composite'
   steps:
     - name: Login to DockerHub
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
       with:
-        username: ${{ inputs.docker_registry_username }}
-        password: ${{ inputs.docker_registry_password }}
+        username: ${{ inputs.dockerhub_organization }}
 
     - name: '[Docker Publish] DockerHub'
       shell: pwsh
@@ -44,7 +45,7 @@ runs:
               --docker_distro=$env:DOCKER_DISTRO --docker_registry dockerhub --verbosity=diagnostic
 
     - name: Login to GitHub
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ghcr.io
         username: ${{ inputs.github_registry_username }}

--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -5,6 +5,6 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Docker
-      uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
+      uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
       with:
         daemon-config: '{ "features": { "containerd-snapshotter": true } }'

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -16,21 +16,21 @@ on:
       publish_images:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
 
-permissions:
-  packages: write
-
 jobs:
-  docker:
+  test:
     name: ${{ matrix.docker_distro }} - net${{ matrix.dotnet_version }}
+    if: inputs.publish_images == false
     runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -84,21 +84,49 @@ jobs:
       - name: Wait for docker backend tests
         wait-all:
 
-      - name: Load DockerHub credentials
-        id: dockerhub-creds
-        if: success() && inputs.publish_images
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
+  publish:
+    name: ${{ matrix.docker_distro }} - net${{ matrix.dotnet_version }}
+    if: inputs.publish_images
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        docker_distro: ${{ fromJson(inputs.docker_distros) }}
+        dotnet_version: ${{ fromJson(inputs.dotnet_versions) }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Restore State
+        uses: $/.github/actions/cache-restore # NOSONAR -- $/ resolves to the running commit.
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        name: Download nuget packages
+        with:
+          name: nuget
+          path: ${{ github.workspace }}/artifacts/packages/nuget
+
+      - name: Set up Docker
+        uses: $/.github/actions/docker-setup # NOSONAR -- $/ resolves to the running commit.
 
       - name: Docker Publish
-        if: success() && inputs.publish_images
         uses: $/.github/actions/docker-publish # NOSONAR -- $/ resolves to the running commit.
         with:
           arch: ${{ inputs.arch }}
           docker_distro: ${{ matrix.docker_distro }}
           dotnet_version: ${{ matrix.dotnet_version }}
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
           github_registry_username: ${{ github.repository_owner }}
           github_registry_password: ${{ github.token }}

--- a/.github/workflows/_docker_manifests.yml
+++ b/.github/workflows/_docker_manifests.yml
@@ -10,21 +10,22 @@ on:
       publish_manifests:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
 
-permissions:
-  packages: write
-
 jobs:
   manifest:
     name: ${{ matrix.docker_distro }} - net${{ matrix.dotnet_version }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -47,20 +48,13 @@ jobs:
       - name: Set up Docker
         uses: $/.github/actions/docker-setup # NOSONAR -- $/ resolves to the running commit.
 
-      - name: Load DockerHub credentials
-        if: inputs.publish_manifests
-        id: dockerhub-creds
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
-        with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Docker Manifests
         uses: $/.github/actions/docker-manifests # NOSONAR -- $/ resolves to the running commit.
         if: inputs.publish_manifests
         with:
           docker_distro: ${{ matrix.docker_distro }}
           dotnet_version: ${{ matrix.dotnet_version }}
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
           github_registry_username: ${{ github.repository_owner }}
           github_registry_password: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
     name: Docker Images (${{ matrix.arch }})
     permissions:
       contents: read
+      id-token: write
       packages: write
     strategy:
       fail-fast: false
@@ -131,22 +132,21 @@ jobs:
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_images: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
 
   docker_linux_manifests:
     needs: [ prepare, docker_linux_images, publish_flags ]
     name: Docker Manifests
     permissions:
       contents: read
+      id-token: write
       packages: write
     uses: $/.github/workflows/_docker_manifests.yml # NOSONAR -- $/ resolves to the running commit.
     with:
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_manifests: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- authenticate Docker Hub image publishing with OIDC through `docker/login-action`
- authenticate Docker Hub manifest publishing with the same short-lived flow
- grant `id-token: write` only to publishing jobs
- stop passing inherited repository secrets into the image and manifest workflows
- keep Docker test jobs on read-only permissions

## Configuration required

Before exercising the publishing path:

- create a Docker Hub OIDC connection for `GitTools/GitVersion` on `refs/heads/main`
- grant write access only to `gittools/gitversion`
- set the repository variable `DOCKERHUB_OIDC_CONNECTIONID` to that connection ID

## Known limitation

Docker Hub README publishing intentionally still uses the existing credential action. The official [`docker/oidc-action` documentation](https://github.com/docker/oidc-action/blob/v1/README.md) currently states that issued tokens are limited to registry login and that broader Docker Hub API authentication is not supported. The README publisher calls the Docker Hub API directly, so migrating that step now would make release publishing fail.

This draft therefore covers the image and manifest portion of #5090, but does not close the issue.

## Validation

- `actionlint .github/workflows/_docker.yml .github/workflows/_docker_manifests.yml .github/workflows/ci.yml`
- parsed both changed composite-action YAML files
- `git diff --check`

Closes to #5090