### PR TITLE
feat: support regex branch exclusions

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -174,6 +174,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []
@@ -211,7 +212,7 @@ update-build-number: true
 version-bump-reset-message: "=semver:"
 version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
-<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The supported built-in configuration for the `GitHubFlow` workflow (`workflow: GitHubFlow/v1`) looks like:
@@ -301,6 +302,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []
@@ -338,7 +340,7 @@ update-build-number: true
 version-bump-reset-message: "=semver:"
 version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
-<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The preview built-in configuration (experimental usage only) for the `TrunkBased` workflow (`workflow: TrunkBased/preview1`) looks like:
@@ -417,6 +419,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []
@@ -450,7 +453,7 @@ update-build-number: true
 version-bump-reset-message: "=semver:"
 version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
-<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The details of the available options are as follows:
@@ -654,6 +657,38 @@ The header property for the `ignore` configuration.
 the search for a [version source][version-sources], not when calculating other
 parts of the version number, such as build metadata.
 :::
+
+#### branches
+
+A sequence of regular expressions matching branch names that should not be
+used as [version sources][version-sources]. Patterns are matched
+case-insensitively against the friendly branch name. For remote-tracking
+branches, the remote name is removed first, so the same pattern matches both
+`release/legacy` and `upstream/release/legacy`. Multiple patterns use OR
+semantics, and `^` and `$` can be used to anchor a match. To require
+case-sensitive matching, prefix a pattern with `(?-i)`.
+
+```yaml
+ignore:
+  branches:
+    - ^experimental/
+    - ^release/legacy$
+```
+
+The current branch and an explicitly requested target branch remain available
+for version calculation even when they match an ignore pattern. During dynamic
+repository normalization, ignored remote-tracking branches are not created or
+updated as local branches, except when the ignored branch is the requested
+target. Ignoring a branch does not exclude commits that are also reachable from
+other references.
+
+Ignored branches remain available as parent branches when GitVersion resolves
+an inherited branch configuration. This preserves the branching configuration
+model without making the ignored reference eligible for auxiliary main-branch
+or release-branch version-source discovery.
+
+Branch exclusions are applied after remote references are fetched. They do not
+prevent GitVersion from fetching an ignored branch from its remote.
 
 #### commits-before
 

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -250,6 +250,38 @@ the search for a [version source][version-sources], not when calculating other
 parts of the version number, such as build metadata.
 :::
 
+#### branches
+
+A sequence of regular expressions matching branch names that should not be
+used as [version sources][version-sources]. Patterns are matched
+case-insensitively against the friendly branch name. For remote-tracking
+branches, the remote name is removed first, so the same pattern matches both
+`release/legacy` and `upstream/release/legacy`. Multiple patterns use OR
+semantics, and `^` and `$` can be used to anchor a match. To require
+case-sensitive matching, prefix a pattern with `(?-i)`.
+
+```yaml
+ignore:
+  branches:
+    - ^experimental/
+    - ^release/legacy$
+```
+
+The current branch and an explicitly requested target branch remain available
+for version calculation even when they match an ignore pattern. During dynamic
+repository normalization, ignored remote-tracking branches are not created or
+updated as local branches, except when the ignored branch is the requested
+target. Ignoring a branch does not exclude commits that are also reachable from
+other references.
+
+Ignored branches remain available as parent branches when GitVersion resolves
+an inherited branch configuration. This preserves the branching configuration
+model without making the ignored reference eligible for auxiliary main-branch
+or release-branch version-source discovery.
+
+Branch exclusions are applied after remote references are fetched. They do not
+prevent GitVersion from fetching an ignored branch from its remote.
+
 #### commits-before
 
 Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:

