### PR TITLE
refactor: resolve configuration once per execution

### DIFF
--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -13,6 +13,7 @@ internal class GitVersionExecutor(
     IConsole console,
     IConfigurationFileLocator configurationFileLocator,
     IConfigurationProvider configurationProvider,
+    Lazy<IGitVersionConfiguration> configuration,
     IConfigurationSerializer configurationSerializer,
     IGitVersionCalculateTool gitVersionCalculateTool,
     IGitVersionOutputTool gitVersionOutputTool,
@@ -26,6 +27,7 @@ internal class GitVersionExecutor(
 
     private readonly IConfigurationFileLocator configurationFileLocator = configurationFileLocator.NotNull();
     private readonly IConfigurationProvider configurationProvider = configurationProvider.NotNull();
+    private readonly Lazy<IGitVersionConfiguration> configuration = configuration.NotNull();
     private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
 
     private readonly IGitVersionCalculateTool gitVersionCalculateTool = gitVersionCalculateTool.NotNull();
@@ -64,9 +66,7 @@ internal class GitVersionExecutor(
 
             var variables = this.gitVersionCalculateTool.CalculateVersionVariables();
 
-            var configuration = this.configurationProvider.Provide(gitVersionOptions.ConfigurationInfo.OverrideConfiguration);
-
-            this.gitVersionOutputTool.OutputVariables(variables, configuration.UpdateBuildNumber);
+            this.gitVersionOutputTool.OutputVariables(variables, this.configuration.Value.UpdateBuildNumber);
             this.gitVersionOutputTool.UpdateAssemblyInfo(variables);
             this.gitVersionOutputTool.UpdateWixVersionFile(variables);
         }
@@ -140,9 +140,9 @@ internal class GitVersionExecutor(
             this.configurationFileLocator.Verify(gitVersionOptions.WorkingDirectory, this.repositoryInfo.ProjectRootDirectory);
         }
 
-        var configuration = this.configurationProvider.Provide();
-        var configurationString = this.configurationSerializer.Serialize(configuration);
-        this.console.WriteLine(configurationString);
+        var configurationValue = this.configurationProvider.Provide();
+        var serializedConfiguration = this.configurationSerializer.Serialize(configurationValue);
+        this.console.WriteLine(serializedConfiguration);
         return true;
     }
 }

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -54,6 +54,27 @@ public class GitVersionExecutorTests : TestBase
         """;
 
     [Test]
+    public void ResolvedConfiguration_IsCreatedOncePerExecution()
+    {
+        var configuration = GitFlowConfigurationBuilder.New.Build();
+        var configurationProvider = Substitute.For<IConfigurationProvider>();
+        configurationProvider.Provide(Arg.Any<IReadOnlyDictionary<object, object?>?>()).Returns(configuration);
+        var options = Options.Create(new GitVersionOptions());
+        var serviceProvider = ConfigureServices(services =>
+        {
+            services.RemoveAll<IConfigurationProvider>();
+            services.AddSingleton(configurationProvider);
+            services.AddSingleton(options);
+        });
+
+        var actual = serviceProvider.GetRequiredService<Lazy<IGitVersionConfiguration>>();
+
+        _ = actual.Value;
+        _ = actual.Value;
+        configurationProvider.Received(1).Provide(options.Value.ConfigurationInfo.OverrideConfiguration);
+    }
+
+    [Test]
     public void CacheKeySameAfterReNormalizing()
     {
         using var fixture = new EmptyRepositoryFixture();

--- a/src/GitVersion.Core/Core/GitVersionContextFactory.cs
+++ b/src/GitVersion.Core/Core/GitVersionContextFactory.cs
@@ -4,13 +4,13 @@ using GitVersion.Extensions;
 namespace GitVersion;
 
 internal class GitVersionContextFactory(
-    IConfigurationProvider configurationProvider,
+    Lazy<IGitVersionConfiguration> configuration,
     IRepositoryStore repositoryStore,
     ITaggedSemanticVersionRepository taggedSemanticVersionRepository,
     IOptions<GitVersionOptions> options)
     : IGitVersionContextFactory
 {
-    private readonly IConfigurationProvider configurationProvider = configurationProvider.NotNull();
+    private readonly Lazy<IGitVersionConfiguration> configuration = configuration.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly ITaggedSemanticVersionRepository taggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
@@ -18,13 +18,12 @@ internal class GitVersionContextFactory(
     public GitVersionContext Create()
     {
         var gitVersionOptions = this.options.Value;
-        var overrideConfiguration = gitVersionOptions.ConfigurationInfo.OverrideConfiguration;
-        var configuration = this.configurationProvider.Provide(overrideConfiguration);
+        var effectiveConfiguration = this.configuration.Value;
 
         var currentBranch = this.repositoryStore.GetTargetBranch(gitVersionOptions.RepositoryInfo.TargetBranch)
             ?? throw new InvalidOperationException("Need a branch to operate on");
         var currentCommit = this.repositoryStore.GetCurrentCommit(
-            currentBranch, gitVersionOptions.RepositoryInfo.CommitId, configuration.Ignore
+            currentBranch, gitVersionOptions.RepositoryInfo.CommitId, effectiveConfiguration.Ignore
         ) ?? throw new GitVersionException("No commits found on the current branch.");
         if (currentBranch.IsDetachedHead)
         {
@@ -35,12 +34,12 @@ internal class GitVersionContextFactory(
         }
 
         var isCurrentCommitTagged = this.taggedSemanticVersionRepository.GetTaggedSemanticVersions(
-            tagPrefix: configuration.TagPrefixPattern,
-            format: configuration.SemanticVersionFormat,
-            ignore: configuration.Ignore
+            tagPrefix: effectiveConfiguration.TagPrefixPattern,
+            format: effectiveConfiguration.SemanticVersionFormat,
+            ignore: effectiveConfiguration.Ignore
         ).Contains(currentCommit);
         var numberOfUncommittedChanges = this.repositoryStore.UncommittedChangesCount;
 
-        return new(currentBranch, currentCommit, configuration, isCurrentCommitTagged, numberOfUncommittedChanges);
+        return new(currentBranch, currentCommit, effectiveConfiguration, isCurrentCommitTagged, numberOfUncommittedChanges);
     }
 }

--- a/src/GitVersion.Core/GitVersionCoreModule.cs
+++ b/src/GitVersion.Core/GitVersionCoreModule.cs
@@ -1,3 +1,4 @@
+using GitVersion.Configuration;
 using GitVersion.Extensions;
 using GitVersion.VersionCalculation;
 using GitVersion.VersionCalculation.Caching;
@@ -21,6 +22,12 @@ public class GitVersionCoreModule : IGitVersionModule
         services.AddSingleton<IBranchRepository, BranchRepository>();
 
         services.AddSingleton<IGitVersionContextFactory, GitVersionContextFactory>();
+        services.AddSingleton(sp => new Lazy<IGitVersionConfiguration>(() =>
+        {
+            var configurationProvider = sp.GetRequiredService<IConfigurationProvider>();
+            var options = sp.GetRequiredService<IOptions<GitVersionOptions>>();
+            return configurationProvider.Provide(options.Value.ConfigurationInfo.OverrideConfiguration);
+        }));
         services.AddSingleton(sp =>
         {
             var contextFactory = sp.GetRequiredService<IGitVersionContextFactory>();

--- a/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
+++ b/src/GitVersion.MsBuild/GitVersionTaskExecutor.cs
@@ -11,14 +11,14 @@ internal class GitVersionTaskExecutor(
     IFileSystem fileSystem,
     IGitVersionOutputTool gitVersionOutputTool,
     IVersionVariableSerializer serializer,
-    IConfigurationProvider configurationProvider,
+    Lazy<IGitVersionConfiguration> configuration,
     IOptions<GitVersionOptions> options)
     : IGitVersionTaskExecutor
 {
     private readonly IFileSystem fileSystem = fileSystem.NotNull();
     private readonly IGitVersionOutputTool gitVersionOutputTool = gitVersionOutputTool.NotNull();
     private readonly IVersionVariableSerializer serializer = serializer.NotNull();
-    private readonly IConfigurationProvider configurationProvider = configurationProvider.NotNull();
+    private readonly Lazy<IGitVersionConfiguration> configuration = configuration.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
     public void GetVersion(GetVersion task)
@@ -103,10 +103,7 @@ internal class GitVersionTaskExecutor(
     {
         var versionVariables = GitVersionVariables(task);
 
-        var gitVersionOptions = this.options.Value;
-        var configuration = this.configurationProvider.Provide(gitVersionOptions.ConfigurationInfo.OverrideConfiguration);
-
-        this.gitVersionOutputTool.OutputVariables(versionVariables, configuration.UpdateBuildNumber);
+        this.gitVersionOutputTool.OutputVariables(versionVariables, this.configuration.Value.UpdateBuildNumber);
     }
 
     private GitVersionVariables GitVersionVariables(GitVersionTaskBase task) => this.serializer.FromFile(task.VersionFile);


### PR DESCRIPTION
## Description

Resolves the effective configuration once per dependency-injection container and shares it through a lazy instance.

This avoids repeated configuration parsing across version calculation, CLI output, and MSBuild output while preserving the existing separate show-config path.

## Context

Extracted from #5148 after review identified the configuration-lifetime change as a separate concern from branch exclusions.

## Validation

- dotnet restore src/GitVersion.slnx
- dotnet format src/GitVersion.slnx --no-restore
- dotnet build src/GitVersion.slnx --no-restore: 0 warnings, 0 errors
- Focused configuration-resolution test: 1 passed
- GitVersion.App.Tests: 356 passed
- GitVersion.MsBuild.Tests: 151 passed