### PR TITLE
Order configuration properties alphabetically

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -41,98 +41,65 @@ The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) l
 <!-- snippet: /docs/workflows/GitFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitFlow/v1.yml'></a>
 ```yml
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   develop:
-    mode: ContinuousDelivery
-    label: alpha
     increment: Minor
+    is-main-branch: false
+    is-release-branch: false
+    is-source-branch-for: []
+    label: alpha
+    mode: ContinuousDelivery
+    pre-release-weight: 0
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-target: true
-    track-merge-message: true
     regex: ^dev(elop)?(ment)?$
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: true
     tracks-release-branches: true
-    is-release-branch: false
-    is-main-branch: false
-    pre-release-weight: 0
   main:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   release:
-    mode: ManualDeployment
-    label: beta
     increment: Minor
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-target: false
     regex: "^releases?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - develop
@@ -140,17 +107,16 @@ branches:
       - release
       - support
       - hotfix
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - develop
@@ -159,40 +125,41 @@ branches:
       - feature
       - support
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ManualDeployment
-    label: beta
     increment: Inherit
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   support:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
     regex: "^support[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
     prevent-increment:
       when-current-commit-tagged: true
     regex: "(?<BranchName>.+)"
@@ -204,11 +171,44 @@ branches:
       - pull-request
       - hotfix
       - support
-    is-source-branch-for: []
-    is-main-branch: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - Fallback
+  - ConfiguredNextVersion
+  - MergeMessage
+  - TaggedCommit
+  - TrackReleaseBranches
+  - VersionInBranchName
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
 <sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -218,36 +218,108 @@ The supported built-in configuration for the `GitHubFlow` workflow (`workflow: G
 <!-- snippet: /docs/workflows/GitHubFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitHubFlow/v1.yml'></a>
 ```yml
-mode: ContinuousDelivery
-label: "{BranchName}"
+assembly-file-versioning-scheme: MajorMinorPatch
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  main:
+    increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
+    prevent-increment:
+      of-merged-branch: true
+    regex: "^master$|^main$"
+    source-branches: []
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  release:
+    increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-branch-merged: false
+      when-current-commit-tagged: false
+    regex: "^releases?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  feature:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "^features?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+    track-merge-message: true
+  pull-request:
+    increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+    source-branches:
+      - main
+      - release
+      - feature
+    track-merge-message: true
+  unknown:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "(?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+      - feature
+      - pull-request
+    track-merge-message: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
+ignore:
+  paths: []
+  sha: []
 increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
 prevent-increment:
   of-merged-branch: false
   when-branch-merged: false
   when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
 regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
-assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
 semantic-version-format: Strict
+source-branches: []
 strategies:
   - Fallback
   - ConfiguredNextVersion
@@ -255,86 +327,14 @@ strategies:
   - TaggedCommit
   - TrackReleaseBranches
   - VersionInBranchName
-branches:
-  main:
-    label: ''
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^master$|^main$"
-    source-branches: []
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
-  release:
-    mode: ManualDeployment
-    label: beta
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
-  feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
-  pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
-  unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    is-source-branch-for: []
-    is-main-branch: false
-ignore:
-  sha: []
-  paths: []
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
 <sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -344,152 +344,113 @@ The preview built-in configuration (experimental usage only) for the `TrunkBased
 <!-- snippet: /docs/workflows/TrunkBased/preview1.yml -->
 <a id='snippet-/docs/workflows/TrunkBased/preview1.yml'></a>
 ```yml
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   main:
-    mode: ContinuousDeployment
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    mode: ContinuousDeployment
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   feature:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Minor
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - main
       - feature
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   unknown:
     increment: Patch
+    is-source-branch-for: []
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "(?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    pre-release-weight: 30000
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - ConfiguredNextVersion
+  - Mainline
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
 ```
 <sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The details of the available options are as follows:
-
-### workflow
-
-The base template of the configuration to use. Possible values are `GitFlow/v1` or `GitHubFlow/v1`. Defaults to `GitFlow/v1` if not set. To create a configuration from scratch without using a base template, please specify an empty string.
-
-### next-version
-
-Allows you to bump the next version explicitly. Useful for bumping `main` or a
-feature branch with breaking changes (i.e., a major increment), indicating what
-the next `git tag` is going to be.
-
-`next-version` is not a permanent replacement for `git tag` and should only be
-used intermittently. Since version 5.5 GitVersion supports `next-version` with
-`mode: Mainline` and should not be treated as a "base version".
-
-If you are using `next-version` and are experiencing weird versioning behaviour,
-please remove it, create a `git tag` with an appropriate version number on an
-appropriate historical commit and see if that resolves any versioning issues
-you may have.
-
-### assembly-versioning-scheme
-
-When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
-to treat the `AssemblyVersion` attribute. Useful to lock the major when using
-Strong Naming. Note: you can use `None` to skip updating the `AssemblyVersion`
-while still updating the `AssemblyFileVersion` and `AssemblyInformationVersion`
-attributes. Valid values: `MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`,
-`Major`, `None`.
-
-For information on using format strings in these properties, see
-[Format Strings](/docs/reference/custom-formatting).
-
-### assembly-file-versioning-scheme
-
-When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
-how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
-skip updating the `AssemblyFileVersion` while still updating the
-`AssemblyVersion` and `AssemblyInformationVersion` attributes. Valid values:
-`MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`, `Major`, `None`.
 
 ### assembly-file-versioning-format
 
@@ -510,17 +471,160 @@ assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
-### assembly-versioning-format
+### assembly-file-versioning-scheme
 