--- a/docs/input/docs/workflows/GitFlow/v1.yml
+++ b/docs/input/docs/workflows/GitFlow/v1.yml
@@ -131,6 +131,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/docs/input/docs/workflows/GitHubFlow/v1.yml
+++ b/docs/input/docs/workflows/GitHubFlow/v1.yml
@@ -80,6 +80,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/docs/input/docs/workflows/TrunkBased/preview1.yml
+++ b/docs/input/docs/workflows/TrunkBased/preview1.yml
@@ -69,6 +69,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/schemas/7.0/GitVersion.configuration.json
+++ b/schemas/7.0/GitVersion.configuration.json
@@ -186,6 +186,10 @@
       "description": "The header property for the ignore configuration.",
       "type": "object",
       "properties": {
+        "branches": {
+          "description": "A sequence of regular expressions matching branch names without the remote prefix to be excluded as version sources. Matching is case-insensitive by default; use (?-i) to enable case-sensitive matching.",
+          "$ref": "#/$defs/hashSetOfString"
+        },
         "commits-before": {
           "format": "date-time",
           "description": "Commits before this date will be ignored. Format: yyyy-MM-ddTHH:mm:ss.",

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -131,6 +131,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
@@ -1,5 +1,3 @@
-using GitVersion.VersionCalculation;
-
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -49,6 +49,17 @@ public class IgnoreConfigurationTests : TestBase
     }
 
     [Test]
+    public void CanDeserializeCompactBranchesSequence()
+    {
+        const string yaml = "ignore:\n  branches: ['^legacy/', '^release/old$']";
+
+        var configuration = this.serializer.ReadConfiguration(yaml);
+
+        configuration.ShouldNotBeNull();
+        configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
+    }
+
+    [Test]
     public void CanDeserializeCompactTagsSequence()
     {
         const string yaml = "ignore:\n  tags: ['^preview-', '^v0\\.']";
@@ -57,6 +68,26 @@ public class IgnoreConfigurationTests : TestBase
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Tags.ShouldBe(["^preview-", "^v0\\."]);
+    }
+
+    [Test]
+    public void CanDeserializeMultilineBranchesAndTagsSequences()
+    {
+        const string yaml =
+            """
+            ignore:
+                branches:
+                    - ^legacy/
+                    - ^release/old$
+                tags:
+                    - ^preview-
+            """;
+
+        var configuration = this.serializer.ReadConfiguration(yaml);
+
+        configuration.ShouldNotBeNull();
+        configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
+        configuration.Ignore.Tags.ShouldBe(["^preview-"]);
     }
 
     [Test]
@@ -86,9 +117,18 @@ public class IgnoreConfigurationTests : TestBase
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
         configuration.Ignore.Before.ShouldBe(null);
+        configuration.Ignore.Branches.ShouldBeEmpty();
         configuration.Ignore.Paths.ShouldBeEmpty();
         configuration.Ignore.Shas.ShouldBeEmpty();
         configuration.Ignore.Tags.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void IsEmpty_WhenBranchPatternIsConfigured_ReturnsFalse()
+    {
+        var ignoreConfig = new IgnoreConfiguration { Branches = ["^legacy/"] };
+
+        ignoreConfig.IsEmpty.ShouldBeFalse();
     }
 
     [Test]
@@ -97,6 +137,19 @@ public class IgnoreConfigurationTests : TestBase
         var ignoreConfig = new IgnoreConfiguration { Tags = ["^preview-"] };
 
         ignoreConfig.IsEmpty.ShouldBeFalse();
+    }
+
+    [Test]
+    public void InvalidIgnoreBranchExpression_ThrowsConfigurationExceptionWithPropertyAndPattern()
+    {
+        const string invalidExpression = "[invalid";
+
+        var exception = Should.Throw<ConfigurationException>(() => GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = [invalidExpression] })
+            .Build());
+
+        exception.Message.ShouldContain("ignore.branches");
+        exception.Message.ShouldContain(invalidExpression);
     }
 
     [Test]
@@ -113,6 +166,17 @@ public class IgnoreConfigurationTests : TestBase
     }
 
     [Test]
+    public void Serialize_IgnoreBranchPatterns_UsesBranchesPropertyName()
+    {
+        var ignoreConfig = new IgnoreConfiguration { Branches = ["^legacy/"] };
+
+        var yaml = this.serializer.Serialize(ignoreConfig);
+
+        yaml.ShouldContain("branches:");
+        yaml.ShouldContain("^legacy/");
+    }
+
+    [Test]
     public void Serialize_IgnoreTagPatterns_UsesTagsPropertyName()
     {
         var ignoreConfig = new IgnoreConfiguration { Tags = ["^preview-"] };
@@ -121,6 +185,14 @@ public class IgnoreConfigurationTests : TestBase
 
         yaml.ShouldContain("tags:");
         yaml.ShouldContain("^preview-");
+    }
+
+    [Test]
+    public void IgnoreConfigurationBuilder_WithBranches_PreservesCollection()
+    {
+        var ignoreConfig = IgnoreConfigurationBuilder.New.WithBranches("^legacy/", "^release/old$").Build();
+
+        ignoreConfig.Branches.ShouldBe(["^legacy/", "^release/old$"]);
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
@@ -131,6 +131,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
@@ -80,6 +80,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
@@ -69,6 +69,7 @@ branches:
 commit-date-format: yyyy-MM-dd
 commit-message-incrementing: Enabled
 ignore:
+  branches: []
   paths: []
   sha: []
   tags: []

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -476,6 +476,7 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
 
     private static void ValidateConfiguration(IGitVersionConfiguration configuration)
     {
+        ValidateIgnoreExpressions("ignore.branches", configuration.Ignore.Branches);
         ValidateIgnoreExpressions("ignore.tags", configuration.Ignore.Tags);
 
         foreach (var (name, branchConfiguration) in configuration.Branches)

--- a/src/GitVersion.Configuration/Builders/IgnoreConfigurationBuilder.cs
+++ b/src/GitVersion.Configuration/Builders/IgnoreConfigurationBuilder.cs
@@ -6,6 +6,8 @@ internal sealed class IgnoreConfigurationBuilder
 
     private DateTimeOffset? before;
 
+    private HashSet<string> branches = [];
+
     private HashSet<string> shas = [];
 
     private HashSet<string> tags = [];
@@ -13,6 +15,24 @@ internal sealed class IgnoreConfigurationBuilder
     public IgnoreConfigurationBuilder WithBefore(DateTimeOffset? value)
     {
         this.before = value;
+        return this;
+    }
+
+    public IgnoreConfigurationBuilder WithBranches(IEnumerable<string> values)
+    {
+        WithBranches(new HashSet<string>(values));
+        return this;
+    }
+
+    public IgnoreConfigurationBuilder WithBranches(params string[] values)
+    {
+        WithBranches(new HashSet<string>(values));
+        return this;
+    }
+
+    public IgnoreConfigurationBuilder WithBranches(HashSet<string> value)
+    {
+        this.branches = value;
         return this;
     }
 
@@ -55,6 +75,7 @@ internal sealed class IgnoreConfigurationBuilder
     public IIgnoreConfiguration Build() => new IgnoreConfiguration
     {
         Before = this.before,
+        Branches = this.branches,
         Shas = this.shas,
         Tags = this.tags
     };

--- a/src/GitVersion.Configuration/IgnoreConfiguration.cs
+++ b/src/GitVersion.Configuration/IgnoreConfiguration.cs
@@ -17,6 +17,12 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
         set => Before = value is null ? null : DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
     }
 
+    IReadOnlySet<string> IIgnoreConfiguration.Branches => Branches;
+
+    [JsonPropertyName("branches")]
+    [JsonPropertyDescription("A sequence of regular expressions matching branch names without the remote prefix to be excluded as version sources. Matching is case-insensitive by default; use (?-i) to enable case-sensitive matching.")]
+    public HashSet<string> Branches { get; set; } = [];
+
     IReadOnlySet<string> IIgnoreConfiguration.Paths => Paths;
 
     [JsonPropertyName("paths")]
@@ -37,5 +43,5 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
     public HashSet<string> Tags { get; set; } = [];
 
     [JsonIgnore]
-    public bool IsEmpty => Before == null && Paths.Count == 0 && Shas.Count == 0 && Tags.Count == 0;
+    public bool IsEmpty => Before == null && Branches.Count == 0 && Paths.Count == 0 && Shas.Count == 0 && Tags.Count == 0;
 }

