### PR TITLE
feat: resolve increments from merged branches

### DIFF
--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
@@ -158,7 +158,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.0-1+4", configuration);
         }
     }
 
@@ -237,8 +237,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+4", configuration);
         }
     }
 
@@ -317,8 +317,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+4", configuration);
         }
     }
 
@@ -868,7 +868,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+4"
-            fixture.AssertFullSemver("0.0.3-1+4", configuration);
+            fixture.AssertFullSemver("0.0.2-1+4", configuration);
         }
     }
 
@@ -1236,7 +1236,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.2.0-2+4"
-            fixture.AssertFullSemver("0.3.0-1+4", configuration);
+            fixture.AssertFullSemver("0.2.0-1+4", configuration);
         }
     }
 
@@ -1315,8 +1315,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+4"
-            fixture.AssertFullSemver("0.3.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+4", configuration);
         }
     }
 
@@ -1612,7 +1612,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.0-1+4", configuration);
         }
     }
 
@@ -1692,7 +1692,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.1-foo.2+3"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.1-1+4", configuration);
         }
     }
 
@@ -1771,8 +1771,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+4", configuration);
         }
     }
 
@@ -2018,7 +2018,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
     }
 
@@ -2108,8 +2108,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
     }
 
@@ -2199,8 +2199,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
     }
 
@@ -2944,7 +2944,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+6"
-            fixture.AssertFullSemver("0.0.3-1+6", configuration);
+            fixture.AssertFullSemver("0.0.2-1+6", configuration);
         }
     }
 
@@ -3366,8 +3366,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.0-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
     }
 
@@ -3457,8 +3457,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+6", configuration);
         }
     }
 
@@ -3798,7 +3798,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
     }
 
@@ -3888,8 +3888,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
     }
 
@@ -3979,8 +3979,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
     }
 
@@ -4190,8 +4190,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -4262,8 +4262,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+2", configuration);
         }
     }
 
@@ -4334,8 +4334,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+2", configuration);
         }
     }
 
@@ -4582,8 +4582,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.0.1-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.0.1-1+2", configuration);
         }
     }
 
@@ -4646,8 +4646,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -4710,8 +4710,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -4839,7 +4839,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.1-2+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            fixture.AssertFullSemver("0.0.1-1+2", configuration);
         }
     }
 
@@ -4958,8 +4958,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -5022,8 +5022,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5150,8 +5150,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -5222,8 +5222,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.1-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.1-1+2", configuration);
         }
     }
 
@@ -5342,8 +5342,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5470,8 +5470,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5542,8 +5542,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+2", configuration);
         }
     }
 
@@ -5614,8 +5614,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+2", configuration);
         }
     }
 
@@ -5979,7 +5979,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -6090,8 +6090,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -6204,8 +6204,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -7313,7 +7313,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+6"
-            fixture.AssertFullSemver("0.0.3-1+6", configuration);
+            fixture.AssertFullSemver("0.0.2-1+6", configuration);
         }
 
         if (!useMainline)
@@ -7919,7 +7919,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.2.0-2+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8026,8 +8026,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8545,7 +8545,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8654,8 +8654,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8766,8 +8766,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9213,7 +9213,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "1.0.0-2+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            fixture.AssertFullSemver("1.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9333,8 +9333,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9458,8 +9458,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -10569,7 +10569,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.1-2+6"
-            fixture.AssertFullSemver("0.0.2-1+6", configuration);
+            fixture.AssertFullSemver("0.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11206,7 +11206,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ not expected
-            fixture.AssertFullSemver("0.2.0-1+6", configuration);
+            fixture.AssertFullSemver("0.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11321,7 +11321,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ not expected
-            fixture.AssertFullSemver("0.2.0-1+6", configuration);
+            fixture.AssertFullSemver("0.1.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11875,7 +11875,7 @@ public class AlignGitFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "1.0.0-2+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            fixture.AssertFullSemver("1.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11995,8 +11995,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -12120,8 +12120,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+6", configuration);
         }
 
         if (!useMainline)

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitFlowWithMainlineVersionStrategy.cs
@@ -230,16 +230,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+4", configuration);
     }
 
     /// <summary>
@@ -310,16 +302,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+4", configuration);
     }
 
     /// <summary>
@@ -1308,16 +1292,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+4", configuration);
     }
 
     /// <summary>
@@ -1684,16 +1660,9 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
-        else
-        {
-            // ❔ expected: "2.0.1-foo.2+3"
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
+        // Mainline: ✅ succeeds as expected
+        // Non-mainline: ❔ expected: "2.0.1-foo.2+3"
+        fixture.AssertFullSemver("2.0.1-1+4", configuration);
     }
 
     /// <summary>
@@ -1764,16 +1733,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+4", configuration);
     }
 
     /// <summary>
@@ -2101,16 +2062,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
     }
 
     /// <summary>
@@ -2192,16 +2145,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
     }
 
     /// <summary>
@@ -3450,16 +3395,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+6", configuration);
     }
 
     /// <summary>
@@ -3881,16 +3818,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
     }
 
     /// <summary>
@@ -3972,16 +3901,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
     }
 
     /// <summary>
@@ -4255,16 +4176,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -4327,16 +4240,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4575,16 +4480,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -4639,16 +4536,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4703,16 +4592,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4951,16 +4832,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5015,16 +4888,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5215,16 +5080,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.1-1+2", configuration);
     }
 
     /// <summary>
@@ -5335,16 +5192,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5535,16 +5384,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -5607,16 +5448,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -6083,16 +5916,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -6197,16 +6022,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8019,16 +7836,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8647,16 +8456,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8759,16 +8560,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -9326,16 +9119,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -9451,16 +9236,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -11313,16 +11090,9 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+6", configuration);
-        }
-        else
-        {
-            // ❔ not expected
-            fixture.AssertFullSemver("0.1.1-1+6", configuration);
-        }
+        // Mainline: ✅ succeeds as expected
+        // Non-mainline: ❔ not expected
+        fixture.AssertFullSemver("0.1.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -11988,16 +11758,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -12113,16 +11875,8 @@ public class AlignGitFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+6", configuration);
 
         if (!useMainline)
         {

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
@@ -158,7 +158,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.0-1+4", configuration);
         }
     }
 
@@ -237,8 +237,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+4", configuration);
         }
     }
 
@@ -317,8 +317,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+4", configuration);
         }
     }
 
@@ -868,7 +868,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+4"
-            fixture.AssertFullSemver("0.0.3-1+4", configuration);
+            fixture.AssertFullSemver("0.0.2-1+4", configuration);
         }
     }
 
@@ -1236,7 +1236,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.2.0-2+4"
-            fixture.AssertFullSemver("0.3.0-1+4", configuration);
+            fixture.AssertFullSemver("0.2.0-1+4", configuration);
         }
     }
 
@@ -1315,8 +1315,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+4"
-            fixture.AssertFullSemver("0.3.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+4", configuration);
         }
     }
 
@@ -1612,7 +1612,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.0-1+4", configuration);
         }
     }
 
@@ -1692,7 +1692,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.1-foo.2+3"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            fixture.AssertFullSemver("2.0.1-1+4", configuration);
         }
     }
 
@@ -1771,8 +1771,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+4"
-            fixture.AssertFullSemver("3.0.0-1+4", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+4", configuration);
         }
     }
 
@@ -2018,7 +2018,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
     }
 
@@ -2108,8 +2108,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
     }
 
@@ -2199,8 +2199,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
     }
 
@@ -2944,7 +2944,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+6"
-            fixture.AssertFullSemver("0.0.3-1+6", configuration);
+            fixture.AssertFullSemver("0.0.2-1+6", configuration);
         }
     }
 
@@ -3366,8 +3366,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.0-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
     }
 
@@ -3457,8 +3457,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+6", configuration);
         }
     }
 
@@ -3798,7 +3798,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
     }
 
@@ -3888,8 +3888,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
     }
 
@@ -3979,8 +3979,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
     }
 
@@ -4190,8 +4190,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -4262,8 +4262,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+2", configuration);
         }
     }
 
@@ -4334,8 +4334,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+2", configuration);
         }
     }
 
@@ -4582,8 +4582,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.0.1-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.0.1-1+2", configuration);
         }
     }
 
@@ -4646,8 +4646,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -4710,8 +4710,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -4839,7 +4839,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.1-2+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            fixture.AssertFullSemver("0.0.1-1+2", configuration);
         }
     }
 
@@ -4958,8 +4958,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -5022,8 +5022,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.0.2-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5150,8 +5150,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.0-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.0-1+2", configuration);
         }
     }
 
@@ -5222,8 +5222,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.1.1-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.1.1-1+2", configuration);
         }
     }
 
@@ -5342,8 +5342,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("0.2.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5470,8 +5470,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.0-1+2", configuration);
         }
     }
 
@@ -5542,8 +5542,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+2", configuration);
         }
     }
 
@@ -5614,8 +5614,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+2"
-            fixture.AssertFullSemver("2.0.0-1+2", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+2", configuration);
         }
     }
 
@@ -5979,7 +5979,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -6090,8 +6090,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -6204,8 +6204,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -7313,7 +7313,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.2-2+6"
-            fixture.AssertFullSemver("0.0.3-1+6", configuration);
+            fixture.AssertFullSemver("0.0.2-1+6", configuration);
         }
 
         if (!useMainline)
@@ -7919,7 +7919,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.2.0-2+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            fixture.AssertFullSemver("0.2.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8026,8 +8026,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "0.2.1-1+6"
-            fixture.AssertFullSemver("0.3.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("0.2.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8545,7 +8545,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "2.0.0-2+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            fixture.AssertFullSemver("2.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8654,8 +8654,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.0.1-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -8766,8 +8766,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "2.1.0-1+6"
-            fixture.AssertFullSemver("3.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("2.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9213,7 +9213,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "1.0.0-2+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            fixture.AssertFullSemver("1.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9333,8 +9333,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -9458,8 +9458,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -10569,7 +10569,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "0.0.1-2+6"
-            fixture.AssertFullSemver("0.0.2-1+6", configuration);
+            fixture.AssertFullSemver("0.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11206,7 +11206,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ not expected
-            fixture.AssertFullSemver("0.2.0-1+6", configuration);
+            fixture.AssertFullSemver("0.1.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11321,7 +11321,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ not expected
-            fixture.AssertFullSemver("0.2.0-1+6", configuration);
+            fixture.AssertFullSemver("0.1.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11875,7 +11875,7 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         else
         {
             // ❔ expected: "1.0.0-2+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            fixture.AssertFullSemver("1.0.0-1+6", configuration);
         }
 
         if (!useMainline)
@@ -11995,8 +11995,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.0.1-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.0.1-1+6", configuration);
         }
 
         if (!useMainline)
@@ -12120,8 +12120,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         }
         else
         {
-            // ❔ expected: "1.1.0-1+6"
-            fixture.AssertFullSemver("2.0.0-1+6", configuration);
+            // ✅ succeeds as expected
+            fixture.AssertFullSemver("1.1.0-1+6", configuration);
         }
 
         if (!useMainline)

--- a/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/AlignGitHubFlowWithMainlineVersionStrategy.cs
@@ -230,16 +230,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+4", configuration);
     }
 
     /// <summary>
@@ -310,16 +302,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+4", configuration);
     }
 
     /// <summary>
@@ -1308,16 +1292,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+4", configuration);
     }
 
     /// <summary>
@@ -1684,16 +1660,9 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
-        else
-        {
-            // ❔ expected: "2.0.1-foo.2+3"
-            fixture.AssertFullSemver("2.0.1-1+4", configuration);
-        }
+        // Mainline: ✅ succeeds as expected
+        // Non-mainline: ❔ expected: "2.0.1-foo.2+3"
+        fixture.AssertFullSemver("2.0.1-1+4", configuration);
     }
 
     /// <summary>
@@ -1764,16 +1733,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+4", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+4", configuration);
     }
 
     /// <summary>
@@ -2101,16 +2062,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
     }
 
     /// <summary>
@@ -2192,16 +2145,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
     }
 
     /// <summary>
@@ -3450,16 +3395,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+6", configuration);
     }
 
     /// <summary>
@@ -3881,16 +3818,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
     }
 
     /// <summary>
@@ -3972,16 +3901,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
     }
 
     /// <summary>
@@ -4255,16 +4176,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -4327,16 +4240,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4575,16 +4480,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -4639,16 +4536,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4703,16 +4592,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -4951,16 +4832,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5015,16 +4888,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5215,16 +5080,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.1.1-1+2", configuration);
     }
 
     /// <summary>
@@ -5335,16 +5192,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.0-1+2", configuration);
     }
 
     /// <summary>
@@ -5535,16 +5384,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+2", configuration);
     }
 
     /// <summary>
@@ -5607,16 +5448,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
         fixture.Remove("pull/2/merge");
         fixture.MergeNoFF("feature/foo");
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+2", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+2", configuration);
     }
 
     /// <summary>
@@ -6083,16 +5916,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -6197,16 +6022,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8019,16 +7836,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.2.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("0.2.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8647,16 +8456,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -8759,16 +8560,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("2.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("2.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -9326,16 +9119,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -9451,16 +9236,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+6", configuration);
 
         if (!useMainline)
         {
@@ -11313,16 +11090,9 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("0.1.1-1+6", configuration);
-        }
-        else
-        {
-            // ❔ not expected
-            fixture.AssertFullSemver("0.1.1-1+6", configuration);
-        }
+        // Mainline: ✅ succeeds as expected
+        // Non-mainline: ❔ not expected
+        fixture.AssertFullSemver("0.1.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -11988,16 +11758,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.0.1-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.0.1-1+6", configuration);
 
         if (!useMainline)
         {
@@ -12113,16 +11875,8 @@ public class AlignGitHubFlowWithMainlineVersionStrategy
 
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
-        if (useMainline)
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
-        else
-        {
-            // ✅ succeeds as expected
-            fixture.AssertFullSemver("1.1.0-1+6", configuration);
-        }
+        // ✅ succeeds as expected
+        fixture.AssertFullSemver("1.1.0-1+6", configuration);
 
         if (!useMainline)
         {

--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -326,7 +326,9 @@ public class FeatureBranchScenarios : TestBase
 
             // create a feature branch from main and verify the version
             fixture.BranchTo("feature/test");
-            fixture.AssertFullSemver("1.0.1-test.1+2", configuration);
+            fixture.AssertFullSemver("1.1.0-test.1+2", configuration);
+            fixture.MakeACommit();
+            fixture.AssertFullSemver("1.1.0-test.1+3", configuration);
         }
     }
 
@@ -416,7 +418,7 @@ public class FeatureBranchScenarios : TestBase
 
                 // create a misnamed feature branch (i.e. it uses the default configuration) from main and verify the version
                 fixture.BranchTo("misnamed");
-                fixture.AssertFullSemver("1.0.1-misnamed.1+2", configuration);
+                fixture.AssertFullSemver("1.1.0-misnamed.1+2", configuration);
             }
         }
     }

--- a/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -322,7 +322,7 @@ public class FeatureBranchScenarios : TestBase
             // merge release into main
             fixture.Checkout(MainBranch);
             fixture.MergeNoFF("release/1.0.0");
-            fixture.AssertFullSemver("1.0.1-2", configuration);
+            fixture.AssertFullSemver("1.1.0-2", configuration);
 
             // create a feature branch from main and verify the version
             fixture.BranchTo("feature/test");
@@ -412,7 +412,7 @@ public class FeatureBranchScenarios : TestBase
                 // merge release into main
                 fixture.Checkout(MainBranch);
                 fixture.MergeNoFF("release/1.0.0");
-                fixture.AssertFullSemver("1.0.1-2", configuration);
+                fixture.AssertFullSemver("1.1.0-2", configuration);
 
                 // create a misnamed feature branch (i.e. it uses the default configuration) from main and verify the version
                 fixture.BranchTo("misnamed");

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -531,4 +531,43 @@ public class PreventIncrementOfMergedBranchScenarios
 
         fixture.AssertFullSemver("1.1.0-3", configuration);
     }
+
+    [Test]
+    public void ResolvesNestedInheritanceFromHistoricalSourceState()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("support", builder => builder
+                .WithRegularExpression("^support$")
+                .WithIncrement(IncrementStrategy.Major)
+            ).WithBranch("integration", builder => builder
+                .WithRegularExpression("^integration$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop", "support")
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("integration")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("support");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("integration");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.Checkout("support");
+        fixture.MakeACommit();
+        fixture.MergeTo("integration");
+        fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-4", configuration);
+    }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -482,6 +482,33 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void HonorsMainBranchFlagInheritedFromSourceBranch()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop")
+                .WithPreventIncrementOfMergedBranch(true)
+                .WithIsMainBranch(null)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithIsMainBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithIsMainBranch(false)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("develop");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
+    [Test]
     public void RetainsIgnoredCurrentTargetAsHistoricalSource()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -8,7 +8,7 @@ namespace GitVersion.Tests.IntegrationTests;
 [Parallelizable(ParallelScope.All)]
 public class PreventIncrementOfMergedBranchScenarios
 {
-    [TestCase(false, false, "1.0.1-2")]
+    [TestCase(false, false, "1.1.0-2")]
     [TestCase(false, true, "1.0.1-2")]
     [TestCase(false, null, "1.1.0-2")]
     [TestCase(true, false, "1.1.0-2")]
@@ -437,6 +437,55 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void HonorsInheritedMainBranchFlag()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIsMainBranch(true)
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+                .WithIsMainBranch(null)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithIsMainBranch(false)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
+    [Test]
+    public void RetainsIgnoredCurrentTargetAsHistoricalSource()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("main", "develop")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
+    [Test]
     public void StopsMergedSourceContributionsAtInterveningTargetTag()
     {
         var configuration = GitFlowConfigurationBuilder.New
@@ -460,6 +509,30 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
         fixture.AssertFullSemver("2.0.1-4", configuration);
+    }
+
+    [Test]
+    public void PreservesCommitMessageDirectivesFromUnrecognizedMergedHistory()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.Checkout("main");
+        fixture.Repository.MergeNoFF("topic/foo", "Integrate topic");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.0-4", configuration);
     }
 
     [Test]
