### PR TITLE
perf(ci): reduce validation time

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -18,6 +18,14 @@ runs:
         path: tools
         key: tools-${{ runner.os }}-${{ hashFiles('./build/**') }}
 
+    - name: Cache NuGet packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', 'NuGet.config', 'nuget.config') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:

--- a/.github/workflows/_artifacts_windows.yml
+++ b/.github/workflows/_artifacts_windows.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    inputs:
+      packages:
+        required: true
+        type: string
 
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
@@ -12,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ Executable, MsBuildFull ]
+        package: ${{ fromJson(inputs.packages) }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/_prepare.yml
+++ b/.github/workflows/_prepare.yml
@@ -44,6 +44,14 @@ jobs:
           path: tools
           key: tools-${{ runner.os }}-${{ hashFiles('./build/**') }}
 
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       contents: read
     outputs:
       can_publish: ${{ steps.flags.outputs.can_publish }}
+      run_full_validation: ${{ steps.flags.outputs.run_full_validation }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -62,7 +63,9 @@ jobs:
       - name: Resolve publish flag
         id: flags
         shell: bash
-        run: echo "can_publish=${{ github.repository == 'GitTools/GitVersion' && github.ref_name == 'main' }}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "can_publish=${{ github.repository == 'GitTools/GitVersion' && github.ref_name == 'main' }}" >> "$GITHUB_OUTPUT"
+          echo "run_full_validation=${{ github.repository == 'GitTools/GitVersion' && (github.ref_name == 'main' || github.event_name == 'merge_group' || github.event_name == 'repository_dispatch') }}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build & Package
@@ -84,13 +87,15 @@ jobs:
 
   artifacts_windows_test:
     name: Artifacts Windows
-    needs: [ build ]
+    needs: [ build, publish_flags ]
     permissions:
       contents: read
     uses: $/.github/workflows/_artifacts_windows.yml # NOSONAR -- $/ resolves to the running commit.
+    with:
+      packages: ${{ fromJson(needs.publish_flags.outputs.run_full_validation) && '["Executable", "MsBuildFull"]' || '["Executable"]' }}
 
   artifacts_linux_test:
-    needs: [ prepare, build ]
+    needs: [ prepare, build, publish_flags ]
     name: Artifacts Linux (${{ matrix.arch }})
     permissions:
       contents: read
@@ -106,7 +111,7 @@ jobs:
     with:
       runner: ${{ matrix.runner }}
       arch: ${{ matrix.arch }}
-      docker_distros: ${{ needs.prepare.outputs.docker_distros }}
+      docker_distros: ${{ fromJson(needs.publish_flags.outputs.run_full_validation) && needs.prepare.outputs.docker_distros || '["ubuntu.24.04"]' }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
 
   docker_linux_images:
@@ -129,7 +134,7 @@ jobs:
     with:
       runner: ${{ matrix.runner }}
       arch: ${{ matrix.arch }}
-      docker_distros: ${{ needs.prepare.outputs.docker_distros }}
+      docker_distros: ${{ fromJson(needs.publish_flags.outputs.run_full_validation) && needs.prepare.outputs.docker_distros || '["ubuntu.24.04"]' }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       publish_images: ${{ fromJson(needs.publish_flags.outputs.can_publish) }}
       dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
@@ -137,6 +142,7 @@ jobs:
   docker_linux_manifests:
     needs: [ prepare, docker_linux_images, publish_flags ]
     name: Docker Manifests
+    if: fromJson(needs.publish_flags.outputs.can_publish)
     permissions:
       contents: read
       id-token: write
@@ -164,6 +170,7 @@ jobs:
   release:
     name: Release
     needs: [ publish, docker_linux_manifests ]
+    if: ${{ always() && needs.publish.result == 'success' && (needs.docker_linux_manifests.result == 'success' || needs.docker_linux_manifests.result == 'skipped') }}
     runs-on: windows-2025-vs2026
     permissions:
       contents: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -52,6 +52,14 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Run Format 'ci' solution
         run: dotnet format ./build/ --verify-no-changes
 

--- a/.github/workflows/new-cli.yml
+++ b/.github/workflows/new-cli.yml
@@ -53,6 +53,14 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Build 'new-cli' solution
         run: dotnet build ./new-cli
 

--- a/build/build/Tasks/Test/UnitTest.cs
+++ b/build/build/Tasks/Test/UnitTest.cs
@@ -55,8 +55,11 @@ public class UnitTest : FrostingTask<BuildContext>
         {
             PathType = DotNetTestPathType.Project,
             Framework = $"net{framework}",
+            // UnitTest depends on Build, which restores the complete solution.
+            // Each test project must still rebuild with ContinuousIntegrationBuild=false
+            // so its snapshot tests retain their expected source paths.
             NoBuild = false,
-            NoRestore = false,
+            NoRestore = true,
             Configuration = context.MsBuildConfiguration,
             MSBuildSettings = new()
         };


### PR DESCRIPTION
## Summary

- Avoid redundant NuGet restores in each legacy test-project invocation.
- Cache NuGet packages across CI jobs.
- Use a reduced artifact and Docker smoke matrix for pull requests while retaining full validation on main, merge-queue, and release-dispatch runs.

## Validation

- Full CI passed on the fork after the change.
- Compared with a rerun of fork main, the mean legacy test job duration fell from 10m 59s to 9m 56s (9.5%).
- The pull-request CI graph emitted 25 jobs instead of 51.
- NuGet cache hits were confirmed on macOS, Windows, and Linux.