--- a/src/GitVersion.Core.Tests/Core/BranchRepositoryTests.cs
+++ b/src/GitVersion.Core.Tests/Core/BranchRepositoryTests.cs
@@ -1,0 +1,59 @@
+using GitVersion.Configuration;
+using GitVersion.Git;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+public class BranchRepositoryTests : TestBase
+{
+    [TestCase("refs/heads/release/legacy")]
+    [TestCase("refs/remotes/origin/release/legacy")]
+    [TestCase("refs/remotes/upstream/release/legacy")]
+    public void IsBranchIgnored_MatchesFriendlyNameWithoutRemoteName(string canonicalName)
+    {
+        var configuration = new IgnoreConfiguration { Branches = ["^release/legacy$"] };
+
+        configuration.IsBranchIgnored(new ReferenceName(canonicalName)).ShouldBeTrue();
+    }
+
+    [Test]
+    public void GetMainBranches_IgnorePatternsUseCaseInsensitiveOrSemanticsWithoutRemote()
+    {
+        var localMain = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/main");
+        var remoteMain = GitRepositoryTestingExtensions.CreateMockBranch("refs/remotes/origin/main");
+        var master = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/master");
+        var repositoryStore = CreateRepositoryStore(localMain, remoteMain, master);
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^legacy/", "^MAIN$"] })
+            .Build();
+
+        var actual = new BranchRepository(repositoryStore).GetMainBranches(configuration).ToArray();
+
+        actual.ShouldBe([master]);
+    }
+
+    [Test]
+    public void FindSourceBranchesOf_IgnoredBranchIsExcludedButSharedCandidatesRemain()
+    {
+        var current = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/feature/current");
+        var main = GitRepositoryTestingExtensions.CreateMockBranch("refs/remotes/origin/main");
+        var develop = GitRepositoryTestingExtensions.CreateMockBranch("refs/heads/develop");
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .Build();
+
+        var actual = new SourceBranchFinder([main, develop], configuration, excludeIgnoredBranches: true)
+            .FindSourceBranchesOf(current).ToArray();
+
+        actual.ShouldBe([develop]);
+    }
+
+    private static IRepositoryStore CreateRepositoryStore(params IBranch[] branches)
+    {
+        var branchCollection = Substitute.For<IBranchCollection>();
+        branchCollection.MockCollectionReturn(branches);
+        var repositoryStore = Substitute.For<IRepositoryStore>();
+        repositoryStore.Branches.Returns(branchCollection);
+        return repositoryStore;
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/ReferenceNameTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ReferenceNameTests.cs
@@ -1,0 +1,40 @@
+using GitVersion.Git;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+public class ReferenceNameTests
+{
+    [TestCase("refs/remotes/origin/release/1.0.0", "release/1.0.0", true)]
+    [TestCase("refs/remotes/upstream/release/1.0.0", "release/1.0.0", false)]
+    public void EquivalentTo_UsesOriginStrippedName(string canonicalName, string name, bool expected)
+    {
+        var referenceName = new ReferenceName(canonicalName);
+
+        referenceName.EquivalentTo(name).ShouldBe(expected);
+    }
+
+    [TestCase("refs/heads/release/1.0.0", "release/1.0.0")]
+    [TestCase("refs/remotes/origin/release/1.0.0", "release/1.0.0")]
+    [TestCase("refs/remotes/upstream/release/1.0.0", "upstream/release/1.0.0")]
+    [TestCase("refs/remotes/pull/123/merge", "pull/123/merge")]
+    [TestCase("refs/pull/123/merge", "refs/pull/123/merge")]
+    public void WithoutOrigin_ReturnsExpectedName(string canonicalName, string expected)
+    {
+        var referenceName = new ReferenceName(canonicalName);
+
+        referenceName.WithoutOrigin.ShouldBe(expected);
+    }
+
+    [TestCase("refs/heads/release/1.0.0", "release/1.0.0")]
+    [TestCase("refs/remotes/origin/release/1.0.0", "release/1.0.0")]
+    [TestCase("refs/remotes/upstream/release/1.0.0", "release/1.0.0")]
+    [TestCase("refs/remotes/pull/123/merge", "pull/123/merge")]
+    [TestCase("refs/pull/123/merge", "refs/pull/123/merge")]
+    public void WithoutRemote_ReturnsExpectedName(string canonicalName, string expected)
+    {
+        var referenceName = new ReferenceName(canonicalName);
+
+        referenceName.WithoutRemote.ShouldBe(expected);
+    }
+}

--- a/src/GitVersion.Core.Tests/IntegrationTests/IgnoreReferenceScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/IgnoreReferenceScenarios.cs
@@ -1,11 +1,75 @@
 using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
+using GitVersion.VersionCalculation;
 
 namespace GitVersion.Tests.IntegrationTests;
 
 [TestFixture]
 public class IgnoreReferenceScenarios : TestBase
 {
+    [Test]
+    public void GivenIgnoredReleaseBranch_WhenTrackingReleaseBranches_ExcludesItsVersionSource()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        fixture.BranchTo("release/0.10.0");
+        fixture.MakeACommit();
+        fixture.MakeACommit();
+        fixture.Checkout(MainBranch);
+        fixture.MakeACommit();
+
+        var trackingConfiguration = CreateTrackingReleaseConfiguration();
+        var ignoredConfiguration = CreateTrackingReleaseConfiguration(new IgnoreConfiguration { Branches = ["^RELEASE/0\\.10\\.0$"] });
+        var noTrackingConfiguration = CreateTrackingReleaseConfiguration(tracksReleaseBranches: false);
+
+        fixture.AssertFullSemver("0.10.1-pre.1+1", trackingConfiguration);
+        fixture.AssertFullSemver("0.0.1-pre.1+2", ignoredConfiguration);
+        fixture.AssertFullSemver("0.0.1-pre.1+2", noTrackingConfiguration);
+    }
+
+    [Test]
+    public void GivenCurrentBranchMatchesIgnorePattern_WhenCalculatingVersion_PreservesCurrentTarget()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        fixture.Repository.MakeACommit();
+        var ignored = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .Build();
+
+        fixture.AssertFullSemver("1.0.1-1", ignored);
+    }
+
+    [Test]
+    public void GivenIgnoredParentBranch_WhenInheritingConfiguration_PreservesParentConfiguration()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("develop");
+        fixture.Repository.MakeACommit();
+        fixture.BranchTo("feature/work");
+        fixture.Repository.MakeACommit();
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^develop$"] })
+            .Build();
+
+        fixture.AssertFullSemver("1.1.0-work.1+2", configuration);
+    }
+
+    [Test]
+    public void GivenIgnoredSourceBranchSharesTaggedHistory_WhenCalculatingVersion_KeepsSharedCommitEligible()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        fixture.BranchTo("feature/work");
+        fixture.Repository.MakeACommit();
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^main$"] })
+            .Build();
+
+        fixture.AssertFullSemver("1.0.1-work.1+1", configuration);
+    }
+
     [Test]
     public void GivenIgnoredTagAndEarlierEligibleTag_WhenCalculatingVersion_UsesEarlierTagAndCountsTargetCommit()
     {
@@ -31,5 +95,23 @@ public class IgnoreReferenceScenarios : TestBase
             .Build();
 
         fixture.AssertFullSemver("1.0.1-1", configuration);
+    }
+
+    private static IGitVersionConfiguration CreateTrackingReleaseConfiguration(
+        IgnoreConfiguration? ignore = null,
+        bool tracksReleaseBranches = true)
+    {
+        var builder = GitFlowConfigurationBuilder.New
+            .WithDeploymentMode(DeploymentMode.ManualDeployment)
+            .WithBranch("unknown", branch => branch.WithIncrement(IncrementStrategy.Patch).WithTracksReleaseBranches(true))
+            .WithBranch(MainBranch, branch => branch.WithLabel("pre").WithTracksReleaseBranches(tracksReleaseBranches))
+            .WithBranch("release", branch => branch.WithLabel("rc"));
+
+        if (ignore is not null)
+        {
+            builder.WithIgnoreConfiguration(ignore);
+        }
+
+        return builder.Build();
     }
 }