@@ -633,6 +706,44 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.Checkout("aggregate");
         fixture.MakeACommit();
         fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void ResolvesAllSiblingInheritancePathsForRetainedTip()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("integration-a", builder => builder
+                .WithRegularExpression("^integration-a$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop")
+                .WithPreventIncrementWhenBranchMerged(true)
+            ).WithBranch("integration-b", builder => builder
+                .WithRegularExpression("^integration-b$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop")
+                .WithPreventIncrementWhenBranchMerged(false)
+            ).WithBranch("aggregate", builder => builder
+                .WithRegularExpression("^aggregate$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("integration-a", "integration-b")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.CreateBranch("integration-a");
+        fixture.CreateBranch("integration-b");
+        fixture.BranchTo("aggregate");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
 
         fixture.AssertFullSemver("1.1.0-3", configuration);
     }

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -619,13 +619,18 @@ public class PreventIncrementOfMergedBranchScenarios
     public void RetainsMergedIncrementAfterMergingMainIntoDescendant()
     {
         var configuration = GitFlowConfigurationBuilder.New
+            .WithIsMainBranch(true)
             .WithBranch("main", builder => builder
                 .WithIncrement(IncrementStrategy.Patch)
                 .WithPreventIncrementOfMergedBranch(true)
+                .WithPreventIncrementWhenBranchMerged(true)
+                .WithIsMainBranch(null)
             ).WithBranch("release", builder => builder
                 .WithIncrement(IncrementStrategy.Minor)
+                .WithIsMainBranch(false)
             ).WithBranch("feature", builder => builder
                 .WithIncrement(IncrementStrategy.Patch)
+                .WithIsMainBranch(false)
             ).Build();
 
         using var fixture = new EmptyRepositoryFixture("main");
@@ -771,6 +776,30 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void PreservesCommitOrderAcrossRecognizedMergeBoundary()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Major)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit("Reset to patch =semver: patch");
+        fixture.Checkout("main");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.Repository.MergeNoFF("topic/foo", "Integrate topic");
+
+        fixture.AssertFullSemver("2.0.0-4", configuration);
+    }
+
+    [Test]
     public void PreservesSideHistoryOfIgnoredUnrecognizedMerge()
     {
         using var fixture = new EmptyRepositoryFixture("main");
@@ -909,6 +938,28 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.MergeTo("main", removeBranchAfterMerging);
 
         fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
+    [Test]
+    public void SkipsUnresolvedFallbackForOrphanedInheritedSource()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("topic", builder => builder
+                .WithRegularExpression("^topics?[/-](?<BranchName>.+)")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches()
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-2", configuration);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -8,15 +8,13 @@ namespace GitVersion.Tests.IntegrationTests;
 [Parallelizable(ParallelScope.All)]
 public class PreventIncrementOfMergedBranchScenarios
 {
-    [TestCase(false, false, "1.0.1-2")]
+    [TestCase(false, false, "1.1.0-2")]
     [TestCase(false, true, "1.0.1-2")]
-    [TestCase(false, null, "1.1.0-2")]
     [TestCase(true, false, "1.1.0-2")]
     [TestCase(true, true, "1.0.1-2")]
-    [TestCase(true, null, "1.1.0-2")]
     public void SelectsIncrementFromTargetAndMergedBranchConfiguration(
         bool preventIncrementOfMergedBranch,
-        bool? preventIncrementWhenBranchMerged,
+        bool preventIncrementWhenBranchMerged,
         string expectedVersion)
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -354,6 +354,27 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void TreatsSelectedSourceTipTagAsTaggedAcrossLabels()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementWhenCurrentCommitTagged(true)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeATaggedCommit("2.0.0");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.0-1", configuration);
+    }
+
+    [Test]
     public void IgnoresFutureDatedTagWhenEvaluatingMergedSourceMessages()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -149,6 +149,28 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.AssertFullSemver("1.0.1-4", configuration);
     }
 
+    [Test]
+    public void NewerMergedSourceResetDiscardsEarlierTargetDirective()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(false)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementWhenBranchMerged(false)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit("Hotfix =semver: patch");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void IncludesTargetIncrementForTargetCommit(bool commitAfterMerge)

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -619,6 +619,32 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void PreservesSideHistoryOfIgnoredUnrecognizedMerge()
+    {
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.Checkout("main");
+        fixture.Repository.MergeNoFF("topic/foo", "Integrate topic");
+        var ignoredMerge = fixture.Repository.Head.Tip;
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Shas = [ignoredMerge.Sha] })
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        fixture.AssertFullSemver("2.0.0-3", configuration);
+    }
+
+    [Test]
     public void ResolvesInheritedIncrementFromHistoricalMergedBranchTip()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -416,6 +416,27 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void RetainsIgnoredCurrentMainForMergedIncrementResolution()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
+    [Test]
     public void StopsMergedSourceContributionsAtInterveningTargetTag()
     {
         var configuration = GitFlowConfigurationBuilder.New
@@ -569,5 +590,50 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.Checkout("main");
 
         fixture.AssertFullSemver("1.1.0-4", configuration);
+    }
+
+    [Test]
+    public void ResolvesAllSiblingHistoricalInheritancePaths()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("integration-a", builder => builder
+                .WithRegularExpression("^integration-a$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop")
+                .WithPreventIncrementWhenBranchMerged(true)
+            ).WithBranch("integration-b", builder => builder
+                .WithRegularExpression("^integration-b$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop")
+                .WithPreventIncrementWhenBranchMerged(false)
+            ).WithBranch("aggregate", builder => builder
+                .WithRegularExpression("^aggregate$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("integration-a", "integration-b")
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("aggregate")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.CreateBranch("integration-a");
+        fixture.CreateBranch("integration-b");
+        fixture.BranchTo("aggregate");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.Checkout("aggregate");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -616,6 +616,64 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void RetainsMergedIncrementAfterMergingMainIntoDescendant()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("release", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+        fixture.BranchTo("release/minor");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+        fixture.Checkout("feature/foo");
+        fixture.MergeNoFF("main");
+
+        fixture.AssertFullSemver("1.1.0-foo.1+4", configuration);
+    }
+
+    [Test]
+    public void RejectsUnrelatedMergeBeforeMergingMainIntoDescendant()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("release", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+        fixture.BranchTo("release/minor");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.Checkout("feature/foo");
+        fixture.BranchTo("feature/side");
+        fixture.MakeACommit();
+        fixture.MergeTo("feature/foo", removeBranchAfterMerging: true);
+        fixture.MergeNoFF("main");
+
+        fixture.AssertFullSemver("1.0.1-foo.1+6", configuration);
+    }
+
+    [Test]
     public void StopsMergedSourceContributionsAtInterveningTargetTag()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -8,7 +8,7 @@ namespace GitVersion.Tests.IntegrationTests;
 [Parallelizable(ParallelScope.All)]
 public class PreventIncrementOfMergedBranchScenarios
 {
-    [TestCase(false, false, "1.1.0-2")]
+    [TestCase(false, false, "1.0.1-2")]
     [TestCase(false, true, "1.0.1-2")]
     [TestCase(false, null, "1.1.0-2")]
     [TestCase(true, false, "1.1.0-2")]
@@ -153,12 +153,13 @@ public class PreventIncrementOfMergedBranchScenarios
     public void NewerMergedSourceResetDiscardsEarlierTargetDirective()
     {
         var configuration = GitFlowConfigurationBuilder.New
+            .WithPreventIncrementWhenBranchMerged(null)
             .WithBranch("main", builder => builder
                 .WithIncrement(IncrementStrategy.Patch)
                 .WithPreventIncrementOfMergedBranch(false)
             ).WithBranch("hotfix", builder => builder
                 .WithIncrement(IncrementStrategy.Patch)
-                .WithPreventIncrementWhenBranchMerged(false)
+                .WithPreventIncrementWhenBranchMerged(null)
             ).Build();
 
         using var fixture = new EmptyRepositoryFixture("main");

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -1,5 +1,6 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
+using LibGit2Sharp;
 
 namespace GitVersion.Tests.IntegrationTests;
 
@@ -331,6 +332,37 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void IgnoresFutureDatedTagWhenEvaluatingMergedSourceMessages()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+                .WithIsMainBranch(true)
+                .WithTrackMergeMessage(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        var futureSignature = new Signature(
+            "A. U. Thor", "thor@valhalla.asgard.com", DateTimeOffset.Now.AddYears(10));
+        var futureCommit = fixture.Repository.Commit(
+            "Breaking change +semver: major", futureSignature, futureSignature,
+            new CommitOptions { AmendPreviousCommit = true });
+        fixture.ApplyTag("1.1.0");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        var targetCommit = fixture.Repository.Head.Tip;
+        targetCommit.Parents.Count().ShouldBe(2);
+        futureCommit.Committer.When.ShouldBeGreaterThan(targetCommit.Committer.When);
+
+        fixture.AssertFullSemver("2.0.0-2", configuration, commitId: targetCommit.Sha);
+    }
+
+    [Test]
     public void RetainsTargetAsPossibleHistoricalSourceBranch()
     {
         var configuration = GitFlowConfigurationBuilder.New
@@ -355,6 +387,58 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.MergeTo("main", removeBranchAfterMerging: true);
 
         fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
+    [Test]
+    public void ExcludesIgnoredBranchesFromHistoricalSourceInference()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^develop$"] })
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("main", "develop")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
+    [Test]
+    public void StopsMergedSourceContributionsAtInterveningTargetTag()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("2.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.ApplyTag("1.0.0");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit("Hotfix +semver: patch");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.1-4", configuration);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -535,6 +535,40 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void RetainsIgnoredHistoricalMainAsSourceOnLinearDescendant()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("main", "develop")
+            ).WithBranch("child", builder => builder
+                .WithRegularExpression("^child$")
+                .WithLabel(string.Empty)
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithSourceBranches("main")
+                .WithPreventIncrementOfMergedBranch(true)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.BranchTo("child");
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("1.0.1-4", configuration);
+    }
+
+    [Test]
     public void StopsMergedSourceContributionsAtInterveningTargetTag()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -829,6 +829,30 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.AssertFullSemver("1.1.0-3", configuration);
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public void UsesGlobalFallbackForOrphanedInheritedSource(bool removeBranchAfterMerging)
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIncrement(IncrementStrategy.Minor)
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("topic", builder => builder
+                .WithRegularExpression("^topics?[/-](?<BranchName>.+)")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches()
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging);
+
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
     [Test]
     public void ResolvesNestedInheritanceFromHistoricalSourceState()
     {

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -1,0 +1,279 @@
+using GitVersion.Configuration;
+using GitVersion.Testing.Extensions;
+
+namespace GitVersion.Tests.IntegrationTests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class PreventIncrementOfMergedBranchScenarios
+{
+    [TestCase(false, false, "1.0.1-2")]
+    [TestCase(false, true, "1.0.1-2")]
+    [TestCase(false, null, "1.1.0-2")]
+    [TestCase(true, false, "1.1.0-2")]
+    [TestCase(true, true, "1.0.1-2")]
+    [TestCase(true, null, "1.1.0-2")]
+    public void SelectsIncrementFromTargetAndMergedBranchConfiguration(
+        bool preventIncrementOfMergedBranch,
+        bool? preventIncrementWhenBranchMerged,
+        string expectedVersion)
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithPreventIncrementWhenBranchMerged(null)
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(preventIncrementOfMergedBranch)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementWhenBranchMerged(preventIncrementWhenBranchMerged)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver(expectedVersion, configuration);
+    }
+
+    [Test]
+    public void UsesHotfixIncrementWhenHotfixIsMergedIntoMain()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver("1.0.1-2", configuration);
+    }
+
+    [Test]
+    public void UsesFeatureIncrementWhenFeatureIsMergedIntoMain()
+    {
+        var configuration = GitHubFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver("1.1.0-2", configuration);
+    }
+
+    [Test]
+    public void RetainsMergedBranchIncrementAfterSubsequentTargetCommit()
+    {
+        var configuration = GitHubFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void UsesHighestIncrementFromMultipleMergedBranches()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver("1.1.0-4", configuration);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void IncludesTargetIncrementForTargetCommit(bool commitAfterMerge)
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        if (!commitAfterMerge)
+        {
+            fixture.MakeACommit();
+        }
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+        if (commitAfterMerge)
+        {
+            fixture.MakeACommit();
+        }
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void IgnoresSourceCommitMessageWhenSourceIncrementIsPrevented()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementWhenBranchMerged(true)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver("1.0.1-2", configuration);
+    }
+
+    [TestCase("Feature +semver: minor", "1.1.0-2")]
+    [TestCase("Feature =semver: patch", "1.0.1-2")]
+    public void UsesEffectiveSourceCommitMessageIncrement(string message, string expectedVersion)
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Major)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit(message);
+        fixture.MergeTo("main");
+
+        fixture.AssertFullSemver(expectedVersion, configuration);
+    }
+
+    [Test]
+    public void ResolvesInheritedIncrementFromMergedBranchSource()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void ResolvesInheritedIncrementFromHistoricalMergedBranchTip()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void PrefersHistoricalSourceOverLaterAbsorbingBranch()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("support", builder => builder
+                .WithRegularExpression("^support$")
+                .WithIncrement(IncrementStrategy.Major)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop", "support")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("support");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+        fixture.Checkout("feature/foo");
+        fixture.MergeTo("support", removeBranchAfterMerging: true);
+        fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+}

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -375,6 +375,31 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void StopsUnrecognizedSideHistoryAtOffFirstParentBase()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Major)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementWhenCurrentCommitTagged(true)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+        fixture.Repository.MergeNoFF("topic/foo", "Integrate topic");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeATaggedCommit("2.0.0");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.0-1", configuration);
+    }
+
+    [Test]
     public void IgnoresFutureDatedTagWhenEvaluatingMergedSourceMessages()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -641,6 +641,28 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void SkipsTargetSegmentsPrunedByInterveningTag()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Major)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("2.0.0");
+        fixture.MakeACommit();
+        fixture.ApplyTag("1.0.0");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.1-3", configuration);
+    }
+
+    [Test]
     public void PreservesCommitMessageDirectivesFromUnrecognizedMergedHistory()
     {
         var configuration = GitFlowConfigurationBuilder.New

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -640,6 +640,31 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void PreservesCommitOrderAcrossUnrecognizedMergedHistory()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("topic/foo");
+        fixture.MakeACommit("Reset to patch =semver: patch");
+        fixture.Checkout("main");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.Repository.MergeNoFF("topic/foo", "Integrate topic");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.0-5", configuration);
+    }
+
+    [Test]
     public void PreservesSideHistoryOfIgnoredUnrecognizedMerge()
     {
         using var fixture = new EmptyRepositoryFixture("main");

--- a/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PreventIncrementOfMergedBranchScenarios.cs
@@ -123,6 +123,31 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.AssertFullSemver("1.1.0-4", configuration);
     }
 
+    [Test]
+    public void LatestMergedSourceResetDiscardsEarlierMergedIncrement()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit("Breaking change +semver: major");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeACommit("Hotfix =semver: patch");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-4", configuration);
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void IncludesTargetIncrementForTargetCommit(bool commitAfterMerge)
@@ -219,6 +244,120 @@ public class PreventIncrementOfMergedBranchScenarios
     }
 
     [Test]
+    public void UsesInheritedPreventIncrementWhenBranchMergedSetting()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithPreventIncrementWhenBranchMerged(false)
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+                .WithPreventIncrementWhenBranchMerged(true)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithPreventIncrementWhenBranchMerged(null)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
+    [Test]
+    public void ScoresLocalAndRemoteInheritedSourceBranchesBeforePreferringLocal()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("integration", builder => builder
+                .WithRegularExpression("^(origin/)?integration$")
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("main", "develop")
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("integration")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        var developTip = fixture.MakeACommit();
+        fixture.BranchTo("integration");
+        fixture.MakeACommit();
+        fixture.Repository.Refs.Add(
+            "refs/remotes/origin/integration", fixture.Repository.Lookup(developTip).Id);
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+        fixture.Remove("integration");
+        fixture.MakeACommit();
+        fixture.BranchTo("integration");
+        fixture.MakeACommit();
+        fixture.Checkout("feature/foo");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.1.0-5", configuration);
+    }
+
+    [Test]
+    public void HonorsPreventIncrementForTaggedMergedSourceTip()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("hotfix", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementWhenCurrentCommitTagged(true)
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("hotfix/foo");
+        fixture.MakeATaggedCommit("2.0.0");
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("2.0.0-1", configuration);
+    }
+
+    [Test]
+    public void RetainsTargetAsPossibleHistoricalSourceBranch()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("main", "develop")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.Checkout("main");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main", removeBranchAfterMerging: true);
+
+        fixture.AssertFullSemver("1.0.1-3", configuration);
+    }
+
+    [Test]
     public void ResolvesInheritedIncrementFromHistoricalMergedBranchTip()
     {
         var configuration = GitFlowConfigurationBuilder.New
@@ -272,6 +411,38 @@ public class PreventIncrementOfMergedBranchScenarios
         fixture.MergeTo("main");
         fixture.Checkout("feature/foo");
         fixture.MergeTo("support", removeBranchAfterMerging: true);
+        fixture.Checkout("main");
+
+        fixture.AssertFullSemver("1.1.0-3", configuration);
+    }
+
+    [Test]
+    public void ResolvesRetainedInheritedBranchFromHistoricalSource()
+    {
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", builder => builder
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true)
+            ).WithBranch("develop", builder => builder
+                .WithIncrement(IncrementStrategy.Minor)
+            ).WithBranch("support", builder => builder
+                .WithRegularExpression("^support$")
+                .WithIncrement(IncrementStrategy.Major)
+            ).WithBranch("feature", builder => builder
+                .WithIncrement(IncrementStrategy.Inherit)
+                .WithSourceBranches("develop", "support")
+            ).Build();
+
+        using var fixture = new EmptyRepositoryFixture("main");
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.CreateBranch("support");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/foo");
+        fixture.MakeACommit();
+        fixture.MergeTo("main");
+        fixture.Checkout("feature/foo");
+        fixture.MergeTo("support");
         fixture.Checkout("main");
 
         fixture.AssertFullSemver("1.1.0-3", configuration);