-Specifies the format of `AssemblyVersion` and
-overwrites the value of `assembly-versioning-scheme`.
-Follows the same formatting semantics as `assembly-file-versioning-format`.
+When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
+how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
+skip updating the `AssemblyFileVersion` while still updating the
+`AssemblyVersion` and `AssemblyInformationVersion` attributes. Valid values:
+`MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`, `Major`, `None`.
 
 ### assembly-informational-format
 
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
+
+### assembly-versioning-format
+
+Specifies the format of `AssemblyVersion` and
+overwrites the value of `assembly-versioning-scheme`.
+Follows the same formatting semantics as `assembly-file-versioning-format`.
+
+### assembly-versioning-scheme
+
+When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
+to treat the `AssemblyVersion` attribute. Useful to lock the major when using
+Strong Naming. Note: you can use `None` to skip updating the `AssemblyVersion`
+while still updating the `AssemblyFileVersion` and `AssemblyInformationVersion`
+attributes. Valid values: `MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`,
+`Major`, `None`.
+
+For information on using format strings in these properties, see
+[Format Strings](/docs/reference/custom-formatting).
+
+### branches
+
+The header for all the individual branch configuration.
+
+### increment
+
+Same as for the [global configuration, explained above](#increment).
+
+### is-main-branch
+
+This indicates that this branch is a main branch. By default `main` and `support/*` are main branches.
+
+### is-release-branch
+
+Indicates this branch config represents a release branch in GitFlow.
+
+### label
+
+The pre-release label to use for this branch. Use the value `{BranchName}` as a placeholder to
+insert the value of the named group `BranchName` from the [regular expression](#regex).
+
+For example: branch `feature/foo` would become a pre-release label
+of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?<BranchName>.+)'`.
+
+Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
+
+You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
+
+**Note:** To clear a default use an empty string: `label: ''`
+
+### label-number-pattern
+
+Pull requests require us to extract the pre-release number out of the branch
+name so `refs/pull/534/merge` builds as `PullRequest534`. This is a regex with
+a named capture group called `Number`.
+
+**Example usage:**
+
+```yaml
+branches:
+  pull-request:
+    mode: ContinuousDelivery
+    label: PullRequest{Number}
+    increment: Inherit
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    track-merge-message: true
+    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+    source-branches:
+    - main
+    - release
+    - feature
+    is-source-branch-for: []
+    pre-release-weight: 30000
+```
+
+### mode
+
+Same as for the [global configuration, explained above](#mode).
+
+### pre-release-weight
+
+Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
+value in order to avoid version collisions across different branches. For
+example, a release branch created after "1.2.3-alpha.55" results in
+"1.2.3-beta.1" and thus e.g. "1.2.3-alpha.4" and "1.2.3-beta.4" would have the
+same file version: "1.2.3.4". One of the ways to use this value is to set
+`assembly-file-versioning-format:
+{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber}`. If the `pre-release-weight`
+is set, it would be added to the `PreReleaseNumber` to get a final
+`AssemblySemFileVer`, otherwise a branch specific default for
+`pre-release-weight` will be used in the calculation. Related Issues [1145][1145]
+and [1366][1366].
+
+### prevent-increment-of-merged-branch
+
+The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when this branch related property is set to true on the target branch.
+
+When `release-2.0.0` is merged into main, we want main to build `2.0.0`. If
+`release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
+prevents incrementing after a versioned branch is merged.
+
+In a GitFlow-based repository, setting this option can have implications on the
+`VersionSourceDistance` output variable. It can rule out a potentially
+better version source proposed by the `MergeMessageBaseVersionStrategy`. For
+more details and an in-depth analysis, please see [the discussion][2506].
+
+### prevent-increment-when-branch-merged
+
+The increment of the merged branch will be ignored when this branch related property is set to `true` on the source branch.
+
+### prevent-increment-when-current-commit-tagged
+
+This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.
+
+### track-merge-message
+
+This property is a branch related property and gives the user the possibility to control the behavior of whether the merge
+commit message will be interpreted as a next version or not. Consider we have a main branch and a `release/1.0.0` branch and
+merge changes from `release/1.0.0` to the `main` branch. If `track-merge-message` is set to `true` then the next version will
+be `1.0.0` otherwise `0.0.1`.
+
+### track-merge-target
+
+Strategy which will look for tagged merge commits directly off the current
+branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
+`1.0.0`. The tag is *not* on develop, but develop should be version `1.0.0` now.
+
+### tracks-release-branches
+
+Indicates this branch config represents develop in GitFlow.
+
+### commit-date-format
+
+Sets the format which will be used to format the `CommitDate` output variable.
+
+### commit-message-incrementing
+
+Sets whether it should be possible to increment the version with special syntax
+in the commit message. See the `*-version-bump-message` options above for
+details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
 
@@ -529,97 +633,6 @@ Follows the same formatting semantics as `assembly-file-versioning-format` and
 can use version variables or environment variables. `CustomVersion` is empty
 when no format is configured. The format can be configured globally and
 overridden for individual branches under `branches`.
-
-### mode
-
-Sets the `mode` of how GitVersion should create a new version. Read more at
-[deployment modes][modes].
-
-### increment
-
-The part of the SemVer to increment when GitVersion detects it needs to be
-increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
-
-The special value `Inherit` means that GitVersion should find the parent branch
-(i.e. the branch where the current branch was branched from), and use its values
-for [increment](#increment) or other branch related properties.
-
-For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
-captured from the merge commit message as the immediate parent when it matches
-an allowed source branch. If the message has no matching target, GitVersion
-falls back to Git ancestry, as it does for ordinary branches.
-
-### tag-prefix
-
-A regular expression which is used to trim Git tags before processing (e.g.,
-v1.0.0). The default value is `[vV]`.
-
-### version-in-branch-pattern
-
-A regular expression which is used to determine the version number in the branch
-name or commit message (e.g., v1.0.0-LTS). This setting only applies on branches
-where the option `is-release-branch` is set to `true`. The default value is
-`(?<version>[vV]?\d+(\.\d+)?(\.\d+)?).*`.
-
-### major-version-bump-message
-
-The regex to match commit messages with to perform a major version increment.
-Default set to `'[+=]semver:\s?(breaking|major)'`, which will match occurrences
-of `+semver: major`, `=semver: major`, and the corresponding `breaking` forms.
-
-### minor-version-bump-message
-
-The regex to match commit messages with to perform a minor version increment.
-Default set to `'[+=]semver:\s?(feature|minor)'`, which will match occurrences
-of `+semver: minor`, `=semver: minor`, and the corresponding `feature` forms.
-
-### patch-version-bump-message
-
-The regex to match commit messages with to perform a patch version increment.
-Default set to `'[+=]semver:\s?(fix|patch)'`, which will match occurrences of
-`+semver: patch`, `=semver: patch`, and the corresponding `fix` forms.
-
-### no-bump-message
-
-Used to tell GitVersion not to increment when in Mainline development mode.
-Default `[+=]semver:\s?(none|skip)`, which will match both the `+semver` and
-`=semver` forms of `none` and `skip`.
-
-When a commit matches **both** the `no-bump-message` **and** any combination of
-the `version-bump-message`, `no-bump-message` takes precedence and no increment is applied.
-
-### version-bump-reset-message
-
-The regex to match a commit message that resets the version bump baseline and
-suppresses the configured branch increment. The default is `=semver:`. The
-increment itself is still selected by the major, minor, patch, and no-bump
-message patterns above, whose defaults accept both `+semver` and `=semver`.
-
-For example, when a branch is configured with `increment: Patch`, a commit
-containing `=semver: none` keeps the current version and a commit containing
-`=semver: minor` selects a minor increment. Unlike the `+semver` form, the `=`
-form resets earlier commit-message increments in the calculation range and can
-lower the configured increment. This setting follows
-`commit-message-incrementing`.
-
-### tag-pre-release-weight
-
-The pre-release weight in case of tagged commits. If the value is not set in the
-configuration, a default weight of 60000 is used instead. If the
-`WeightedPreReleaseNumber` [variable][variables] is 0 and this parameter is set,
-its value is used. This helps if your branching model is GitFlow and the last
-release build, which is often tagged, can utilize this parameter to produce a
-monotonically increasing build number.
-
-### commit-message-incrementing
-
-Sets whether it should be possible to increment the version with special syntax
-in the commit message. See the `*-version-bump-message` options above for
-details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
-
-### commit-date-format
-
-Sets the format which will be used to format the `CommitDate` output variable.
 
 ### ignore
 
@@ -630,26 +643,6 @@ The header property for the `ignore` configuration.
 the search for a [version source][version-sources], not when calculating other
 parts of the version number, such as build metadata.
 :::
-
-#### sha
-
-A sequence of SHAs to be excluded from the version calculations. Useful when
-there is a rogue commit in history yielding a bad version. You can use either
-style below:
-
-```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
-```
-
-or
-
-```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
-```
 
 #### commits-before
 
@@ -706,6 +699,79 @@ This can lead to unexpected behavior on case-insensitive file systems, such as W
 A commit is ignored by the `ignore.paths` configuration only if **all paths** changed in that commit match one or more of the specified regular expressions. If a path in a commit does not match any one of the ignore patterns, that commit will be included in version calculations.
 :::
 
+#### sha
+
+A sequence of SHAs to be excluded from the version calculations. Useful when
+there is a rogue commit in history yielding a bad version. You can use either
+style below:
+
+```yaml
+ignore:
+  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+```
+
+or
+
+```yaml
+ignore:
+  sha:
+    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+```
+
+### increment
+
+The part of the SemVer to increment when GitVersion detects it needs to be
+increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
+
+The special value `Inherit` means that GitVersion should find the parent branch
+(i.e. the branch where the current branch was branched from), and use its values
+for [increment](#increment) or other branch related properties.
+
+For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
+captured from the merge commit message as the immediate parent when it matches
+an allowed source branch. If the message has no matching target, GitVersion
+falls back to Git ancestry, as it does for ordinary branches.
+
+### is-source-branch-for
+
+The reverse of `source-branches`. This property was introduced to keep it easy
+to extend GitVersion's config.
+
+It exists to make it easier to extend GitVersion's configuration. If only
+`source-branches` exists and you add a new branch type, for instance
+`unstable/`, you then need to re-define the `source-branches` configuration
+value for existing branches (like feature/) to now include the new unstable
+branch.
+
+A complete example:
+
+```yaml
+branches:
+  unstable:
+    regex: ...
+    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+```
+
+Without this configuration value you would have to do:
+
+```yaml
+branches:
+  unstable:
+    regex:
+  feature:
+    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+  release:
+    source-branches: ['unstable', 'develop']
+  etc...
+```
+
+### major-version-bump-message
+
+The regex to match commit messages with to perform a major version increment.
+Default set to `'[+=]semver:\s?(breaking|major)'`, which will match occurrences
+of `+semver: major`, `=semver: major`, and the corresponding `breaking` forms.
+
 ### merge-message-formats
 
 Custom merge message formats to enable identification of merge messages that do not
@@ -727,6 +793,153 @@ The regular expression should contain the following capture groups:
 Custom merge message formats are evaluated *before* any built in formats.
 Support for [Conventional Commits][conventional-commits] can be
 [configured][conventional-commits-config].
+
+### minor-version-bump-message
+
+The regex to match commit messages with to perform a minor version increment.
+Default set to `'[+=]semver:\s?(feature|minor)'`, which will match occurrences
+of `+semver: minor`, `=semver: minor`, and the corresponding `feature` forms.
+
+### mode
+
+Sets the `mode` of how GitVersion should create a new version. Read more at
+[deployment modes][modes].
+
+### next-version
+
+Allows you to bump the next version explicitly. Useful for bumping `main` or a
+feature branch with breaking changes (i.e., a major increment), indicating what
+the next `git tag` is going to be.
+
+`next-version` is not a permanent replacement for `git tag` and should only be
+used intermittently. Since version 5.5 GitVersion supports `next-version` with
+`mode: Mainline` and should not be treated as a "base version".
+
+If you are using `next-version` and are experiencing weird versioning behaviour,
+please remove it, create a `git tag` with an appropriate version number on an
+appropriate historical commit and see if that resolves any versioning issues
+you may have.
+
+### no-bump-message
+
+Used to tell GitVersion not to increment when in Mainline development mode.
+Default `[+=]semver:\s?(none|skip)`, which will match both the `+semver` and
+`=semver` forms of `none` and `skip`.
+
+When a commit matches **both** the `no-bump-message` **and** any combination of
+the `version-bump-message`, `no-bump-message` takes precedence and no increment is applied.
+
+### patch-version-bump-message
+
+The regex to match commit messages with to perform a patch version increment.
+Default set to `'[+=]semver:\s?(fix|patch)'`, which will match occurrences of
+`+semver: patch`, `=semver: patch`, and the corresponding `fix` forms.
+
+### regex
+
+This is the regex which is used to match the current branch to the correct
+branch configuration.
+
+[Named groups](https://learn.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions) can be used to dynamically label pre-releases based on the branch name, or parts of it. See [Label](#label) for more details and examples.
+
+### semantic-version-format
+
+Specifies the semantic version format that is used when parsing the string.
+Can be `Strict` - using the [regex](https://regex101.com/r/Ly7O1x/3/)
+or `Loose` the old way of parsing. The default if not specified is `Strict`
+Example of invalid `Strict`, but valid `Loose`
+
+```log
+1.2-alpha4
+01.02.03-rc03
+1.2.3.4
+```
+
+### source-branches
+
+Because Git commits only refer to parent commits (not branches) GitVersion
+sometimes cannot tell which branch the current branch was branched from.
+
+Take this commit graph
+
+```shell
+* release/v1.0.0   * feature/foo
+| ________________/
+|/
+*
+*
+* (main)
+```
+
+By looking at this graph, you cannot tell which of these scenarios happened:
+
+* feature/foo branches off release/v1.0.0
+  * Branch release/v1.0.0 from main
+  * Branch feature/foo from release/v1.0.0
+  * Add a commit to both release/v1.0.0 and feature/foo
+  * release/v1.0.0 is the base for feature/foo
+* release/v1.0.0 branches off feature/foo
+  * Branch feature/foo from main
+  * Branch release/v1.0.0 from feature/foo
+  * Add a commit to both release/v1.0.0 and feature/foo
+  * feature/foo is the base for release/v1.0.0
+
+Or put more simply, you cannot tell which branch was created first,
+`release/v1.0.0` or `feature/foo`.
+
+To resolve this issue, we give GitVersion a hint about our branching workflows
+by telling it what types of branches a branch can be created from. For example,
+feature branches are, by default, configured to have the following source
+branches:
+
+`source-branches: ['main', 'develop', 'feature', 'hotfix', 'support']`
+
+This means that we will never bother to evaluate pull request branches as merge
+base options and being explicit in this way also improves the performance of
+GitVersion.
+
+### strategies
+
+Specifies which version strategy implementation (one or more) will be used to determine the next version.
+These strategies can be combined, and the order in which they are specified does not matter.
+The configuration accepts the following values:
+
+* Fallback
+* ConfiguredNextVersion
+* MergeMessage
+* TaggedCommit
+* TrackReleaseBranches
+* VersionInBranchName
+* Mainline
+
+[1145]: https://github.com/GitTools/GitVersion/issues/1145
+
+[1366]: https://github.com/GitTools/GitVersion/issues/1366
+
+[2506]: https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037
+
+[conventional-commits-config]: /docs/reference/version-increments#conventional-commit-messages
+
+[conventional-commits]: https://www.conventionalcommits.org/
+
+[modes]: /docs/reference/modes
+
+[variables]: /docs/reference/variables
+
+[version-sources]: /docs/reference/version-sources
+### tag-pre-release-weight
+
+The pre-release weight in case of tagged commits. If the value is not set in the
+configuration, a default weight of 60000 is used instead. If the
+`WeightedPreReleaseNumber` [variable][variables] is 0 and this parameter is set,
+its value is used. This helps if your branching model is GitFlow and the last
+release build, which is often tagged, can utilize this parameter to produce a
+monotonically increasing build number.
+
+### tag-prefix
+
+A regular expression which is used to trim Git tags before processing (e.g.,
+v1.0.0). The default value is `[vV]`.
 
 ### update-build-number
 
@@ -832,241 +1045,27 @@ used (recommended).
 We don't envision many people needing to change most of these configuration
 values, but here they are if you need to:
 
-### regex
+### version-bump-reset-message
 
-This is the regex which is used to match the current branch to the correct
-branch configuration.
+The regex to match a commit message that resets the version bump baseline and
+suppresses the configured branch increment. The default is `=semver:`. The
+increment itself is still selected by the major, minor, patch, and no-bump
+message patterns above, whose defaults accept both `+semver` and `=semver`.
 
-[Named groups](https://learn.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions) can be used to dynamically label pre-releases based on the branch name, or parts of it. See [Label](#label) for more details and examples.
+For example, when a branch is configured with `increment: Patch`, a commit
+containing `=semver: none` keeps the current version and a commit containing
+`=semver: minor` selects a minor increment. Unlike the `+semver` form, the `=`
+form resets earlier commit-message increments in the calculation range and can
+lower the configured increment. This setting follows
+`commit-message-incrementing`.
 
-### source-branches
+### version-in-branch-pattern
 
-Because Git commits only refer to parent commits (not branches) GitVersion
-sometimes cannot tell which branch the current branch was branched from.
+A regular expression which is used to determine the version number in the branch
+name or commit message (e.g., v1.0.0-LTS). This setting only applies on branches
+where the option `is-release-branch` is set to `true`. The default value is
+`(?<version>[vV]?\d+(\.\d+)?(\.\d+)?).*`.
 
-Take this commit graph
+### workflow
 
-```shell
-* release/v1.0.0   * feature/foo
-| ________________/
-|/
-*
-*
-* (main)
-```
-
-By looking at this graph, you cannot tell which of these scenarios happened:
-
-* feature/foo branches off release/v1.0.0
-  * Branch release/v1.0.0 from main
-  * Branch feature/foo from release/v1.0.0
-  * Add a commit to both release/v1.0.0 and feature/foo
-  * release/v1.0.0 is the base for feature/foo
-* release/v1.0.0 branches off feature/foo
-  * Branch feature/foo from main
-  * Branch release/v1.0.0 from feature/foo
-  * Add a commit to both release/v1.0.0 and feature/foo
-  * feature/foo is the base for release/v1.0.0
-
-Or put more simply, you cannot tell which branch was created first,
-`release/v1.0.0` or `feature/foo`.
-
-To resolve this issue, we give GitVersion a hint about our branching workflows
-by telling it what types of branches a branch can be created from. For example,
-feature branches are, by default, configured to have the following source
-branches:
-
-`source-branches: ['main', 'develop', 'feature', 'hotfix', 'support']`
-
-This means that we will never bother to evaluate pull request branches as merge
-base options and being explicit in this way also improves the performance of
-GitVersion.
-
-### is-source-branch-for
-
-The reverse of `source-branches`. This property was introduced to keep it easy
-to extend GitVersion's config.
-
-It exists to make it easier to extend GitVersion's configuration. If only
-`source-branches` exists and you add a new branch type, for instance
-`unstable/`, you then need to re-define the `source-branches` configuration
-value for existing branches (like feature/) to now include the new unstable
-branch.
-
-A complete example:
-
-```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
-```
-
-Without this configuration value you would have to do:
-
-```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
-```
-
-### branches
-
-The header for all the individual branch configuration.
-
-### mode
-
-Same as for the [global configuration, explained above](#mode).
-
-### label
-
-The pre-release label to use for this branch. Use the value `{BranchName}` as a placeholder to
-insert the value of the named group `BranchName` from the [regular expression](#regex).
-
-For example: branch `feature/foo` would become a pre-release label
-of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?<BranchName>.+)'`.
-
-Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
-
-You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
-
-**Note:** To clear a default use an empty string: `label: ''`
-
-### increment
-
-Same as for the [global configuration, explained above](#increment).
-
-### prevent-increment-of-merged-branch
-
-The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when this branch related property is set to true on the target branch.
-
-When `release-2.0.0` is merged into main, we want main to build `2.0.0`. If
-`release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
-prevents incrementing after a versioned branch is merged.
-
-In a GitFlow-based repository, setting this option can have implications on the
-`VersionSourceDistance` output variable. It can rule out a potentially
-better version source proposed by the `MergeMessageBaseVersionStrategy`. For
-more details and an in-depth analysis, please see [the discussion][2506].
-
-### prevent-increment-when-branch-merged
-
-The increment of the merged branch will be ignored when this branch related property is set to `true` on the source branch.
-
-### prevent-increment-when-current-commit-tagged
-
-This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.
-
-### label-number-pattern
-
-Pull requests require us to extract the pre-release number out of the branch
-name so `refs/pull/534/merge` builds as `PullRequest534`. This is a regex with
-a named capture group called `Number`.
-
-**Example usage:**
-
-```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
-```
-
-### track-merge-target
-
-Strategy which will look for tagged merge commits directly off the current
-branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
-`1.0.0`. The tag is *not* on develop, but develop should be version `1.0.0` now.
-
-### track-merge-message
-
-This property is a branch related property and gives the user the possibility to control the behavior of whether the merge
-commit message will be interpreted as a next version or not. Consider we have a main branch and a `release/1.0.0` branch and
-merge changes from `release/1.0.0` to the `main` branch. If `track-merge-message` is set to `true` then the next version will
-be `1.0.0` otherwise `0.0.1`.
-
-### tracks-release-branches
-
-Indicates this branch config represents develop in GitFlow.
-
-### is-release-branch
-
-Indicates this branch config represents a release branch in GitFlow.
-
-### is-main-branch
-
-This indicates that this branch is a main branch. By default `main` and `support/*` are main branches.
-
-### pre-release-weight
-
-Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
-value in order to avoid version collisions across different branches. For
-example, a release branch created after "1.2.3-alpha.55" results in
-"1.2.3-beta.1" and thus e.g. "1.2.3-alpha.4" and "1.2.3-beta.4" would have the
-same file version: "1.2.3.4". One of the ways to use this value is to set
-`assembly-file-versioning-format:
-{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber}`. If the `pre-release-weight`
-is set, it would be added to the `PreReleaseNumber` to get a final
-`AssemblySemFileVer`, otherwise a branch specific default for
-`pre-release-weight` will be used in the calculation. Related Issues [1145][1145]
-and [1366][1366].
-
-### semantic-version-format
-
-Specifies the semantic version format that is used when parsing the string.
-Can be `Strict` - using the [regex](https://regex101.com/r/Ly7O1x/3/)
-or `Loose` the old way of parsing. The default if not specified is `Strict`
-Example of invalid `Strict`, but valid `Loose`
-
-```log
-1.2-alpha4
-01.02.03-rc03
-1.2.3.4
-```
-
-### strategies
-
-Specifies which version strategy implementation (one or more) will be used to determine the next version.
-These strategies can be combined, and the order in which they are specified does not matter.
-The configuration accepts the following values:
-
-* Fallback
-* ConfiguredNextVersion
-* MergeMessage
-* TaggedCommit
-* TrackReleaseBranches
-* VersionInBranchName
-* Mainline
-
-[1145]: https://github.com/GitTools/GitVersion/issues/1145
-
-[1366]: https://github.com/GitTools/GitVersion/issues/1366
-
-[2506]: https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037
-
-[conventional-commits-config]: /docs/reference/version-increments#conventional-commit-messages
-
-[conventional-commits]: https://www.conventionalcommits.org/
-
-[modes]: /docs/reference/modes
-
-[variables]: /docs/reference/variables
-
-[version-sources]: /docs/reference/version-sources
+The base template of the configuration to use. Possible values are `GitFlow/v1` or `GitHubFlow/v1`. Defaults to `GitFlow/v1` if not set. To create a configuration from scratch without using a base template, please specify an empty string.

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -50,45 +50,6 @@ snippet: /docs/workflows/TrunkBased/preview1.yml
 
 The details of the available options are as follows:
 
-### workflow
-
-The base template of the configuration to use. Possible values are `GitFlow/v1` or `GitHubFlow/v1`. Defaults to `GitFlow/v1` if not set. To create a configuration from scratch without using a base template, please specify an empty string.
-
-### next-version
-
-Allows you to bump the next version explicitly. Useful for bumping `main` or a
-feature branch with breaking changes (i.e., a major increment), indicating what
-the next `git tag` is going to be.
-
-`next-version` is not a permanent replacement for `git tag` and should only be
-used intermittently. Since version 5.5 GitVersion supports `next-version` with
-`mode: Mainline` and should not be treated as a "base version".
-
-If you are using `next-version` and are experiencing weird versioning behaviour,
-please remove it, create a `git tag` with an appropriate version number on an
-appropriate historical commit and see if that resolves any versioning issues
-you may have.
-
-### assembly-versioning-scheme
-
-When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
-to treat the `AssemblyVersion` attribute. Useful to lock the major when using
-Strong Naming. Note: you can use `None` to skip updating the `AssemblyVersion`
-while still updating the `AssemblyFileVersion` and `AssemblyInformationVersion`
-attributes. Valid values: `MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`,
-`Major`, `None`.
-
-For information on using format strings in these properties, see
-[Format Strings](/docs/reference/custom-formatting).
-
-### assembly-file-versioning-scheme
-
-When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
-how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
-skip updating the `AssemblyFileVersion` while still updating the
-`AssemblyVersion` and `AssemblyInformationVersion` attributes. Valid values:
-`MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`, `Major`, `None`.
-
 ### assembly-file-versioning-format
 
 Specifies the format of `AssemblyFileVersion` and
@@ -108,17 +69,160 @@ assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
-### assembly-versioning-format
+### assembly-file-versioning-scheme
 
-Specifies the format of `AssemblyVersion` and
-overwrites the value of `assembly-versioning-scheme`.
-Follows the same formatting semantics as `assembly-file-versioning-format`.
+When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
+how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
+skip updating the `AssemblyFileVersion` while still updating the
+`AssemblyVersion` and `AssemblyInformationVersion` attributes. Valid values:
+`MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`, `Major`, `None`.
 
 ### assembly-informational-format
 
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
+
+### assembly-versioning-format
+
+Specifies the format of `AssemblyVersion` and
+overwrites the value of `assembly-versioning-scheme`.
+Follows the same formatting semantics as `assembly-file-versioning-format`.
+
+### assembly-versioning-scheme
+
+When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
+to treat the `AssemblyVersion` attribute. Useful to lock the major when using
+Strong Naming. Note: you can use `None` to skip updating the `AssemblyVersion`
+while still updating the `AssemblyFileVersion` and `AssemblyInformationVersion`
+attributes. Valid values: `MajorMinorPatchTag`, `MajorMinorPatch`, `MajorMinor`,
+`Major`, `None`.
+
+For information on using format strings in these properties, see
+[Format Strings](/docs/reference/custom-formatting).
+
+### branches
+
+The header for all the individual branch configuration.
+
+### increment
+
+Same as for the [global configuration, explained above](#increment).
+
+### is-main-branch
+
+This indicates that this branch is a main branch. By default `main` and `support/*` are main branches.
+
+### is-release-branch
+
+Indicates this branch config represents a release branch in GitFlow.
+
+### label
+
+The pre-release label to use for this branch. Use the value `{BranchName}` as a placeholder to
+insert the value of the named group `BranchName` from the [regular expression](#regex).
+
+For example: branch `feature/foo` would become a pre-release label
+of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?<BranchName>.+)'`.
+
+Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
+
+You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
+
+**Note:** To clear a default use an empty string: `label: ''`
+
+### label-number-pattern
+
+Pull requests require us to extract the pre-release number out of the branch
+name so `refs/pull/534/merge` builds as `PullRequest534`. This is a regex with
+a named capture group called `Number`.
+
+**Example usage:**
+
+```yaml
+branches:
+  pull-request:
+    mode: ContinuousDelivery
+    label: PullRequest{Number}
+    increment: Inherit
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    track-merge-message: true
+    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+    source-branches:
+    - main
+    - release
+    - feature
+    is-source-branch-for: []
+    pre-release-weight: 30000
+```
+
+### mode
+
+Same as for the [global configuration, explained above](#mode).
+
+### pre-release-weight
+
+Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
+value in order to avoid version collisions across different branches. For
+example, a release branch created after "1.2.3-alpha.55" results in
+"1.2.3-beta.1" and thus e.g. "1.2.3-alpha.4" and "1.2.3-beta.4" would have the
+same file version: "1.2.3.4". One of the ways to use this value is to set
+`assembly-file-versioning-format:
+{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber}`. If the `pre-release-weight`
+is set, it would be added to the `PreReleaseNumber` to get a final
+`AssemblySemFileVer`, otherwise a branch specific default for
+`pre-release-weight` will be used in the calculation. Related Issues [1145][1145]
+and [1366][1366].
+
+### prevent-increment-of-merged-branch
+
+The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when this branch related property is set to true on the target branch.
+
+When `release-2.0.0` is merged into main, we want main to build `2.0.0`. If
+`release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
+prevents incrementing after a versioned branch is merged.
+
+In a GitFlow-based repository, setting this option can have implications on the
+`VersionSourceDistance` output variable. It can rule out a potentially
+better version source proposed by the `MergeMessageBaseVersionStrategy`. For
+more details and an in-depth analysis, please see [the discussion][2506].
+
+### prevent-increment-when-branch-merged
+
+The increment of the merged branch will be ignored when this branch related property is set to `true` on the source branch.
+
+### prevent-increment-when-current-commit-tagged
+
+This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.
+
+### track-merge-message
+
+This property is a branch related property and gives the user the possibility to control the behavior of whether the merge
+commit message will be interpreted as a next version or not. Consider we have a main branch and a `release/1.0.0` branch and
+merge changes from `release/1.0.0` to the `main` branch. If `track-merge-message` is set to `true` then the next version will
+be `1.0.0` otherwise `0.0.1`.
+
+### track-merge-target
+
+Strategy which will look for tagged merge commits directly off the current
+branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
+`1.0.0`. The tag is *not* on develop, but develop should be version `1.0.0` now.
+
+### tracks-release-branches
+
+Indicates this branch config represents develop in GitFlow.
+
+### commit-date-format
+
+Sets the format which will be used to format the `CommitDate` output variable.
+
+### commit-message-incrementing
+
+Sets whether it should be possible to increment the version with special syntax
+in the commit message. See the `*-version-bump-message` options above for
+details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
 
@@ -127,97 +231,6 @@ Follows the same formatting semantics as `assembly-file-versioning-format` and
 can use version variables or environment variables. `CustomVersion` is empty
 when no format is configured. The format can be configured globally and
 overridden for individual branches under `branches`.
-
-### mode
-
-Sets the `mode` of how GitVersion should create a new version. Read more at
-[deployment modes][modes].
-
-### increment
-
-The part of the SemVer to increment when GitVersion detects it needs to be
-increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
-
-The special value `Inherit` means that GitVersion should find the parent branch
-(i.e. the branch where the current branch was branched from), and use its values
-for [increment](#increment) or other branch related properties.
-
-For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
-captured from the merge commit message as the immediate parent when it matches
-an allowed source branch. If the message has no matching target, GitVersion
-falls back to Git ancestry, as it does for ordinary branches.
-
-### tag-prefix
-
-A regular expression which is used to trim Git tags before processing (e.g.,
-v1.0.0). The default value is `[vV]`.
-
-### version-in-branch-pattern
-
-A regular expression which is used to determine the version number in the branch
-name or commit message (e.g., v1.0.0-LTS). This setting only applies on branches
-where the option `is-release-branch` is set to `true`. The default value is
-`(?<version>[vV]?\d+(\.\d+)?(\.\d+)?).*`.
-
-### major-version-bump-message
-
-The regex to match commit messages with to perform a major version increment.
-Default set to `'[+=]semver:\s?(breaking|major)'`, which will match occurrences
-of `+semver: major`, `=semver: major`, and the corresponding `breaking` forms.
-
-### minor-version-bump-message
-
-The regex to match commit messages with to perform a minor version increment.
-Default set to `'[+=]semver:\s?(feature|minor)'`, which will match occurrences
-of `+semver: minor`, `=semver: minor`, and the corresponding `feature` forms.
-
-### patch-version-bump-message
-
-The regex to match commit messages with to perform a patch version increment.
-Default set to `'[+=]semver:\s?(fix|patch)'`, which will match occurrences of
-`+semver: patch`, `=semver: patch`, and the corresponding `fix` forms.
-
-### no-bump-message
-
-Used to tell GitVersion not to increment when in Mainline development mode.
-Default `[+=]semver:\s?(none|skip)`, which will match both the `+semver` and
-`=semver` forms of `none` and `skip`.
-
-When a commit matches **both** the `no-bump-message` **and** any combination of
-the `version-bump-message`, `no-bump-message` takes precedence and no increment is applied.
-
-### version-bump-reset-message
-
-The regex to match a commit message that resets the version bump baseline and
-suppresses the configured branch increment. The default is `=semver:`. The
-increment itself is still selected by the major, minor, patch, and no-bump
-message patterns above, whose defaults accept both `+semver` and `=semver`.
-
-For example, when a branch is configured with `increment: Patch`, a commit
-containing `=semver: none` keeps the current version and a commit containing
-`=semver: minor` selects a minor increment. Unlike the `+semver` form, the `=`
-form resets earlier commit-message increments in the calculation range and can
-lower the configured increment. This setting follows
-`commit-message-incrementing`.
-
-### tag-pre-release-weight
-
-The pre-release weight in case of tagged commits. If the value is not set in the
-configuration, a default weight of 60000 is used instead. If the
-`WeightedPreReleaseNumber` [variable][variables] is 0 and this parameter is set,
-its value is used. This helps if your branching model is GitFlow and the last
-release build, which is often tagged, can utilize this parameter to produce a
-monotonically increasing build number.
-
-### commit-message-incrementing
-
-Sets whether it should be possible to increment the version with special syntax
-in the commit message. See the `*-version-bump-message` options above for
-details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
-
-### commit-date-format
-
-Sets the format which will be used to format the `CommitDate` output variable.
 
 ### ignore
 
@@ -228,26 +241,6 @@ The header property for the `ignore` configuration.
 the search for a [version source][version-sources], not when calculating other
 parts of the version number, such as build metadata.
 :::
-
-#### sha
-
-A sequence of SHAs to be excluded from the version calculations. Useful when
-there is a rogue commit in history yielding a bad version. You can use either
-style below:
-
-```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
-```
-
-or
-
-```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
-```
 
 #### commits-before
 
@@ -304,6 +297,79 @@ This can lead to unexpected behavior on case-insensitive file systems, such as W
 A commit is ignored by the `ignore.paths` configuration only if **all paths** changed in that commit match one or more of the specified regular expressions. If a path in a commit does not match any one of the ignore patterns, that commit will be included in version calculations.
 :::
 
+#### sha
+
+A sequence of SHAs to be excluded from the version calculations. Useful when
+there is a rogue commit in history yielding a bad version. You can use either
+style below:
+
+```yaml
+ignore:
+  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+```
+
+or
+
+```yaml
+ignore:
+  sha:
+    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+```
+
+### increment
+
+The part of the SemVer to increment when GitVersion detects it needs to be
+increased, such as for commits after a tag: `Major`, `Minor`, `Patch`, `None`.
+
+The special value `Inherit` means that GitVersion should find the parent branch
+(i.e. the branch where the current branch was branched from), and use its values
+for [increment](#increment) or other branch related properties.
+
+For a synthetic pull request merge ref, GitVersion uses the `TargetBranch`
+captured from the merge commit message as the immediate parent when it matches
+an allowed source branch. If the message has no matching target, GitVersion
+falls back to Git ancestry, as it does for ordinary branches.
+
+### is-source-branch-for
+
+The reverse of `source-branches`. This property was introduced to keep it easy
+to extend GitVersion's config.
+
+It exists to make it easier to extend GitVersion's configuration. If only
+`source-branches` exists and you add a new branch type, for instance
+`unstable/`, you then need to re-define the `source-branches` configuration
+value for existing branches (like feature/) to now include the new unstable
+branch.
+
+A complete example:
+
+```yaml
+branches:
+  unstable:
+    regex: ...
+    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+```
+
+Without this configuration value you would have to do:
+
+```yaml
+branches:
+  unstable:
+    regex:
+  feature:
+    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+  release:
+    source-branches: ['unstable', 'develop']
+  etc...
+```
+
+### major-version-bump-message
+
+The regex to match commit messages with to perform a major version increment.
+Default set to `'[+=]semver:\s?(breaking|major)'`, which will match occurrences
+of `+semver: major`, `=semver: major`, and the corresponding `breaking` forms.
+
 ### merge-message-formats
 
 Custom merge message formats to enable identification of merge messages that do not
@@ -325,6 +391,153 @@ The regular expression should contain the following capture groups:
 Custom merge message formats are evaluated *before* any built in formats.
 Support for [Conventional Commits][conventional-commits] can be
 [configured][conventional-commits-config].
+
+### minor-version-bump-message
+
+The regex to match commit messages with to perform a minor version increment.
+Default set to `'[+=]semver:\s?(feature|minor)'`, which will match occurrences
+of `+semver: minor`, `=semver: minor`, and the corresponding `feature` forms.
+
+### mode
+
+Sets the `mode` of how GitVersion should create a new version. Read more at
+[deployment modes][modes].
+
+### next-version
+
+Allows you to bump the next version explicitly. Useful for bumping `main` or a
+feature branch with breaking changes (i.e., a major increment), indicating what
+the next `git tag` is going to be.
+
+`next-version` is not a permanent replacement for `git tag` and should only be
+used intermittently. Since version 5.5 GitVersion supports `next-version` with
+`mode: Mainline` and should not be treated as a "base version".
+
+If you are using `next-version` and are experiencing weird versioning behaviour,
+please remove it, create a `git tag` with an appropriate version number on an
+appropriate historical commit and see if that resolves any versioning issues
+you may have.
+
+### no-bump-message
+
+Used to tell GitVersion not to increment when in Mainline development mode.
+Default `[+=]semver:\s?(none|skip)`, which will match both the `+semver` and
+`=semver` forms of `none` and `skip`.
+
+When a commit matches **both** the `no-bump-message` **and** any combination of
+the `version-bump-message`, `no-bump-message` takes precedence and no increment is applied.
+
+### patch-version-bump-message
+
+The regex to match commit messages with to perform a patch version increment.
+Default set to `'[+=]semver:\s?(fix|patch)'`, which will match occurrences of
+`+semver: patch`, `=semver: patch`, and the corresponding `fix` forms.
+
+### regex
+
+This is the regex which is used to match the current branch to the correct
+branch configuration.
+
+[Named groups](https://learn.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions) can be used to dynamically label pre-releases based on the branch name, or parts of it. See [Label](#label) for more details and examples.
+
+### semantic-version-format
+
+Specifies the semantic version format that is used when parsing the string.
+Can be `Strict` - using the [regex](https://regex101.com/r/Ly7O1x/3/)
+or `Loose` the old way of parsing. The default if not specified is `Strict`
+Example of invalid `Strict`, but valid `Loose`
+
+```log
+1.2-alpha4
+01.02.03-rc03
+1.2.3.4
+```
+
+### source-branches
+
+Because Git commits only refer to parent commits (not branches) GitVersion
+sometimes cannot tell which branch the current branch was branched from.
+
+Take this commit graph
+
+```shell
+* release/v1.0.0   * feature/foo
+| ________________/
+|/
+*
+*
+* (main)
+```
+
+By looking at this graph, you cannot tell which of these scenarios happened:
+
+* feature/foo branches off release/v1.0.0
+  * Branch release/v1.0.0 from main
+  * Branch feature/foo from release/v1.0.0
+  * Add a commit to both release/v1.0.0 and feature/foo
+  * release/v1.0.0 is the base for feature/foo
+* release/v1.0.0 branches off feature/foo
+  * Branch feature/foo from main
+  * Branch release/v1.0.0 from feature/foo
+  * Add a commit to both release/v1.0.0 and feature/foo
+  * feature/foo is the base for release/v1.0.0
+
+Or put more simply, you cannot tell which branch was created first,
+`release/v1.0.0` or `feature/foo`.
+
+To resolve this issue, we give GitVersion a hint about our branching workflows
+by telling it what types of branches a branch can be created from. For example,
+feature branches are, by default, configured to have the following source
+branches:
+
+`source-branches: ['main', 'develop', 'feature', 'hotfix', 'support']`
+
+This means that we will never bother to evaluate pull request branches as merge
+base options and being explicit in this way also improves the performance of
+GitVersion.
+
+### strategies
+
+Specifies which version strategy implementation (one or more) will be used to determine the next version.
+These strategies can be combined, and the order in which they are specified does not matter.
+The configuration accepts the following values:
+
+* Fallback
+* ConfiguredNextVersion
+* MergeMessage
+* TaggedCommit
+* TrackReleaseBranches
+* VersionInBranchName
+* Mainline
+
+[1145]: https://github.com/GitTools/GitVersion/issues/1145
+
+[1366]: https://github.com/GitTools/GitVersion/issues/1366
+
+[2506]: https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037
+
+[conventional-commits-config]: /docs/reference/version-increments#conventional-commit-messages
+
+[conventional-commits]: https://www.conventionalcommits.org/
+
+[modes]: /docs/reference/modes
+
+[variables]: /docs/reference/variables
+
+[version-sources]: /docs/reference/version-sources
+### tag-pre-release-weight
+
+The pre-release weight in case of tagged commits. If the value is not set in the
+configuration, a default weight of 60000 is used instead. If the
+`WeightedPreReleaseNumber` [variable][variables] is 0 and this parameter is set,
+its value is used. This helps if your branching model is GitFlow and the last
+release build, which is often tagged, can utilize this parameter to produce a
+monotonically increasing build number.
+
+### tag-prefix
+
+A regular expression which is used to trim Git tags before processing (e.g.,
+v1.0.0). The default value is `[vV]`.
 
 ### update-build-number
 
@@ -430,241 +643,27 @@ used (recommended).
 We don't envision many people needing to change most of these configuration
 values, but here they are if you need to:
 
-### regex
+### version-bump-reset-message
 
-This is the regex which is used to match the current branch to the correct
-branch configuration.
+The regex to match a commit message that resets the version bump baseline and
+suppresses the configured branch increment. The default is `=semver:`. The
+increment itself is still selected by the major, minor, patch, and no-bump
+message patterns above, whose defaults accept both `+semver` and `=semver`.
 
-[Named groups](https://learn.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named-matched-subexpressions) can be used to dynamically label pre-releases based on the branch name, or parts of it. See [Label](#label) for more details and examples.
+For example, when a branch is configured with `increment: Patch`, a commit
+containing `=semver: none` keeps the current version and a commit containing
+`=semver: minor` selects a minor increment. Unlike the `+semver` form, the `=`
+form resets earlier commit-message increments in the calculation range and can
+lower the configured increment. This setting follows
+`commit-message-incrementing`.
 
-### source-branches
+### version-in-branch-pattern
 
-Because Git commits only refer to parent commits (not branches) GitVersion
-sometimes cannot tell which branch the current branch was branched from.
+A regular expression which is used to determine the version number in the branch
+name or commit message (e.g., v1.0.0-LTS). This setting only applies on branches
+where the option `is-release-branch` is set to `true`. The default value is
+`(?<version>[vV]?\d+(\.\d+)?(\.\d+)?).*`.
 
-Take this commit graph
+### workflow
 
-```shell
-* release/v1.0.0   * feature/foo
-| ________________/
-|/
-*
-*
-* (main)
-```
-
-By looking at this graph, you cannot tell which of these scenarios happened:
-
-* feature/foo branches off release/v1.0.0
-  * Branch release/v1.0.0 from main
-  * Branch feature/foo from release/v1.0.0
-  * Add a commit to both release/v1.0.0 and feature/foo
-  * release/v1.0.0 is the base for feature/foo
-* release/v1.0.0 branches off feature/foo
-  * Branch feature/foo from main
-  * Branch release/v1.0.0 from feature/foo
-  * Add a commit to both release/v1.0.0 and feature/foo
-  * feature/foo is the base for release/v1.0.0
-
-Or put more simply, you cannot tell which branch was created first,
-`release/v1.0.0` or `feature/foo`.
-
-To resolve this issue, we give GitVersion a hint about our branching workflows
-by telling it what types of branches a branch can be created from. For example,
-feature branches are, by default, configured to have the following source
-branches:
-
-`source-branches: ['main', 'develop', 'feature', 'hotfix', 'support']`
-
-This means that we will never bother to evaluate pull request branches as merge
-base options and being explicit in this way also improves the performance of
-GitVersion.
-
-### is-source-branch-for
-
-The reverse of `source-branches`. This property was introduced to keep it easy
-to extend GitVersion's config.
-
-It exists to make it easier to extend GitVersion's configuration. If only
-`source-branches` exists and you add a new branch type, for instance
-`unstable/`, you then need to re-define the `source-branches` configuration
-value for existing branches (like feature/) to now include the new unstable
-branch.
-
-A complete example:
-
-```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
-```
-
-Without this configuration value you would have to do:
-
-```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
-```
-
-### branches
-
-The header for all the individual branch configuration.
-
-### mode
-
-Same as for the [global configuration, explained above](#mode).
-
-### label
-
-The pre-release label to use for this branch. Use the value `{BranchName}` as a placeholder to
-insert the value of the named group `BranchName` from the [regular expression](#regex).
-
-For example: branch `feature/foo` would become a pre-release label
-of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?<BranchName>.+)'`.
-
-Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
-
-You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
-
-**Note:** To clear a default use an empty string: `label: ''`
-
-### increment
-
-Same as for the [global configuration, explained above](#increment).
-
-### prevent-increment-of-merged-branch
-
-The increment of the branch merged to will be ignored, regardless of whether the merged branch has a version number or not, when this branch related property is set to true on the target branch.
-
-When `release-2.0.0` is merged into main, we want main to build `2.0.0`. If
-`release-2.0.0` is merged into develop we want it to build `2.1.0`, this option
-prevents incrementing after a versioned branch is merged.
-
-In a GitFlow-based repository, setting this option can have implications on the
-`VersionSourceDistance` output variable. It can rule out a potentially
-better version source proposed by the `MergeMessageBaseVersionStrategy`. For
-more details and an in-depth analysis, please see [the discussion][2506].
-
-### prevent-increment-when-branch-merged
-
-The increment of the merged branch will be ignored when this branch related property is set to `true` on the source branch.
-
-### prevent-increment-when-current-commit-tagged
-
-This branch related property controls the behvior whether to use the tagged (value set to true) or the incremented (value set to false) semantic version. Defaults to true.
-
-### label-number-pattern
-
-Pull requests require us to extract the pre-release number out of the branch
-name so `refs/pull/534/merge` builds as `PullRequest534`. This is a regex with
-a named capture group called `Number`.
-
-**Example usage:**
-
-```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
-```
-
-### track-merge-target
-
-Strategy which will look for tagged merge commits directly off the current
-branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
-`1.0.0`. The tag is *not* on develop, but develop should be version `1.0.0` now.
-
-### track-merge-message
-
-This property is a branch related property and gives the user the possibility to control the behavior of whether the merge
-commit message will be interpreted as a next version or not. Consider we have a main branch and a `release/1.0.0` branch and
-merge changes from `release/1.0.0` to the `main` branch. If `track-merge-message` is set to `true` then the next version will
-be `1.0.0` otherwise `0.0.1`.
-
-### tracks-release-branches
-
-Indicates this branch config represents develop in GitFlow.
-
-### is-release-branch
-
-Indicates this branch config represents a release branch in GitFlow.
-
-### is-main-branch
-
-This indicates that this branch is a main branch. By default `main` and `support/*` are main branches.
-
-### pre-release-weight
-
-Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
-value in order to avoid version collisions across different branches. For
-example, a release branch created after "1.2.3-alpha.55" results in
-"1.2.3-beta.1" and thus e.g. "1.2.3-alpha.4" and "1.2.3-beta.4" would have the
-same file version: "1.2.3.4". One of the ways to use this value is to set
-`assembly-file-versioning-format:
-{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber}`. If the `pre-release-weight`
-is set, it would be added to the `PreReleaseNumber` to get a final
-`AssemblySemFileVer`, otherwise a branch specific default for
-`pre-release-weight` will be used in the calculation. Related Issues [1145][1145]
-and [1366][1366].
-
-### semantic-version-format
-
-Specifies the semantic version format that is used when parsing the string.
-Can be `Strict` - using the [regex](https://regex101.com/r/Ly7O1x/3/)
-or `Loose` the old way of parsing. The default if not specified is `Strict`
-Example of invalid `Strict`, but valid `Loose`
-
-```log
-1.2-alpha4
-01.02.03-rc03
-1.2.3.4
-```
-
-### strategies
-
-Specifies which version strategy implementation (one or more) will be used to determine the next version.
-These strategies can be combined, and the order in which they are specified does not matter.
-The configuration accepts the following values:
-
-* Fallback
-* ConfiguredNextVersion
-* MergeMessage
-* TaggedCommit
-* TrackReleaseBranches
-* VersionInBranchName
-* Mainline
-
-[1145]: https://github.com/GitTools/GitVersion/issues/1145
-
-[1366]: https://github.com/GitTools/GitVersion/issues/1366
-
-[2506]: https://github.com/GitTools/GitVersion/pull/2506#issuecomment-754754037
-
-[conventional-commits-config]: /docs/reference/version-increments#conventional-commit-messages
-
-[conventional-commits]: https://www.conventionalcommits.org/
-
-[modes]: /docs/reference/modes
-
-[variables]: /docs/reference/variables
-
-[version-sources]: /docs/reference/version-sources
+The base template of the configuration to use. Possible values are `GitFlow/v1` or `GitHubFlow/v1`. Defaults to `GitFlow/v1` if not set. To create a configuration from scratch without using a base template, please specify an empty string.

--- a/docs/input/docs/workflows/GitFlow/v1.yml
+++ b/docs/input/docs/workflows/GitFlow/v1.yml
@@ -1,95 +1,62 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   develop:
-    mode: ContinuousDelivery
-    label: alpha
     increment: Minor
+    is-main-branch: false
+    is-release-branch: false
+    is-source-branch-for: []
+    label: alpha
+    mode: ContinuousDelivery
+    pre-release-weight: 0
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-target: true
-    track-merge-message: true
     regex: ^dev(elop)?(ment)?$
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: true
     tracks-release-branches: true
-    is-release-branch: false
-    is-main-branch: false
-    pre-release-weight: 0
   main:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   release:
-    mode: ManualDeployment
-    label: beta
     increment: Minor
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-target: false
     regex: "^releases?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - develop
@@ -97,17 +64,16 @@ branches:
       - release
       - support
       - hotfix
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - develop
@@ -116,40 +82,41 @@ branches:
       - feature
       - support
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ManualDeployment
-    label: beta
     increment: Inherit
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   support:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
     regex: "^support[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
     prevent-increment:
       when-current-commit-tagged: true
     regex: "(?<BranchName>.+)"
@@ -161,8 +128,41 @@ branches:
       - pull-request
       - hotfix
       - support
-    is-source-branch-for: []
-    is-main-branch: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - Fallback
+  - ConfiguredNextVersion
+  - MergeMessage
+  - TaggedCommit
+  - TrackReleaseBranches
+  - VersionInBranchName
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/docs/input/docs/workflows/GitHubFlow/v1.yml
+++ b/docs/input/docs/workflows/GitHubFlow/v1.yml
@@ -1,33 +1,105 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
+assembly-file-versioning-scheme: MajorMinorPatch
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  main:
+    increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
+    prevent-increment:
+      of-merged-branch: true
+    regex: "^master$|^main$"
+    source-branches: []
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  release:
+    increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-branch-merged: false
+      when-current-commit-tagged: false
+    regex: "^releases?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  feature:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "^features?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+    track-merge-message: true
+  pull-request:
+    increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+    source-branches:
+      - main
+      - release
+      - feature
+    track-merge-message: true
+  unknown:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "(?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+      - feature
+      - pull-request
+    track-merge-message: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
+ignore:
+  paths: []
+  sha: []
 increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
 prevent-increment:
   of-merged-branch: false
   when-branch-merged: false
   when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
 regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
-assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
 semantic-version-format: Strict
+source-branches: []
 strategies:
   - Fallback
   - ConfiguredNextVersion
@@ -35,83 +107,11 @@ strategies:
   - TaggedCommit
   - TrackReleaseBranches
   - VersionInBranchName
-branches:
-  main:
-    label: ''
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^master$|^main$"
-    source-branches: []
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
-  release:
-    mode: ManualDeployment
-    label: beta
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
-  feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
-  pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
-  unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    is-source-branch-for: []
-    is-main-branch: false
-ignore:
-  sha: []
-  paths: []
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/docs/input/docs/workflows/TrunkBased/preview1.yml
+++ b/docs/input/docs/workflows/TrunkBased/preview1.yml
@@ -1,102 +1,102 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   main:
-    mode: ContinuousDeployment
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    mode: ContinuousDeployment
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   feature:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Minor
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - main
       - feature
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   unknown:
     increment: Patch
+    is-source-branch-for: []
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "(?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    pre-release-weight: 30000
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - ConfiguredNextVersion
+  - Mainline
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/schemas/7.0/GitVersion.configuration.json
+++ b/schemas/7.0/GitVersion.configuration.json
@@ -73,15 +73,6 @@
               "string"
             ]
           },
-          "mode": {
-            "description": "The deployment mode for this branch. Can be 'ManualDeployment', 'ContinuousDelivery', 'ContinuousDeployment'.",
-            "enum": [
-              "ManualDeployment",
-              "ContinuousDelivery",
-              "ContinuousDeployment",
-              null
-            ]
-          },
           "increment": {
             "description": "The increment strategy for this branch. Can be 'Inherit', 'Patch', 'Minor', 'Major', 'None'.",
             "$ref": "#/$defs/incrementStrategy"
@@ -109,6 +100,15 @@
             "type": [
               "null",
               "string"
+            ]
+          },
+          "mode": {
+            "description": "The deployment mode for this branch. Can be 'ManualDeployment', 'ContinuousDelivery', 'ContinuousDeployment'.",
+            "enum": [
+              "ManualDeployment",
+              "ContinuousDelivery",
+              "ContinuousDeployment",
+              null
             ]
           },
           "pre-release-weight": {
@@ -180,15 +180,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "mode": {
-      "description": "The deployment mode for this branch. Can be 'ManualDeployment', 'ContinuousDelivery', 'ContinuousDeployment'.",
-      "enum": [
-        "ManualDeployment",
-        "ContinuousDelivery",
-        "ContinuousDeployment",
-        null
       ]
     },
     "ignore": {
@@ -267,6 +258,15 @@
         "string"
       ]
     },
+    "mode": {
+      "description": "The deployment mode for this branch. Can be 'ManualDeployment', 'ContinuousDelivery', 'ContinuousDeployment'.",
+      "enum": [
+        "ManualDeployment",
+        "ContinuousDelivery",
+        "ContinuousDeployment",
+        null
+      ]
+    },
     "next-version": {
       "description": "Allows you to bump the next version explicitly. Useful for bumping main or a feature branch with breaking changes",
       "type": [
@@ -278,15 +278,6 @@
       "format": "regex",
       "description": "Used to tell GitVersion not to increment when in Mainline development mode. Defaults to '[+=]semver:\\s?(none|skip)'",
       "default": "[+=]semver:\\s?(none|skip)",
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "version-bump-reset-message": {
-      "format": "regex",
-      "description": "The regular expression to match commit messages that reset the version bump baseline and suppress the configured branch increment. Defaults to '=semver:'",
-      "default": "=semver:",
       "type": [
         "null",
         "string"
@@ -332,6 +323,29 @@
       "description": "The source branches for this branch.",
       "$ref": "#/$defs/hashSetOfString"
     },
+    "strategies": {
+      "description": "Specifies which version strategies (one or more) will be used to determine the next version. Following values are available: 'ConfiguredNextVersion', 'MergeMessage', 'TaggedCommit', 'TrackReleaseBranches', 'VersionInBranchName' and 'Mainline'.",
+      "type": "array",
+      "items": {
+        "enum": [
+          "None",
+          "Fallback",
+          "ConfiguredNextVersion",
+          "MergeMessage",
+          "TaggedCommit",
+          "TrackReleaseBranches",
+          "VersionInBranchName",
+          "Mainline"
+        ]
+      }
+    },
+    "tag-pre-release-weight": {
+      "description": "The pre-release weight in case of tagged commits. Defaults to 60000.",
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "tag-prefix": {
       "format": "regex",
       "description": "A regular expression which is used to trim Git tags before processing. Defaults to '[vV]?'",
@@ -339,13 +353,6 @@
       "type": [
         "null",
         "string"
-      ]
-    },
-    "tag-pre-release-weight": {
-      "description": "The pre-release weight in case of tagged commits. Defaults to 60000.",
-      "type": [
-        "null",
-        "integer"
       ]
     },
     "track-merge-message": {
@@ -374,6 +381,15 @@
       "default": "true",
       "type": "boolean"
     },
+    "version-bump-reset-message": {
+      "format": "regex",
+      "description": "The regular expression to match commit messages that reset the version bump baseline and suppress the configured branch increment. Defaults to '=semver:'",
+      "default": "=semver:",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "version-in-branch-pattern": {
       "format": "regex",
       "description": "A regular expression which is used to determine the version number in the branch name or commit message (e.g., v1.0.0-LTS). Defaults to '(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*'.",
@@ -382,22 +398,6 @@
         "null",
         "string"
       ]
-    },
-    "strategies": {
-      "description": "Specifies which version strategies (one or more) will be used to determine the next version. Following values are available: 'ConfiguredNextVersion', 'MergeMessage', 'TaggedCommit', 'TrackReleaseBranches', 'VersionInBranchName' and 'Mainline'.",
-      "type": "array",
-      "items": {
-        "enum": [
-          "None",
-          "Fallback",
-          "ConfiguredNextVersion",
-          "MergeMessage",
-          "TaggedCommit",
-          "TrackReleaseBranches",
-          "VersionInBranchName",
-          "Mainline"
-        ]
-      }
     },
     "workflow": {
       "description": "The base template of the configuration to use. Possible values are: 'GitFlow/v1' or 'GitHubFlow/v1'",

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.CanWriteOutEffectiveConfiguration.approved.txt
@@ -1,95 +1,62 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   develop:
-    mode: ContinuousDelivery
-    label: alpha
     increment: Minor
+    is-main-branch: false
+    is-release-branch: false
+    is-source-branch-for: []
+    label: alpha
+    mode: ContinuousDelivery
+    pre-release-weight: 0
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-target: true
-    track-merge-message: true
     regex: ^dev(elop)?(ment)?$
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: true
     tracks-release-branches: true
-    is-release-branch: false
-    is-main-branch: false
-    pre-release-weight: 0
   main:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   release:
-    mode: ManualDeployment
-    label: beta
     increment: Minor
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-target: false
     regex: "^releases?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - develop
@@ -97,17 +64,16 @@ branches:
       - release
       - support
       - hotfix
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - develop
@@ -116,40 +82,41 @@ branches:
       - feature
       - support
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ManualDeployment
-    label: beta
     increment: Inherit
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   support:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
     regex: "^support[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
     prevent-increment:
       when-current-commit-tagged: true
     regex: "(?<BranchName>.+)"
@@ -161,8 +128,41 @@ branches:
       - pull-request
       - hotfix
       - support
-    is-source-branch-for: []
-    is-main-branch: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - Fallback
+  - ConfiguredNextVersion
+  - MergeMessage
+  - TaggedCommit
+  - TrackReleaseBranches
+  - VersionInBranchName
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
@@ -1,0 +1,44 @@
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationSerializerTests
+{
+    private readonly ConfigurationSerializer serializer = new();
+
+    [Test]
+    public void Serialize_OrdersConfigurationPropertiesAndPreservesBranchNames()
+    {
+        var configuration = new GitVersionConfiguration
+        {
+            Branches = new Dictionary<string, BranchConfiguration>
+            {
+                ["z-last"] = new() { Label = "z", Increment = IncrementStrategy.Minor },
+                ["a-first"] = new() { Label = "a", Increment = IncrementStrategy.Major }
+            }
+        };
+
+        var yaml = this.serializer.Serialize(configuration);
+        var lines = yaml.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var rootPropertyNames = lines
+            .Where(line => !char.IsWhiteSpace(line[0]))
+            .Select(GetPropertyName)
+            .ToArray();
+
+        rootPropertyNames.ShouldBe(rootPropertyNames.Order(StringComparer.Ordinal));
+        yaml.IndexOf("  z-last:", StringComparison.Ordinal)
+            .ShouldBeLessThan(yaml.IndexOf("  a-first:", StringComparison.Ordinal));
+
+        var firstBranchProperties = lines
+            .SkipWhile(line => line != "  z-last:")
+            .Skip(1)
+            .TakeWhile(line => line.StartsWith("    ", StringComparison.Ordinal))
+            .Select(GetPropertyName)
+            .ToArray();
+
+        firstBranchProperties.ShouldBe(firstBranchProperties.Order(StringComparer.Ordinal));
+    }
+
+    private static string GetPropertyName(string line) => line.TrimStart().Split(':', 2)[0];
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -16,17 +16,17 @@ public class IgnoreConfigurationTests : TestBase
         const string yaml =
             """
             ignore:
-                sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98]
                 commits-before: 2015-10-23T12:23:15
+                sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98]
             """;
 
         var configuration = this.serializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
+        configuration.Ignore.Before.ShouldBe(DateTimeOffset.Parse("2015-10-23T12:23:15", CultureInfo.InvariantCulture));
         configuration.Ignore.Shas.ShouldNotBeEmpty();
         configuration.Ignore.Shas.ShouldBe(["b6c0c9fda88830ebcd563e500a5a7da5a1658e98"]);
-        configuration.Ignore.Before.ShouldBe(DateTimeOffset.Parse("2015-10-23T12:23:15", CultureInfo.InvariantCulture));
     }
 
     [Test]
@@ -57,8 +57,9 @@ public class IgnoreConfigurationTests : TestBase
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
-        configuration.Ignore.Shas.ShouldBeEmpty();
         configuration.Ignore.Before.ShouldBe(null);
+        configuration.Ignore.Paths.ShouldBeEmpty();
+        configuration.Ignore.Shas.ShouldBeEmpty();
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
@@ -1,95 +1,62 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   develop:
-    mode: ContinuousDelivery
-    label: alpha
     increment: Minor
+    is-main-branch: false
+    is-release-branch: false
+    is-source-branch-for: []
+    label: alpha
+    mode: ContinuousDelivery
+    pre-release-weight: 0
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-target: true
-    track-merge-message: true
     regex: ^dev(elop)?(ment)?$
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: true
     tracks-release-branches: true
-    is-release-branch: false
-    is-main-branch: false
-    pre-release-weight: 0
   main:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   release:
-    mode: ManualDeployment
-    label: beta
     increment: Minor
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-target: false
     regex: "^releases?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - develop
@@ -97,17 +64,16 @@ branches:
       - release
       - support
       - hotfix
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - develop
@@ -116,40 +82,41 @@ branches:
       - feature
       - support
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ManualDeployment
-    label: beta
     increment: Inherit
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
       - support
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   support:
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
     regex: "^support[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
     increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
     prevent-increment:
       when-current-commit-tagged: true
     regex: "(?<BranchName>.+)"
@@ -161,8 +128,41 @@ branches:
       - pull-request
       - hotfix
       - support
-    is-source-branch-for: []
-    is-main-branch: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - Fallback
+  - ConfiguredNextVersion
+  - MergeMessage
+  - TaggedCommit
+  - TrackReleaseBranches
+  - VersionInBranchName
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
@@ -1,33 +1,105 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
+assembly-file-versioning-scheme: MajorMinorPatch
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  main:
+    increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    pre-release-weight: 55000
+    prevent-increment:
+      of-merged-branch: true
+    regex: "^master$|^main$"
+    source-branches: []
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  release:
+    increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: beta
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-branch-merged: false
+      when-current-commit-tagged: false
+    regex: "^releases?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+    track-merge-message: true
+    track-merge-target: false
+    tracks-release-branches: false
+  feature:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    pre-release-weight: 30000
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "^features?[\\/-](?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+    track-merge-message: true
+  pull-request:
+    increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+    source-branches:
+      - main
+      - release
+      - feature
+    track-merge-message: true
+  unknown:
+    increment: Inherit
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ManualDeployment
+    prevent-increment:
+      when-current-commit-tagged: false
+    regex: "(?<BranchName>.+)"
+    source-branches:
+      - main
+      - release
+      - feature
+      - pull-request
+    track-merge-message: false
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
+ignore:
+  paths: []
+  sha: []
 increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
 prevent-increment:
   of-merged-branch: false
   when-branch-merged: false
   when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
 regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
-assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
 semantic-version-format: Strict
+source-branches: []
 strategies:
   - Fallback
   - ConfiguredNextVersion
@@ -35,83 +107,11 @@ strategies:
   - TaggedCommit
   - TrackReleaseBranches
   - VersionInBranchName
-branches:
-  main:
-    label: ''
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^master$|^main$"
-    source-branches: []
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
-  release:
-    mode: ManualDeployment
-    label: beta
-    increment: Patch
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    track-merge-target: false
-    track-merge-message: true
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    is-source-branch-for: []
-    tracks-release-branches: false
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
-  feature:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
-  pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
-  unknown:
-    mode: ManualDeployment
-    label: "{BranchName}"
-    increment: Inherit
-    prevent-increment:
-      when-current-commit-tagged: false
-    track-merge-message: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    is-source-branch-for: []
-    is-main-branch: false
-ignore:
-  sha: []
-  paths: []
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
@@ -1,102 +1,102 @@
-mode: ContinuousDelivery
-label: "{BranchName}"
-increment: Inherit
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-track-merge-target: false
-track-merge-message: true
-commit-message-incrementing: Enabled
-regex: ''
-source-branches: []
-is-source-branch-for: []
-tracks-release-branches: false
-is-release-branch: false
-is-main-branch: false
-assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
-tag-prefix: "[vV]?"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-version-bump-reset-message: "=semver:"
-tag-pre-release-weight: 60000
-commit-date-format: yyyy-MM-dd
-merge-message-formats: {}
-update-build-number: true
-semantic-version-format: Strict
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   main:
-    mode: ContinuousDeployment
-    label: ''
     increment: Patch
+    is-main-branch: true
+    is-release-branch: false
+    is-source-branch-for: []
+    label: ''
+    mode: ContinuousDeployment
+    pre-release-weight: 55000
     prevent-increment:
       of-merged-branch: true
-    track-merge-target: false
-    track-merge-message: true
     regex: "^master$|^main$"
     source-branches: []
-    is-source-branch-for: []
+    track-merge-message: true
+    track-merge-target: false
     tracks-release-branches: false
-    is-release-branch: false
-    is-main-branch: true
-    pre-release-weight: 55000
   feature:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Minor
+    is-main-branch: false
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^features?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-main-branch: false
-    pre-release-weight: 30000
+    track-merge-message: true
   hotfix:
-    mode: ContinuousDelivery
-    label: "{BranchName}"
     increment: Patch
+    is-main-branch: false
+    is-release-branch: true
+    is-source-branch-for: []
+    label: "{BranchName}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    is-release-branch: true
-    is-main-branch: false
-    pre-release-weight: 30000
   pull-request:
-    mode: ContinuousDelivery
-    label: "PullRequest{Number}"
     increment: Inherit
+    is-source-branch-for: []
+    label: "PullRequest{Number}"
+    mode: ContinuousDelivery
+    pre-release-weight: 30000
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    track-merge-message: true
     regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
     source-branches:
       - main
       - feature
       - hotfix
-    is-source-branch-for: []
-    pre-release-weight: 30000
+    track-merge-message: true
   unknown:
     increment: Patch
+    is-source-branch-for: []
+    pre-release-weight: 30000
     prevent-increment:
       when-current-commit-tagged: false
     regex: "(?<BranchName>.+)"
     source-branches:
       - main
-    is-source-branch-for: []
-    pre-release-weight: 30000
+commit-date-format: yyyy-MM-dd
+commit-message-incrementing: Enabled
 ignore:
-  sha: []
   paths: []
+  sha: []
+increment: Inherit
+is-main-branch: false
+is-release-branch: false
+is-source-branch-for: []
+label: "{BranchName}"
+major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+merge-message-formats: {}
+minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+mode: ContinuousDelivery
+no-bump-message: "[+=]semver:\\s?(none|skip)"
+patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+regex: ''
+semantic-version-format: Strict
+source-branches: []
+strategies:
+  - ConfiguredNextVersion
+  - Mainline
+tag-pre-release-weight: 60000
+tag-prefix: "[vV]?"
+track-merge-message: true
+track-merge-target: false
+tracks-release-branches: false
+update-build-number: true
+version-bump-reset-message: "=semver:"
+version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -4,6 +4,12 @@ namespace GitVersion.Configuration;
 
 internal class ConfigurationSerializer : IConfigurationSerializer
 {
+    private static readonly HashSet<string> PreserveKeyOrderFor =
+    [
+        "branches",
+        "merge-message-formats"
+    ];
+
     private static readonly ConfigurationYamlContext GeneratedContext = ConfigurationYamlContext.Default;
 
     private static readonly YamlSerializerOptions SerializerOptions = new()
@@ -37,7 +43,11 @@ internal class ConfigurationSerializer : IConfigurationSerializer
     }
 
     public string Serialize(object graph)
-        => YamlSerializer.Serialize(graph, SerializerOptions);
+    {
+        var yaml = YamlSerializer.Serialize(graph, SerializerOptions);
+        var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
+    }
 
     public IGitVersionConfiguration? ReadConfiguration(string input) => Deserialize<GitVersionConfiguration?>(input);
 
@@ -75,6 +85,31 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
         return result;
     }
+
+    private static Dictionary<string, object?> OrderProperties(
+        IReadOnlyDictionary<string, object?> source,
+        bool orderKeys = true)
+    {
+        IEnumerable<KeyValuePair<string, object?>> entries = orderKeys
+            ? source.OrderBy(element => element.Key, StringComparer.Ordinal)
+            : source;
+        Dictionary<string, object?> result = [];
+
+        foreach (var (key, value) in entries)
+        {
+            result[key] = OrderValue(value, orderKeys: !PreserveKeyOrderFor.Contains(key));
+        }
+
+        return result;
+    }
+
+    private static object? OrderValue(object? value, bool orderKeys) => value switch
+    {
+        IReadOnlyDictionary<string, object?> dictionary => OrderProperties(dictionary, orderKeys),
+        IDictionary<string, object?> dictionary => OrderProperties(new Dictionary<string, object?>(dictionary), orderKeys),
+        IList list => list.Cast<object?>().Select(item => OrderValue(item, orderKeys: true)).ToList(),
+        _ => value
+    };
 
     private sealed class HyphenatedJsonNamingPolicy : JsonNamingPolicy
     {

--- a/src/GitVersion.Configuration/IgnoreConfiguration.cs
+++ b/src/GitVersion.Configuration/IgnoreConfiguration.cs
@@ -17,13 +17,6 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
         set => Before = value is null ? null : DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
     }
 
-    [JsonIgnore]
-    IReadOnlySet<string> IIgnoreConfiguration.Shas => Shas;
-
-    [JsonPropertyName("sha")]
-    [JsonPropertyDescription("A sequence of SHAs to be excluded from the version calculations.")]
-    public HashSet<string> Shas { get; set; } = [];
-
     IReadOnlySet<string> IIgnoreConfiguration.Paths => Paths;
 
     [JsonPropertyName("paths")]
@@ -31,5 +24,12 @@ internal record IgnoreConfiguration : IIgnoreConfiguration
     public HashSet<string> Paths { get; set; } = [];
 
     [JsonIgnore]
-    public bool IsEmpty => Before == null && Shas.Count == 0 && Paths.Count == 0;
+    IReadOnlySet<string> IIgnoreConfiguration.Shas => Shas;
+
+    [JsonPropertyName("sha")]
+    [JsonPropertyDescription("A sequence of SHAs to be excluded from the version calculations.")]
+    public HashSet<string> Shas { get; set; } = [];
+
+    [JsonIgnore]
+    public bool IsEmpty => Before == null && Paths.Count == 0 && Shas.Count == 0;
 }

--- a/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IIgnoreConfiguration.cs
@@ -6,11 +6,11 @@ public interface IIgnoreConfiguration
     /// <summary>Gets the cut-off date before which commits are ignored; <see langword="null"/> means no date filter is applied.</summary>
     DateTimeOffset? Before { get; }
 
-    /// <summary>Gets the set of commit SHAs that should be excluded from version calculation.</summary>
-    IReadOnlySet<string> Shas { get; }
-
     /// <summary>Gets the set of file paths whose changes should be ignored during version calculation.</summary>
     IReadOnlySet<string> Paths { get; }
+
+    /// <summary>Gets the set of commit SHAs that should be excluded from version calculation.</summary>
+    IReadOnlySet<string> Shas { get; }
 
     /// <summary>Gets a value indicating whether this configuration contains no ignore rules.</summary>
     bool IsEmpty { get; }

--- a/src/GitVersion.Schema/Extensions.cs
+++ b/src/GitVersion.Schema/Extensions.cs
@@ -8,15 +8,57 @@ internal static class Extensions
 {
     extension(JsonSchema jsonSchema)
     {
-        public void WriteToFile(string outputFileName)
+        public void WriteToFile(string outputFileName, bool orderPropertiesByName = false)
         {
             var jsonDocument = jsonSchema.ToJsonDocument();
 
             using var fs = File.Create(outputFileName);
             using var writer = new Utf8JsonWriter(fs, new() { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-            jsonDocument.WriteTo(writer);
+            if (orderPropertiesByName)
+            {
+                WriteElement(writer, jsonDocument.RootElement);
+            }
+            else
+            {
+                jsonDocument.WriteTo(writer);
+            }
             writer.Flush();
             fs.Flush();
+        }
+    }
+
+    private static void WriteElement(Utf8JsonWriter writer, JsonElement element, bool orderMembers = false)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                IEnumerable<JsonProperty> properties = element.EnumerateObject();
+                if (orderMembers)
+                {
+                    properties = properties.OrderBy(property => property.Name, StringComparer.Ordinal);
+                }
+
+                foreach (var property in properties)
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteElement(writer, property.Value, property.NameEquals("properties"));
+                }
+                writer.WriteEndObject();
+                break;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                {
+                    WriteElement(writer, item);
+                }
+                writer.WriteEndArray();
+                break;
+
+            default:
+                element.WriteTo(writer);
+                break;
         }
     }
 }

--- a/src/GitVersion.Schema/Program.cs
+++ b/src/GitVersion.Schema/Program.cs
@@ -38,7 +38,7 @@ var schema = builder.FromType<GitVersionConfiguration>(configuration).Build();
 
 var fileName = Path.Combine(schemasDirectory, schemaVersion, "GitVersion.configuration.json");
 Console.WriteLine($"Writing schema to {fileName}");
-schema.WriteToFile(fileName);
+schema.WriteToFile(fileName, orderPropertiesByName: true);
 
 configuration.PropertyNameResolver = PropertyNameResolvers.AsDeclared;
 


### PR DESCRIPTION
## Summary

- serialize configuration properties alphabetically at every configuration level
- preserve intentional dictionary ordering for branch names and custom merge-message formats
- order generated configuration schema properties by their serialized names
- align reference documentation, workflow examples, and approved snapshots

## Stack

1. This preparation PR
2. [#5147](https://github.com/GitTools/GitVersion/pull/5147) - ignore tags
3. [#5148](https://github.com/GitTools/GitVersion/pull/5148) - ignore branches

## Validation

- `dotnet build src/GitVersion.slnx --no-restore`
- `dotnet format --verify-no-changes src/GitVersion.slnx --no-restore`
- `dotnet test src/GitVersion.slnx --no-build` - 37,202 passed
- regenerated only `schemas/7.0/GitVersion.configuration.json`