--- a/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/RemoteRepositoryScenarios.cs
@@ -1,4 +1,5 @@
 using GitVersion.Agents;
+using GitVersion.Configuration;
 using GitVersion.Testing.Extensions;
 using LibGit2Sharp;
 
@@ -69,6 +70,99 @@ public class RemoteRepositoryScenarios : TestBase
 
         fixture.AssertFullSemver("1.0.0-beta.1+10");
         fixture.AssertFullSemver("1.0.0-beta.1+10", repository: fixture.LocalRepositoryFixture.Repository);
+    }
+
+    [Test]
+    public void GivenIgnoredRemoteBranch_WhenNormalizing_DoesNotCreateOrUpdateItsLocalBranch()
+    {
+        using var fixture = new RemoteRepositoryFixture(
+            path =>
+            {
+                Repository.Init(path);
+                var repository = new Repository(path);
+                repository.MakeCommits(2);
+                repository.CreateBranch("legacy/old");
+                repository.CreateBranch("feature/keep");
+                return repository;
+            });
+
+        var localRepository = fixture.LocalRepositoryFixture.Repository;
+        var ignoredRemoteBranch = localRepository.Branches["origin/legacy/old"];
+        ignoredRemoteBranch.ShouldNotBeNull();
+        var ignoredLocalBranch = localRepository.CreateBranch("legacy/old", ignoredRemoteBranch.Tip);
+        var originalIgnoredTip = ignoredLocalBranch.Tip.Sha;
+
+        Commands.Checkout(fixture.Repository, "legacy/old");
+        fixture.Repository.MakeACommit();
+
+        var gitVersionOptions = new GitVersionOptions
+        {
+            WorkingDirectory = fixture.LocalRepositoryFixture.RepositoryPath,
+            Settings = { NoNormalize = false, NoFetch = false }
+        };
+        var options = Options.Create(gitVersionOptions);
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^legacy/"] })
+            .Build();
+        var configurationProvider = Substitute.For<IConfigurationProvider>();
+        configurationProvider.Provide(Arg.Any<IReadOnlyDictionary<object, object?>?>()).Returns(configuration);
+
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            services.AddSingleton<IEnvironment>(environment);
+            services.AddSingleton(configurationProvider);
+        });
+        sp.DiscoverRepository();
+
+        sp.GetRequiredService<IGitPreparer>().Prepare();
+
+        localRepository.Branches["legacy/old"].Tip.Sha.ShouldBe(originalIgnoredTip);
+        localRepository.Branches["feature/keep"].ShouldNotBeNull();
+    }
+
+    [Test]
+    public void GivenTargetBranchMatchesIgnorePattern_WhenNormalizing_CreatesTargetBranch()
+    {
+        const string targetBranch = "legacy/target";
+        using var fixture = new RemoteRepositoryFixture(
+            path =>
+            {
+                Repository.Init(path);
+                var repository = new Repository(path);
+                repository.MakeCommits(2);
+                repository.CreateBranch(targetBranch);
+                return repository;
+            });
+
+        var gitVersionOptions = new GitVersionOptions
+        {
+            WorkingDirectory = fixture.LocalRepositoryFixture.RepositoryPath,
+            RepositoryInfo = { TargetBranch = targetBranch },
+            Settings = { NoNormalize = false, NoFetch = false }
+        };
+        var options = Options.Create(gitVersionOptions);
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable(AzurePipelines.EnvironmentVariableName, "true");
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Branches = ["^legacy/"] })
+            .Build();
+        var configurationProvider = Substitute.For<IConfigurationProvider>();
+        configurationProvider.Provide(Arg.Any<IReadOnlyDictionary<object, object?>?>()).Returns(configuration);
+
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            services.AddSingleton<IEnvironment>(environment);
+            services.AddSingleton(configurationProvider);
+        });
+        sp.DiscoverRepository();
+
+        sp.GetRequiredService<IGitPreparer>().Prepare();
+
+        fixture.LocalRepositoryFixture.Repository.Branches[targetBranch].ShouldNotBeNull();
     }
 
     [Test]