--- a/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -49,7 +49,7 @@ public class PullRequestScenarios : TestBase
         fixture.MergeNoFF("feature/foo");
 
         // ✅ succeeds as expected
-        fixture.AssertFullSemver("2.0.0-2", configuration);
+        fixture.AssertFullSemver("1.1.0-2", configuration);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/IntegrationTests/ShaLabelScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ShaLabelScenarios.cs
@@ -105,6 +105,47 @@ public class ShaLabelScenarios : TestBase
         actual.Sha.ShouldBe(fixture.Repository.Head.Tip.Sha);
     }
 
+    [TestCase("managed", "ShortSha")]
+    [TestCase("libgit2", "ShortSha")]
+    [TestCase("managed", "Sha")]
+    [TestCase("libgit2", "Sha")]
+    public void MergedSourceLabelUsesCalculationCommitForHistoryReset(string backend, string placeholder)
+    {
+        using var backendScope = new BackendScope(backend);
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/topic");
+        fixture.MakeACommit("source change +semver: major");
+        var sourceSha = fixture.Repository.Head.Tip.Sha;
+        fixture.MergeTo("main");
+        var currentSha = fixture.Repository.Head.Tip.Sha;
+        var label = "ci-sha" + (placeholder == "Sha" ? currentSha : currentSha[..7]);
+        fixture.Repository.Tags.Add($"0.9.0-{label}.1", sourceSha);
+
+        IGitVersionConfiguration Configuration(string sourceLabel) => GitFlowConfigurationBuilder.New
+            .WithBranch("main", b => b
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementOfMergedBranch(true))
+            .WithBranch("feature", b => b
+                .WithLabel(sourceLabel)
+                .WithIncrement(IncrementStrategy.Patch)
+                .WithPreventIncrementWhenBranchMerged(false))
+            .Build();
+
+        var literal = fixture.GetVersion(Configuration(label));
+        var actual = fixture.GetVersion(Configuration($"ci-sha{{{placeholder}}}"));
+
+        currentSha.ShouldNotBe(sourceSha);
+        literal.FullSemVer.ShouldBe("1.0.1-2");
+        actual.FullSemVer.ShouldBe(literal.FullSemVer);
+
+        fixture.MakeACommit();
+        var historical = fixture.GetVersion(
+            Configuration($"ci-sha{{{placeholder}}}"), commitId: currentSha);
+        historical.Sha.ShouldBe(currentSha);
+        historical.FullSemVer.ShouldBe(actual.FullSemVer);
+    }
+
     private sealed class BackendScope : IDisposable
     {
         private readonly string? original = System.Environment.GetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName);

--- a/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/VersionInMergedBranchNameScenarios.cs
@@ -25,9 +25,9 @@ public class VersionInMergedBranchNameScenarios : TestBase
         fixture.AssertFullSemver("1.1.0-alpha.5");
     }
 
-    [TestCase("release")]
-    [TestCase("hotfix")]
-    public void DoesNotTakeVersionFromBranchWithAccidentalVersion(string branch)
+    [TestCase("release", "1.1.0-2")]
+    [TestCase("hotfix", "1.0.1-2")]
+    public void DoesNotTakeVersionFromBranchWithAccidentalVersion(string branch, string expectedVersion)
     {
         using var fixture = new EmptyRepositoryFixture();
 
@@ -37,7 +37,7 @@ public class VersionInMergedBranchNameScenarios : TestBase
         fixture.Checkout("main");
         fixture.MergeNoFF($"{branch}/downgrade-some-lib-to-3.2.1");
 
-        fixture.AssertFullSemver("1.0.1-2");
+        fixture.AssertFullSemver(expectedVersion);
     }
 
     [Test]

