### PR TITLE
(deps): Bump the microsoft group with 3 updates

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion>18.8.2</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>18.9.6</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>5.6.0</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Updated [Microsoft.Build](https://www.nuget.org/packages/Microsoft.Build) from 18.8.2 to 18.9.6.

Updated [Microsoft.Build.Tasks.Core](https://www.nuget.org/packages/Microsoft.Build.Tasks.Core) from 18.8.2 to 18.9.6.

Updated [Microsoft.Build.Utilities.Core](https://www.nuget.org/packages/Microsoft.Build.Utilities.Core) from 18.8.2 to 18.9.6.

---

This PR follows the repository Dependabot grouped-update convention, but was created manually.