--- a/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
@@ -6,6 +6,9 @@ public interface IIgnoreConfiguration
     /// <summary>Gets the cut-off date before which commits are ignored; <see langword="null"/> means no date filter is applied.</summary>
     DateTimeOffset? Before { get; }
 
+    /// <summary>Gets the regular expressions matching branch names that should be excluded as version sources.</summary>
+    IReadOnlySet<string> Branches { get; }
+
     /// <summary>Gets the set of file paths whose changes should be ignored during version calculation.</summary>
     IReadOnlySet<string> Paths { get; }
 

--- a/src/GitVersion.Core/Core/BranchRepository.cs
+++ b/src/GitVersion.Core/Core/BranchRepository.cs
@@ -26,6 +26,11 @@ internal sealed class BranchRepository(IRepositoryStore repositoryStore) : IBran
                 continue;
             }
 
+            if (configuration.Ignore.IsBranchIgnored(branch.Name))
+            {
+                continue;
+            }
+
             var branchConfiguration = configuration.GetBranchConfiguration(branch.Name);
             if (predicate(branchConfiguration))
             {

--- a/src/GitVersion.Core/Core/GitPreparer.cs
+++ b/src/GitVersion.Core/Core/GitPreparer.cs
@@ -14,6 +14,7 @@ internal class GitPreparer(
     IEnvironment environment,
     ICurrentBuildAgent buildAgent,
     IOptions<GitVersionOptions> options,
+    Lazy<IGitVersionConfiguration> configuration,
     IMutatingGitRepository repository,
     IGitRepositoryInfo repositoryInfo,
     Lazy<GitVersionContext> versionContext)
@@ -24,6 +25,7 @@ internal class GitPreparer(
     private readonly IEnvironment environment = environment.NotNull();
     private readonly IMutatingGitRepository repository = repository.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
+    private readonly Lazy<IGitVersionConfiguration> configuration = configuration.NotNull();
     private readonly IGitRepositoryInfo repositoryInfo = repositoryInfo.NotNull();
     private readonly ICurrentBuildAgent buildAgent = buildAgent.NotNull();
     private readonly RetryAction<LockedFileException> retryAction = new();
@@ -146,7 +148,7 @@ internal class GitPreparer(
         using (this.logger.StartIndentedScope($"Normalizing git directory for branch '{targetBranch}'"))
         {
             // Normalize (download branches) before using the branch
-            NormalizeGitDirectory(this.options.Value.Settings.NoFetch || this.buildAgent.PreventFetch(), targetBranch, isDynamicRepository);
+            NormalizeGitDirectory(this.options.Value.Settings.NoFetch || this.buildAgent.PreventFetch(), targetBranch, isDynamicRepository, this.configuration.Value.Ignore);
         }
     }
 
@@ -156,7 +158,7 @@ internal class GitPreparer(
     /// This is designed to be run *only on the build server* which checks out repositories in different ways.
     /// It is not recommended to run normalization against a local repository
     /// </summary>
-    private void NormalizeGitDirectory(bool noFetch, string? currentBranchName, bool isDynamicRepository)
+    private void NormalizeGitDirectory(bool noFetch, string? currentBranchName, bool isDynamicRepository, IIgnoreConfiguration ignoreConfiguration)
     {
         var authentication = this.options.Value.AuthenticationInfo;
         // Need to ensure the HEAD does not move, this is essentially a BugCheck
@@ -169,7 +171,7 @@ internal class GitPreparer(
         EnsureRepositoryHeadDuringNormalisation(nameof(FetchRemotesIfRequired), expectedSha);
         EnsureLocalBranchExistsForCurrentBranch(remote, currentBranchName);
         EnsureRepositoryHeadDuringNormalisation(nameof(EnsureLocalBranchExistsForCurrentBranch), expectedSha);
-        CreateOrUpdateLocalBranchesFromRemoteTrackingOnes(remote.Name);
+        CreateOrUpdateLocalBranchesFromRemoteTrackingOnes(remote.Name, currentBranchName, ignoreConfiguration);
         EnsureRepositoryHeadDuringNormalisation(nameof(CreateOrUpdateLocalBranchesFromRemoteTrackingOnes), expectedSha);
 
         var currentBranch = this.repository.Branches.FirstOrDefault(x => x.Name.EquivalentTo(currentBranchName));
@@ -337,7 +339,8 @@ internal class GitPreparer(
         throw new WarningException(message);
     }
 
-    private void CreateOrUpdateLocalBranchesFromRemoteTrackingOnes(string remoteName)
+    private void CreateOrUpdateLocalBranchesFromRemoteTrackingOnes(
+        string remoteName, string? currentBranchName, IIgnoreConfiguration ignoreConfiguration)
     {
         var prefix = $"refs/remotes/{remoteName}/";
         var remoteHeadCanonicalName = $"{prefix}HEAD";
@@ -352,8 +355,8 @@ internal class GitPreparer(
             var branchName = remoteTrackingReferenceName[prefix.Length..];
             var localReferenceName = ReferenceName.FromBranchName(branchName);
 
-            // We do not want to touch our current branch
-            if (this.repository.Head.Name.EquivalentTo(branchName))
+            if (ShouldSkipRemoteTrackingReference(
+                    branchName, localReferenceName, remoteTrackingReferenceName, currentBranchName, ignoreConfiguration))
             {
                 continue;
             }
@@ -384,6 +387,28 @@ internal class GitPreparer(
                 this.repository.Branches.UpdateTrackedBranch(branch, remoteTrackingReferenceName);
             }
         }
+    }
+
+    private bool ShouldSkipRemoteTrackingReference(
+        string branchName,
+        ReferenceName localReferenceName,
+        string remoteTrackingReferenceName,
+        string? currentBranchName,
+        IIgnoreConfiguration ignoreConfiguration)
+    {
+        // We do not want to touch our current branch.
+        if (this.repository.Head.Name.EquivalentTo(branchName) || localReferenceName.EquivalentTo(currentBranchName))
+        {
+            return true;
+        }
+
+        if (!ignoreConfiguration.IsBranchIgnored(localReferenceName))
+        {
+            return false;
+        }
+
+        this.logger.LogInformation("Skipping ignored remote tracking branch '{RemoteTrackingReferenceName}'.", remoteTrackingReferenceName);
+        return true;
     }
 
     public void EnsureLocalBranchExistsForCurrentBranch(IRemote remote, string? currentBranch)

--- a/src/GitVersion.Core/Core/MergeCommitFinder.cs
+++ b/src/GitVersion.Core/Core/MergeCommitFinder.cs
@@ -8,7 +8,8 @@ internal class MergeCommitFinder(
     IRepositoryStore repositoryStore,
     IGitVersionConfiguration configuration,
     IEnumerable<IBranch> excludedBranches,
-    ILogger logger)
+    ILogger logger,
+    bool excludeIgnoredBranches)
 {
     private readonly IEnumerable<IBranch> branches = repositoryStore.ExcludingBranches(excludedBranches.NotNull());
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
@@ -37,7 +38,7 @@ internal class MergeCommitFinder(
 
     private IEnumerable<BranchCommit> FindMergeBases(IBranch branch)
     {
-        var sourceBranches = new SourceBranchFinder(this.branches, this.configuration)
+        var sourceBranches = new SourceBranchFinder(this.branches, this.configuration, excludeIgnoredBranches)
             .FindSourceBranchesOf(branch);
 
         foreach (var sourceBranch in sourceBranches)

--- a/src/GitVersion.Core/Core/RepositoryStore.cs
+++ b/src/GitVersion.Core/Core/RepositoryStore.cs
@@ -117,7 +117,8 @@ internal class RepositoryStore(ILogger<RepositoryStore> logger, IGitRepository r
 
         var referenceLookup = this.repository.References.ToLookup(r => r.TargetIdentifier);
 
-        var commitBranches = FindCommitBranchesBranchedFrom(branch, configuration, excludedBranches).ToHashSet();
+        var commitBranches = FindCommitBranchesBranchedFrom(
+            branch, configuration, excludedBranches, excludeIgnoredBranches: false).ToHashSet();
 
         var ignore = CollectIgnoredMergeCommitBranches(branch, commitBranches);
 
@@ -214,7 +215,7 @@ internal class RepositoryStore(ILogger<RepositoryStore> logger, IGitRepository r
             }
 
             var possibleBranches =
-                new MergeCommitFinder(this, configuration, excludedBranches, this.logger)
+                new MergeCommitFinder(this, configuration, excludedBranches, this.logger, excludeIgnoredBranches: true)
                     .FindMergeCommitsFor(branch)
                     .ToList();
 
@@ -239,7 +240,8 @@ internal class RepositoryStore(ILogger<RepositoryStore> logger, IGitRepository r
 
     public IEnumerable<BranchCommit> FindCommitBranchesBranchedFrom(
             IBranch branch, IGitVersionConfiguration configuration, params IBranch[] excludedBranches)
-        => FindCommitBranchesBranchedFrom(branch, configuration, (IEnumerable<IBranch>)excludedBranches);
+        => FindCommitBranchesBranchedFrom(
+            branch, configuration, excludedBranches, excludeIgnoredBranches: true);
 
     public IReadOnlyList<ICommit> GetCommitLog(ICommit? baseVersionSource, ICommit currentCommit, IIgnoreConfiguration ignore)
     {
@@ -301,13 +303,17 @@ internal class RepositoryStore(ILogger<RepositoryStore> logger, IGitRepository r
     private IBranch? FindBranch(string branchName) => this.repository.Branches.FirstOrDefault(x => x.Name.EquivalentTo(branchName));
 
     private List<BranchCommit> FindCommitBranchesBranchedFrom(
-        IBranch branch, IGitVersionConfiguration configuration, IEnumerable<IBranch> excludedBranches)
+        IBranch branch,
+        IGitVersionConfiguration configuration,
+        IEnumerable<IBranch> excludedBranches,
+        bool excludeIgnoredBranches)
     {
         using (this.logger.StartIndentedScope($"Finding branches source of '{branch}'"))
         {
             if (branch.Tip != null)
             {
-                return [.. new MergeCommitFinder(this, configuration, excludedBranches, this.logger).FindMergeCommitsFor(branch)];
+                return [.. new MergeCommitFinder(
+                    this, configuration, excludedBranches, this.logger, excludeIgnoredBranches).FindMergeCommitsFor(branch)];
             }
 
             this.logger.LogWarning("Branch {Branch} has no tip.", branch);

--- a/src/GitVersion.Core/Core/SourceBranchFinder.cs
+++ b/src/GitVersion.Core/Core/SourceBranchFinder.cs
@@ -5,24 +5,35 @@ using GitVersion.Git;
 
 namespace GitVersion;
 
-internal class SourceBranchFinder(IEnumerable<IBranch> excludedBranches, IGitVersionConfiguration configuration)
+internal class SourceBranchFinder(
+    IEnumerable<IBranch> excludedBranches,
+    IGitVersionConfiguration configuration,
+    bool excludeIgnoredBranches)
 {
     private readonly IGitVersionConfiguration configuration = configuration.NotNull();
     private readonly IEnumerable<IBranch> excludedBranches = excludedBranches.NotNull();
 
     public IEnumerable<IBranch> FindSourceBranchesOf(IBranch branch)
     {
-        var predicate = new SourceBranchPredicate(branch, this.configuration);
+        var predicate = new SourceBranchPredicate(branch, this.configuration, excludeIgnoredBranches);
         return this.excludedBranches.Where(predicate.IsSourceBranch);
     }
 
-    private sealed class SourceBranchPredicate(IBranch branch, IGitVersionConfiguration configuration)
+    private sealed class SourceBranchPredicate(
+        IBranch branch,
+        IGitVersionConfiguration configuration,
+        bool excludeIgnoredBranches)
     {
         private readonly IEnumerable<Regex> sourceBranchRegexes = GetSourceBranchRegexes(branch, configuration);
 
         public bool IsSourceBranch(INamedReference sourceBranchCandidate)
         {
             if (Equals(sourceBranchCandidate, branch))
+            {
+                return false;
+            }
+
+            if (excludeIgnoredBranches && configuration.Ignore.IsBranchIgnored(sourceBranchCandidate.Name))
             {
                 return false;
             }

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -116,6 +116,15 @@ internal static class ConfigurationExtensions
 
             return !ignoreConfig.IsEmpty ? source.Where(element => ShouldBeIncluded(element, ignoreConfig)) : source;
         }
+
+        public bool IsBranchIgnored(ReferenceName branchName)
+        {
+            ignoreConfig.NotNull();
+            branchName.NotNull();
+
+            return ignoreConfig.Branches.Any(expression =>
+                RegexPatterns.Cache.GetOrAdd(expression).IsMatch(branchName.WithoutRemote));
+        }
     }
 
     private static bool IsTagIgnored(string tagName, IIgnoreConfiguration ignore)

--- a/src/GitVersion.Core/Git/ReferenceName.cs
+++ b/src/GitVersion.Core/Git/ReferenceName.cs
@@ -38,6 +38,7 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
 
         Friendly = Shorten();
         WithoutOrigin = RemoveOrigin();
+        WithoutRemote = RemoveRemote();
     }
 
     /// <summary>Parses <paramref name="canonicalName"/> as a canonical Git reference name, throwing when the input is not a valid canonical form.</summary>
@@ -65,6 +66,9 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
 
     /// <summary>Gets the friendly name with the <c>origin/</c> prefix removed for remote-tracking branches.</summary>
     public string WithoutOrigin { get; }
+
+    /// <summary>Gets the friendly name with the remote name removed for remote-tracking branches.</summary>
+    public string WithoutRemote { get; }
 
     /// <summary>Gets a value indicating whether this is a local branch reference.</summary>
     public bool IsLocalBranch { get; }
@@ -150,6 +154,20 @@ public sealed class ReferenceName : IEquatable<ReferenceName?>, IComparable<Refe
         if (IsRemoteBranch && !IsPullRequest && Friendly.StartsWith(OriginPrefix, StringComparison.Ordinal))
         {
             return Friendly[OriginPrefix.Length..];
+        }
+
+        return Friendly;
+    }
+
+    private string RemoveRemote()
+    {
+        if (IsRemoteBranch && !IsPullRequest)
+        {
+            var separatorIndex = Friendly.IndexOf('/');
+            if (separatorIndex >= 0)
+            {
+                return Friendly[(separatorIndex + 1)..];
+            }
         }
 
         return Friendly;

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -3,7 +3,9 @@ GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> strin
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.IGitVersionConfiguration.VersionBumpResetMessage.get -> string?
+GitVersion.Configuration.IIgnoreConfiguration.Branches.get -> System.Collections.Generic.IReadOnlySet<string!>!
 GitVersion.Configuration.IIgnoreConfiguration.Tags.get -> System.Collections.Generic.IReadOnlySet<string!>!
+GitVersion.Git.ReferenceName.WithoutRemote.get -> string!
 GitVersion.VersionCalculation.CommitMessageIncrement
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement() -> void
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement(GitVersion.VersionField Increment, bool VersionBumpNeedsToBeReset) -> void

--- a/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
+++ b/src/GitVersion.Core/VersionCalculation/EffectiveBranchConfigurationFinder.cs
@@ -82,7 +82,7 @@ internal sealed class EffectiveBranchConfigurationFinder(ILogger<EffectiveBranch
             return null;
         }
 
-        var targetBranch = new SourceBranchFinder(this.repositoryStore.Branches, configuration)
+        var targetBranch = new SourceBranchFinder(this.repositoryStore.Branches, configuration, excludeIgnoredBranches: false)
             .FindSourceBranchesOf(branch)
             .Where(candidate => candidate.Name.EquivalentTo(mergeMessage.TargetBranch))
             .MinBy(candidate => candidate.IsRemote);


### PR DESCRIPTION
## Description

Adds `ignore.branches`, a sequence of regular expressions for excluding auxiliary branches from version-source discovery and build-server normalization.

- Matches case-insensitively against branch names without the local or remote prefix.
- Uses OR semantics and treats local and remote-tracking names equivalently.
- Preserves the current branch and explicitly selected target branch.
- Keeps shared commits, shared tags, and configuration inheritance eligible.
- Avoids creating or updating ignored local branches during normalization while leaving existing local refs untouched.
- Includes configuration, public API, generated schema/workflows, documentation, calculation scenarios, and normalization coverage.

## Related issue

Closes #5130.

## Stack

1. [#5151](https://github.com/GitTools/GitVersion/pull/5151) - order configuration properties alphabetically
2. [#5147](https://github.com/GitTools/GitVersion/pull/5147) - ignore tags
3. This PR - ignore branches

Depends-On: GitTools/GitVersion#5147

## Validation

- `GitVersion.Configuration.Tests`: 113 passed.
- Focused `GitVersion.Core.Tests` with LibGit2Sharp: 29 passed.
- Focused `GitVersion.Core.Tests` with managed Git: 29 passed.
- BuildPrepare completed successfully with zero warnings and errors.
- `dotnet format src/GitVersion.slnx --no-restore` completed successfully.
- Regenerated only `schemas/7.0/GitVersion.configuration.json`.

## Checklist

- [x] Code follows the project style.
- [x] Documentation is updated.
- [x] Tests cover the change.
- [x] New and existing affected tests pass.