--- a/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
@@ -36,16 +36,33 @@ public class IncrementStrategyFinderTests
 
     private sealed class StubTaggedSemanticVersionRepository : ITaggedSemanticVersionRepository
     {
-        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfBranch(
-            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersionsOfBranch(
+            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
+        {
+            _ = branch;
+            _ = tagPrefix;
+            _ = format;
+            _ = ignore;
             throw new NotSupportedException();
+        }
 
-        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfMergeTarget(
-            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersionsOfMergeTarget(
+            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
+        {
+            _ = branch;
+            _ = tagPrefix;
+            _ = format;
+            _ = ignore;
             throw new NotSupportedException();
+        }
 
-        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(
-            string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersions(
+            string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
+        {
+            _ = tagPrefix;
+            _ = format;
+            _ = ignore;
             throw new NotSupportedException();
+        }
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
@@ -15,10 +15,12 @@ public class IncrementStrategyFinderTests
         commit.Sha.Returns("0123456789012345678901234567890123456789");
         commit.Message.Returns("feature: custom increment");
 
+        var repositoryStore = Substitute.For<IRepositoryStore>();
         var finder = new IncrementStrategyFinder(
             new(() => throw new InvalidOperationException()),
-            Substitute.For<IRepositoryStore>(),
-            new StubTaggedSemanticVersionRepository(),
+            repositoryStore,
+            new TaggedSemanticVersionRepository(
+                NullLogger<TaggedSemanticVersionRepository>.Instance, repositoryStore),
             Substitute.For<IEffectiveBranchConfigurationFinder>(),
             Substitute.For<IEnvironment>());
         var nonMatchingConfiguration = GitFlowConfigurationBuilder.New
@@ -32,37 +34,5 @@ public class IncrementStrategyFinderTests
             .ShouldBe(VersionField.None);
         finder.GetIncrementForcedByCommit(commit, matchingConfiguration).Increment
             .ShouldBe(VersionField.Minor);
-    }
-
-    private sealed class StubTaggedSemanticVersionRepository : ITaggedSemanticVersionRepository
-    {
-        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersionsOfBranch(
-            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
-        {
-            _ = branch;
-            _ = tagPrefix;
-            _ = format;
-            _ = ignore;
-            throw new NotSupportedException();
-        }
-
-        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersionsOfMergeTarget(
-            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
-        {
-            _ = branch;
-            _ = tagPrefix;
-            _ = format;
-            _ = ignore;
-            throw new NotSupportedException();
-        }
-
-        ILookup<ICommit, SemanticVersionWithTag> ITaggedSemanticVersionRepository.GetTaggedSemanticVersions(
-            string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore)
-        {
-            _ = tagPrefix;
-            _ = format;
-            _ = ignore;
-            throw new NotSupportedException();
-        }
     }
 }

--- a/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
+++ b/src/GitVersion.Core.Tests/VersionCalculation/IncrementStrategyFinderTests.cs
@@ -1,0 +1,51 @@
+using GitVersion.Configuration;
+using GitVersion.Git;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Tests.VersionCalculation;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class IncrementStrategyFinderTests
+{
+    [Test]
+    public void ParsesCachedCommitWithTheRequestedConfiguration()
+    {
+        var commit = Substitute.For<ICommit>();
+        commit.Sha.Returns("0123456789012345678901234567890123456789");
+        commit.Message.Returns("feature: custom increment");
+
+        var finder = new IncrementStrategyFinder(
+            new(() => throw new InvalidOperationException()),
+            Substitute.For<IRepositoryStore>(),
+            new StubTaggedSemanticVersionRepository(),
+            Substitute.For<IEffectiveBranchConfigurationFinder>(),
+            Substitute.For<IEnvironment>());
+        var nonMatchingConfiguration = GitFlowConfigurationBuilder.New
+            .WithMinorVersionBumpMessage("^minor:")
+            .Build();
+        var matchingConfiguration = GitFlowConfigurationBuilder.New
+            .WithMinorVersionBumpMessage("^feature:")
+            .Build();
+
+        finder.GetIncrementForcedByCommit(commit, nonMatchingConfiguration).Increment
+            .ShouldBe(VersionField.None);
+        finder.GetIncrementForcedByCommit(commit, matchingConfiguration).Increment
+            .ShouldBe(VersionField.Minor);
+    }
+
+    private sealed class StubTaggedSemanticVersionRepository : ITaggedSemanticVersionRepository
+    {
+        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfBranch(
+            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+            throw new NotSupportedException();
+
+        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersionsOfMergeTarget(
+            IBranch branch, string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+            throw new NotSupportedException();
+
+        public ILookup<ICommit, SemanticVersionWithTag> GetTaggedSemanticVersions(
+            string? tagPrefix, SemanticVersionFormat format, IIgnoreConfiguration ignore) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -64,7 +64,9 @@ internal sealed class EffectiveBranchConfigurationFinder(ILogger<EffectiveBranch
         foreach (var sourceBranch in sourceBranches)
         {
             foreach (var effectiveConfiguration
-                in GetEffectiveConfigurationsRecursive(sourceBranch, configuration, branchConfiguration, traversedBranches, resolvePullRequestTarget: false))
+                in GetEffectiveConfigurationsRecursive(
+                    sourceBranch, configuration, branchConfiguration,
+                    new(traversedBranches, traversedBranches.Comparer), resolvePullRequestTarget: false))
             {
                 yield return effectiveConfiguration;
             }

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -99,8 +99,11 @@ internal class IncrementStrategyFinder(
         ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement,
         EffectiveConfiguration targetConfiguration, string? targetLabel, CommitMessageIncrement targetIncrement)
     {
+        var commitLog = this.repositoryStore
+            .GetCommitLog(baseVersionSource, currentCommit, targetConfiguration.Ignore);
+        var includedCommits = commitLog.Select(commit => commit.Sha).ToHashSet();
         var history = GetFirstParentCommitHistory(
-            currentCommit, baseVersionSource, targetConfiguration).ToArray();
+            currentCommit, baseVersionSource, targetConfiguration, includedCommits).ToArray();
 
         if (!history.Any(item => item.MergedBranch is not null))
         {
@@ -117,6 +120,9 @@ internal class IncrementStrategyFinder(
                 targetConfiguration.Ignore)
             .Select(commit => commit.Sha)
             .ToHashSet();
+        var commitOrder = commitLog
+            .Select((commit, index) => (commit.Sha, Index: index))
+            .ToDictionary(item => item.Sha, item => item.Index);
         var defaultTargetIncrement = DetermineIncrementedField(
             commitMessageIncrement: null, shouldIncrement, targetConfiguration).Increment;
         List<ICommit> targetSegment = [];
@@ -137,7 +143,7 @@ internal class IncrementStrategyFinder(
             if (targetSegment.Count != 0)
             {
                 yield return GetTargetIncrement(
-                    targetSegment, targetCommitHistory, shouldIncrement, targetConfiguration);
+                    targetSegment, targetCommitHistory, commitOrder, shouldIncrement, targetConfiguration);
                 targetSegment.Clear();
             }
 
@@ -161,18 +167,14 @@ internal class IncrementStrategyFinder(
         if (targetSegment.Count != 0)
         {
             yield return GetTargetIncrement(
-                targetSegment, targetCommitHistory, shouldIncrement, targetConfiguration);
+                targetSegment, targetCommitHistory, commitOrder, shouldIncrement, targetConfiguration);
         }
     }
 
     private IEnumerable<CommitHistoryEntry> GetFirstParentCommitHistory(
-        ICommit currentCommit, ICommit? baseVersionSource, EffectiveConfiguration targetConfiguration)
+        ICommit currentCommit, ICommit? baseVersionSource, EffectiveConfiguration targetConfiguration,
+        IReadOnlySet<string> includedCommits)
     {
-        var commitLog = this.repositoryStore
-            .GetCommitLog(baseVersionSource, currentCommit, targetConfiguration.Ignore)
-            .Select(commit => commit.Sha)
-            .ToHashSet();
-
         for (ICommit? commit = currentCommit; commit is not null; commit = commit.Parents.FirstOrDefault())
         {
             if (baseVersionSource?.Equals(commit) == true)
@@ -180,7 +182,7 @@ internal class IncrementStrategyFinder(
                 yield break;
             }
 
-            var isCommitIncluded = commitLog.Contains(commit.Sha);
+            var isCommitIncluded = includedCommits.Contains(commit.Sha);
             ReferenceName? mergedBranch = null;
             if (isCommitIncluded
                 && commit.IsMergeCommit
@@ -215,9 +217,16 @@ internal class IncrementStrategyFinder(
 
     private CommitMessageIncrement GetTargetIncrement(
         IEnumerable<ICommit> targetCommits, IReadOnlySet<string> targetCommitHistory,
+        IReadOnlyDictionary<string, int> commitOrder,
         bool shouldIncrement, EffectiveConfiguration targetConfiguration) =>
         DetermineIncrementedField(
-            FindCommitMessageIncrement(targetConfiguration, targetCommits, targetCommitHistory),
+            FindCommitMessageIncrement(
+                targetConfiguration,
+                targetCommits
+                    .Where(commit => targetCommitHistory.Contains(commit.Sha))
+                    .DistinctBy(commit => commit.Sha)
+                    .OrderBy(commit => commitOrder[commit.Sha]),
+                targetCommitHistory),
             shouldIncrement,
             targetConfiguration);
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -16,10 +16,11 @@ internal class IncrementStrategyFinder(
     private readonly Dictionary<string, CommitMessageIncrement?> commitIncrementCache = [];
     private readonly Dictionary<(string Commit, bool IsMergedTipBaseVersionSource, EffectiveConfiguration Target),
         MergedBranchIncrement[]> mergedBranchIncrementCache = [];
-    private readonly Dictionary<(string Branch, string? Tip), EffectiveBranchConfiguration[]> effectiveBranchConfigurationCache = [];
+    private readonly Dictionary<(string Branch, string? Tip), EffectiveConfiguration[]> effectiveConfigurationCache = [];
     private readonly Dictionary<string, HashSet<string>> firstParentHistoryCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
+    private readonly Dictionary<string, bool> linearMainBranchHistoryCache = [];
 
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
@@ -38,9 +39,7 @@ internal class IncrementStrategyFinder(
         var targetIncrement = DetermineIncrementedFieldInternal(
             currentCommit, baseVersionSource, shouldIncrement, configuration, label);
 
-        if (!configuration.IsMainBranch
-            || !configuration.TrackMergeMessage
-            || Context.Configuration.GetBranchConfiguration(Context.CurrentBranch.Name).IsMainBranch != true)
+        if (!configuration.TrackMergeMessage || !HasLinearMainBranchHistory(currentCommit))
         {
             return targetIncrement.Increment;
         }
@@ -286,10 +285,7 @@ internal class IncrementStrategyFinder(
 
         if (existingBranch is not null)
         {
-            var configurations = GetEffectiveBranchConfigurations(existingBranch)
-                .Select(candidate => candidate.Value)
-                .Distinct()
-                .ToArray();
+            var configurations = GetEffectiveConfigurations(existingBranch);
             if (configurations.Length != 0)
             {
                 return configurations;
@@ -304,9 +300,9 @@ internal class IncrementStrategyFinder(
         var inheritedConfigurations = FindClosestSourceBranches(
                 mergedBranchTip, sourceBranchConfiguration, Context.Configuration,
                 this.repositoryStore)
-            .SelectMany(GetEffectiveBranchConfigurations)
+            .SelectMany(source => GetEffectiveConfigurations(source.Branch, source.Tip))
             .Select(source => new EffectiveConfiguration(
-                Context.Configuration, sourceBranchConfiguration, source.Value))
+                Context.Configuration, sourceBranchConfiguration, source))
             .Distinct()
             .ToArray();
 
@@ -315,14 +311,60 @@ internal class IncrementStrategyFinder(
             : [Context.Configuration.GetEffectiveConfiguration(mergedBranch, targetConfiguration)];
     }
 
-    private EffectiveBranchConfiguration[] GetEffectiveBranchConfigurations(IBranch branch) =>
-        this.effectiveBranchConfigurationCache.GetOrAdd(
-            (branch.Name.ToString(), branch.Tip?.Sha),
-            () => [.. this.effectiveBranchConfigurationFinder
-                .GetConfigurations(branch, Context.Configuration)
-            ]);
+    private EffectiveConfiguration[] GetEffectiveConfigurations(IBranch branch, ICommit? tip = null)
+    {
+        tip ??= branch.Tip;
+        return this.effectiveConfigurationCache.GetOrAdd(
+            (branch.Name.ToString(), tip?.Sha),
+            () => branch.Tip?.Equals(tip) == true
+                ? [.. this.effectiveBranchConfigurationFinder
+                    .GetConfigurations(branch, Context.Configuration)
+                    .Select(configuration => configuration.Value)
+                    .Distinct()]
+                : [.. GetHistoricalEffectiveConfigurations(
+                    branch, tip, new(StringComparer.OrdinalIgnoreCase)).Distinct()]
+        );
+    }
 
-    private IEnumerable<IBranch> FindClosestSourceBranches(
+    private IEnumerable<EffectiveConfiguration> GetHistoricalEffectiveConfigurations(
+        IBranch branch, ICommit? tip, HashSet<string> traversedBranches)
+    {
+        if (tip is null || !traversedBranches.Add(branch.Name.WithoutOrigin))
+        {
+            yield break;
+        }
+
+        var branchConfiguration = Context.Configuration.GetBranchConfiguration(branch.Name);
+        if (branchConfiguration.Increment != IncrementStrategy.Inherit)
+        {
+            yield return new(Context.Configuration, branchConfiguration);
+            yield break;
+        }
+
+        var sources = FindClosestSourceBranches(
+                tip, branchConfiguration, Context.Configuration, this.repositoryStore)
+            .ToArray();
+        if (sources.Length == 0)
+        {
+            if (Context.Configuration.Increment != IncrementStrategy.Inherit)
+            {
+                yield return new(Context.Configuration, branchConfiguration);
+            }
+            yield break;
+        }
+
+        foreach (var source in sources)
+        {
+            foreach (var parentConfiguration in GetHistoricalEffectiveConfigurations(
+                source.Branch, source.Tip, traversedBranches))
+            {
+                yield return new(
+                    Context.Configuration, branchConfiguration, parentConfiguration);
+            }
+        }
+    }
+
+    private IEnumerable<HistoricalSourceBranch> FindClosestSourceBranches(
         ICommit mergedBranchTip, IBranchConfiguration mergedBranchConfiguration,
         IGitVersionConfiguration configuration, IRepositoryStore repositoryStore)
     {
@@ -331,7 +373,7 @@ internal class IncrementStrategyFinder(
                 && IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
-        List<IBranch> result = [];
+        List<HistoricalSourceBranch> result = [];
         foreach (var candidate in candidates)
         {
             if (candidate.Tip is null)
@@ -339,28 +381,28 @@ internal class IncrementStrategyFinder(
                 continue;
             }
 
-            if (GetFirstParentSourceDistance(mergedBranchTip, candidate.Tip) is not { } distance)
+            if (FindFirstParentSource(mergedBranchTip, candidate.Tip) is not { } source)
             {
                 continue;
             }
-            if (distance < closestDistance)
+            if (source.Distance < closestDistance)
             {
-                closestDistance = distance;
+                closestDistance = source.Distance;
                 result.Clear();
             }
-            if (distance == closestDistance)
+            if (source.Distance == closestDistance)
             {
-                result.Add(candidate);
+                result.Add(new(candidate, source.Commit));
             }
         }
 
         return result
-            .GroupBy(candidate => candidate.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.MinBy(candidate => candidate.IsRemote))
-            .OfType<IBranch>();
+            .GroupBy(candidate => candidate.Branch.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.OrderBy(candidate => candidate.Branch.IsRemote).First());
     }
 
-    private int? GetFirstParentSourceDistance(ICommit mergedBranchTip, ICommit sourceBranchTip)
+    private (ICommit Commit, int Distance)? FindFirstParentSource(
+        ICommit mergedBranchTip, ICommit sourceBranchTip)
     {
         var sourceHistory = this.firstParentHistoryCache.GetOrAdd(sourceBranchTip.Sha, () =>
         {
@@ -377,12 +419,44 @@ internal class IncrementStrategyFinder(
         {
             if (sourceHistory.Contains(commit.Sha))
             {
-                return distance;
+                return (commit, distance);
             }
             distance++;
         }
         return null;
     }
+
+    private bool HasLinearMainBranchHistory(ICommit commit) =>
+        this.linearMainBranchHistoryCache.GetOrAdd(commit.Sha, () =>
+        {
+            var closestDistance = int.MaxValue;
+            foreach (var branch in this.repositoryStore.Branches)
+            {
+                if (Context.Configuration.Ignore.IsBranchIgnored(branch.Name)
+                    || Context.Configuration.GetBranchConfiguration(branch.Name).IsMainBranch != true
+                    || branch.Tip is not { } tip
+                    || FindFirstParentSource(commit, tip) is not { } source)
+                {
+                    continue;
+                }
+                closestDistance = Math.Min(closestDistance, source.Distance);
+            }
+
+            if (closestDistance == int.MaxValue)
+            {
+                return false;
+            }
+
+            for (ICommit? current = commit; closestDistance > 0;
+                 current = current?.Parents.FirstOrDefault(), closestDistance--)
+            {
+                if (current?.IsMergeCommit == true)
+                {
+                    return false;
+                }
+            }
+            return true;
+        });
 
     private static bool IsConfiguredSourceBranch(
         IBranch candidate, IBranchConfiguration mergedBranchConfiguration,
@@ -409,6 +483,8 @@ internal class IncrementStrategyFinder(
 
     private readonly record struct MergedBranchIncrement(
         CommitMessageIncrement Increment, bool? PreventIncrementWhenBranchMerged);
+
+    private readonly record struct HistoricalSourceBranch(IBranch Branch, ICommit Tip);
 
     private readonly record struct CommitHistoryEntry(ICommit Commit, ReferenceName? MergedBranch);
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -111,7 +111,7 @@ internal class IncrementStrategyFinder(
         targetIncrement = DetermineIncrementedFieldInternal(
             currentCommit, baseVersionSource, shouldIncrement,
             targetConfiguration, targetLabel,
-            history.Select(item => item.Commit.Sha).ToHashSet());
+            history.SelectMany(item => item.TargetCommits).Select(commit => commit.Sha).ToHashSet());
 
         var targetCommitHistory = GetCommitHistory(
                 targetConfiguration.TagPrefixPattern,
@@ -133,7 +133,7 @@ internal class IncrementStrategyFinder(
 
             if (entry.MergedBranch is not { } mergedBranch)
             {
-                targetSegment.Add(entry.Commit);
+                targetSegment.AddRange(entry.TargetCommits);
                 continue;
             }
 
@@ -195,7 +195,21 @@ internal class IncrementStrategyFinder(
                 mergedBranch = mergeMessage.MergedBranch;
             }
 
-            yield return new(commit, mergedBranch);
+            ICommit[] targetCommits = [commit];
+            if (commit.IsMergeCommit && mergedBranch is null)
+            {
+                var firstParent = commit.Parents[0];
+                targetCommits =
+                [
+                    commit,
+                    .. commit.Parents.Skip(1)
+                        .SelectMany(parent => this.repositoryStore.GetCommitLog(
+                            firstParent, parent, targetConfiguration.Ignore))
+                        .DistinctBy(parent => parent.Sha)
+                ];
+            }
+
+            yield return new(commit, mergedBranch, targetCommits);
         }
     }
 
@@ -370,7 +384,8 @@ internal class IncrementStrategyFinder(
         IGitVersionConfiguration configuration, IRepositoryStore repositoryStore)
     {
         var candidates = repositoryStore.Branches
-            .Where(branch => !configuration.Ignore.IsBranchIgnored(branch.Name)
+            .Where(branch => (!configuration.Ignore.IsBranchIgnored(branch.Name)
+                    || branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin))
                 && IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
@@ -433,7 +448,7 @@ internal class IncrementStrategyFinder(
             var closestDistance = int.MaxValue;
             foreach (var branch in this.repositoryStore.Branches)
             {
-                if (Context.Configuration.GetBranchConfiguration(branch.Name).IsMainBranch != true
+                if (!Context.Configuration.GetEffectiveConfiguration(branch.Name).IsMainBranch
                     || branch.Tip is not { } tip
                     || FindFirstParentSource(commit, tip) is not { } source)
                 {
@@ -476,9 +491,9 @@ internal class IncrementStrategyFinder(
                 : sourceIncrement;
         }
 
-        return preventIncrementWhenBranchMerged is null
-            ? new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset)
-            : new(targetIncrement, VersionBumpNeedsToBeReset: false);
+        return preventIncrementWhenBranchMerged == true
+            ? new(targetIncrement, VersionBumpNeedsToBeReset: false)
+            : new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset);
     }
 
     private readonly record struct MergedBranchIncrement(
@@ -486,7 +501,8 @@ internal class IncrementStrategyFinder(
 
     private readonly record struct HistoricalSourceBranch(IBranch Branch, ICommit Tip);
 
-    private readonly record struct CommitHistoryEntry(ICommit Commit, ReferenceName? MergedBranch);
+    private readonly record struct CommitHistoryEntry(
+        ICommit Commit, ReferenceName? MergedBranch, IReadOnlyList<ICommit> TargetCommits);
 
     private CommitMessageIncrement? GetIncrementForCommits(EffectiveConfiguration configuration, ICommit[] commits)
     {

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -356,7 +356,8 @@ internal class IncrementStrategyFinder(
         foreach (var source in sources)
         {
             foreach (var parentConfiguration in GetHistoricalEffectiveConfigurations(
-                source.Branch, source.Tip, traversedBranches))
+                source.Branch, source.Tip,
+                new(traversedBranches, traversedBranches.Comparer)))
             {
                 yield return new(
                     Context.Configuration, branchConfiguration, parentConfiguration);
@@ -432,8 +433,7 @@ internal class IncrementStrategyFinder(
             var closestDistance = int.MaxValue;
             foreach (var branch in this.repositoryStore.Branches)
             {
-                if (Context.Configuration.Ignore.IsBranchIgnored(branch.Name)
-                    || Context.Configuration.GetBranchConfiguration(branch.Name).IsMainBranch != true
+                if (Context.Configuration.GetBranchConfiguration(branch.Name).IsMainBranch != true
                     || branch.Tip is not { } tip
                     || FindFirstParentSource(commit, tip) is not { } source)
                 {

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -382,7 +382,7 @@ internal class IncrementStrategyFinder(
     {
         var candidates = repositoryStore.Branches
             .Where(branch => (!configuration.Ignore.IsBranchIgnored(branch.Name)
-                    || branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin))
+                    || IsCurrentOrLinearMainBranch(branch))
                 && IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
@@ -412,6 +412,21 @@ internal class IncrementStrategyFinder(
         return result
             .GroupBy(candidate => candidate.Branch.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
             .Select(group => group.OrderBy(candidate => candidate.Branch.IsRemote).First());
+    }
+
+    private bool IsCurrentOrLinearMainBranch(IBranch branch)
+    {
+        if (branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin))
+        {
+            return true;
+        }
+        if (branch.Tip is not { } tip
+            || !GetEffectiveConfigurations(branch).Any(configuration => configuration.IsMainBranch)
+            || FindFirstParentSource(Context.CurrentCommit, tip) is not { } source)
+        {
+            return false;
+        }
+        return !ContainsMergeCommit(Context.CurrentCommit, source.Distance);
     }
 
     private (ICommit Commit, int Distance)? FindFirstParentSource(

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -111,21 +111,23 @@ internal class IncrementStrategyFinder(
         var commitOrder = commitLog
             .Select((commit, index) => (commit.Sha, Index: index))
             .ToDictionary(item => item.Sha, item => item.Index);
+        var orderedHistory = history
+            .SelectMany(entry => entry.MergedBranch is not null
+                ? [new IncrementHistoryEntry(entry.Commit, entry.MergedBranch)]
+                : entry.TargetCommits.Select(commit => new IncrementHistoryEntry(commit, MergedBranch: null)))
+            .Where(entry => targetCommitHistory.Contains(entry.Commit.Sha))
+            .GroupBy(entry => entry.Commit.Sha)
+            .Select(group => group.OrderByDescending(entry => entry.MergedBranch is not null).First())
+            .OrderBy(entry => commitOrder[entry.Commit.Sha]);
         var defaultTargetIncrement = DetermineIncrementedField(
             commitMessageIncrement: null, shouldIncrement, targetConfiguration).Increment;
         List<ICommit> targetSegment = [];
 
-        foreach (var entry in history)
+        foreach (var entry in orderedHistory)
         {
             if (entry.MergedBranch is not { } mergedBranch)
             {
-                targetSegment.AddRange(entry.TargetCommits
-                    .Where(commit => targetCommitHistory.Contains(commit.Sha)));
-                continue;
-            }
-
-            if (!targetCommitHistory.Contains(entry.Commit.Sha))
-            {
+                targetSegment.Add(entry.Commit);
                 continue;
             }
 
@@ -393,9 +395,15 @@ internal class IncrementStrategyFinder(
             .Distinct()
             .ToArray();
 
-        return inheritedConfigurations.Length != 0
-            ? inheritedConfigurations
-            : [Context.Configuration.GetEffectiveConfiguration(mergedBranch)];
+        if (inheritedConfigurations.Length != 0)
+        {
+            return inheritedConfigurations;
+        }
+
+        var fallbackConfiguration = Context.Configuration.GetEffectiveConfiguration(mergedBranch);
+        return fallbackConfiguration.Increment == IncrementStrategy.Inherit
+            ? []
+            : [fallbackConfiguration];
     }
 
     private EffectiveConfiguration[] GetEffectiveConfigurations(IBranch branch, ICommit? tip = null)
@@ -626,6 +634,8 @@ internal class IncrementStrategyFinder(
 
     private readonly record struct CommitHistoryEntry(
         ICommit Commit, ReferenceName? MergedBranch, IReadOnlyList<ICommit> TargetCommits);
+
+    private readonly record struct IncrementHistoryEntry(ICommit Commit, ReferenceName? MergedBranch);
 
     private readonly record struct CommitIncrementCacheKey(
         string Commit, Regex Major, Regex Minor, Regex Patch, Regex NoBump, Regex Reset);

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -21,6 +21,7 @@ internal class IncrementStrategyFinder(
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
     private readonly Dictionary<(string Commit, EffectiveConfiguration Target), bool> linearMainBranchHistoryCache = [];
+    private readonly Dictionary<string, HashSet<string>> reachableCommitCache = [];
 
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
@@ -175,9 +176,10 @@ internal class IncrementStrategyFinder(
         ICommit currentCommit, ICommit? baseVersionSource, EffectiveConfiguration targetConfiguration,
         IReadOnlySet<string> includedCommits)
     {
+        var commitsReachableFromBase = GetReachableCommitShas(baseVersionSource);
         for (ICommit? commit = currentCommit; commit is not null; commit = commit.Parents.FirstOrDefault())
         {
-            if (baseVersionSource?.Equals(commit) == true)
+            if (commitsReachableFromBase.Contains(commit.Sha))
             {
                 yield break;
             }
@@ -213,6 +215,36 @@ internal class IncrementStrategyFinder(
 
             yield return new(commit, mergedBranch, targetCommits);
         }
+    }
+
+    private HashSet<string> GetReachableCommitShas(ICommit? commit)
+    {
+        if (commit is null)
+        {
+            return [];
+        }
+
+        return this.reachableCommitCache.GetOrAdd(commit.Sha, () =>
+        {
+            HashSet<string> result = [];
+            var pending = new Stack<ICommit>();
+            pending.Push(commit);
+
+            while (pending.TryPop(out var current))
+            {
+                if (!result.Add(current.Sha))
+                {
+                    continue;
+                }
+
+                foreach (var parent in current.Parents)
+                {
+                    pending.Push(parent);
+                }
+            }
+
+            return result;
+        });
     }
 
     private CommitMessageIncrement GetTargetIncrement(

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -570,9 +570,9 @@ internal class IncrementStrategyFinder(
                 : sourceIncrement;
         }
 
-        return preventIncrementWhenBranchMerged == true
-            ? new(targetIncrement, VersionBumpNeedsToBeReset: false)
-            : new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset);
+        return preventIncrementWhenBranchMerged is null
+            ? new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset)
+            : new(targetIncrement, VersionBumpNeedsToBeReset: false);
     }
 
     private readonly record struct MergedBranchIncrement(

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -132,7 +132,8 @@ internal class IncrementStrategyFinder(
         {
             if (entry.MergedBranch is not { } mergedBranch)
             {
-                targetSegment.AddRange(entry.TargetCommits);
+                targetSegment.AddRange(entry.TargetCommits
+                    .Where(commit => targetCommitHistory.Contains(commit.Sha)));
                 continue;
             }
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -260,23 +260,6 @@ internal class IncrementStrategyFinder(
         return result;
     }
 
-    private CommitMessageIncrement? FindCommitMessageIncrement(
-        EffectiveConfiguration configuration, IEnumerable<ICommit> commits, IReadOnlySet<string> commitHistory)
-    {
-        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.Disabled)
-        {
-            return null;
-        }
-
-        commits = commits.Where(commit => commitHistory.Contains(commit.Sha));
-        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
-        {
-            commits = commits.Where(commit => commit.Parents.Count > 1);
-        }
-
-        return GetIncrementForCommits(configuration, [.. commits]);
-    }
-
     private bool ShouldIncrementTaggedCommit(
         ICommit commit, ICommit? baseVersionSource, EffectiveConfiguration configuration, string? label) =>
         !commit.Equals(baseVersionSource)
@@ -487,6 +470,23 @@ internal class IncrementStrategyFinder(
         return GetIncrementForCommits(configuration,
             commits: [.. commits]
         );
+    }
+
+    private CommitMessageIncrement? FindCommitMessageIncrement(
+        EffectiveConfiguration configuration, IEnumerable<ICommit> commits, IReadOnlySet<string> commitHistory)
+    {
+        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.Disabled)
+        {
+            return null;
+        }
+
+        commits = commits.Where(commit => commitHistory.Contains(commit.Sha));
+        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
+        {
+            commits = commits.Where(commit => commit.Parents.Count > 1);
+        }
+
+        return GetIncrementForCommits(configuration, [.. commits]);
     }
 
     private static Regex TryGetRegexOrDefault(string? messageRegex, Regex defaultRegex) =>

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -13,7 +13,7 @@ internal class IncrementStrategyFinder(
     IEnvironment environment)
     : IIncrementStrategyFinder
 {
-    private readonly Dictionary<string, CommitMessageIncrement?> commitIncrementCache = [];
+    private readonly Dictionary<CommitIncrementCacheKey, CommitMessageIncrement?> commitIncrementCache = [];
     private readonly Dictionary<(string Commit, bool IsMergedTipBaseVersionSource, EffectiveConfiguration Target),
         MergedBranchIncrement[]> mergedBranchIncrementCache = [];
     private readonly Dictionary<(string Branch, string? Tip), EffectiveConfiguration[]> effectiveConfigurationCache = [];
@@ -108,11 +108,6 @@ internal class IncrementStrategyFinder(
             yield break;
         }
 
-        targetIncrement = DetermineIncrementedFieldInternal(
-            currentCommit, baseVersionSource, shouldIncrement,
-            targetConfiguration, targetLabel,
-            history.SelectMany(item => item.TargetCommits).Select(commit => commit.Sha).ToHashSet());
-
         var targetCommitHistory = GetCommitHistory(
                 targetConfiguration.TagPrefixPattern,
                 targetConfiguration.SemanticVersionFormat,
@@ -122,6 +117,8 @@ internal class IncrementStrategyFinder(
                 targetConfiguration.Ignore)
             .Select(commit => commit.Sha)
             .ToHashSet();
+        var defaultTargetIncrement = DetermineIncrementedField(
+            commitMessageIncrement: null, shouldIncrement, targetConfiguration).Increment;
         List<ICommit> targetSegment = [];
 
         foreach (var entry in history)
@@ -157,7 +154,7 @@ internal class IncrementStrategyFinder(
             if (sourceIncrements.Length != 0)
             {
                 yield return ConsolidateMergedBranchIncrements(
-                    sourceIncrements, targetConfiguration, targetIncrement.Increment);
+                    sourceIncrements, targetConfiguration, defaultTargetIncrement);
             }
         }
 
@@ -504,6 +501,9 @@ internal class IncrementStrategyFinder(
     private readonly record struct CommitHistoryEntry(
         ICommit Commit, ReferenceName? MergedBranch, IReadOnlyList<ICommit> TargetCommits);
 
+    private readonly record struct CommitIncrementCacheKey(
+        string Commit, Regex Major, Regex Minor, Regex Patch, Regex NoBump, Regex Reset);
+
     private CommitMessageIncrement? GetIncrementForCommits(EffectiveConfiguration configuration, ICommit[] commits)
     {
         commits.NotNull();
@@ -672,8 +672,11 @@ internal class IncrementStrategyFinder(
             [.. this.repositoryStore.GetCommitsReacheableFromHead(headCommit, ignore)]);
 
     private CommitMessageIncrement? GetIncrementFromCommit(
-        ICommit commit, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex noBumpRegex, Regex versionBumpResetRegex) =>
-        this.commitIncrementCache.GetOrAdd(commit.Sha, () =>
+        ICommit commit, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex noBumpRegex, Regex versionBumpResetRegex)
+    {
+        var key = new CommitIncrementCacheKey(
+            commit.Sha, majorRegex, minorRegex, patchRegex, noBumpRegex, versionBumpResetRegex);
+        return this.commitIncrementCache.GetOrAdd(key, () =>
         {
             var increment = GetIncrementFromMessage(commit.Message, majorRegex, minorRegex, patchRegex, noBumpRegex);
             if (!increment.HasValue)
@@ -683,6 +686,7 @@ internal class IncrementStrategyFinder(
 
             return new(increment.Value, versionBumpResetRegex.IsMatch(commit.Message));
         });
+    }
 
     private static VersionField? GetIncrementFromMessage(string message, Regex majorRegex, Regex minorRegex, Regex patchRegex, Regex noBumpRegex)
     {

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -123,14 +123,14 @@ internal class IncrementStrategyFinder(
 
         foreach (var entry in history)
         {
-            if (!targetCommitHistory.Contains(entry.Commit.Sha))
-            {
-                continue;
-            }
-
             if (entry.MergedBranch is not { } mergedBranch)
             {
                 targetSegment.AddRange(entry.TargetCommits);
+                continue;
+            }
+
+            if (!targetCommitHistory.Contains(entry.Commit.Sha))
+            {
                 continue;
             }
 
@@ -179,31 +179,34 @@ internal class IncrementStrategyFinder(
             {
                 yield break;
             }
-            if (!commitLog.Contains(commit.Sha))
-            {
-                continue;
-            }
 
+            var isCommitIncluded = commitLog.Contains(commit.Sha);
             ReferenceName? mergedBranch = null;
-            if (commit.IsMergeCommit
+            if (isCommitIncluded
+                && commit.IsMergeCommit
                 && commit.Parents.Count == 2
                 && MergeMessage.TryParse(commit, Context.Configuration, out var mergeMessage))
             {
                 mergedBranch = mergeMessage.MergedBranch;
             }
 
-            ICommit[] targetCommits = [commit];
+            ICommit[] targetCommits = isCommitIncluded ? [commit] : [];
             if (commit.IsMergeCommit && mergedBranch is null)
             {
                 var firstParent = commit.Parents[0];
                 targetCommits =
                 [
-                    commit,
+                    .. targetCommits,
                     .. commit.Parents.Skip(1)
                         .SelectMany(parent => this.repositoryStore.GetCommitLog(
                             firstParent, parent, targetConfiguration.Ignore))
                         .DistinctBy(parent => parent.Sha)
                 ];
+            }
+
+            if (targetCommits.Length == 0)
+            {
+                continue;
             }
 
             yield return new(commit, mergedBranch, targetCommits);

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -20,7 +20,7 @@ internal class IncrementStrategyFinder(
     private readonly Dictionary<string, HashSet<string>> firstParentHistoryCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
-    private readonly Dictionary<string, bool> linearMainBranchHistoryCache = [];
+    private readonly Dictionary<(string Commit, EffectiveConfiguration Target), bool> linearMainBranchHistoryCache = [];
 
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
@@ -39,7 +39,7 @@ internal class IncrementStrategyFinder(
         var targetIncrement = DetermineIncrementedFieldInternal(
             currentCommit, baseVersionSource, shouldIncrement, configuration, label);
 
-        if (!configuration.TrackMergeMessage || !HasLinearMainBranchHistory(currentCommit))
+        if (!configuration.TrackMergeMessage || !HasLinearMainBranchHistory(currentCommit, configuration))
         {
             return targetIncrement.Increment;
         }
@@ -439,13 +439,23 @@ internal class IncrementStrategyFinder(
         return null;
     }
 
-    private bool HasLinearMainBranchHistory(ICommit commit) =>
-        this.linearMainBranchHistoryCache.GetOrAdd(commit.Sha, () =>
+    private bool HasLinearMainBranchHistory(ICommit commit, EffectiveConfiguration targetConfiguration)
+    {
+        if (IsPullRequestBranch(Context.CurrentBranch, Context.Configuration))
+        {
+            return false;
+        }
+
+        return this.linearMainBranchHistoryCache.GetOrAdd((commit.Sha, targetConfiguration), () =>
         {
             var closestDistance = int.MaxValue;
             foreach (var branch in this.repositoryStore.Branches)
             {
-                if (!Context.Configuration.GetEffectiveConfiguration(branch.Name).IsMainBranch
+                var isCurrentBranch = branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin);
+                var isMainBranch = isCurrentBranch
+                    ? targetConfiguration.IsMainBranch
+                    : GetEffectiveConfigurations(branch).Any(configuration => configuration.IsMainBranch);
+                if (!isMainBranch
                     || branch.Tip is not { } tip
                     || FindFirstParentSource(commit, tip) is not { } source)
                 {
@@ -469,6 +479,12 @@ internal class IncrementStrategyFinder(
             }
             return true;
         });
+    }
+
+    private static bool IsPullRequestBranch(IBranch branch, IGitVersionConfiguration configuration) =>
+        branch.Name.IsPullRequest
+        || configuration.Branches.TryGetValue(ConfigurationConstants.PullRequestBranchKey, out var pullRequestConfiguration)
+        && pullRequestConfiguration.IsMatch(branch.Name.WithoutOrigin);
 
     private static bool IsConfiguredSourceBranch(
         IBranch candidate, IBranchConfiguration mergedBranchConfiguration,

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -6,16 +6,27 @@ using GitVersion.Git;
 namespace GitVersion.VersionCalculation;
 
 internal class IncrementStrategyFinder(
+    Lazy<GitVersionContext> contextLazy,
     IRepositoryStore repositoryStore,
-    ITaggedSemanticVersionRepository taggedSemanticVersionRepository)
+    ITaggedSemanticVersionRepository taggedSemanticVersionRepository,
+    IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder,
+    IEnvironment environment)
     : IIncrementStrategyFinder
 {
     private readonly Dictionary<string, CommitMessageIncrement?> commitIncrementCache = [];
+    private readonly Dictionary<(string Commit, EffectiveConfiguration Target), VersionField[]> mergedBranchIncrementCache = [];
+    private readonly Dictionary<(string Branch, string? Tip), EffectiveBranchConfiguration[]> effectiveBranchConfigurationCache = [];
+    private readonly Dictionary<string, HashSet<string>> firstParentHistoryCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
 
+    private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly ITaggedSemanticVersionRepository taggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
+    private readonly IEffectiveBranchConfigurationFinder effectiveBranchConfigurationFinder = effectiveBranchConfigurationFinder.NotNull();
+    private readonly IEnvironment environment = environment.NotNull();
+
+    private GitVersionContext Context => this.contextLazy.Value;
 
     public VersionField DetermineIncrementedField(
         ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement, EffectiveConfiguration configuration, string? label)
@@ -23,7 +34,31 @@ internal class IncrementStrategyFinder(
         currentCommit.NotNull();
         configuration.NotNull();
 
-        var commitMessageIncrement = FindCommitMessageIncrement(configuration, baseVersionSource, currentCommit, label);
+        var targetIncrement = DetermineIncrementedFieldInternal(
+            currentCommit, baseVersionSource, shouldIncrement, configuration, label);
+
+        if (!configuration.IsMainBranch
+            || !configuration.TrackMergeMessage
+            || Context.Configuration.GetBranchConfiguration(Context.CurrentBranch.Name).IsMainBranch != true)
+        {
+            return targetIncrement;
+        }
+
+        var increments = GetIncrementsFromCommitHistory(
+            currentCommit, baseVersionSource, shouldIncrement, configuration, label, targetIncrement).ToArray();
+
+        return increments.Length == 0
+            ? targetIncrement
+            : increments.Aggregate(VersionField.None, (result, increment) => result.Consolidate(increment));
+    }
+
+    private VersionField DetermineIncrementedFieldInternal(
+        ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement,
+        EffectiveConfiguration configuration, string? label,
+        IReadOnlySet<string>? includedCommits = null)
+    {
+        var commitMessageIncrement = FindCommitMessageIncrement(
+            configuration, baseVersionSource, currentCommit, label, includedCommits);
 
         var defaultIncrement = configuration.Increment.ToVersionField();
 
@@ -42,6 +77,227 @@ internal class IncrementStrategyFinder(
         }
 
         return commitMessageIncrement.Value.Increment;
+    }
+
+    private IEnumerable<VersionField> GetIncrementsFromCommitHistory(
+        ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement,
+        EffectiveConfiguration targetConfiguration, string? targetLabel, VersionField targetIncrement)
+    {
+        var configuration = Context.Configuration;
+        var commitLog = this.repositoryStore
+            .GetCommitLog(baseVersionSource, currentCommit, targetConfiguration.Ignore)
+            .Select(commit => commit.Sha)
+            .ToHashSet();
+        List<ICommit> targetCommits = [];
+        Dictionary<string, (ICommit Commit, ReferenceName MergedBranch)> mergedBranches = [];
+
+        for (ICommit? commit = currentCommit; commit is not null; commit = commit.Parents.FirstOrDefault())
+        {
+            if (baseVersionSource?.Equals(commit) == true)
+            {
+                break;
+            }
+            if (!commitLog.Contains(commit.Sha))
+            {
+                continue;
+            }
+
+            targetCommits.Add(commit);
+            if (!commit.IsMergeCommit
+                || commit.Parents.Count != 2
+                || !MergeMessage.TryParse(commit, configuration, out var mergeMessage)
+                || mergeMessage.MergedBranch is not { } mergedBranch)
+            {
+                continue;
+            }
+
+            mergedBranches.Add(commit.Sha, (commit, mergedBranch));
+        }
+
+        if (mergedBranches.Count == 0)
+        {
+            yield return targetIncrement;
+            yield break;
+        }
+
+        var targetCommitShas = targetCommits.Select(commit => commit.Sha).ToHashSet();
+        targetIncrement = DetermineIncrementedFieldInternal(
+            currentCommit, baseVersionSource, shouldIncrement,
+            targetConfiguration, targetLabel, targetCommitShas);
+
+        var mergedBranchCommits = mergedBranches.Keys.ToHashSet();
+        var hasTargetContribution = targetCommits.Any(commit => !mergedBranchCommits.Contains(commit.Sha))
+            || FindCommitMessageIncrement(
+                targetConfiguration, baseVersionSource, currentCommit, targetLabel, mergedBranchCommits) is not null;
+        if (hasTargetContribution)
+        {
+            yield return targetIncrement;
+        }
+
+        foreach (var (commit, mergedBranch) in mergedBranches.Values)
+        {
+            var sourceBranchConfiguration = configuration.GetBranchConfiguration(mergedBranch);
+            var preventIncrementWhenBranchMerged = sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
+                ?? configuration.PreventIncrement.WhenBranchMerged;
+
+            foreach (var sourceIncrement in this.mergedBranchIncrementCache.GetOrAdd(
+                         (commit.Sha, targetConfiguration), () =>
+                         {
+                             var mergeBase = this.repositoryStore.FindMergeBase(commit.Parents[0], commit.Parents[1]);
+
+                             return [.. GetSourceConfigurations(
+                                     mergedBranch, commit.Parents[1], sourceBranchConfiguration, targetConfiguration)
+                                 .Select(sourceConfiguration => DetermineIncrementedFieldInternal(
+                                     currentCommit: commit.Parents[1],
+                                     baseVersionSource: mergeBase,
+                                     shouldIncrement: true,
+                                     configuration: sourceConfiguration,
+                                     label: sourceConfiguration.GetBranchSpecificLabel(
+                                         mergedBranch, null, this.environment)
+                                 ))];
+                         }))
+            {
+                yield return SelectIncrement(
+                    targetConfiguration.PreventIncrementOfMergedBranch,
+                    preventIncrementWhenBranchMerged,
+                    targetIncrement,
+                    sourceIncrement
+                );
+            }
+        }
+    }
+
+    private IEnumerable<EffectiveConfiguration> GetSourceConfigurations(
+        ReferenceName mergedBranch, ICommit mergedBranchTip,
+        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration targetConfiguration)
+    {
+        var existingBranch = this.repositoryStore.Branches
+            .Where(candidate => candidate.Name.EquivalentTo(mergedBranch.WithoutOrigin)
+                && candidate.Tip?.Equals(mergedBranchTip) == true)
+            .MinBy(candidate => candidate.IsRemote);
+
+        if (existingBranch is not null)
+        {
+            var configurations = GetEffectiveBranchConfigurations(existingBranch)
+                .Select(candidate => candidate.Value)
+                .Distinct()
+                .ToArray();
+            if (configurations.Length != 0)
+            {
+                return configurations;
+            }
+        }
+
+        if (sourceBranchConfiguration.Increment != IncrementStrategy.Inherit)
+        {
+            return [Context.Configuration.GetEffectiveConfiguration(mergedBranch)];
+        }
+
+        var inheritedConfigurations = FindClosestSourceBranches(
+                mergedBranchTip, sourceBranchConfiguration, Context.Configuration,
+                Context.CurrentBranch.Name, this.repositoryStore)
+            .SelectMany(GetEffectiveBranchConfigurations)
+            .Select(source => new EffectiveConfiguration(
+                Context.Configuration, sourceBranchConfiguration, source.Value))
+            .Distinct()
+            .ToArray();
+
+        return inheritedConfigurations.Length != 0
+            ? inheritedConfigurations
+            : [Context.Configuration.GetEffectiveConfiguration(mergedBranch, targetConfiguration)];
+    }
+
+    private EffectiveBranchConfiguration[] GetEffectiveBranchConfigurations(IBranch branch) =>
+        this.effectiveBranchConfigurationCache.GetOrAdd(
+            (branch.Name.ToString(), branch.Tip?.Sha),
+            () => [.. this.effectiveBranchConfigurationFinder
+                .GetConfigurations(branch, Context.Configuration)
+            ]);
+
+    private IEnumerable<IBranch> FindClosestSourceBranches(
+        ICommit mergedBranchTip, IBranchConfiguration mergedBranchConfiguration,
+        IGitVersionConfiguration configuration, ReferenceName currentBranch,
+        IRepositoryStore repositoryStore)
+    {
+        var candidates = repositoryStore.Branches
+            .Where(branch => IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration)
+                // The current target contains the merged tip through this merge and cannot be the
+                // topic's source. Other configured source branches may legitimately absorb it later.
+                && !branch.Name.EquivalentTo(currentBranch.WithoutOrigin))
+            .GroupBy(branch => branch.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.MinBy(branch => branch.IsRemote))
+            .OfType<IBranch>();
+
+        var closestDistance = int.MaxValue;
+        List<IBranch> result = [];
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Tip is null)
+            {
+                continue;
+            }
+
+            if (GetFirstParentSourceDistance(mergedBranchTip, candidate.Tip) is not { } distance)
+            {
+                continue;
+            }
+            if (distance < closestDistance)
+            {
+                closestDistance = distance;
+                result.Clear();
+            }
+            if (distance == closestDistance)
+            {
+                result.Add(candidate);
+            }
+        }
+
+        return result;
+    }
+
+    private int? GetFirstParentSourceDistance(ICommit mergedBranchTip, ICommit sourceBranchTip)
+    {
+        var sourceHistory = this.firstParentHistoryCache.GetOrAdd(sourceBranchTip.Sha, () =>
+        {
+            HashSet<string> result = [];
+            for (ICommit? commit = sourceBranchTip; commit is not null; commit = commit.Parents.FirstOrDefault())
+            {
+                result.Add(commit.Sha);
+            }
+            return result;
+        });
+
+        var distance = 0;
+        for (ICommit? commit = mergedBranchTip; commit is not null; commit = commit.Parents.FirstOrDefault())
+        {
+            if (sourceHistory.Contains(commit.Sha))
+            {
+                return distance;
+            }
+            distance++;
+        }
+        return null;
+    }
+
+    private static bool IsConfiguredSourceBranch(
+        IBranch candidate, IBranchConfiguration mergedBranchConfiguration,
+        IGitVersionConfiguration configuration) =>
+        mergedBranchConfiguration.SourceBranches.Any(sourceBranch =>
+            configuration.Branches.TryGetValue(sourceBranch, out var sourceBranchConfiguration)
+            && sourceBranchConfiguration.IsMatch(candidate.Name.WithoutOrigin));
+
+    private static VersionField SelectIncrement(
+        bool preventIncrementOfMergedBranch, bool? preventIncrementWhenBranchMerged,
+        VersionField targetIncrement, VersionField sourceIncrement)
+    {
+        if (preventIncrementOfMergedBranch)
+        {
+            return preventIncrementWhenBranchMerged == true ? targetIncrement : sourceIncrement;
+        }
+
+        return preventIncrementWhenBranchMerged is null
+            ? targetIncrement.Consolidate(sourceIncrement)
+            : targetIncrement;
     }
 
     private CommitMessageIncrement? GetIncrementForCommits(EffectiveConfiguration configuration, ICommit[] commits)
@@ -79,7 +335,8 @@ internal class IncrementStrategyFinder(
     }
 
     private CommitMessageIncrement? FindCommitMessageIncrement(
-        EffectiveConfiguration configuration, ICommit? baseVersionSource, ICommit currentCommit, string? label)
+        EffectiveConfiguration configuration, ICommit? baseVersionSource, ICommit currentCommit, string? label,
+        IReadOnlySet<string>? includedCommits = null)
     {
         if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.Disabled)
         {
@@ -94,6 +351,11 @@ internal class IncrementStrategyFinder(
             label: label,
             ignore: configuration.Ignore
         );
+
+        if (includedCommits is not null)
+        {
+            commits = commits.Where(commit => includedCommits.Contains(commit.Sha));
+        }
 
         if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
         {

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -266,18 +266,17 @@ internal class IncrementStrategyFinder(
                         mergedBranch, mergeCommit.Parents[1], sourceBranchConfiguration)
                     .Select(sourceConfiguration => GetMergedBranchIncrement(
                         mergeCommit.Parents[1], mergedBranch, baseVersionSource, mergeBase,
-                        sourceBranchConfiguration, sourceConfiguration, targetConfiguration))];
+                        sourceConfiguration, targetConfiguration))];
             });
 
     private MergedBranchIncrement GetMergedBranchIncrement(
         ICommit mergedBranchTip, ReferenceName mergedBranch, ICommit? baseVersionSource, ICommit? mergeBase,
-        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration,
-        EffectiveConfiguration targetConfiguration)
+        EffectiveConfiguration sourceConfiguration, EffectiveConfiguration targetConfiguration)
     {
         var sourceLabel = sourceConfiguration.GetBranchSpecificLabel(
             mergedBranch, null, this.environment);
         var preventIncrementWhenBranchMerged = ResolvePreventIncrementWhenBranchMerged(
-            sourceBranchConfiguration, sourceConfiguration, targetConfiguration);
+            sourceConfiguration, targetConfiguration);
         var shouldIncrement = ShouldIncrementTaggedCommit(
             mergedBranchTip, baseVersionSource, sourceConfiguration, sourceLabel);
         var sourceIncrement = DetermineIncrementedFieldInternal(
@@ -301,20 +300,16 @@ internal class IncrementStrategyFinder(
         return new(sourceIncrement, preventIncrementWhenBranchMerged);
     }
 
-    private bool? ResolvePreventIncrementWhenBranchMerged(
-        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration,
-        EffectiveConfiguration targetConfiguration)
+    private static bool ResolvePreventIncrementWhenBranchMerged(
+        EffectiveConfiguration sourceConfiguration, EffectiveConfiguration targetConfiguration)
     {
         // Updating a descendant from main carries main's version floor; it does not complete main as a source branch.
         if (sourceConfiguration.IsMainBranch && !targetConfiguration.IsMainBranch)
         {
-            return null;
+            return false;
         }
 
-        return sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
-            ?? (sourceBranchConfiguration.Increment == IncrementStrategy.Inherit
-                ? sourceConfiguration.PreventIncrementWhenBranchMerged
-                : Context.Configuration.PreventIncrement.WhenBranchMerged);
+        return sourceConfiguration.PreventIncrementWhenBranchMerged;
     }
 
     private static CommitMessageIncrement ConsolidateIncrements(
@@ -612,23 +607,19 @@ internal class IncrementStrategyFinder(
             && sourceBranchConfiguration.IsMatch(candidate.Name.WithoutOrigin));
 
     private static CommitMessageIncrement SelectIncrement(
-        bool preventIncrementOfMergedBranch, bool? preventIncrementWhenBranchMerged,
-        VersionField targetIncrement, CommitMessageIncrement sourceIncrement)
-    {
-        if (preventIncrementOfMergedBranch)
+        bool preventIncrementOfMergedBranch, bool preventIncrementWhenBranchMerged,
+        VersionField targetIncrement, CommitMessageIncrement sourceIncrement) =>
+        (preventIncrementOfMergedBranch, preventIncrementWhenBranchMerged) switch
         {
-            return preventIncrementWhenBranchMerged == true
-                ? new(targetIncrement, VersionBumpNeedsToBeReset: false)
-                : sourceIncrement;
-        }
-
-        return preventIncrementWhenBranchMerged is null
-            ? new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset)
-            : new(targetIncrement, VersionBumpNeedsToBeReset: false);
-    }
+            (false, false) => new(
+                targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset),
+            (false, true) => new(targetIncrement, VersionBumpNeedsToBeReset: false),
+            (true, false) => sourceIncrement,
+            (true, true) => new(targetIncrement, VersionBumpNeedsToBeReset: false)
+        };
 
     private readonly record struct MergedBranchIncrement(
-        CommitMessageIncrement Increment, bool? PreventIncrementWhenBranchMerged);
+        CommitMessageIncrement Increment, bool PreventIncrementWhenBranchMerged);
 
     private readonly record struct HistoricalSourceBranch(IBranch Branch, ICommit Tip);
 

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -127,6 +127,11 @@ internal class IncrementStrategyFinder(
 
         foreach (var entry in history)
         {
+            if (!targetCommitHistory.Contains(entry.Commit.Sha))
+            {
+                continue;
+            }
+
             if (entry.MergedBranch is not { } mergedBranch)
             {
                 targetSegment.Add(entry.Commit);
@@ -267,6 +272,7 @@ internal class IncrementStrategyFinder(
         || !this.taggedSemanticVersionRepository
             .GetTaggedSemanticVersions(
                 configuration.TagPrefixPattern, configuration.SemanticVersionFormat, configuration.Ignore)[commit]
+            .Where(versionWithTag => versionWithTag.Tag.Commit.When <= Context.CurrentCommit.When)
             .Any(versionWithTag => versionWithTag.Value.IsMatchForBranchSpecificLabel(label));
 
     private IEnumerable<EffectiveConfiguration> GetSourceConfigurations(
@@ -321,7 +327,8 @@ internal class IncrementStrategyFinder(
         IGitVersionConfiguration configuration, IRepositoryStore repositoryStore)
     {
         var candidates = repositoryStore.Branches
-            .Where(branch => IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
+            .Where(branch => !configuration.Ignore.IsBranchIgnored(branch.Name)
+                && IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
         List<IBranch> result = [];
@@ -501,6 +508,7 @@ internal class IncrementStrategyFinder(
             [.. this.taggedSemanticVersionRepository
                 .GetTaggedSemanticVersions(tagPrefix, semanticVersionFormat, ignore)
                 .SelectMany(versionWithTags => versionWithTags)
+                .Where(versionWithTag => versionWithTag.Tag.Commit.When <= Context.CurrentCommit.When)
                 .Where(versionWithTag => versionWithTag.Value.IsMatchForBranchSpecificLabel(label))
                 .Select(versionWithTag => versionWithTag.Tag.TargetSha)]
         );

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -14,7 +14,8 @@ internal class IncrementStrategyFinder(
     : IIncrementStrategyFinder
 {
     private readonly Dictionary<string, CommitMessageIncrement?> commitIncrementCache = [];
-    private readonly Dictionary<(string Commit, EffectiveConfiguration Target), VersionField[]> mergedBranchIncrementCache = [];
+    private readonly Dictionary<(string Commit, bool IsMergedTipBaseVersionSource, EffectiveConfiguration Target),
+        MergedBranchIncrement[]> mergedBranchIncrementCache = [];
     private readonly Dictionary<(string Branch, string? Tip), EffectiveBranchConfiguration[]> effectiveBranchConfigurationCache = [];
     private readonly Dictionary<string, HashSet<string>> firstParentHistoryCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
@@ -41,18 +42,28 @@ internal class IncrementStrategyFinder(
             || !configuration.TrackMergeMessage
             || Context.Configuration.GetBranchConfiguration(Context.CurrentBranch.Name).IsMainBranch != true)
         {
-            return targetIncrement;
+            return targetIncrement.Increment;
         }
 
         var increments = GetIncrementsFromCommitHistory(
-            currentCommit, baseVersionSource, shouldIncrement, configuration, label, targetIncrement).ToArray();
+            currentCommit, baseVersionSource, shouldIncrement, configuration, label, targetIncrement);
 
-        return increments.Length == 0
-            ? targetIncrement
-            : increments.Aggregate(VersionField.None, (result, increment) => result.Consolidate(increment));
+        var result = VersionField.None;
+        var hasIncrement = false;
+        foreach (var increment in increments)
+        {
+            hasIncrement = true;
+            result = result.Consolidate(increment.Increment);
+            if (increment.VersionBumpNeedsToBeReset)
+            {
+                break;
+            }
+        }
+
+        return hasIncrement ? result : targetIncrement.Increment;
     }
 
-    private VersionField DetermineIncrementedFieldInternal(
+    private CommitMessageIncrement DetermineIncrementedFieldInternal(
         ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement,
         EffectiveConfiguration configuration, string? label,
         IReadOnlySet<string>? includedCommits = null)
@@ -60,12 +71,18 @@ internal class IncrementStrategyFinder(
         var commitMessageIncrement = FindCommitMessageIncrement(
             configuration, baseVersionSource, currentCommit, label, includedCommits);
 
+        return DetermineIncrementedField(commitMessageIncrement, shouldIncrement, configuration);
+    }
+
+    private static CommitMessageIncrement DetermineIncrementedField(
+        CommitMessageIncrement? commitMessageIncrement, bool shouldIncrement, EffectiveConfiguration configuration)
+    {
         var defaultIncrement = configuration.Increment.ToVersionField();
 
         // use the default branch configuration increment strategy if there are no commit message overrides
         if (commitMessageIncrement == null)
         {
-            return shouldIncrement ? defaultIncrement : VersionField.None;
+            return new(shouldIncrement ? defaultIncrement : VersionField.None, VersionBumpNeedsToBeReset: false);
         }
 
         // don't increment for less than the branch configuration increment, if the absence of commit messages would have
@@ -73,99 +90,201 @@ internal class IncrementStrategyFinder(
         if (shouldIncrement && !commitMessageIncrement.Value.VersionBumpNeedsToBeReset
             && commitMessageIncrement.Value.Increment < defaultIncrement)
         {
-            return defaultIncrement;
+            return new(defaultIncrement, VersionBumpNeedsToBeReset: false);
         }
 
-        return commitMessageIncrement.Value.Increment;
+        return commitMessageIncrement.Value;
     }
 
-    private IEnumerable<VersionField> GetIncrementsFromCommitHistory(
+    private IEnumerable<CommitMessageIncrement> GetIncrementsFromCommitHistory(
         ICommit currentCommit, ICommit? baseVersionSource, bool shouldIncrement,
-        EffectiveConfiguration targetConfiguration, string? targetLabel, VersionField targetIncrement)
+        EffectiveConfiguration targetConfiguration, string? targetLabel, CommitMessageIncrement targetIncrement)
     {
-        var configuration = Context.Configuration;
+        var history = GetFirstParentCommitHistory(
+            currentCommit, baseVersionSource, targetConfiguration).ToArray();
+
+        if (!history.Any(item => item.MergedBranch is not null))
+        {
+            yield return targetIncrement;
+            yield break;
+        }
+
+        targetIncrement = DetermineIncrementedFieldInternal(
+            currentCommit, baseVersionSource, shouldIncrement,
+            targetConfiguration, targetLabel,
+            history.Select(item => item.Commit.Sha).ToHashSet());
+
+        var targetCommitHistory = GetCommitHistory(
+                targetConfiguration.TagPrefixPattern,
+                targetConfiguration.SemanticVersionFormat,
+                baseVersionSource,
+                currentCommit,
+                targetLabel,
+                targetConfiguration.Ignore)
+            .Select(commit => commit.Sha)
+            .ToHashSet();
+        List<ICommit> targetSegment = [];
+
+        foreach (var entry in history)
+        {
+            if (entry.MergedBranch is not { } mergedBranch)
+            {
+                targetSegment.Add(entry.Commit);
+                continue;
+            }
+
+            if (targetSegment.Count != 0)
+            {
+                yield return GetTargetIncrement(
+                    targetSegment, targetCommitHistory, shouldIncrement, targetConfiguration);
+                targetSegment.Clear();
+            }
+
+            var targetMergeMessageIncrement = FindCommitMessageIncrement(
+                targetConfiguration, [entry.Commit], targetCommitHistory);
+            if (targetMergeMessageIncrement is not null)
+            {
+                yield return DetermineIncrementedField(
+                    targetMergeMessageIncrement, shouldIncrement, targetConfiguration);
+            }
+
+            var sourceIncrements = GetMergedBranchIncrements(
+                entry.Commit, mergedBranch, baseVersionSource, targetConfiguration);
+            if (sourceIncrements.Length != 0)
+            {
+                yield return ConsolidateMergedBranchIncrements(
+                    sourceIncrements, targetConfiguration, targetIncrement.Increment);
+            }
+        }
+
+        if (targetSegment.Count != 0)
+        {
+            yield return GetTargetIncrement(
+                targetSegment, targetCommitHistory, shouldIncrement, targetConfiguration);
+        }
+    }
+
+    private IEnumerable<CommitHistoryEntry> GetFirstParentCommitHistory(
+        ICommit currentCommit, ICommit? baseVersionSource, EffectiveConfiguration targetConfiguration)
+    {
         var commitLog = this.repositoryStore
             .GetCommitLog(baseVersionSource, currentCommit, targetConfiguration.Ignore)
             .Select(commit => commit.Sha)
             .ToHashSet();
-        List<ICommit> targetCommits = [];
-        Dictionary<string, (ICommit Commit, ReferenceName MergedBranch)> mergedBranches = [];
 
         for (ICommit? commit = currentCommit; commit is not null; commit = commit.Parents.FirstOrDefault())
         {
             if (baseVersionSource?.Equals(commit) == true)
             {
-                break;
+                yield break;
             }
             if (!commitLog.Contains(commit.Sha))
             {
                 continue;
             }
 
-            targetCommits.Add(commit);
-            if (!commit.IsMergeCommit
-                || commit.Parents.Count != 2
-                || !MergeMessage.TryParse(commit, configuration, out var mergeMessage)
-                || mergeMessage.MergedBranch is not { } mergedBranch)
+            ReferenceName? mergedBranch = null;
+            if (commit.IsMergeCommit
+                && commit.Parents.Count == 2
+                && MergeMessage.TryParse(commit, Context.Configuration, out var mergeMessage))
             {
-                continue;
+                mergedBranch = mergeMessage.MergedBranch;
             }
 
-            mergedBranches.Add(commit.Sha, (commit, mergedBranch));
-        }
-
-        if (mergedBranches.Count == 0)
-        {
-            yield return targetIncrement;
-            yield break;
-        }
-
-        var targetCommitShas = targetCommits.Select(commit => commit.Sha).ToHashSet();
-        targetIncrement = DetermineIncrementedFieldInternal(
-            currentCommit, baseVersionSource, shouldIncrement,
-            targetConfiguration, targetLabel, targetCommitShas);
-
-        var mergedBranchCommits = mergedBranches.Keys.ToHashSet();
-        var hasTargetContribution = targetCommits.Any(commit => !mergedBranchCommits.Contains(commit.Sha))
-            || FindCommitMessageIncrement(
-                targetConfiguration, baseVersionSource, currentCommit, targetLabel, mergedBranchCommits) is not null;
-        if (hasTargetContribution)
-        {
-            yield return targetIncrement;
-        }
-
-        foreach (var (commit, mergedBranch) in mergedBranches.Values)
-        {
-            var sourceBranchConfiguration = configuration.GetBranchConfiguration(mergedBranch);
-            var preventIncrementWhenBranchMerged = sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
-                ?? configuration.PreventIncrement.WhenBranchMerged;
-
-            foreach (var sourceIncrement in this.mergedBranchIncrementCache.GetOrAdd(
-                         (commit.Sha, targetConfiguration), () =>
-                         {
-                             var mergeBase = this.repositoryStore.FindMergeBase(commit.Parents[0], commit.Parents[1]);
-
-                             return [.. GetSourceConfigurations(
-                                     mergedBranch, commit.Parents[1], sourceBranchConfiguration, targetConfiguration)
-                                 .Select(sourceConfiguration => DetermineIncrementedFieldInternal(
-                                     currentCommit: commit.Parents[1],
-                                     baseVersionSource: mergeBase,
-                                     shouldIncrement: true,
-                                     configuration: sourceConfiguration,
-                                     label: sourceConfiguration.GetBranchSpecificLabel(
-                                         mergedBranch, null, this.environment)
-                                 ))];
-                         }))
-            {
-                yield return SelectIncrement(
-                    targetConfiguration.PreventIncrementOfMergedBranch,
-                    preventIncrementWhenBranchMerged,
-                    targetIncrement,
-                    sourceIncrement
-                );
-            }
+            yield return new(commit, mergedBranch);
         }
     }
+
+    private CommitMessageIncrement GetTargetIncrement(
+        IEnumerable<ICommit> targetCommits, IReadOnlySet<string> targetCommitHistory,
+        bool shouldIncrement, EffectiveConfiguration targetConfiguration) =>
+        DetermineIncrementedField(
+            FindCommitMessageIncrement(targetConfiguration, targetCommits, targetCommitHistory),
+            shouldIncrement,
+            targetConfiguration);
+
+    private MergedBranchIncrement[] GetMergedBranchIncrements(
+        ICommit mergeCommit, ReferenceName mergedBranch, ICommit? baseVersionSource,
+        EffectiveConfiguration targetConfiguration) =>
+        this.mergedBranchIncrementCache.GetOrAdd(
+            (mergeCommit.Sha, mergeCommit.Parents[1].Equals(baseVersionSource), targetConfiguration), () =>
+            {
+                var sourceBranchConfiguration = Context.Configuration.GetBranchConfiguration(mergedBranch);
+                var mergeBase = this.repositoryStore.FindMergeBase(
+                    mergeCommit.Parents[0], mergeCommit.Parents[1]);
+
+                return [.. GetSourceConfigurations(
+                        mergedBranch, mergeCommit.Parents[1], sourceBranchConfiguration, targetConfiguration)
+                    .Select(sourceConfiguration => GetMergedBranchIncrement(
+                        mergeCommit.Parents[1], mergedBranch, baseVersionSource, mergeBase,
+                        sourceBranchConfiguration, sourceConfiguration))];
+            });
+
+    private MergedBranchIncrement GetMergedBranchIncrement(
+        ICommit mergedBranchTip, ReferenceName mergedBranch, ICommit? baseVersionSource, ICommit? mergeBase,
+        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration)
+    {
+        var sourceLabel = sourceConfiguration.GetBranchSpecificLabel(
+            mergedBranch, null, this.environment);
+        var preventIncrementWhenBranchMerged = sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
+            ?? (sourceBranchConfiguration.Increment == IncrementStrategy.Inherit
+                ? sourceConfiguration.PreventIncrementWhenBranchMerged
+                : Context.Configuration.PreventIncrement.WhenBranchMerged);
+        var sourceIncrement = DetermineIncrementedFieldInternal(
+            currentCommit: mergedBranchTip,
+            baseVersionSource: mergeBase,
+            shouldIncrement: ShouldIncrementTaggedCommit(
+                mergedBranchTip, baseVersionSource, sourceConfiguration, sourceLabel),
+            configuration: sourceConfiguration,
+            label: sourceLabel
+        );
+
+        return new(sourceIncrement, preventIncrementWhenBranchMerged);
+    }
+
+    private static CommitMessageIncrement ConsolidateMergedBranchIncrements(
+        IEnumerable<MergedBranchIncrement> sourceIncrements,
+        EffectiveConfiguration targetConfiguration, VersionField targetIncrement)
+    {
+        var result = new CommitMessageIncrement(VersionField.None, VersionBumpNeedsToBeReset: false);
+        foreach (var sourceIncrement in sourceIncrements)
+        {
+            result = result.Consolidate(SelectIncrement(
+                targetConfiguration.PreventIncrementOfMergedBranch,
+                sourceIncrement.PreventIncrementWhenBranchMerged,
+                targetIncrement,
+                sourceIncrement.Increment
+            ));
+        }
+
+        return result;
+    }
+
+    private CommitMessageIncrement? FindCommitMessageIncrement(
+        EffectiveConfiguration configuration, IEnumerable<ICommit> commits, IReadOnlySet<string> commitHistory)
+    {
+        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.Disabled)
+        {
+            return null;
+        }
+
+        commits = commits.Where(commit => commitHistory.Contains(commit.Sha));
+        if (configuration.CommitMessageIncrementing == CommitMessageIncrementMode.MergeMessageOnly)
+        {
+            commits = commits.Where(commit => commit.Parents.Count > 1);
+        }
+
+        return GetIncrementForCommits(configuration, [.. commits]);
+    }
+
+    private bool ShouldIncrementTaggedCommit(
+        ICommit commit, ICommit? baseVersionSource, EffectiveConfiguration configuration, string? label) =>
+        !commit.Equals(baseVersionSource)
+        || !configuration.PreventIncrementWhenCurrentCommitTagged
+        || !this.taggedSemanticVersionRepository
+            .GetTaggedSemanticVersions(
+                configuration.TagPrefixPattern, configuration.SemanticVersionFormat, configuration.Ignore)[commit]
+            .Any(versionWithTag => versionWithTag.Value.IsMatchForBranchSpecificLabel(label));
 
     private IEnumerable<EffectiveConfiguration> GetSourceConfigurations(
         ReferenceName mergedBranch, ICommit mergedBranchTip,
@@ -195,7 +314,7 @@ internal class IncrementStrategyFinder(
 
         var inheritedConfigurations = FindClosestSourceBranches(
                 mergedBranchTip, sourceBranchConfiguration, Context.Configuration,
-                Context.CurrentBranch.Name, this.repositoryStore)
+                this.repositoryStore)
             .SelectMany(GetEffectiveBranchConfigurations)
             .Select(source => new EffectiveConfiguration(
                 Context.Configuration, sourceBranchConfiguration, source.Value))
@@ -216,17 +335,10 @@ internal class IncrementStrategyFinder(
 
     private IEnumerable<IBranch> FindClosestSourceBranches(
         ICommit mergedBranchTip, IBranchConfiguration mergedBranchConfiguration,
-        IGitVersionConfiguration configuration, ReferenceName currentBranch,
-        IRepositoryStore repositoryStore)
+        IGitVersionConfiguration configuration, IRepositoryStore repositoryStore)
     {
         var candidates = repositoryStore.Branches
-            .Where(branch => IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration)
-                // The current target contains the merged tip through this merge and cannot be the
-                // topic's source. Other configured source branches may legitimately absorb it later.
-                && !branch.Name.EquivalentTo(currentBranch.WithoutOrigin))
-            .GroupBy(branch => branch.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.MinBy(branch => branch.IsRemote))
-            .OfType<IBranch>();
+            .Where(branch => IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
         List<IBranch> result = [];
@@ -252,7 +364,10 @@ internal class IncrementStrategyFinder(
             }
         }
 
-        return result;
+        return result
+            .GroupBy(candidate => candidate.Name.WithoutOrigin, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.MinBy(candidate => candidate.IsRemote))
+            .OfType<IBranch>();
     }
 
     private int? GetFirstParentSourceDistance(ICommit mergedBranchTip, ICommit sourceBranchTip)
@@ -286,19 +401,26 @@ internal class IncrementStrategyFinder(
             configuration.Branches.TryGetValue(sourceBranch, out var sourceBranchConfiguration)
             && sourceBranchConfiguration.IsMatch(candidate.Name.WithoutOrigin));
 
-    private static VersionField SelectIncrement(
+    private static CommitMessageIncrement SelectIncrement(
         bool preventIncrementOfMergedBranch, bool? preventIncrementWhenBranchMerged,
-        VersionField targetIncrement, VersionField sourceIncrement)
+        VersionField targetIncrement, CommitMessageIncrement sourceIncrement)
     {
         if (preventIncrementOfMergedBranch)
         {
-            return preventIncrementWhenBranchMerged == true ? targetIncrement : sourceIncrement;
+            return preventIncrementWhenBranchMerged == true
+                ? new(targetIncrement, VersionBumpNeedsToBeReset: false)
+                : sourceIncrement;
         }
 
         return preventIncrementWhenBranchMerged is null
-            ? targetIncrement.Consolidate(sourceIncrement)
-            : targetIncrement;
+            ? new(targetIncrement.Consolidate(sourceIncrement.Increment), sourceIncrement.VersionBumpNeedsToBeReset)
+            : new(targetIncrement, VersionBumpNeedsToBeReset: false);
     }
+
+    private readonly record struct MergedBranchIncrement(
+        CommitMessageIncrement Increment, bool? PreventIncrementWhenBranchMerged);
+
+    private readonly record struct CommitHistoryEntry(ICommit Commit, ReferenceName? MergedBranch);
 
     private CommitMessageIncrement? GetIncrementForCommits(EffectiveConfiguration configuration, ICommit[] commits)
     {

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -274,7 +274,7 @@ internal class IncrementStrategyFinder(
                     mergeCommit.Parents[0], mergeCommit.Parents[1]);
 
                 return [.. GetSourceConfigurations(
-                        mergedBranch, mergeCommit.Parents[1], sourceBranchConfiguration, targetConfiguration)
+                        mergedBranch, mergeCommit.Parents[1], sourceBranchConfiguration)
                     .Select(sourceConfiguration => GetMergedBranchIncrement(
                         mergeCommit.Parents[1], mergedBranch, baseVersionSource, mergeBase,
                         sourceBranchConfiguration, sourceConfiguration))];
@@ -332,7 +332,7 @@ internal class IncrementStrategyFinder(
 
     private IEnumerable<EffectiveConfiguration> GetSourceConfigurations(
         ReferenceName mergedBranch, ICommit mergedBranchTip,
-        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration targetConfiguration)
+        IBranchConfiguration sourceBranchConfiguration)
     {
         var existingBranch = this.repositoryStore.Branches
             .Where(candidate => candidate.Name.EquivalentTo(mergedBranch.WithoutOrigin)
@@ -364,7 +364,7 @@ internal class IncrementStrategyFinder(
 
         return inheritedConfigurations.Length != 0
             ? inheritedConfigurations
-            : [Context.Configuration.GetEffectiveConfiguration(mergedBranch, targetConfiguration)];
+            : [Context.Configuration.GetEffectiveConfiguration(mergedBranch)];
     }
 
     private EffectiveConfiguration[] GetEffectiveConfigurations(IBranch branch, ICommit? tip = null)

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -20,7 +20,7 @@ internal class IncrementStrategyFinder(
     private readonly Dictionary<string, HashSet<string>> firstParentHistoryCache = [];
     private readonly Dictionary<string, Dictionary<string, int>> headCommitsMapCache = [];
     private readonly Dictionary<string, ICommit[]> headCommitsCache = [];
-    private readonly Dictionary<(string Commit, EffectiveConfiguration Target), bool> linearMainBranchHistoryCache = [];
+    private readonly Dictionary<(string Commit, EffectiveConfiguration Target), bool> compatibleMainBranchHistoryCache = [];
     private readonly Dictionary<string, HashSet<string>> reachableCommitCache = [];
 
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
@@ -40,27 +40,14 @@ internal class IncrementStrategyFinder(
         var targetIncrement = DetermineIncrementedFieldInternal(
             currentCommit, baseVersionSource, shouldIncrement, configuration, label);
 
-        if (!configuration.TrackMergeMessage || !HasLinearMainBranchHistory(currentCommit, configuration))
+        if (!configuration.TrackMergeMessage || !HasCompatibleMainBranchHistory(currentCommit, configuration))
         {
             return targetIncrement.Increment;
         }
 
         var increments = GetIncrementsFromCommitHistory(
             currentCommit, baseVersionSource, shouldIncrement, configuration, label, targetIncrement);
-
-        var result = VersionField.None;
-        var hasIncrement = false;
-        foreach (var increment in increments)
-        {
-            hasIncrement = true;
-            result = result.Consolidate(increment.Increment);
-            if (increment.VersionBumpNeedsToBeReset)
-            {
-                break;
-            }
-        }
-
-        return hasIncrement ? result : targetIncrement.Increment;
+        return ConsolidateIncrements(increments, targetIncrement).Increment;
     }
 
     private CommitMessageIncrement DetermineIncrementedFieldInternal(
@@ -277,29 +264,73 @@ internal class IncrementStrategyFinder(
                         mergedBranch, mergeCommit.Parents[1], sourceBranchConfiguration)
                     .Select(sourceConfiguration => GetMergedBranchIncrement(
                         mergeCommit.Parents[1], mergedBranch, baseVersionSource, mergeBase,
-                        sourceBranchConfiguration, sourceConfiguration))];
+                        sourceBranchConfiguration, sourceConfiguration, targetConfiguration))];
             });
 
     private MergedBranchIncrement GetMergedBranchIncrement(
         ICommit mergedBranchTip, ReferenceName mergedBranch, ICommit? baseVersionSource, ICommit? mergeBase,
-        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration)
+        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration,
+        EffectiveConfiguration targetConfiguration)
     {
         var sourceLabel = sourceConfiguration.GetBranchSpecificLabel(
             mergedBranch, null, this.environment);
-        var preventIncrementWhenBranchMerged = sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
-            ?? (sourceBranchConfiguration.Increment == IncrementStrategy.Inherit
-                ? sourceConfiguration.PreventIncrementWhenBranchMerged
-                : Context.Configuration.PreventIncrement.WhenBranchMerged);
+        var preventIncrementWhenBranchMerged = ResolvePreventIncrementWhenBranchMerged(
+            sourceBranchConfiguration, sourceConfiguration, targetConfiguration);
+        var shouldIncrement = ShouldIncrementTaggedCommit(
+            mergedBranchTip, baseVersionSource, sourceConfiguration, sourceLabel);
         var sourceIncrement = DetermineIncrementedFieldInternal(
             currentCommit: mergedBranchTip,
             baseVersionSource: mergeBase,
-            shouldIncrement: ShouldIncrementTaggedCommit(
-                mergedBranchTip, baseVersionSource, sourceConfiguration, sourceLabel),
+            shouldIncrement: shouldIncrement,
             configuration: sourceConfiguration,
             label: sourceLabel
         );
 
+        if (sourceConfiguration.TrackMergeMessage
+            && HasCompatibleMainBranchHistory(mergedBranchTip, sourceConfiguration))
+        {
+            sourceIncrement = ConsolidateIncrements(
+                GetIncrementsFromCommitHistory(
+                    mergedBranchTip, mergeBase, shouldIncrement,
+                    sourceConfiguration, sourceLabel, sourceIncrement),
+                sourceIncrement);
+        }
+
         return new(sourceIncrement, preventIncrementWhenBranchMerged);
+    }
+
+    private bool? ResolvePreventIncrementWhenBranchMerged(
+        IBranchConfiguration sourceBranchConfiguration, EffectiveConfiguration sourceConfiguration,
+        EffectiveConfiguration targetConfiguration)
+    {
+        // Updating a descendant from main carries main's version floor; it does not complete main as a source branch.
+        if (sourceConfiguration.IsMainBranch && !targetConfiguration.IsMainBranch)
+        {
+            return null;
+        }
+
+        return sourceBranchConfiguration.PreventIncrement.WhenBranchMerged
+            ?? (sourceBranchConfiguration.Increment == IncrementStrategy.Inherit
+                ? sourceConfiguration.PreventIncrementWhenBranchMerged
+                : Context.Configuration.PreventIncrement.WhenBranchMerged);
+    }
+
+    private static CommitMessageIncrement ConsolidateIncrements(
+        IEnumerable<CommitMessageIncrement> increments, CommitMessageIncrement fallback)
+    {
+        var result = new CommitMessageIncrement(VersionField.None, VersionBumpNeedsToBeReset: false);
+        var hasIncrement = false;
+        foreach (var increment in increments)
+        {
+            hasIncrement = true;
+            result = result.Consolidate(increment);
+            if (increment.VersionBumpNeedsToBeReset)
+            {
+                break;
+            }
+        }
+
+        return hasIncrement ? result : fallback;
     }
 
     private static CommitMessageIncrement ConsolidateMergedBranchIncrements(
@@ -427,7 +458,7 @@ internal class IncrementStrategyFinder(
     {
         var candidates = repositoryStore.Branches
             .Where(branch => (!configuration.Ignore.IsBranchIgnored(branch.Name)
-                    || IsCurrentOrLinearMainBranch(branch))
+                    || IsCurrentOrCompatibleMainBranch(branch))
                 && IsConfiguredSourceBranch(branch, mergedBranchConfiguration, configuration));
 
         var closestDistance = int.MaxValue;
@@ -459,7 +490,7 @@ internal class IncrementStrategyFinder(
             .Select(group => group.OrderBy(candidate => candidate.Branch.IsRemote).First());
     }
 
-    private bool IsCurrentOrLinearMainBranch(IBranch branch)
+    private bool IsCurrentOrCompatibleMainBranch(IBranch branch)
     {
         if (branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin))
         {
@@ -471,21 +502,14 @@ internal class IncrementStrategyFinder(
         {
             return false;
         }
-        return !ContainsMergeCommit(Context.CurrentCommit, source.Distance);
+        return !ContainsNonMainMergeCommit(
+            Context.CurrentCommit, source.Distance, [GetFirstParentHistory(tip)]);
     }
 
     private (ICommit Commit, int Distance)? FindFirstParentSource(
         ICommit mergedBranchTip, ICommit sourceBranchTip)
     {
-        var sourceHistory = this.firstParentHistoryCache.GetOrAdd(sourceBranchTip.Sha, () =>
-        {
-            HashSet<string> result = [];
-            for (ICommit? commit = sourceBranchTip; commit is not null; commit = commit.Parents.FirstOrDefault())
-            {
-                result.Add(commit.Sha);
-            }
-            return result;
-        });
+        var sourceHistory = GetFirstParentHistory(sourceBranchTip);
 
         var distance = 0;
         for (ICommit? commit = mergedBranchTip; commit is not null; commit = commit.Parents.FirstOrDefault())
@@ -499,17 +523,23 @@ internal class IncrementStrategyFinder(
         return null;
     }
 
-    private bool HasLinearMainBranchHistory(ICommit commit, EffectiveConfiguration targetConfiguration)
+    private bool HasCompatibleMainBranchHistory(ICommit commit, EffectiveConfiguration targetConfiguration)
     {
         if (IsPullRequestBranch(Context.CurrentBranch, Context.Configuration))
         {
             return false;
         }
 
-        return this.linearMainBranchHistoryCache.GetOrAdd((commit.Sha, targetConfiguration), () =>
+        return this.compatibleMainBranchHistoryCache.GetOrAdd((commit.Sha, targetConfiguration), () =>
         {
             var closestDistance = GetClosestMainBranchDistance(commit, targetConfiguration);
-            return closestDistance != int.MaxValue && !ContainsMergeCommit(commit, closestDistance);
+            var mainBranchHistories = this.repositoryStore.Branches
+                .Where(branch => IsMainBranch(branch, targetConfiguration) && branch.Tip is not null)
+                .Select(branch => GetFirstParentHistory(branch.Tip!))
+                .ToArray();
+
+            return closestDistance != int.MaxValue
+                && !ContainsNonMainMergeCommit(commit, closestDistance, mainBranchHistories);
         });
     }
 
@@ -534,12 +564,26 @@ internal class IncrementStrategyFinder(
             ? targetConfiguration.IsMainBranch
             : GetEffectiveConfigurations(branch).Any(configuration => configuration.IsMainBranch);
 
-    private static bool ContainsMergeCommit(ICommit commit, int distance)
+    private HashSet<string> GetFirstParentHistory(ICommit tip) =>
+        this.firstParentHistoryCache.GetOrAdd(tip.Sha, () =>
+        {
+            HashSet<string> result = [];
+            for (ICommit? commit = tip; commit is not null; commit = commit.Parents.FirstOrDefault())
+            {
+                result.Add(commit.Sha);
+            }
+            return result;
+        });
+
+    private static bool ContainsNonMainMergeCommit(
+        ICommit commit, int distance, IReadOnlyCollection<HashSet<string>> mainBranchHistories)
     {
         for (ICommit? current = commit; distance > 0;
              current = current?.Parents.FirstOrDefault(), distance--)
         {
-            if (current?.IsMergeCommit == true)
+            if (current?.IsMergeCommit == true
+                && current.Parents.Skip(1).Any(parent =>
+                    mainBranchHistories.All(history => !history.Contains(parent.Sha))))
             {
                 return true;
             }

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -448,37 +448,43 @@ internal class IncrementStrategyFinder(
 
         return this.linearMainBranchHistoryCache.GetOrAdd((commit.Sha, targetConfiguration), () =>
         {
-            var closestDistance = int.MaxValue;
-            foreach (var branch in this.repositoryStore.Branches)
-            {
-                var isCurrentBranch = branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin);
-                var isMainBranch = isCurrentBranch
-                    ? targetConfiguration.IsMainBranch
-                    : GetEffectiveConfigurations(branch).Any(configuration => configuration.IsMainBranch);
-                if (!isMainBranch
-                    || branch.Tip is not { } tip
-                    || FindFirstParentSource(commit, tip) is not { } source)
-                {
-                    continue;
-                }
-                closestDistance = Math.Min(closestDistance, source.Distance);
-            }
-
-            if (closestDistance == int.MaxValue)
-            {
-                return false;
-            }
-
-            for (ICommit? current = commit; closestDistance > 0;
-                 current = current?.Parents.FirstOrDefault(), closestDistance--)
-            {
-                if (current?.IsMergeCommit == true)
-                {
-                    return false;
-                }
-            }
-            return true;
+            var closestDistance = GetClosestMainBranchDistance(commit, targetConfiguration);
+            return closestDistance != int.MaxValue && !ContainsMergeCommit(commit, closestDistance);
         });
+    }
+
+    private int GetClosestMainBranchDistance(ICommit commit, EffectiveConfiguration targetConfiguration)
+    {
+        var closestDistance = int.MaxValue;
+        foreach (var branch in this.repositoryStore.Branches)
+        {
+            if (!IsMainBranch(branch, targetConfiguration)
+                || branch.Tip is not { } tip
+                || FindFirstParentSource(commit, tip) is not { } source)
+            {
+                continue;
+            }
+            closestDistance = Math.Min(closestDistance, source.Distance);
+        }
+        return closestDistance;
+    }
+
+    private bool IsMainBranch(IBranch branch, EffectiveConfiguration targetConfiguration) =>
+        branch.Name.EquivalentTo(Context.CurrentBranch.Name.WithoutOrigin)
+            ? targetConfiguration.IsMainBranch
+            : GetEffectiveConfigurations(branch).Any(configuration => configuration.IsMainBranch);
+
+    private static bool ContainsMergeCommit(ICommit commit, int distance)
+    {
+        for (ICommit? current = commit; distance > 0;
+             current = current?.Parents.FirstOrDefault(), distance--)
+        {
+            if (current?.IsMergeCommit == true)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static bool IsPullRequestBranch(IBranch branch, IGitVersionConfiguration configuration) =>

--- a/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/IncrementStrategyFinder.cs
@@ -274,7 +274,7 @@ internal class IncrementStrategyFinder(
         EffectiveConfiguration sourceConfiguration, EffectiveConfiguration targetConfiguration)
     {
         var sourceLabel = sourceConfiguration.GetBranchSpecificLabel(
-            mergedBranch, null, this.environment);
+            mergedBranch, null, this.environment, Context.CurrentCommit);
         var preventIncrementWhenBranchMerged = ResolvePreventIncrementWhenBranchMerged(
             sourceConfiguration, targetConfiguration);
         var shouldIncrement = ShouldIncrementTaggedCommit(

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -39,20 +39,27 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
 
     private static VersionField ConsolidateIncrement(MainlineCommit commit, MainlineContext context, BaseVersion baseVersion)
     {
-        var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
         var increment = VersionField.None;
 
-        if (!effectiveConfiguration.PreventIncrementOfMergedBranch)
+        var effectiveConfiguration1 = commit.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration1.PreventIncrementOfMergedBranch)
         {
             increment = increment.Consolidate(context.Increment);
         }
 
-        if (!effectiveConfiguration.PreventIncrementWhenBranchMerged)
+        var effectiveConfiguration2 = commit.ChildIteration!.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration2.PreventIncrementWhenBranchMerged)
         {
             increment = increment.Consolidate(baseVersion.Operator?.Increment);
         }
 
-        if (effectiveConfiguration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+        if (effectiveConfiguration1.PreventIncrementOfMergedBranch
+            && effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        if (effectiveConfiguration1.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
         {
             increment = increment.Consolidate(commit.Increment);
         }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -40,20 +40,27 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
 
     private static VersionField ConsolidateIncrement(MainlineCommit commit, MainlineContext context, BaseVersion baseVersion)
     {
-        var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
         var increment = VersionField.None;
 
-        if (!effectiveConfiguration.PreventIncrementOfMergedBranch)
+        var effectiveConfiguration1 = commit.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration1.PreventIncrementOfMergedBranch)
         {
             increment = increment.Consolidate(context.Increment);
         }
 
-        if (!effectiveConfiguration.PreventIncrementWhenBranchMerged)
+        var effectiveConfiguration2 = commit.ChildIteration!.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration2.PreventIncrementWhenBranchMerged)
         {
             increment = increment.Consolidate(baseVersion.Operator?.Increment);
         }
 
-        if (effectiveConfiguration.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+        if (effectiveConfiguration1.PreventIncrementOfMergedBranch
+            && effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        if (effectiveConfiguration1.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
         {
             increment = increment.Consolidate(commit.Increment);
         }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -25,27 +25,10 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
                    incrementStrategyFinder: context.IncrementStrategyFinder,
                    configuration: context.Configuration,
                    environment: context.Environment
-               );
+            );
 
             context.Label ??= baseVersion.Operator?.Label;
-
-            var increment = VersionField.None;
-
-            if (!commit.GetEffectiveConfiguration(context.Configuration).PreventIncrementOfMergedBranch)
-            {
-                increment = increment.Consolidate(context.Increment);
-            }
-
-            if (!commit.ChildIteration.GetEffectiveConfiguration(context.Configuration).PreventIncrementWhenBranchMerged)
-            {
-                increment = increment.Consolidate(baseVersion.Operator?.Increment);
-            }
-
-            if (commit.GetEffectiveConfiguration(context.Configuration).CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
-            {
-                increment = increment.Consolidate(commit.Increment);
-            }
-            context.Increment = increment;
+            context.Increment = ConsolidateIncrement(commit, context, baseVersion);
 
             if (baseVersion.BaseVersionSource is not null)
             {
@@ -80,5 +63,35 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
 
             context.BaseVersionSource = commit.Value;
         }
+    }
+
+    private static VersionField ConsolidateIncrement(MainlineCommit commit, MainlineContext context, BaseVersion baseVersion)
+    {
+        var increment = VersionField.None;
+
+        var effectiveConfiguration1 = commit.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration1.PreventIncrementOfMergedBranch)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        var effectiveConfiguration2 = commit.ChildIteration!.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(baseVersion.Operator?.Increment);
+        }
+
+        if (effectiveConfiguration1.PreventIncrementOfMergedBranch
+            && effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        if (effectiveConfiguration1.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+        {
+            increment = increment.Consolidate(commit.Increment);
+        }
+
+        return increment;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -26,27 +26,10 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
                    configuration: context.Configuration,
                    environment: context.Environment,
                    currentCommit: context.CurrentCommit
-               );
+            );
 
             context.Label ??= baseVersion.Operator?.Label;
-
-            var increment = VersionField.None;
-
-            if (!commit.GetEffectiveConfiguration(context.Configuration).PreventIncrementOfMergedBranch)
-            {
-                increment = increment.Consolidate(context.Increment);
-            }
-
-            if (!commit.ChildIteration.GetEffectiveConfiguration(context.Configuration).PreventIncrementWhenBranchMerged)
-            {
-                increment = increment.Consolidate(baseVersion.Operator?.Increment);
-            }
-
-            if (commit.GetEffectiveConfiguration(context.Configuration).CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
-            {
-                increment = increment.Consolidate(commit.Increment);
-            }
-            context.Increment = increment;
+            context.Increment = ConsolidateIncrement(commit, context, baseVersion);
 
             if (baseVersion.BaseVersionSource is not null)
             {
@@ -81,5 +64,35 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
 
             context.BaseVersionSource = commit.Value;
         }
+    }
+
+    private static VersionField ConsolidateIncrement(MainlineCommit commit, MainlineContext context, BaseVersion baseVersion)
+    {
+        var increment = VersionField.None;
+
+        var effectiveConfiguration1 = commit.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration1.PreventIncrementOfMergedBranch)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        var effectiveConfiguration2 = commit.ChildIteration!.GetEffectiveConfiguration(context.Configuration);
+        if (!effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(baseVersion.Operator?.Increment);
+        }
+
+        if (effectiveConfiguration1.PreventIncrementOfMergedBranch
+            && effectiveConfiguration2.PreventIncrementWhenBranchMerged)
+        {
+            increment = increment.Consolidate(context.Increment);
+        }
+
+        if (effectiveConfiguration1.CommitMessageIncrementing != CommitMessageIncrementMode.Disabled)
+        {
+            increment = increment.Consolidate(commit.Increment);
+        }
+
+        return increment;
     }
 }


### PR DESCRIPTION
## Description

Moves merged-branch increment selection into `IncrementStrategyFinder.DetermineIncrementedField`, so every version strategy that already uses the finder receives the same behavior without adding a separate strategy or configuration surface.

For a branch with merge-message tracking enabled that is either an effective main branch or a compatible descendant preserving main-branch history through linear work and main-to-descendant updates, the finder separates first-parent target work from recognized two-parent merges. It calculates each source branch's effective increment from the merged history, preserves source `+semver` / `=semver` handling, and applies the target/source settings as follows:

| Target `of-merged-branch` | Source `when-branch-merged` | Effective contribution |
| --- | --- | --- |
| `false` | `false` | Target + source increment |
| `false` | `true` | Target increment |
| `true` | `false` | Source increment |
| `true` | `true` | Target increment |

Main-to-descendant update merges carry main's recursively derived version floor rather than treating main as a completed source branch. Unrelated intervening merges still keep the descendant outside merge-history processing.

Direct target commits still contribute the target increment, unrecognized merge histories remain target-configured work, synthetic pull-request refs stay outside merge-history processing, and the highest contribution across multiple merges wins. Inherited source increments are resolved from the historical merged tip, including deleted or recreated topic refs and source branches that absorb the topic later. Per-merge and ancestry results use configuration-aware cache keys because the finder evaluates multiple base-version candidates for the same current commit.

## Related Issue

Resolves #4433

## Motivation and Context

Outside mainline calculation, a no-fast-forward merge currently falls back to the target branch's configured increment. This makes a patch hotfix merged into a minor-increment main branch produce a minor version, and a minor feature merged into a patch-increment main branch produce a patch version. The increment finder already owns configured and commit-message increment precedence, so handling merged histories there keeps the behavior consistent across dependent version strategies.

## How Has This Been Tested?

Revalidated on Linux with .NET SDK 10.0.400 at `6d1169c5f` after rebasing onto `88086843`:

- Added 46 integration cases covering the four effective configuration combinations, GitFlow/GitHubFlow acceptance scenarios, multiple merges and reset directives, target work before and after a merge, source commit-message overrides, unrecognized and ignored-merge side histories including chronological directive ordering across recognized boundaries, tagged and future-dated source tips including selected stable tags across source labels, inherited prevention and effective main-branch settings including source-branch inheritance, ignored branches including current and compatible-descendant main-history exceptions, synthetic pull-request refs, intervening target tags, pruned target segments, and off-first-parent base boundaries, nested and sibling inheritance for historical and retained tips, descendant-branch version floors including main update merges and an unrelated-merge guard, historical/local/remote source resolution, and retained/deleted orphan fallback parity including unresolved-`Inherit` skipping.
- Added a focused `IncrementStrategyFinder` unit case proving that commit-message cache entries are isolated by regex configuration.
- Updated the existing GitFlow/GitHubFlow alignment and merge scenarios to assert the corrected results.
- `dotnet build ./src/GitVersion.slnx --no-restore --verbosity:minimal -m:1` — succeeded with 0 warnings and 0 errors.
- `dotnet test --solution ./src/GitVersion.slnx --no-build --no-restore --max-parallel-test-modules 1 --no-progress --output Normal` with `TMPDIR` and `RUNNER_TEMP` set to a clean directory under `/var/tmp` with no `.git` ancestor — 37,498 succeeded, 0 failed.
- `dotnet format --verify-no-changes ./src/GitVersion.slnx --no-restore` — succeeded.
- `git diff --check` — succeeded.

## Screenshots (if appropriate):

N/A

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.


