### PR TITLE
Implement versioned calculation and output configuration

### DIFF
--- a/.gitversion.yml
+++ b/.gitversion.yml
@@ -1,9 +1,11 @@
 # $schema: https://gitversion.net/schemas/7.0/GitVersion.configuration.json
-workflow: GitFlow/v1
-mode: ManualDeployment
-next-version: 7.0.0
-branches:
-  main:
-    label: alpha
-  support:
-    label: beta
+calculation:
+  workflow: GitFlow/v1
+  mode: ManualDeployment
+  next-version: 7.0.0
+  branches:
+    main:
+      label: alpha
+    support:
+      label: beta
+output: {}

--- a/build/build/Tasks/Clean.cs
+++ b/build/build/Tasks/Clean.cs
@@ -17,5 +17,6 @@ public sealed class Clean : FrostingTask<BuildContext>
         context.CleanDirectory(Paths.Native);
         context.CleanDirectory(Paths.Packages);
         context.CleanDirectory(Paths.Artifacts);
+        context.CleanDirectory(Paths.Tools);
     }
 }

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -32,8 +32,9 @@ The following supported workflow configurations are available in GitVersion and 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 
 ```yaml
-workflow: GitHubFlow/v1
-tag-prefix: '[abc]'
+calculation:
+  workflow: GitHubFlow/v1
+  tag-prefix: '[abc]'
 ```
 
 The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) looks like:
@@ -41,178 +42,188 @@ The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) l
 <!-- snippet: /docs/workflows/GitFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitFlow/v1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The supported built-in configuration for the `GitHubFlow` workflow (`workflow: GitHubFlow/v1`) looks like:
@@ -220,127 +231,134 @@ The supported built-in configuration for the `GitHubFlow` workflow (`workflow: G
 <!-- snippet: /docs/workflows/GitHubFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitHubFlow/v1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The preview built-in configuration (experimental usage only) for the `TrunkBased` workflow (`workflow: TrunkBased/preview1`) looks like:
@@ -348,112 +366,120 @@ The preview built-in configuration (experimental usage only) for the `TrunkBased
 <!-- snippet: /docs/workflows/TrunkBased/preview1.yml -->
 <a id='snippet-/docs/workflows/TrunkBased/preview1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The details of the available options are as follows:

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -32,8 +32,9 @@ The following supported workflow configurations are available in GitVersion and 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 
 ```yaml
-workflow: GitHubFlow/v1
-tag-prefix: '[abc]'
+calculation:
+  workflow: GitHubFlow/v1
+  tag-prefix: '[abc]'
 ```
 
 The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) looks like:

--- a/docs/input/docs/workflows/GitFlow/v1.yml
+++ b/docs/input/docs/workflows/GitFlow/v1.yml
@@ -1,170 +1,180 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/docs/input/docs/workflows/GitHubFlow/v1.yml
+++ b/docs/input/docs/workflows/GitHubFlow/v1.yml
@@ -1,119 +1,126 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/docs/input/docs/workflows/TrunkBased/preview1.yml
+++ b/docs/input/docs/workflows/TrunkBased/preview1.yml
@@ -1,104 +1,112 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -9,19 +9,100 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ArgumentParserTests : TestBase
 {
     private IEnvironment environment = null!;
     private IArgumentParser argumentParser = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void SetUp()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         var sp = ConfigureServices(services => services.AddModule(new GitVersionAppModule()));
         this.environment = sp.GetRequiredService<IEnvironment>();
         this.argumentParser = sp.GetRequiredService<IArgumentParser>();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void OverrideConfigSupportsNestedV7RootAndBranchPaths()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var arguments = this.argumentParser.ParseArguments(
+            "--override-config calculation.tag-prefix=custom- " +
+            "--override-config calculation.branches.main.increment=Major " +
+            "--override-config output.branches.main.pre-release-weight=42");
+
+        var normalized = ConfigurationDocumentMapper.Normalize(
+            arguments.OverrideConfiguration!, ConfigurationVersion.V7, "test override");
+        ConfigurationHelper configurationHelper = new(normalized);
+        var configuration = configurationHelper.Configuration;
+        configuration.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        configuration.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV6PathInV7WithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config tag-prefix=custom-"));
+
+        exception.Message.ShouldContain("calculation.tag-prefix");
+        exception.Message.ShouldContain("config migrate");
+    }
+
+    [Test]
+    public void OverrideConfigRejectsPropertyInWrongV7SectionWithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config calculation.update-build-number=false"));
+
+        exception.Message.ShouldContain("output.update-build-number");
+    }
+
+    [Test]
+    public void OverrideConfigSupportsV6BranchPath()
+    {
+        var arguments = this.argumentParser.ParseArguments("--override-config branches.main.increment=Major");
+
+        ConfigurationHelper configurationHelper = new(arguments.OverrideConfiguration);
+        configurationHelper.Configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV7PathInV6WithReplacement()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config output.update-build-number=false"));
+
+        exception.Message.ShouldContain("update-build-number");
+        exception.Message.ShouldContain("config migrate");
+    }
+
+    [Test]
+    public void OverrideConfigBatchValidationDoesNotApplyAnyValues()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        var parser = new OverrideConfigurationOptionParser();
+
+        Should.Throw<WarningException>(() => parser.SetValues(
+            ["calculation.tag-prefix=custom-", "tag-prefix=legacy"], "--override-config"));
+
+        parser.GetOverrideConfiguration().ShouldBeEmpty();
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -1,0 +1,58 @@
+using GitVersion.App.Tests.Helpers;
+using GitVersion.Configuration;
+using GitVersion.Helpers;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+public class ConfigurationVersionIntegrationTests
+{
+    [Test]
+    public void V6AndV7ConfigurationCalculateTheSameVersion()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        var configurationPath = FileSystemHelper.Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName);
+
+        FileSystemHelper.File.WriteAllText(configurationPath, "next-version: 2.0.0");
+        var v6Result = Execute(fixture.RepositoryPath, "v6");
+
+        FileSystemHelper.File.WriteAllText(configurationPath, """
+                                                             calculation:
+                                                               next-version: 2.0.0
+                                                             output: {}
+                                                             """);
+        var v7Result = Execute(fixture.RepositoryPath, "v7");
+
+        v6Result.ExitCode.ShouldBe(0);
+        v7Result.ExitCode.ShouldBe(0);
+        GetFullSemVer(v7Result.Output!).ShouldBe(GetFullSemVer(v6Result.Output!));
+    }
+
+    [TestCase("v6", false)]
+    [TestCase("v7", true)]
+    public void ShowConfigUsesSelectedConfigurationStructure(string version, bool nested)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var result = GitVersionHelper.ExecuteIn(
+            fixture.RepositoryPath,
+            " --show-config",
+            logToFile: false,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, version));
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotBeNull();
+        result.Output.Contains("calculation:", StringComparison.Ordinal).ShouldBe(nested);
+        result.Output.Contains("output:", StringComparison.Ordinal).ShouldBe(nested);
+    }
+
+    private static ExecutionResults Execute(string repositoryPath, string version) =>
+        GitVersionHelper.ExecuteIn(
+            repositoryPath,
+            arguments: null,
+            logToFile: false,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, version));
+
+    private static string? GetFullSemVer(string json) =>
+        JsonDocument.Parse(json).RootElement.GetProperty("FullSemVer").GetString();
+}

--- a/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
@@ -9,19 +9,58 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class LegacyArgumentParserTests : TestBase
 {
     private IEnvironment environment = null!;
     private IArgumentParser argumentParser = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void SetUp()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         var sp = ConfigureServices(services => services.AddModule(new GitVersionAppModule(useLegacyParser: true)));
         this.environment = sp.GetRequiredService<IEnvironment>();
         this.argumentParser = sp.GetRequiredService<IArgumentParser>();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void OverrideConfigSupportsNestedV7RootAndBranchPaths()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var arguments = this.argumentParser.ParseArguments(
+            "/overrideconfig calculation.tag-prefix=custom- " +
+            "/overrideconfig calculation.branches.main.increment=Major " +
+            "/overrideconfig output.branches.main.pre-release-weight=42");
+
+        var normalized = ConfigurationDocumentMapper.Normalize(
+            arguments.OverrideConfiguration!, ConfigurationVersion.V7, "test override");
+        ConfigurationHelper configurationHelper = new(normalized);
+        var configuration = configurationHelper.Configuration;
+        configuration.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        configuration.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV6PathInV7WithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("/overrideconfig tag-prefix=custom-"));
+
+        exception.Message.ShouldContain("calculation.tag-prefix");
+        exception.Message.ShouldContain("config migrate");
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -150,10 +150,12 @@ public class PullRequestInBuildAgentTest
     }
 
     private const string GitLabMergeRequestPullRequestConfig = """
-        workflow: GitFlow/v1
-        branches:
-          pull-request:
-            regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+        calculation:
+          workflow: GitFlow/v1
+          branches:
+            pull-request:
+              regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+        output: {}
         """;
 
     private static async Task VerifyGitLabMergeRequestVersionIsCalculatedProperly(string mergeRequestRef, Dictionary<string, string> env)

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -591,24 +591,7 @@ internal class ArgumentParser(
         }
 
         var parser = new OverrideConfigurationOptionParser();
-
-        foreach (var keyValueOption in values)
-        {
-            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
-            if (keyAndValue.Length != 2)
-            {
-                throw new WarningException($"Could not parse --override-config option: {keyValueOption}. Ensure it is in format 'key=value'.");
-            }
-
-            var optionKey = keyAndValue[0].ToLowerInvariant();
-            if (!OverrideConfigurationOptionParser.SupportedProperties.Contains(optionKey))
-            {
-                throw new WarningException($"Could not parse --override-config option: {keyValueOption}. Unsupported key '{optionKey}'.");
-            }
-
-            parser.SetValue(optionKey, keyAndValue[1]);
-        }
-
+        parser.SetValues(values, "--override-config");
         arguments.OverrideConfiguration = parser.GetOverrideConfiguration();
     }
 

--- a/src/GitVersion.App/LegacyArgumentParser.cs
+++ b/src/GitVersion.App/LegacyArgumentParser.cs
@@ -511,25 +511,7 @@ internal class LegacyArgumentParser(
         }
 
         var parser = new OverrideConfigurationOptionParser();
-
-        // key=value
-        foreach (var keyValueOption in values)
-        {
-            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
-            if (keyAndValue.Length != 2)
-            {
-                throw new WarningException($"Could not parse /overrideconfig option: {keyValueOption}. Ensure it is in format 'key=value'.");
-            }
-
-            var optionKey = keyAndValue[0].ToLowerInvariant();
-            if (!OverrideConfigurationOptionParser.SupportedProperties.Contains(optionKey))
-            {
-                throw new WarningException($"Could not parse /overrideconfig option: {keyValueOption}. Unsupported key '{optionKey}'.");
-            }
-
-            parser.SetValue(optionKey, keyAndValue[1]);
-        }
-
+        parser.SetValues(values, "/overrideconfig");
         arguments.OverrideConfiguration = parser.GetOverrideConfiguration();
     }
 

--- a/src/GitVersion.App/OverrideConfigurationOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigurationOptionParser.cs
@@ -12,6 +12,9 @@ internal class OverrideConfigurationOptionParser
 
     internal static ILookup<string?, PropertyInfo> SupportedProperties => _lazySupportedProperties.Value;
 
+    private static readonly Lazy<HashSet<string>> _lazySupportedBranchProperties =
+        new(GetSupportedBranchProperties, true);
+
     /// <summary>
     /// Dynamically creates <see cref="System.Linq.ILookup{TKey, TElement}"/> of
     /// <see cref="GitVersionConfiguration"/> properties supported as a part of command line '/overrideconfig' option.
@@ -50,7 +53,172 @@ internal class OverrideConfigurationOptionParser
                || unwrappedType == typeof(VersionStrategies[]);
     }
 
-    internal void SetValue(string key, string value) => this.overrideConfiguration[key] = QuotedStringHelpers.UnquoteText(value);
+    internal static bool TryValidate(string key, out string? error)
+    {
+        var version = ConfigurationVersionSelector.Resolve();
+        var segments = key.Split('.');
+        if (IsValidPath(version, segments))
+        {
+            error = null;
+            return true;
+        }
+
+        var replacement = GetReplacement(version, segments);
+        error = replacement is null
+            ? $"Unsupported key '{key}'."
+            : $"Key '{key}' is not valid in the selected configuration structure. Use '{replacement}' instead. " +
+              "Run 'gitversion config migrate' to convert a legacy configuration.";
+        return false;
+    }
+
+    internal void SetValues(IReadOnlyCollection<string> values, string optionName)
+    {
+        List<(string Key, string Value)> parsedOptions = [];
+
+        foreach (var keyValueOption in values)
+        {
+            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
+            if (keyAndValue.Length != 2)
+            {
+                throw new WarningException($"Could not parse {optionName} option: {keyValueOption}. Ensure it is in format 'key=value'.");
+            }
+
+            var optionKey = keyAndValue[0].ToLowerInvariant();
+            if (!TryValidate(optionKey, out var error))
+            {
+                throw new WarningException($"Could not parse {optionName} option: {keyValueOption}. {error}");
+            }
+
+            parsedOptions.Add((optionKey, keyAndValue[1]));
+        }
+
+        foreach (var (key, value) in parsedOptions)
+        {
+            SetValue(key, value);
+        }
+    }
+
+    internal void SetValue(string key, string value)
+    {
+        var segments = key.Split('.');
+        IDictionary<object, object?> current = this.overrideConfiguration;
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            var segment = segments[index];
+            if (!current.TryGetValue(segment, out var nested))
+            {
+                nested = new Dictionary<object, object?>();
+                current[segment] = nested;
+            }
+
+            current = (IDictionary<object, object?>)nested!;
+        }
+
+        current[segments[^1]] = QuotedStringHelpers.UnquoteText(value);
+    }
 
     internal IReadOnlyDictionary<object, object?> GetOverrideConfiguration() => this.overrideConfiguration;
+
+    private static HashSet<string> GetSupportedBranchProperties() => typeof(BranchConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(property => IsSupportedPropertyType(property.PropertyType) && property.CanWrite)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    private static bool IsValidPath(ConfigurationVersion version, IReadOnlyList<string> segments)
+    {
+        if (version == ConfigurationVersion.V6)
+        {
+            return segments.Count switch
+            {
+                1 => SupportedProperties.Contains(segments[0]),
+                3 when segments[0] == ConfigurationDocumentMapper.BranchesPropertyName
+                    => _lazySupportedBranchProperties.Value.Contains(segments[2]),
+                _ => false
+            };
+        }
+
+        if (segments.Count == 2 && IsSection(segments[0]))
+        {
+            return SupportedProperties.Contains(segments[1])
+                   && IsCorrectSection(segments[0], segments[1], branchProperty: false);
+        }
+
+        return segments.Count == 4
+               && IsSection(segments[0])
+               && segments[1] == ConfigurationDocumentMapper.BranchesPropertyName
+               && _lazySupportedBranchProperties.Value.Contains(segments[3])
+               && IsCorrectSection(segments[0], segments[3], branchProperty: true);
+    }
+
+    private static string? GetReplacement(ConfigurationVersion version, IReadOnlyList<string> segments) =>
+        version == ConfigurationVersion.V7
+            ? GetV7Replacement(segments)
+            : GetV6Replacement(segments);
+
+    private static string? GetV7Replacement(IReadOnlyList<string> segments)
+    {
+        if (IsFlatRootPath(segments))
+        {
+            return $"{GetSection(segments[0], branchProperty: false)}.{segments[0]}";
+        }
+
+        if (IsFlatBranchPath(segments))
+        {
+            return $"{GetSection(segments[2], branchProperty: true)}.{string.Join('.', segments)}";
+        }
+
+        if (IsNestedRootPath(segments))
+        {
+            return $"{GetSection(segments[1], branchProperty: false)}.{segments[1]}";
+        }
+
+        return IsNestedBranchPath(segments)
+            ? $"{GetSection(segments[3], branchProperty: true)}.{string.Join('.', segments.Skip(1))}"
+            : null;
+    }
+
+    private static string? GetV6Replacement(IReadOnlyList<string> segments)
+    {
+        if (IsNestedRootPath(segments))
+        {
+            return segments[1];
+        }
+
+        return IsNestedBranchPath(segments) ? string.Join('.', segments.Skip(1)) : null;
+    }
+
+    private static bool IsFlatRootPath(IReadOnlyList<string> segments) =>
+        segments.Count == 1 && SupportedProperties.Contains(segments[0]);
+
+    private static bool IsFlatBranchPath(IReadOnlyList<string> segments) =>
+        segments.Count == 3
+        && segments[0] == ConfigurationDocumentMapper.BranchesPropertyName
+        && _lazySupportedBranchProperties.Value.Contains(segments[2]);
+
+    private static bool IsNestedRootPath(IReadOnlyList<string> segments) =>
+        segments.Count == 2
+        && IsSection(segments[0])
+        && SupportedProperties.Contains(segments[1]);
+
+    private static bool IsNestedBranchPath(IReadOnlyList<string> segments) =>
+        segments.Count == 4
+        && IsSection(segments[0])
+        && segments[1] == ConfigurationDocumentMapper.BranchesPropertyName
+        && _lazySupportedBranchProperties.Value.Contains(segments[3]);
+
+    private static bool IsSection(string value)
+        => value is ConfigurationDocumentMapper.CalculationSectionName or ConfigurationDocumentMapper.OutputSectionName;
+
+    private static bool IsCorrectSection(string section, string propertyName, bool branchProperty)
+        => section == GetSection(propertyName, branchProperty);
+
+    private static string GetSection(string propertyName, bool branchProperty)
+    {
+        var isOutput = branchProperty
+            ? ConfigurationDocumentMapper.IsOutputBranchProperty(propertyName)
+            : ConfigurationDocumentMapper.IsOutputProperty(propertyName);
+        return isOutput ? ConfigurationDocumentMapper.OutputSectionName : ConfigurationDocumentMapper.CalculationSectionName;
+    }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationDocumentMapperTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationDocumentMapperTests.cs
@@ -1,0 +1,155 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationDocumentMapperTests
+{
+    [Test]
+    public void AssignsEverySerializedPropertyToExactlyOneV7Section()
+    {
+        var serializedProperties = typeof(GitVersionConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.GetCustomAttribute<JsonPropertyNameAttribute>() is not null)
+            .ToArray();
+        var calculationProperties = GetInterfacePropertyNames(typeof(ICalculationConfiguration));
+        calculationProperties.Remove(nameof(ICalculationConfiguration.VersionStrategy));
+        calculationProperties.Add(nameof(GitVersionConfiguration.VersionStrategies));
+        var outputProperties = GetInterfacePropertyNames(typeof(IOutputConfiguration));
+
+        calculationProperties.Intersect(outputProperties)
+            .ShouldBe([nameof(ICalculationConfiguration.Branches)]);
+        calculationProperties.Union(outputProperties).Order()
+            .ShouldBe(serializedProperties.Select(property => property.Name).Order());
+
+        var expectedOutputPropertyNames = serializedProperties
+            .Where(property => outputProperties.Contains(property.Name)
+                && property.Name != nameof(IOutputConfiguration.Branches))
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Order();
+        serializedProperties
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Where(ConfigurationDocumentMapper.IsOutputProperty)
+            .Order()
+            .ShouldBe(expectedOutputPropertyNames);
+
+        var branchProperties = typeof(BranchConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.GetCustomAttribute<JsonPropertyNameAttribute>() is not null)
+            .ToArray();
+        var calculationBranchProperties = GetInterfacePropertyNames(typeof(ICalculationBranchConfiguration));
+        var outputBranchProperties = GetInterfacePropertyNames(typeof(IOutputBranchConfiguration));
+
+        calculationBranchProperties.Intersect(outputBranchProperties).ShouldBeEmpty();
+        calculationBranchProperties.Union(outputBranchProperties).Order()
+            .ShouldBe(branchProperties.Select(property => property.Name).Order());
+        branchProperties
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Where(ConfigurationDocumentMapper.IsOutputBranchProperty)
+            .Order()
+            .ShouldBe(branchProperties
+                .Where(property => outputBranchProperties.Contains(property.Name))
+                .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+                .Order());
+    }
+
+    [Test]
+    public void DetectsEmptyFlatNestedAndMixedDocuments()
+    {
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?>())
+            .ShouldBe(ConfigurationDocumentKind.Empty);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?> { ["tag-prefix"] = "v" })
+            .ShouldBe(ConfigurationDocumentKind.V6);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?> { ["calculation"] = new Dictionary<object, object?>() })
+            .ShouldBe(ConfigurationDocumentKind.V7);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?>
+        {
+            ["calculation"] = new Dictionary<object, object?>(),
+            ["tag-prefix"] = "v"
+        })
+            .ShouldBe(ConfigurationDocumentKind.Mixed);
+    }
+
+    [Test]
+    public void FlattensAndMergesCalculationAndOutputBranches()
+    {
+        Dictionary<object, object?> document = new()
+        {
+            ["calculation"] = new Dictionary<object, object?>
+            {
+                ["tag-prefix"] = "v",
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["increment"] = "Patch" }
+                }
+            },
+            ["output"] = new Dictionary<object, object?>
+            {
+                ["update-build-number"] = false,
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["pre-release-weight"] = 42 },
+                    ["develop"] = new Dictionary<object, object?> { ["custom-version-format"] = "{SemVer}" }
+                }
+            }
+        };
+
+        var result = ConfigurationDocumentMapper.Flatten(document);
+
+        result["tag-prefix"].ShouldBe("v");
+        result["update-build-number"].ShouldBe(false);
+        var branches = result["branches"].ShouldBeOfType<Dictionary<object, object?>>();
+        var main = branches["main"].ShouldBeOfType<Dictionary<object, object?>>();
+        main["increment"].ShouldBe("Patch");
+        main["pre-release-weight"].ShouldBe(42);
+        branches.ContainsKey("develop").ShouldBeTrue();
+    }
+
+    [Test]
+    public void RejectsMixedAndSelectedVersionMismatches()
+    {
+        Dictionary<object, object?> flat = new() { ["tag-prefix"] = "v" };
+        Dictionary<object, object?> nested = new() { ["calculation"] = new Dictionary<object, object?>() };
+        Dictionary<object, object?> mixed = new()
+        {
+            ["calculation"] = new Dictionary<object, object?>(),
+            ["tag-prefix"] = "v"
+        };
+
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(flat, ConfigurationVersion.V7, "test"));
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(nested, ConfigurationVersion.V6, "test"));
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(mixed, ConfigurationVersion.V7, "test"));
+    }
+
+    [Test]
+    public void RejectsPropertiesInTheWrongV7SectionWithReplacement()
+    {
+        Dictionary<object, object?> wrongRoot = new()
+        {
+            ["calculation"] = new Dictionary<object, object?> { ["update-build-number"] = false }
+        };
+        Dictionary<object, object?> wrongBranch = new()
+        {
+            ["output"] = new Dictionary<object, object?>
+            {
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["increment"] = "Major" }
+                }
+            }
+        };
+
+        Should.Throw<ConfigurationException>(() => ConfigurationDocumentMapper.Flatten(wrongRoot))
+            .Message.ShouldContain("output.update-build-number");
+        Should.Throw<ConfigurationException>(() => ConfigurationDocumentMapper.Flatten(wrongBranch))
+            .Message.ShouldContain("calculation.branches.<branch>.increment");
+    }
+
+    private static HashSet<string> GetInterfacePropertyNames(Type interfaceType) =>
+        interfaceType.GetInterfaces()
+            .Append(interfaceType)
+            .SelectMany(type => type.GetProperties())
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -7,15 +7,19 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationProviderTests : TestBase
 {
     private string repoPath = null!;
     private ConfigurationProvider configurationProvider = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void Setup()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         this.repoPath = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "MyGitRepo");
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services => services.AddSingleton(options));
@@ -23,6 +27,93 @@ public class ConfigurationProviderTests : TestBase
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
 
         ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void ProvidesNestedV7ConfigurationAndMergesOutputOnlyWorkflowBranch()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        const string text = """
+                            calculation:
+                              workflow: GitFlow/v1
+                              tag-prefix: custom-
+                            output:
+                              update-build-number: false
+                              branches:
+                                develop:
+                                  custom-version-format: '{SemVer}'
+                                  pre-release-weight: 42
+                            """;
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
+
+        var configuration = this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        configuration.Calculation.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Output.UpdateBuildNumber.ShouldBeFalse();
+        configuration.Calculation.Branches.ShouldContainKey("develop");
+        configuration.Output.Branches["develop"].CustomVersionFormat.ShouldBe("{SemVer}");
+        configuration.Output.Branches["develop"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void ResolvesEquivalentV6AndV7Configuration()
+    {
+        const string v6 = """
+                          tag-prefix: custom-
+                          update-build-number: false
+                          branches:
+                            main:
+                              increment: Major
+                              pre-release-weight: 42
+                          """;
+        const string v7 = """
+                          calculation:
+                            tag-prefix: custom-
+                            branches:
+                              main:
+                                increment: Major
+                          output:
+                            update-build-number: false
+                            branches:
+                              main:
+                                pre-release-weight: 42
+                          """;
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+        IGitVersionConfiguration legacy;
+        using (this.fileSystem.SetupConfigFile(path: this.repoPath, text: v6))
+        {
+            legacy = this.configurationProvider.ProvideForDirectory(this.repoPath);
+        }
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        using (this.fileSystem.SetupConfigFile(path: this.repoPath, text: v7))
+        {
+            var nested = this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+            ConfigurationSerializer.SerializeLegacy(nested).ShouldBe(ConfigurationSerializer.SerializeLegacy(legacy));
+        }
+    }
+
+    [Test]
+    public void RejectsMixedV7Configuration()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        const string text = """
+                            calculation:
+                              tag-prefix: custom-
+                            update-build-number: false
+                            """;
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
+
+        var exception = Should.Throw<ConfigurationException>(() =>
+            this.configurationProvider.ProvideForDirectory(this.repoPath));
+
+        exception.Message.ShouldContain("mixes the v6 flat configuration structure");
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
@@ -1,9 +1,51 @@
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationSerializerTests
 {
     private readonly ConfigurationSerializer serializer = new();
+
+    [Test]
+    public void SerializesV7CalculationAndOutputSectionsAndRoundTrips()
+    {
+        using var scope = new EnvironmentVariableScope("v7");
+        var configuration = new GitVersionConfiguration
+        {
+            TagPrefixPattern = "custom-",
+            UpdateBuildNumber = false,
+            Branches = new Dictionary<string, BranchConfiguration>
+            {
+                ["main"] = new() { Increment = IncrementStrategy.Major, PreReleaseWeight = 42 }
+            }
+        };
+
+        var yaml = this.serializer.Serialize(configuration);
+        var roundTrip = ConfigurationSerializer.ReadConfiguration(yaml);
+
+        yaml.ShouldContain("calculation:");
+        yaml.ShouldContain("output:");
+        yaml.ShouldContain("  tag-prefix: custom-");
+        yaml.ShouldContain("    main:");
+        roundTrip.ShouldNotBeNull();
+        roundTrip.TagPrefixPattern.ShouldBe("custom-");
+        roundTrip.UpdateBuildNumber.ShouldBeFalse();
+        roundTrip.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        roundTrip.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void SerializesFlatConfigurationWhenV6IsSelected()
+    {
+        using var scope = new EnvironmentVariableScope("v6");
+        var configuration = new GitVersionConfiguration { TagPrefixPattern = "custom-" };
+
+        var yaml = this.serializer.Serialize(configuration);
+
+        yaml.ShouldContain("tag-prefix: custom-");
+        yaml.ShouldNotContain("calculation:");
+        yaml.ShouldNotContain("output:");
+    }
 
     [Test]
     public void Serialize_OrdersConfigurationPropertiesAndPreservesBranchNames()
@@ -39,4 +81,15 @@ public class ConfigurationSerializerTests
     }
 
     private static string GetPropertyName(string line) => line.TrimStart().Split(':', 2)[0];
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.original);
+    }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -6,9 +6,22 @@ using SharpYaml;
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class IgnoreConfigurationTests : TestBase
 {
     private readonly ConfigurationSerializer serializer = new();
+    private string? originalConfigurationVersion;
+
+    [SetUp]
+    public void Setup()
+    {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
     public void CanDeserialize()
@@ -20,7 +33,7 @@ public class IgnoreConfigurationTests : TestBase
                 sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98]
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -40,7 +53,7 @@ public class IgnoreConfigurationTests : TestBase
                     - 6c19c7c219ecf8dbc468042baefa73a1b213e8b1
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -53,7 +66,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "ignore:\n  branches: ['^legacy/', '^release/old$']";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
@@ -64,7 +77,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "ignore:\n  tags: ['^preview-', '^v0\\.']";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Tags.ShouldBe(["^preview-", "^v0\\."]);
@@ -83,7 +96,7 @@ public class IgnoreConfigurationTests : TestBase
                     - ^preview-
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
@@ -101,7 +114,7 @@ public class IgnoreConfigurationTests : TestBase
                     - ^v0\.
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Tags.ShouldBe(["^preview-", "^v0\\."]);
@@ -112,7 +125,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "next-version: 1.0";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -212,7 +225,7 @@ public class IgnoreConfigurationTests : TestBase
                 commits-before: bad format date
             """;
 
-        Should.Throw<YamlException>(() => this.serializer.ReadConfiguration(yaml));
+        Should.Throw<YamlException>(() => ConfigurationSerializer.ReadConfiguration(yaml));
     }
 
     [Test]
@@ -220,7 +233,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "strategies: ConfiguredNextVersion, TaggedCommit";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.VersionStrategy.ShouldBe(VersionStrategies.ConfiguredNextVersion | VersionStrategies.TaggedCommit);

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
@@ -1,170 +1,180 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
@@ -1,119 +1,126 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
@@ -1,104 +1,112 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration/BranchConfiguration.cs
+++ b/src/GitVersion.Configuration/BranchConfiguration.cs
@@ -25,6 +25,9 @@ internal record BranchConfiguration : IBranchConfiguration
     [JsonIgnore]
     IPreventIncrementConfiguration IBranchConfiguration.PreventIncrement => PreventIncrement;
 
+    [JsonIgnore]
+    IPreventIncrementConfiguration ICalculationBranchConfiguration.PreventIncrement => PreventIncrement;
+
     [JsonPropertyName("prevent-increment")]
     [JsonPropertyDescription("The prevent increment configuration section.")]
     public PreventIncrementConfiguration PreventIncrement { get; set; } = new();
@@ -56,12 +59,18 @@ internal record BranchConfiguration : IBranchConfiguration
     [JsonIgnore]
     IReadOnlyCollection<string> IBranchConfiguration.SourceBranches => SourceBranches;
 
+    [JsonIgnore]
+    IReadOnlyCollection<string> ICalculationBranchConfiguration.SourceBranches => SourceBranches;
+
     [JsonPropertyName("is-source-branch-for")]
     [JsonPropertyDescription("The branches that this branch is a source branch.")]
     public HashSet<string> IsSourceBranchFor { get; set; } = [];
 
     [JsonIgnore]
     IReadOnlyCollection<string> IBranchConfiguration.IsSourceBranchFor => IsSourceBranchFor;
+
+    [JsonIgnore]
+    IReadOnlyCollection<string> ICalculationBranchConfiguration.IsSourceBranchFor => IsSourceBranchFor;
 
     [JsonPropertyName("tracks-release-branches")]
     [JsonPropertyDescription("Indicates this branch configuration represents develop in GitFlow.")]

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -338,45 +338,47 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
 
     public TConfigurationBuilder WithConfiguration(IGitVersionConfiguration value)
     {
-        WithAssemblyVersioningScheme(value.AssemblyVersioningScheme);
-        WithAssemblyFileVersioningScheme(value.AssemblyFileVersioningScheme);
-        WithAssemblyInformationalFormat(value.AssemblyInformationalFormat);
-        WithAssemblyVersioningFormat(value.AssemblyVersioningFormat);
-        WithAssemblyFileVersioningFormat(value.AssemblyFileVersioningFormat);
-        WithCustomVersionFormat(value.CustomVersionFormat);
-        WithTagPrefixPattern(value.TagPrefixPattern);
-        WithVersionInBranchPattern(value.VersionInBranchPattern);
-        WithNextVersion(value.NextVersion);
-        WithMajorVersionBumpMessage(value.MajorVersionBumpMessage);
-        WithMinorVersionBumpMessage(value.MinorVersionBumpMessage);
-        WithPatchVersionBumpMessage(value.PatchVersionBumpMessage);
-        WithNoBumpMessage(value.NoBumpMessage);
-        WithVersionBumpResetMessage(value.VersionBumpResetMessage);
-        WithTagPreReleaseWeight(value.TagPreReleaseWeight);
-        WithIgnoreConfiguration(value.Ignore);
-        WithCommitDateFormat(value.CommitDateFormat);
-        WithUpdateBuildNumber(value.UpdateBuildNumber);
-        WithSemanticVersionFormat(value.SemanticVersionFormat);
-        WithVersionStrategy(value.VersionStrategy);
-        WithMergeMessageFormats(value.MergeMessageFormats);
+        var calculation = value.Calculation;
+        var output = value.Output;
+        WithAssemblyVersioningScheme(output.AssemblyVersioningScheme);
+        WithAssemblyFileVersioningScheme(output.AssemblyFileVersioningScheme);
+        WithAssemblyInformationalFormat(output.AssemblyInformationalFormat);
+        WithAssemblyVersioningFormat(output.AssemblyVersioningFormat);
+        WithAssemblyFileVersioningFormat(output.AssemblyFileVersioningFormat);
+        WithCustomVersionFormat(output.CustomVersionFormat);
+        WithTagPrefixPattern(calculation.TagPrefixPattern);
+        WithVersionInBranchPattern(calculation.VersionInBranchPattern);
+        WithNextVersion(calculation.NextVersion);
+        WithMajorVersionBumpMessage(calculation.MajorVersionBumpMessage);
+        WithMinorVersionBumpMessage(calculation.MinorVersionBumpMessage);
+        WithPatchVersionBumpMessage(calculation.PatchVersionBumpMessage);
+        WithNoBumpMessage(calculation.NoBumpMessage);
+        WithVersionBumpResetMessage(calculation.VersionBumpResetMessage);
+        WithTagPreReleaseWeight(output.TagPreReleaseWeight);
+        WithIgnoreConfiguration(calculation.Ignore);
+        WithCommitDateFormat(output.CommitDateFormat);
+        WithUpdateBuildNumber(output.UpdateBuildNumber);
+        WithSemanticVersionFormat(calculation.SemanticVersionFormat);
+        WithVersionStrategy(calculation.VersionStrategy);
+        WithMergeMessageFormats(calculation.MergeMessageFormats);
         foreach (var (name, branchConfiguration) in value.Branches)
         {
             WithBranch(name).WithConfiguration(branchConfiguration);
         }
-        WithDeploymentMode(value.DeploymentMode);
-        WithLabel(value.Label);
-        WithIncrement(value.Increment);
-        WithPreventIncrementOfMergedBranch(value.PreventIncrement.OfMergedBranch);
-        WithPreventIncrementWhenBranchMerged(value.PreventIncrement.WhenBranchMerged);
-        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrement.WhenCurrentCommitTagged);
-        WithTrackMergeTarget(value.TrackMergeTarget);
-        WithTrackMergeMessage(value.TrackMergeMessage);
-        WithCommitMessageIncrementing(value.CommitMessageIncrementing);
-        WithRegularExpression(value.RegularExpression);
-        WithTracksReleaseBranches(value.TracksReleaseBranches);
-        WithIsReleaseBranch(value.IsReleaseBranch);
-        WithIsMainBranch(value.IsMainBranch);
-        WithPreReleaseWeight(value.PreReleaseWeight);
+        WithDeploymentMode(calculation.DeploymentMode);
+        WithLabel(calculation.Label);
+        WithIncrement(calculation.Increment);
+        WithPreventIncrementOfMergedBranch(calculation.PreventIncrement.OfMergedBranch);
+        WithPreventIncrementWhenBranchMerged(calculation.PreventIncrement.WhenBranchMerged);
+        WithPreventIncrementWhenCurrentCommitTagged(calculation.PreventIncrement.WhenCurrentCommitTagged);
+        WithTrackMergeTarget(calculation.TrackMergeTarget);
+        WithTrackMergeMessage(calculation.TrackMergeMessage);
+        WithCommitMessageIncrementing(calculation.CommitMessageIncrementing);
+        WithRegularExpression(calculation.RegularExpression);
+        WithTracksReleaseBranches(calculation.TracksReleaseBranches);
+        WithIsReleaseBranch(calculation.IsReleaseBranch);
+        WithIsMainBranch(calculation.IsMainBranch);
+        WithPreReleaseWeight(output.PreReleaseWeight);
         return (TConfigurationBuilder)this;
     }
 

--- a/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
+++ b/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
@@ -1,0 +1,318 @@
+namespace GitVersion.Configuration;
+
+internal enum ConfigurationDocumentKind
+{
+    Empty,
+    V6,
+    V7,
+    Mixed
+}
+
+internal static class ConfigurationDocumentMapper
+{
+    public const string CalculationSectionName = "calculation";
+    public const string OutputSectionName = "output";
+    public const string BranchesPropertyName = "branches";
+
+    private static readonly HashSet<string> OutputPropertyNames =
+    [
+        "assembly-file-versioning-format",
+        "assembly-file-versioning-scheme",
+        "assembly-informational-format",
+        "assembly-versioning-format",
+        "assembly-versioning-scheme",
+        "commit-date-format",
+        "custom-version-format",
+        "pre-release-weight",
+        "tag-pre-release-weight",
+        "update-build-number"
+    ];
+
+    private static readonly HashSet<string> OutputBranchPropertyNames =
+    [
+        "custom-version-format",
+        "pre-release-weight"
+    ];
+
+    private static readonly HashSet<string> KnownPropertyNames = typeof(GitVersionConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    private static readonly HashSet<string> KnownBranchPropertyNames = typeof(BranchConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    public static ConfigurationDocumentKind Detect(IReadOnlyDictionary<object, object?> document)
+    {
+        if (document.Count == 0)
+        {
+            return ConfigurationDocumentKind.Empty;
+        }
+
+        var hasNested = document.ContainsKey(CalculationSectionName) || document.ContainsKey(OutputSectionName);
+        var hasFlat = document.Keys.OfType<string>().Any(key =>
+            !key.Equals(CalculationSectionName, StringComparison.Ordinal)
+            && !key.Equals(OutputSectionName, StringComparison.Ordinal));
+
+        return (hasNested, hasFlat) switch
+        {
+            (true, true) => ConfigurationDocumentKind.Mixed,
+            (true, false) => ConfigurationDocumentKind.V7,
+            _ => ConfigurationDocumentKind.V6
+        };
+    }
+
+    public static Dictionary<object, object?> Normalize(
+        IReadOnlyDictionary<object, object?> document,
+        ConfigurationVersion selectedVersion,
+        string source)
+    {
+        var kind = Detect(document);
+        if (kind == ConfigurationDocumentKind.Mixed)
+        {
+            throw new ConfigurationException(
+                $"The {source} mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure. Run 'gitversion config migrate' to convert a v6 configuration.");
+        }
+
+        if (kind == ConfigurationDocumentKind.V6 && selectedVersion == ConfigurationVersion.V7)
+        {
+            throw new ConfigurationException(
+                $"The {source} uses the legacy v6 configuration structure, but {ConfigurationVersionSelector.EnvironmentVariableName}=v7 is selected. " +
+                $"Run 'gitversion config migrate' or set {ConfigurationVersionSelector.EnvironmentVariableName}=v6 temporarily.");
+        }
+
+        if (kind == ConfigurationDocumentKind.V7 && selectedVersion == ConfigurationVersion.V6)
+        {
+            throw new ConfigurationException(
+                $"The {source} uses the v7 configuration structure, but {ConfigurationVersionSelector.EnvironmentVariableName}=v6 is selected. " +
+                $"Remove the override or set {ConfigurationVersionSelector.EnvironmentVariableName}=v7.");
+        }
+
+        return kind == ConfigurationDocumentKind.V7 ? Flatten(document) : CloneDictionary(document);
+    }
+
+    public static Dictionary<object, object?> NormalizeInternal(IReadOnlyDictionary<object, object?> document, string source)
+    {
+        var kind = Detect(document);
+        return kind switch
+        {
+            ConfigurationDocumentKind.Empty => [],
+            ConfigurationDocumentKind.V6 => CloneDictionary(document),
+            ConfigurationDocumentKind.V7 => Flatten(document),
+            _ => throw new ConfigurationException(
+                $"The {source} mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure.")
+        };
+    }
+
+    public static Dictionary<object, object?> Flatten(IReadOnlyDictionary<object, object?> document)
+    {
+        Dictionary<object, object?> result = [];
+        Dictionary<object, object?> branches = [];
+
+        FlattenSection(document, CalculationSectionName, result, branches);
+        FlattenSection(document, OutputSectionName, result, branches);
+
+        if (branches.Count != 0)
+        {
+            result[BranchesPropertyName] = branches;
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, object?> Nest(IReadOnlyDictionary<string, object?> document)
+    {
+        Dictionary<string, object?> calculation = [];
+        Dictionary<string, object?> output = [];
+
+        foreach (var (key, value) in document)
+        {
+            if (key.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                SplitBranches(value, calculation, output);
+            }
+            else if (OutputPropertyNames.Contains(key))
+            {
+                output[key] = value;
+            }
+            else
+            {
+                calculation[key] = value;
+            }
+        }
+
+        return new Dictionary<string, object?>
+        {
+            [CalculationSectionName] = calculation,
+            [OutputSectionName] = output
+        };
+    }
+
+    public static bool IsOutputProperty(string propertyName) => OutputPropertyNames.Contains(propertyName);
+
+    public static bool IsOutputBranchProperty(string propertyName) => OutputBranchPropertyNames.Contains(propertyName);
+
+    private static void FlattenSection(
+        IReadOnlyDictionary<object, object?> document,
+        string sectionName,
+        IDictionary<object, object?> result,
+        IDictionary<object, object?> branches)
+    {
+        if (!document.TryGetValue(sectionName, out var sectionValue) || sectionValue is null)
+        {
+            return;
+        }
+
+        if (sectionValue is not IReadOnlyDictionary<object, object?> section)
+        {
+            throw new ConfigurationException($"Configuration section '{sectionName}' must be a mapping.");
+        }
+
+        foreach (var (key, value) in section)
+        {
+            if (key is string propertyName && propertyName.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                MergeBranches(branches, value, sectionName);
+                continue;
+            }
+
+            if (key is string configuredPropertyName)
+            {
+                ValidatePropertyOwnership(sectionName, configuredPropertyName, branchProperty: false);
+            }
+
+            if (!result.TryAdd(key, CloneValue(value)))
+            {
+                throw new ConfigurationException(
+                    $"Configuration property '{key}' is defined in both '{CalculationSectionName}' and '{OutputSectionName}'.");
+            }
+        }
+    }
+
+    private static void MergeBranches(IDictionary<object, object?> target, object? value, string sectionName)
+    {
+        if (value is not IReadOnlyDictionary<object, object?> source)
+        {
+            throw new ConfigurationException($"Configuration property '{sectionName}.{BranchesPropertyName}' must be a mapping.");
+        }
+
+        foreach (var (branchName, branchValue) in source)
+        {
+            if (branchValue is not IReadOnlyDictionary<object, object?> branch)
+            {
+                throw new ConfigurationException(
+                    $"Configuration branch '{sectionName}.{BranchesPropertyName}.{branchName}' must be a mapping.");
+            }
+
+            foreach (var propertyName in branch.Keys.OfType<string>())
+            {
+                ValidatePropertyOwnership(sectionName, propertyName, branchProperty: true);
+            }
+
+            if (!target.TryGetValue(branchName, out var existing))
+            {
+                target[branchName] = CloneDictionary(branch);
+                continue;
+            }
+
+            if (existing is not IDictionary<object, object?> targetBranch)
+            {
+                throw new ConfigurationException($"Configuration branch '{branchName}' must be a mapping.");
+            }
+
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                if (!targetBranch.TryAdd(propertyName, CloneValue(propertyValue)))
+                {
+                    throw new ConfigurationException(
+                        $"Configuration branch property '{branchName}.{propertyName}' is defined in both " +
+                        $"'{CalculationSectionName}' and '{OutputSectionName}'.");
+                }
+            }
+        }
+    }
+
+    private static void SplitBranches(
+        object? value,
+        IDictionary<string, object?> calculation,
+        IDictionary<string, object?> output)
+    {
+        if (value is not IReadOnlyDictionary<string, object?> branches)
+        {
+            return;
+        }
+
+        Dictionary<string, object?> calculationBranches = [];
+        Dictionary<string, object?> outputBranches = [];
+
+        foreach (var (branchName, branchValue) in branches)
+        {
+            if (branchValue is not IReadOnlyDictionary<string, object?> branch)
+            {
+                continue;
+            }
+
+            Dictionary<string, object?> calculationBranch = [];
+            Dictionary<string, object?> outputBranch = [];
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                (OutputBranchPropertyNames.Contains(propertyName) ? outputBranch : calculationBranch)[propertyName] = propertyValue;
+            }
+
+            if (calculationBranch.Count != 0)
+            {
+                calculationBranches[branchName] = calculationBranch;
+            }
+
+            if (outputBranch.Count != 0)
+            {
+                outputBranches[branchName] = outputBranch;
+            }
+        }
+
+        if (calculationBranches.Count != 0)
+        {
+            calculation[BranchesPropertyName] = calculationBranches;
+        }
+
+        if (outputBranches.Count != 0)
+        {
+            output[BranchesPropertyName] = outputBranches;
+        }
+    }
+
+    private static Dictionary<object, object?> CloneDictionary(IReadOnlyDictionary<object, object?> dictionary)
+        => dictionary.ToDictionary(item => item.Key, item => CloneValue(item.Value));
+
+    private static void ValidatePropertyOwnership(string sectionName, string propertyName, bool branchProperty)
+    {
+        var knownProperties = branchProperty ? KnownBranchPropertyNames : KnownPropertyNames;
+        if (!knownProperties.Contains(propertyName))
+        {
+            return;
+        }
+
+        var belongsToOutput = branchProperty
+            ? OutputBranchPropertyNames.Contains(propertyName)
+            : OutputPropertyNames.Contains(propertyName);
+        var expectedSection = belongsToOutput ? OutputSectionName : CalculationSectionName;
+        if (!sectionName.Equals(expectedSection, StringComparison.Ordinal))
+        {
+            var branchPath = branchProperty ? $"{BranchesPropertyName}.<branch>." : string.Empty;
+            throw new ConfigurationException(
+                $"Configuration property '{sectionName}.{branchPath}{propertyName}' belongs under " +
+                $"'{expectedSection}.{branchPath}{propertyName}'.");
+        }
+    }
+
+    private static object? CloneValue(object? value) => value switch
+    {
+        IReadOnlyDictionary<object, object?> dictionary => CloneDictionary(dictionary),
+        _ => value
+    };
+}

--- a/src/GitVersion.Configuration/ConfigurationHelper.cs
+++ b/src/GitVersion.Configuration/ConfigurationHelper.cs
@@ -6,8 +6,8 @@ internal class ConfigurationHelper
 {
     private static ConfigurationSerializer Serializer => new();
     private string Yaml => this.yaml ??= this.dictionary == null
-        ? Serializer.Serialize(this.configuration!)
-        : Serializer.Serialize(this.dictionary);
+        ? ConfigurationSerializer.SerializeLegacy(this.configuration!)
+        : ConfigurationSerializer.SerializeLegacy(this.dictionary);
     private string? yaml;
 
     internal IReadOnlyDictionary<object, object?> Dictionary
@@ -19,14 +19,14 @@ internal class ConfigurationHelper
                 return this.dictionary;
             }
 
-            this.yaml ??= Serializer.Serialize(this.configuration!);
+            this.yaml ??= ConfigurationSerializer.SerializeLegacy(this.configuration!);
             this.dictionary = Serializer.Deserialize<Dictionary<object, object?>>(this.yaml);
             return this.dictionary;
         }
     }
     private IReadOnlyDictionary<object, object?>? dictionary;
 
-    public IGitVersionConfiguration Configuration => this.configuration ??= Serializer.Deserialize<GitVersionConfiguration>(Yaml);
+    public IGitVersionConfiguration Configuration => this.configuration ??= ConfigurationSerializer.DeserializeLegacyConfiguration(Yaml)!;
     private IGitVersionConfiguration? configuration;
 
     internal ConfigurationHelper(string yaml) => this.yaml = yaml.NotNull();

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -43,16 +43,27 @@ internal class ConfigurationProvider(
     private IGitVersionConfiguration ProvideConfiguration(string? configFile,
                                                           IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
-        var overrideConfigurationFromFile = ReadOverrideConfiguration(configFile);
+        var configurationVersion = ConfigurationVersionSelector.Resolve();
+        this.logger.LogInformation("Configuration version: {ConfigurationVersion}", ConfigurationVersionSelector.ResolveName());
+        var configurationFromFile = ReadOverrideConfiguration(configFile);
+        var overrideConfigurationFromFile = configurationFromFile is null
+            ? null
+            : ConfigurationDocumentMapper.Normalize(configurationFromFile, configurationVersion, "configuration file");
+        var normalizedOverrideConfiguration = overrideConfiguration is null
+            ? null
+            : ConfigurationDocumentMapper.NormalizeInternal(overrideConfiguration, "runtime override configuration");
 
-        var workflow = GetWorkflow(overrideConfiguration, overrideConfigurationFromFile);
+        var workflow = GetWorkflow(normalizedOverrideConfiguration, overrideConfigurationFromFile);
 
         IConfigurationBuilder configurationBuilder = (workflow is null)
             ? GitFlowConfigurationBuilder.New
             : ConfigurationBuilder.New;
 
-        var overrideConfigurationFromWorkflow = WorkflowManager.GetOverrideConfiguration(workflow);
-        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, overrideConfiguration }
+        var workflowConfiguration = WorkflowManager.GetOverrideConfiguration(workflow);
+        var overrideConfigurationFromWorkflow = workflowConfiguration is null
+            ? null
+            : ConfigurationDocumentMapper.NormalizeInternal(workflowConfiguration, "embedded workflow");
+        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, normalizedOverrideConfiguration }
                      .OfType<IReadOnlyDictionary<object, object?>>())
         {
             configurationBuilder.AddOverride(item);

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -29,14 +29,7 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
         if (typeof(T) == typeof(GitVersionConfiguration))
         {
-            try
-            {
-                return (T)(object)YamlSerializer.Deserialize<GitVersionConfiguration>(input, GeneratedContext)!;
-            }
-            catch (Exception exception) when (exception is not YamlException)
-            {
-                throw new YamlException(exception.Message, exception);
-            }
+            return (T)(object)DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document")!;
         }
 
         return YamlSerializer.Deserialize<T>(input, SerializerOptions)!;
@@ -44,12 +37,42 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
     public string Serialize(object graph)
     {
-        var yaml = YamlSerializer.Serialize(graph, SerializerOptions);
+        var yaml = SerializeLegacy(graph);
         var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        if (graph is IGitVersionConfiguration && ConfigurationVersionSelector.Resolve() == ConfigurationVersion.V7)
+        {
+            configuration = ConfigurationDocumentMapper.Nest(configuration);
+        }
+
         return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
     }
 
-    public IGitVersionConfiguration? ReadConfiguration(string input) => Deserialize<GitVersionConfiguration?>(input);
+    public static IGitVersionConfiguration? ReadConfiguration(string input)
+        => DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document");
+
+    internal static string SerializeLegacy(object graph) => YamlSerializer.Serialize(graph, SerializerOptions);
+
+    internal static GitVersionConfiguration? DeserializeLegacyConfiguration(string input)
+        => DeserializeConfiguration(input, ConfigurationVersion.V6, "internal effective configuration");
+
+    private static GitVersionConfiguration? DeserializeConfiguration(
+        string input,
+        ConfigurationVersion version,
+        string source)
+    {
+        try
+        {
+            var graph = YamlSerializer.Deserialize<Dictionary<string, object?>>(input, SerializerOptions);
+            var objectGraph = ConvertToObjectDictionary(graph);
+            var normalized = ConfigurationDocumentMapper.Normalize(objectGraph, version, source);
+            var normalizedYaml = YamlSerializer.Serialize(normalized, SerializerOptions);
+            return YamlSerializer.Deserialize<GitVersionConfiguration>(normalizedYaml, GeneratedContext);
+        }
+        catch (Exception exception) when (exception is not YamlException and not ConfigurationException)
+        {
+            throw new YamlException(exception.Message, exception);
+        }
+    }
 
     private static Dictionary<object, object?> ConvertToObjectDictionary(IReadOnlyDictionary<string, object?>? source)
     {

--- a/src/GitVersion.Configuration/GitVersionConfiguration.cs
+++ b/src/GitVersion.Configuration/GitVersionConfiguration.cs
@@ -7,6 +7,12 @@ namespace GitVersion.Configuration;
 
 internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersionConfiguration
 {
+    [JsonIgnore]
+    public ICalculationConfiguration Calculation => new CalculationConfiguration(this);
+
+    [JsonIgnore]
+    public IOutputConfiguration Output => new OutputConfiguration(this);
+
     [JsonPropertyName("workflow")]
     [JsonPropertyDescription("The base template of the configuration to use. Possible values are: 'GitFlow/v1' or 'GitHubFlow/v1'")]
     public string? Workflow { get; set; }
@@ -148,4 +154,52 @@ internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersio
         Label = BranchNamePlaceholder,
         Increment = IncrementStrategy.Inherit
     };
+
+    private sealed class CalculationConfiguration(GitVersionConfiguration configuration) : ICalculationConfiguration
+    {
+        public string? Workflow => configuration.Workflow;
+        public string? TagPrefixPattern => configuration.TagPrefixPattern;
+        public string? VersionInBranchPattern => configuration.VersionInBranchPattern;
+        public string? NextVersion => configuration.NextVersion;
+        public string? MajorVersionBumpMessage => configuration.MajorVersionBumpMessage;
+        public string? MinorVersionBumpMessage => configuration.MinorVersionBumpMessage;
+        public string? PatchVersionBumpMessage => configuration.PatchVersionBumpMessage;
+        public string? NoBumpMessage => configuration.NoBumpMessage;
+        public string? VersionBumpResetMessage => configuration.VersionBumpResetMessage;
+        public IReadOnlyDictionary<string, string> MergeMessageFormats => configuration.MergeMessageFormats;
+        public SemanticVersionFormat SemanticVersionFormat => configuration.SemanticVersionFormat;
+        public VersionStrategies VersionStrategy => ((IGitVersionConfiguration)configuration).VersionStrategy;
+        public IReadOnlyDictionary<string, ICalculationBranchConfiguration> Branches
+            => configuration.Branches.ToDictionary(element => element.Key, ICalculationBranchConfiguration (element) => element.Value);
+        public IIgnoreConfiguration Ignore => configuration.Ignore;
+        public DeploymentMode? DeploymentMode => configuration.DeploymentMode;
+        public string? Label => configuration.Label;
+        public IncrementStrategy Increment => configuration.Increment;
+        public IPreventIncrementConfiguration PreventIncrement => configuration.PreventIncrement;
+        public bool? TrackMergeTarget => configuration.TrackMergeTarget;
+        public bool? TrackMergeMessage => configuration.TrackMergeMessage;
+        public CommitMessageIncrementMode? CommitMessageIncrementing => configuration.CommitMessageIncrementing;
+        public string? RegularExpression => configuration.RegularExpression;
+        public IReadOnlyCollection<string> SourceBranches => configuration.SourceBranches;
+        public IReadOnlyCollection<string> IsSourceBranchFor => configuration.IsSourceBranchFor;
+        public bool? TracksReleaseBranches => configuration.TracksReleaseBranches;
+        public bool? IsReleaseBranch => configuration.IsReleaseBranch;
+        public bool? IsMainBranch => configuration.IsMainBranch;
+    }
+
+    private sealed class OutputConfiguration(GitVersionConfiguration configuration) : IOutputConfiguration
+    {
+        public AssemblyVersioningScheme? AssemblyVersioningScheme => configuration.AssemblyVersioningScheme;
+        public AssemblyFileVersioningScheme? AssemblyFileVersioningScheme => configuration.AssemblyFileVersioningScheme;
+        public string? AssemblyInformationalFormat => configuration.AssemblyInformationalFormat;
+        public string? AssemblyVersioningFormat => configuration.AssemblyVersioningFormat;
+        public string? AssemblyFileVersioningFormat => configuration.AssemblyFileVersioningFormat;
+        public int? TagPreReleaseWeight => configuration.TagPreReleaseWeight;
+        public string? CommitDateFormat => configuration.CommitDateFormat;
+        public bool UpdateBuildNumber => configuration.UpdateBuildNumber;
+        public IReadOnlyDictionary<string, IOutputBranchConfiguration> Branches
+            => configuration.Branches.ToDictionary(element => element.Key, IOutputBranchConfiguration (element) => element.Value);
+        public string? CustomVersionFormat => configuration.CustomVersionFormat;
+        public int? PreReleaseWeight => configuration.PreReleaseWeight;
+    }
 }

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -1,0 +1,48 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class ConfigurationVersionSelectorTests : TestBase
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase("v6", true)]
+    [TestCase("V6", true)]
+    [TestCase(" v6 ", true)]
+    [TestCase("v7", false)]
+    [TestCase("V7", false)]
+    [TestCase(" v7 ", false)]
+    public void ResolvesKnownValues(string? value, bool isV6)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        ConfigurationVersionSelector.Resolve().ShouldBe(isV6 ? ConfigurationVersion.V6 : ConfigurationVersion.V7);
+    }
+
+    [TestCase("6")]
+    [TestCase("7")]
+    [TestCase("true")]
+    [TestCase("legacy")]
+    public void FailsFastOnUnknownValues(string value)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        var exception = Should.Throw<InvalidOperationException>(() => ConfigurationVersionSelector.Resolve());
+        exception.Message.ShouldContain(value);
+        exception.Message.ShouldContain("v6");
+        exception.Message.ShouldContain("v7");
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.original);
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -18,6 +18,7 @@ public class GitVersionExecutorTests : TestBase
     private IFileSystem fileSystem = null!;
     private GitVersionCacheProvider gitVersionCacheProvider = null!;
     private IServiceProvider sp = null!;
+    private string? originalConfigurationVersion;
 
     private const string versionCacheFileContent =
         """
@@ -52,6 +53,17 @@ public class GitVersionExecutorTests : TestBase
           "WeightedPreReleaseNumber": 19
         }
         """;
+
+    [SetUp]
+    public void SetupConfigurationVersion()
+    {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+    }
+
+    [TearDown]
+    public void RestoreConfigurationVersion() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
     public void ResolvedConfiguration_IsCreatedOncePerExecution()

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -66,6 +66,23 @@ public class GitVersionExecutorTests : TestBase
         System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
+    public void ConfigurationVersionChangeInvalidatesCache()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        var options = new GitVersionOptions { WorkingDirectory = fixture.RepositoryPath };
+        _ = GetGitVersionCalculator(options);
+        var cacheKeyFactory = this.sp.GetRequiredService<IGitVersionCacheKeyFactory>();
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+        var v6Key = cacheKeyFactory.Create(null);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        var v7Key = cacheKeyFactory.Create(null);
+
+        v7Key.ShouldNotBe(v6Key);
+    }
+
+    [Test]
     public void ResolvedConfiguration_IsCreatedOncePerExecution()
     {
         var configuration = GitFlowConfigurationBuilder.New.Build();

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.Configuration;
+
+internal enum ConfigurationVersion
+{
+    V6,
+    V7
+}
+
+internal static class ConfigurationVersionSelector
+{
+    public const string EnvironmentVariableName = "GITVERSION_CONFIGURATION_VERSION";
+
+    public static ConfigurationVersion Resolve()
+    {
+        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
+
+        return value switch
+        {
+            null or "" => ConfigurationVersion.V7,
+            _ when value.Equals("v6", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V6,
+            _ when value.Equals("v7", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V7,
+            _ => throw new InvalidOperationException(
+                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'v6' and 'v7'.")
+        };
+    }
+
+    public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
+}

--- a/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
@@ -4,35 +4,35 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.Configuration;
 
 /// <summary>Represents the version-related configuration for a specific branch or branch pattern.</summary>
-public interface IBranchConfiguration
+public interface IBranchConfiguration : ICalculationBranchConfiguration, IOutputBranchConfiguration
 {
     /// <summary>Gets the deployment mode used to compute versions on this branch.</summary>
-    DeploymentMode? DeploymentMode { get; }
+    new DeploymentMode? DeploymentMode { get; }
 
     /// <summary>Gets the pre-release label applied to versions produced on this branch.</summary>
-    string? Label { get; }
+    new string? Label { get; }
 
     /// <summary>Gets the format string used to compute the custom version output on this branch.</summary>
-    string? CustomVersionFormat => null;
+    new string? CustomVersionFormat => null;
 
     /// <summary>Gets the version field that is incremented when creating a new release from this branch.</summary>
-    IncrementStrategy Increment { get; }
+    new IncrementStrategy Increment { get; }
 
     /// <summary>Gets the configuration that controls under what conditions automatic version increments are suppressed.</summary>
-    IPreventIncrementConfiguration PreventIncrement { get; }
+    new IPreventIncrementConfiguration PreventIncrement { get; }
 
     /// <summary>Gets a value indicating whether to track the merge target branch for version calculation.</summary>
-    bool? TrackMergeTarget { get; }
+    new bool? TrackMergeTarget { get; }
 
     /// <summary>Gets a value indicating whether merge commit messages are considered when determining version increments.</summary>
-    bool? TrackMergeMessage { get; }
+    new bool? TrackMergeMessage { get; }
 
     /// <summary>Gets the mode that controls how commit messages drive version increments.</summary>
-    CommitMessageIncrementMode? CommitMessageIncrementing { get; }
+    new CommitMessageIncrementMode? CommitMessageIncrementing { get; }
 
     /// <summary>Gets the regular expression that matches branch names eligible for this configuration.</summary>
     [StringSyntax(StringSyntaxAttribute.Regex)]
-    string? RegularExpression { get; }
+    new string? RegularExpression { get; }
 
     /// <summary>Returns whether the given branch name matches the <see cref="RegularExpression"/> for this configuration.</summary>
     bool IsMatch(string branchName)
@@ -47,22 +47,22 @@ public interface IBranchConfiguration
     }
 
     /// <summary>Gets the names of branches that this branch may be branched from.</summary>
-    IReadOnlyCollection<string> SourceBranches { get; }
+    new IReadOnlyCollection<string> SourceBranches { get; }
 
     /// <summary>Gets the names of branches for which this branch may act as a source.</summary>
-    IReadOnlyCollection<string> IsSourceBranchFor { get; }
+    new IReadOnlyCollection<string> IsSourceBranchFor { get; }
 
     /// <summary>Gets a value indicating whether this branch tracks release branches.</summary>
-    bool? TracksReleaseBranches { get; }
+    new bool? TracksReleaseBranches { get; }
 
     /// <summary>Gets a value indicating whether this branch is a release branch.</summary>
-    bool? IsReleaseBranch { get; }
+    new bool? IsReleaseBranch { get; }
 
     /// <summary>Gets a value indicating whether this branch is treated as a main/trunk branch.</summary>
-    bool? IsMainBranch { get; }
+    new bool? IsMainBranch { get; }
 
     /// <summary>Gets the numeric weight applied to the pre-release tag number to produce a weighted pre-release number.</summary>
-    int? PreReleaseWeight { get; }
+    new int? PreReleaseWeight { get; }
 
     /// <summary>Returns a new configuration that inherits unset values from <paramref name="configuration"/>.</summary>
     IBranchConfiguration Inherit(IBranchConfiguration configuration);

--- a/src/GitVersion.Core/Configuration/ICalculationBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/ICalculationBranchConfiguration.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Configuration;
+
+/// <summary>Represents branch settings that affect semantic-version calculation.</summary>
+public interface ICalculationBranchConfiguration
+{
+    /// <summary>Gets the deployment mode used to compute versions on this branch.</summary>
+    DeploymentMode? DeploymentMode { get; }
+
+    /// <summary>Gets the pre-release label applied to versions produced on this branch.</summary>
+    string? Label { get; }
+
+    /// <summary>Gets the version field that is incremented when creating a new release from this branch.</summary>
+    IncrementStrategy Increment { get; }
+
+    /// <summary>Gets the configuration that controls under what conditions automatic version increments are suppressed.</summary>
+    IPreventIncrementConfiguration PreventIncrement { get; }
+
+    /// <summary>Gets a value indicating whether to track the merge target branch for version calculation.</summary>
+    bool? TrackMergeTarget { get; }
+
+    /// <summary>Gets a value indicating whether merge commit messages are considered when determining version increments.</summary>
+    bool? TrackMergeMessage { get; }
+
+    /// <summary>Gets the mode that controls how commit messages drive version increments.</summary>
+    CommitMessageIncrementMode? CommitMessageIncrementing { get; }
+
+    /// <summary>Gets the regular expression that matches branch names eligible for this configuration.</summary>
+    [StringSyntax(StringSyntaxAttribute.Regex)]
+    string? RegularExpression { get; }
+
+    /// <summary>Gets the names of branches that this branch may be branched from.</summary>
+    IReadOnlyCollection<string> SourceBranches { get; }
+
+    /// <summary>Gets the names of branches for which this branch may act as a source.</summary>
+    IReadOnlyCollection<string> IsSourceBranchFor { get; }
+
+    /// <summary>Gets a value indicating whether this branch tracks release branches.</summary>
+    bool? TracksReleaseBranches { get; }
+
+    /// <summary>Gets a value indicating whether this branch is a release branch.</summary>
+    bool? IsReleaseBranch { get; }
+
+    /// <summary>Gets a value indicating whether this branch is treated as a main/trunk branch.</summary>
+    bool? IsMainBranch { get; }
+}

--- a/src/GitVersion.Core/Configuration/ICalculationConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/ICalculationConfiguration.cs
@@ -1,0 +1,49 @@
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Configuration;
+
+/// <summary>Represents settings that participate in semantic-version calculation.</summary>
+public interface ICalculationConfiguration : ICalculationBranchConfiguration
+{
+    /// <inheritdoc cref="IGitVersionConfiguration.Workflow"/>
+    string? Workflow { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.TagPrefixPattern"/>
+    string? TagPrefixPattern { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionInBranchPattern"/>
+    string? VersionInBranchPattern { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.NextVersion"/>
+    string? NextVersion { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MajorVersionBumpMessage"/>
+    string? MajorVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MinorVersionBumpMessage"/>
+    string? MinorVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.PatchVersionBumpMessage"/>
+    string? PatchVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.NoBumpMessage"/>
+    string? NoBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionBumpResetMessage"/>
+    string? VersionBumpResetMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MergeMessageFormats"/>
+    IReadOnlyDictionary<string, string> MergeMessageFormats { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.SemanticVersionFormat"/>
+    SemanticVersionFormat SemanticVersionFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionStrategy"/>
+    VersionStrategies VersionStrategy { get; }
+
+    /// <summary>Gets calculation settings for each configured branch.</summary>
+    IReadOnlyDictionary<string, ICalculationBranchConfiguration> Branches { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.Ignore"/>
+    IIgnoreConfiguration Ignore { get; }
+}

--- a/src/GitVersion.Core/Configuration/IGitVersionConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IGitVersionConfiguration.cs
@@ -5,6 +5,12 @@ namespace GitVersion.Configuration;
 /// <summary>Represents the top-level GitVersion configuration, extending branch-level configuration with global settings.</summary>
 public interface IGitVersionConfiguration : IBranchConfiguration
 {
+    /// <summary>Gets the settings that participate in semantic-version calculation.</summary>
+    ICalculationConfiguration Calculation { get; }
+
+    /// <summary>Gets the settings that affect rendered version output.</summary>
+    IOutputConfiguration Output { get; }
+
     /// <summary>Gets the name of the workflow preset (e.g. <c>GitFlow/v1</c> or <c>GitHubFlow/v1</c>) used as a base configuration.</summary>
     string? Workflow { get; }
 

--- a/src/GitVersion.Core/Configuration/IOutputBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IOutputBranchConfiguration.cs
@@ -1,0 +1,11 @@
+namespace GitVersion.Configuration;
+
+/// <summary>Represents branch settings that affect rendered version output.</summary>
+public interface IOutputBranchConfiguration
+{
+    /// <summary>Gets the format string used to compute the custom version output on this branch.</summary>
+    string? CustomVersionFormat { get; }
+
+    /// <summary>Gets the numeric weight applied to the pre-release tag number to produce a weighted pre-release number.</summary>
+    int? PreReleaseWeight { get; }
+}

--- a/src/GitVersion.Core/Configuration/IOutputConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IOutputConfiguration.cs
@@ -1,0 +1,32 @@
+namespace GitVersion.Configuration;
+
+/// <summary>Represents settings that affect assembly, build-server, and formatted version output.</summary>
+public interface IOutputConfiguration : IOutputBranchConfiguration
+{
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyVersioningScheme"/>
+    AssemblyVersioningScheme? AssemblyVersioningScheme { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyFileVersioningScheme"/>
+    AssemblyFileVersioningScheme? AssemblyFileVersioningScheme { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyInformationalFormat"/>
+    string? AssemblyInformationalFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyVersioningFormat"/>
+    string? AssemblyVersioningFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyFileVersioningFormat"/>
+    string? AssemblyFileVersioningFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.TagPreReleaseWeight"/>
+    int? TagPreReleaseWeight { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.CommitDateFormat"/>
+    string? CommitDateFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.UpdateBuildNumber"/>
+    bool UpdateBuildNumber { get; }
+
+    /// <summary>Gets output settings for each configured branch.</summary>
+    IReadOnlyDictionary<string, IOutputBranchConfiguration> Branches { get; }
+}

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -2,10 +2,54 @@
 GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration
+GitVersion.Configuration.ICalculationBranchConfiguration.CommitMessageIncrementing.get -> GitVersion.VersionCalculation.CommitMessageIncrementMode?
+GitVersion.Configuration.ICalculationBranchConfiguration.DeploymentMode.get -> GitVersion.VersionCalculation.DeploymentMode?
+GitVersion.Configuration.ICalculationBranchConfiguration.Increment.get -> GitVersion.IncrementStrategy
+GitVersion.Configuration.ICalculationBranchConfiguration.IsMainBranch.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.IsReleaseBranch.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.IsSourceBranchFor.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+GitVersion.Configuration.ICalculationBranchConfiguration.Label.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration.PreventIncrement.get -> GitVersion.Configuration.IPreventIncrementConfiguration!
+GitVersion.Configuration.ICalculationBranchConfiguration.RegularExpression.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration.SourceBranches.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+GitVersion.Configuration.ICalculationBranchConfiguration.TrackMergeMessage.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.TrackMergeTarget.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.TracksReleaseBranches.get -> bool?
+GitVersion.Configuration.ICalculationConfiguration
+GitVersion.Configuration.ICalculationConfiguration.Branches.get -> System.Collections.Generic.IReadOnlyDictionary<string!, GitVersion.Configuration.ICalculationBranchConfiguration!>!
+GitVersion.Configuration.ICalculationConfiguration.Ignore.get -> GitVersion.Configuration.IIgnoreConfiguration!
+GitVersion.Configuration.ICalculationConfiguration.MajorVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.MergeMessageFormats.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+GitVersion.Configuration.ICalculationConfiguration.MinorVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.NextVersion.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.NoBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.PatchVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.SemanticVersionFormat.get -> GitVersion.SemanticVersionFormat
+GitVersion.Configuration.ICalculationConfiguration.TagPrefixPattern.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionBumpResetMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionInBranchPattern.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionStrategy.get -> GitVersion.VersionCalculation.VersionStrategies
+GitVersion.Configuration.ICalculationConfiguration.Workflow.get -> string?
+GitVersion.Configuration.IGitVersionConfiguration.Calculation.get -> GitVersion.Configuration.ICalculationConfiguration!
+GitVersion.Configuration.IGitVersionConfiguration.Output.get -> GitVersion.Configuration.IOutputConfiguration!
 GitVersion.Configuration.IGitVersionConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IIgnoreConfiguration.Branches.get -> System.Collections.Generic.IReadOnlySet<string!>!
 GitVersion.Configuration.IIgnoreConfiguration.Tags.get -> System.Collections.Generic.IReadOnlySet<string!>!
 GitVersion.Git.ReferenceName.WithoutRemote.get -> string!
+GitVersion.Configuration.IOutputBranchConfiguration
+GitVersion.Configuration.IOutputBranchConfiguration.CustomVersionFormat.get -> string?
+GitVersion.Configuration.IOutputBranchConfiguration.PreReleaseWeight.get -> int?
+GitVersion.Configuration.IOutputConfiguration
+GitVersion.Configuration.IOutputConfiguration.AssemblyFileVersioningFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyFileVersioningScheme.get -> GitVersion.Configuration.AssemblyFileVersioningScheme?
+GitVersion.Configuration.IOutputConfiguration.AssemblyInformationalFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyVersioningFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyVersioningScheme.get -> GitVersion.Configuration.AssemblyVersioningScheme?
+GitVersion.Configuration.IOutputConfiguration.Branches.get -> System.Collections.Generic.IReadOnlyDictionary<string!, GitVersion.Configuration.IOutputBranchConfiguration!>!
+GitVersion.Configuration.IOutputConfiguration.CommitDateFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.TagPreReleaseWeight.get -> int?
+GitVersion.Configuration.IOutputConfiguration.UpdateBuildNumber.get -> bool
 GitVersion.VersionCalculation.CommitMessageIncrement
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement() -> void
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement(GitVersion.VersionField Increment, bool VersionBumpNeedsToBeReset) -> void

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -32,8 +32,9 @@ internal class GitVersionCacheKeyFactory(
         var repositorySnapshotHash = GetRepositorySnapshotHash();
         var repositoryTargetHash = GetRepositoryTargetHash();
         var overrideConfigHash = GetOverrideConfigHash(overrideConfiguration);
+        var configurationVersionHash = GetHash(ConfigurationVersionSelector.ResolveName());
 
-        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, repositoryTargetHash, overrideConfigHash);
+        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, repositoryTargetHash, overrideConfigHash, configurationVersionHash);
         return new(compositeHash);
     }
 

--- a/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
@@ -36,7 +36,11 @@ public class WriteVersionInfoTest : TestTaskBase
     public void WriteVersionInfoTaskShouldNotUpdateBuildNumberInAzurePipeline(string buildNumber)
     {
         var task = new WriteVersionInfoToBuildLog();
-        const string content = "update-build-number: false";
+        const string content = """
+                               calculation: {}
+                               output:
+                                 update-build-number: false
+                               """;
 
         using var result = ExecuteMsBuildTaskInAzurePipeline(task, buildNumber, content);
 


### PR DESCRIPTION
Closes #5132.

Implements versioned configuration selection and the nested `calculation` / `output` model for v7.0, including version-aware validation for `--override-config` and cache inputs.

The follow-on migration and switch cleanup issues will stack above this PR.

Validation: Release build, complete test suite, formatting verification, and regenerated documentation/schema checks.