### PR TITLE
Document v7 configuration layout and migration

### DIFF
--- a/.gitversion.yml
+++ b/.gitversion.yml
@@ -1,9 +1,11 @@
 # $schema: https://gitversion.net/schemas/7.0/GitVersion.configuration.json
-workflow: GitFlow/v1
-mode: ManualDeployment
-next-version: 7.0.0
-branches:
-  main:
-    label: alpha
-  support:
-    label: beta
+calculation:
+  workflow: GitFlow/v1
+  mode: ManualDeployment
+  next-version: 7.0.0
+  branches:
+    main:
+      label: alpha
+    support:
+      label: beta
+output: {}

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -55,6 +55,26 @@ The command-line interface has been migrated from Windows-style (`/switch` and s
 
 As a temporary migration aid, set the environment variable `GITVERSION_USE_V6_ARGUMENT_PARSER=true` to restore the legacy `/switch` and `-switch` argument handling. This escape hatch will be removed in a future release.
 
+### Configuration structure and migration
+
+v7 configuration now separates calculation from output:
+
+```yaml
+calculation:
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+```
+
+v7.0 defaults to the nested layout. `GITVERSION_CONFIGURATION_VERSION=v6` is a
+temporary flat-layout fallback that logs a migration warning for user files.
+Convert files with `gitversion config migrate`. The command
+writes YAML to stdout by default, supports `--config`, `--output`,
+`--in-place`, and `--force`, and warns that comments cannot be preserved when
+replacing a file.
+
 #### Full argument mapping
 
 | Old argument                  | New argument                     | Short alias                    | Env var alternative          |

--- a/build/build/Tasks/Clean.cs
+++ b/build/build/Tasks/Clean.cs
@@ -17,5 +17,6 @@ public sealed class Clean : FrostingTask<BuildContext>
         context.CleanDirectory(Paths.Native);
         context.CleanDirectory(Paths.Packages);
         context.CleanDirectory(Paths.Artifacts);
+        context.CleanDirectory(Paths.Tools);
     }
 }

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -117,6 +117,25 @@ gitversion --url https://github.com/org/repo.git --branch main --username user -
 
 For current command details and examples, see [CLI Arguments](/docs/usage/cli/arguments).
 
+## Configuration migration
+
+GitVersion v7 stores settings under `calculation` and `output`. Convert an
+existing flat v6 YAML document with the POSIX-only migration command:
+
+```shell
+gitversion config migrate
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+The first command discovers `GitVersion.yml` and emits v7 YAML to stdout.
+`--output` requires `--force` to replace an existing file and cannot be used
+with `--in-place`. In-place migration warns because comments cannot be
+preserved. The command does not need a Git repository and migrating its v7
+output again is idempotent. In v7.0, you can temporarily validate a flat file
+with `GITVERSION_CONFIGURATION_VERSION=v6`; GitVersion warns once for that
+fallback.
+
 ## Git backend
 
 GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable. When the variable is not set (or empty), the release's default backend is used — you never need to set it. Setting it to any value other than `libgit2` or `managed` (case-insensitive) is an error: GitVersion fails fast instead of silently running the default backend with a typo unnoticed.
@@ -138,7 +157,8 @@ The environment variables relevant to migrating from v6 to v7:
 
 | Variable                            | Purpose                                                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `GITVERSION_GIT_BACKEND`            | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
+| `GITVERSION_CONFIGURATION_VERSION`   | Selects the configuration layout: `v7` (default) or temporary flat `v6` fallback.                                   |
+| `GITVERSION_GIT_BACKEND`             | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
 | `GITVERSION_USE_V6_ARGUMENT_PARSER` | Set to `true` to temporarily restore the legacy v6 (`/switch`) argument parser. Removed in a future release.        |
 | `GITVERSION_REMOTE_USERNAME`        | Alternative to `--username` for dynamic-repository credentials.                                                     |
 | `GITVERSION_REMOTE_PASSWORD`        | Alternative to `--password` for dynamic-repository credentials.                                                     |

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -21,6 +21,72 @@ found that is generally what is needed when using GitFlow.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## v7 configuration layout
+
+GitVersion v7 separates version **calculation** from version **output**. Put
+calculation settings under `calculation` and settings that format or publish
+the calculated version under `output`:
+
+```yaml
+calculation:
+  workflow: GitHubFlow/v1
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+  branches:
+    main:
+      pre-release-weight: 55000
+```
+
+`calculation.branches` contains branch-discovery and version-calculation
+settings. `output.branches` contains branch-specific output settings. A branch
+may appear in either section or both; GitVersion combines both sections into
+one effective branch configuration.
+
+| v6 flat setting | v7 location |
+| --- | --- |
+| `assembly-file-versioning-format`, `assembly-file-versioning-scheme`, `assembly-informational-format`, `assembly-versioning-format`, `assembly-versioning-scheme`, `commit-date-format`, `custom-version-format`, `pre-release-weight`, `tag-pre-release-weight`, `update-build-number` | `output.<setting>` |
+| Every other root setting, including `branches`, `ignore`, `next-version`, `strategies`, `tag-prefix`, and `workflow` | `calculation.<setting>` |
+| Branch `custom-version-format`, `pre-release-weight` | `output.branches.<branch>.<setting>` |
+| Every other branch setting, including `increment`, `label`, `mode`, `regex`, and `source-branches` | `calculation.branches.<branch>.<setting>` |
+
+In v7, `gitversion --show-config` emits this nested structure. The temporary
+v6 flat format can be selected only with
+`GITVERSION_CONFIGURATION_VERSION=v6` in v7.0; GitVersion warns when it loads
+a user configuration that way.
+
+### Migrating an existing configuration
+
+Use the POSIX-only migration command to convert a v6 document without opening
+a repository:
+
+```shell
+# Discover GitVersion.yml in the target/current directory and write YAML to stdout
+gitversion config migrate
+
+# Select an input explicitly, write a new file, or replace that input
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+`--output` refuses to overwrite an existing file unless `--force` is supplied;
+`--output` and `--in-place` cannot be combined. `--in-place` warns because
+comments cannot be preserved. The command is deterministic: migrating an
+already nested v7 document produces the same YAML again.
+
+### Overriding v7 configuration
+
+`--override-config` uses the selected configuration structure. With the v7
+default, use nested keys such as
+`--override-config calculation.tag-prefix='[vV]?'` and
+`--override-config output.update-build-number=false`. Branch overrides follow
+the same ownership map, for example
+`calculation.branches.main.increment=Patch` and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement.
+
 ## Global configuration
 
 The following supported workflow configurations are available in GitVersion and can be referenced by the workflow property:
@@ -494,6 +560,8 @@ expression with `(?-i)`, for example `(?-i)^experimental-`.
 
 ### assembly-file-versioning-format
 
+This is an `output` setting: `output.assembly-file-versioning-format`.
+
 Specifies the format of `AssemblyFileVersion` and
 overwrites the value of `assembly-file-versioning-scheme`.
 
@@ -502,16 +570,21 @@ or a process-scoped environment variable (when prefixed with `env:`).  For examp
 
 ```yaml
 # use a variable if non-null or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
 
 # use an environment variable or raise an error if not available
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 
 # use an environment variable if available or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
 ### assembly-file-versioning-scheme
+
+This is an `output` setting: `output.assembly-file-versioning-scheme`.
 
 When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
 how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
@@ -521,17 +594,23 @@ skip updating the `AssemblyFileVersion` while still updating the
 
 ### assembly-informational-format
 
+This is an `output` setting: `output.assembly-informational-format`.
+
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
 
 ### assembly-versioning-format
 
+This is an `output` setting: `output.assembly-versioning-format`.
+
 Specifies the format of `AssemblyVersion` and
 overwrites the value of `assembly-versioning-scheme`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 
 ### assembly-versioning-scheme
+
+This is an `output` setting: `output.assembly-versioning-scheme`.
 
 When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
 to treat the `AssemblyVersion` attribute. Useful to lock the major when using
@@ -582,22 +661,26 @@ a named capture group called `Number`.
 **Example usage:**
 
 ```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
+calculation:
+  branches:
+    pull-request:
+      mode: ContinuousDelivery
+      label: PullRequest{Number}
+      increment: Inherit
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      track-merge-message: true
+      regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+      source-branches:
+      - main
+      - release
+      - feature
+      is-source-branch-for: []
+output:
+  branches:
+    pull-request:
+      pre-release-weight: 30000
 ```
 
 ### mode
@@ -605,6 +688,9 @@ branches:
 Same as for the [global configuration, explained above](#mode).
 
 ### pre-release-weight
+
+This is an output setting: `output.pre-release-weight` globally or
+`output.branches.<branch>.pre-release-weight` for a branch.
 
 Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
 value in order to avoid version collisions across different branches. For
@@ -658,6 +744,8 @@ Indicates this branch config represents develop in GitFlow.
 
 ### commit-date-format
 
+This is an `output` setting: `output.commit-date-format`.
+
 Sets the format which will be used to format the `CommitDate` output variable.
 
 ### commit-message-incrementing
@@ -667,6 +755,9 @@ in the commit message. See the `*-version-bump-message` options above for
 details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
+
+This is an `output` setting: `output.custom-version-format` globally or
+`output.branches.<branch>.custom-version-format` for a branch.
 
 Specifies the format of the `CustomVersion` output variable.
 Follows the same formatting semantics as `assembly-file-versioning-format` and
@@ -695,10 +786,11 @@ semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  branches:
-    - ^experimental/
-    - ^release/legacy$
+calculation:
+  ignore:
+    branches:
+      - ^experimental/
+      - ^release/legacy$
 ```
 
 The current branch and an explicitly requested target branch remain available
@@ -727,9 +819,10 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
 
 ```yaml
-ignore:
-  paths:
-    - ^docs\/
+calculation:
+  ignore:
+    paths:
+      - ^docs\/
 ```
 
 ##### *Monorepo*
@@ -740,17 +833,19 @@ As an example, consider a monorepo consisting of subdirectories for `ProjectA`, 
 * Specific match on `/ProjectB/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^\/ProductB\/.*`
+calculation:
+  ignore:
+    paths:
+      - `^\/ProductB\/.*`
 ```
 
 * Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+calculation:
+  ignore:
+    paths:
+      - `^(?!\/ProductA\/|\/LibraryC\/).*`
 ```
 
 A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
@@ -779,17 +874,19 @@ there is a rogue commit in history yielding a bad version. You can use either
 style below:
 
 ```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+calculation:
+  ignore:
+    sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
 ```
 
 or
 
 ```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+calculation:
+  ignore:
+    sha:
+      - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+      - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
 ```
 
 #### tags
@@ -801,10 +898,11 @@ use OR semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  tags:
-    - ^experimental-
-    - ^v0\.
+calculation:
+  ignore:
+    tags:
+      - ^experimental-
+      - ^v0\.
 ```
 
 Ignoring a tag does not ignore the commit it points to. The commit remains part
@@ -838,23 +936,25 @@ branch.
 A complete example:
 
 ```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+calculation:
+  branches:
+    unstable:
+      regex: ...
+      is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
 ```
 
 Without this configuration value you would have to do:
 
 ```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
+calculation:
+  branches:
+    unstable:
+      regex:
+    feature:
+      source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+    release:
+      source-branches: ['unstable', 'develop']
+    etc...
 ```
 
 ### major-version-bump-message
@@ -1038,7 +1138,12 @@ Configures GitVersion to update the build number or not when running on a build 
 
 ## Branch configuration
 
-Then we have branch specific configuration, which looks something like this:
+The following **v4 migration example** illustrates the change from regular-expression
+keys to named branch configurations. It uses the legacy flat layout and is retained
+only for that historical migration context; it is not a valid v7 configuration. For
+new v7 configuration, place branch calculation settings under `calculation.branches`
+and branch output settings under `output.branches`, as shown in the [v7 configuration
+layout](#v7-configuration-layout).
 
 :::{.alert .alert-info}
 **Note**
@@ -1046,8 +1151,7 @@ Then we have branch specific configuration, which looks something like this:
 v4 changed from using regexes for keys, to named configs
 :::
 
-If you have branch specific configuration upgrading to v4 will force you to
-upgrade.
+If you have branch-specific configuration, upgrading to v4 required this change.
 
 ```yaml
 workflow: 'GitHubFlow/v1'

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -32,8 +32,9 @@ The following supported workflow configurations are available in GitVersion and 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 
 ```yaml
-workflow: GitHubFlow/v1
-tag-prefix: '[abc]'
+calculation:
+  workflow: GitHubFlow/v1
+  tag-prefix: '[abc]'
 ```
 
 The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) looks like:
@@ -41,178 +42,188 @@ The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) l
 <!-- snippet: /docs/workflows/GitFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitFlow/v1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitFlow/v1.yml#L1-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The supported built-in configuration for the `GitHubFlow` workflow (`workflow: GitHubFlow/v1`) looks like:
@@ -220,127 +231,134 @@ The supported built-in configuration for the `GitHubFlow` workflow (`workflow: G
 <!-- snippet: /docs/workflows/GitHubFlow/v1.yml -->
 <a id='snippet-/docs/workflows/GitHubFlow/v1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/GitHubFlow/v1.yml#L1-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/GitHubFlow/v1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The preview built-in configuration (experimental usage only) for the `TrunkBased` workflow (`workflow: TrunkBased/preview1`) looks like:
@@ -348,112 +366,120 @@ The preview built-in configuration (experimental usage only) for the `TrunkBased
 <!-- snippet: /docs/workflows/TrunkBased/preview1.yml -->
 <a id='snippet-/docs/workflows/TrunkBased/preview1.yml'></a>
 ```yml
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true
 ```
-<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/docs/workflows/TrunkBased/preview1.yml#L1-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-/docs/workflows/TrunkBased/preview1.yml' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The details of the available options are as follows:

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -32,8 +32,9 @@ The following supported workflow configurations are available in GitVersion and 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 
 ```yaml
-workflow: GitHubFlow/v1
-tag-prefix: '[abc]'
+calculation:
+  workflow: GitHubFlow/v1
+  tag-prefix: '[abc]'
 ```
 
 The built-in configuration for the `GitFlow` workflow (`workflow: GitFlow/v1`) looks like:

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -21,6 +21,72 @@ found that is generally what is needed when using GitFlow.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## v7 configuration layout
+
+GitVersion v7 separates version **calculation** from version **output**. Put
+calculation settings under `calculation` and settings that format or publish
+the calculated version under `output`:
+
+```yaml
+calculation:
+  workflow: GitHubFlow/v1
+  branches:
+    main:
+      increment: Patch
+output:
+  update-build-number: true
+  branches:
+    main:
+      pre-release-weight: 55000
+```
+
+`calculation.branches` contains branch-discovery and version-calculation
+settings. `output.branches` contains branch-specific output settings. A branch
+may appear in either section or both; GitVersion combines both sections into
+one effective branch configuration.
+
+| v6 flat setting | v7 location |
+| --- | --- |
+| `assembly-file-versioning-format`, `assembly-file-versioning-scheme`, `assembly-informational-format`, `assembly-versioning-format`, `assembly-versioning-scheme`, `commit-date-format`, `custom-version-format`, `pre-release-weight`, `tag-pre-release-weight`, `update-build-number` | `output.<setting>` |
+| Every other root setting, including `branches`, `ignore`, `next-version`, `strategies`, `tag-prefix`, and `workflow` | `calculation.<setting>` |
+| Branch `custom-version-format`, `pre-release-weight` | `output.branches.<branch>.<setting>` |
+| Every other branch setting, including `increment`, `label`, `mode`, `regex`, and `source-branches` | `calculation.branches.<branch>.<setting>` |
+
+In v7, `gitversion --show-config` emits this nested structure. The temporary
+v6 flat format can be selected only with
+`GITVERSION_CONFIGURATION_VERSION=v6` in v7.0; GitVersion warns when it loads
+a user configuration that way.
+
+### Migrating an existing configuration
+
+Use the POSIX-only migration command to convert a v6 document without opening
+a repository:
+
+```shell
+# Discover GitVersion.yml in the target/current directory and write YAML to stdout
+gitversion config migrate
+
+# Select an input explicitly, write a new file, or replace that input
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+`--output` refuses to overwrite an existing file unless `--force` is supplied;
+`--output` and `--in-place` cannot be combined. `--in-place` warns because
+comments cannot be preserved. The command is deterministic: migrating an
+already nested v7 document produces the same YAML again.
+
+### Overriding v7 configuration
+
+`--override-config` uses the selected configuration structure. With the v7
+default, use nested keys such as
+`--override-config calculation.tag-prefix='[vV]?'` and
+`--override-config output.update-build-number=false`. Branch overrides follow
+the same ownership map, for example
+`calculation.branches.main.increment=Patch` and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement.
+
 ## Global configuration
 
 The following supported workflow configurations are available in GitVersion and can be referenced by the workflow property:
@@ -61,6 +127,8 @@ expression with `(?-i)`, for example `(?-i)^experimental-`.
 
 ### assembly-file-versioning-format
 
+This is an `output` setting: `output.assembly-file-versioning-format`.
+
 Specifies the format of `AssemblyFileVersion` and
 overwrites the value of `assembly-file-versioning-scheme`.
 
@@ -69,16 +137,21 @@ or a process-scoped environment variable (when prefixed with `env:`).  For examp
 
 ```yaml
 # use a variable if non-null or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
 
 # use an environment variable or raise an error if not available
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER}'
 
 # use an environment variable if available or a fallback value otherwise
-assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
+output:
+  assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:BUILD_NUMBER ?? 42}'
 ```
 
 ### assembly-file-versioning-scheme
+
+This is an `output` setting: `output.assembly-file-versioning-scheme`.
 
 When updating assembly info, `assembly-file-versioning-scheme` tells GitVersion
 how to treat the `AssemblyFileVersion` attribute. Note: you can use `None` to
@@ -88,17 +161,23 @@ skip updating the `AssemblyFileVersion` while still updating the
 
 ### assembly-informational-format
 
+This is an `output` setting: `output.assembly-informational-format`.
+
 Specifies the format of `AssemblyInformationalVersion`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 The default value is `{InformationalVersion}`.
 
 ### assembly-versioning-format
 
+This is an `output` setting: `output.assembly-versioning-format`.
+
 Specifies the format of `AssemblyVersion` and
 overwrites the value of `assembly-versioning-scheme`.
 Follows the same formatting semantics as `assembly-file-versioning-format`.
 
 ### assembly-versioning-scheme
+
+This is an `output` setting: `output.assembly-versioning-scheme`.
 
 When updating assembly info, `assembly-versioning-scheme` tells GitVersion how
 to treat the `AssemblyVersion` attribute. Useful to lock the major when using
@@ -149,22 +228,26 @@ a named capture group called `Number`.
 **Example usage:**
 
 ```yaml
-branches:
-  pull-request:
-    mode: ContinuousDelivery
-    label: PullRequest{Number}
-    increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    track-merge-message: true
-    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
-    source-branches:
-    - main
-    - release
-    - feature
-    is-source-branch-for: []
-    pre-release-weight: 30000
+calculation:
+  branches:
+    pull-request:
+      mode: ContinuousDelivery
+      label: PullRequest{Number}
+      increment: Inherit
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      track-merge-message: true
+      regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
+      source-branches:
+      - main
+      - release
+      - feature
+      is-source-branch-for: []
+output:
+  branches:
+    pull-request:
+      pre-release-weight: 30000
 ```
 
 ### mode
@@ -172,6 +255,9 @@ branches:
 Same as for the [global configuration, explained above](#mode).
 
 ### pre-release-weight
+
+This is an output setting: `output.pre-release-weight` globally or
+`output.branches.<branch>.pre-release-weight` for a branch.
 
 Provides a way to translate the `PreReleaseLabelName` ([variables][variables]) to a numeric
 value in order to avoid version collisions across different branches. For
@@ -225,6 +311,8 @@ Indicates this branch config represents develop in GitFlow.
 
 ### commit-date-format
 
+This is an `output` setting: `output.commit-date-format`.
+
 Sets the format which will be used to format the `CommitDate` output variable.
 
 ### commit-message-incrementing
@@ -234,6 +322,9 @@ in the commit message. See the `*-version-bump-message` options above for
 details on the syntax. Default set to `Enabled`; set to `Disabled` to disable.
 
 ### custom-version-format
+
+This is an `output` setting: `output.custom-version-format` globally or
+`output.branches.<branch>.custom-version-format` for a branch.
 
 Specifies the format of the `CustomVersion` output variable.
 Follows the same formatting semantics as `assembly-file-versioning-format` and
@@ -262,10 +353,11 @@ semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  branches:
-    - ^experimental/
-    - ^release/legacy$
+calculation:
+  ignore:
+    branches:
+      - ^experimental/
+      - ^release/legacy$
 ```
 
 The current branch and an explicitly requested target branch remain available
@@ -294,9 +386,10 @@ Date and time in the format `yyyy-MM-ddTHH:mm:ss` (eg `commits-before:
 A sequence of regular expressions that represent paths in the repository. Commits that modify these paths will be excluded from version calculations. For example, to filter out commits that belong to `docs`:
 
 ```yaml
-ignore:
-  paths:
-    - ^docs\/
+calculation:
+  ignore:
+    paths:
+      - ^docs\/
 ```
 
 ##### *Monorepo*
@@ -307,17 +400,19 @@ As an example, consider a monorepo consisting of subdirectories for `ProjectA`, 
 * Specific match on `/ProjectB/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^\/ProductB\/.*`
+calculation:
+  ignore:
+    paths:
+      - `^\/ProductB\/.*`
 ```
 
 * Negative lookahead on anything other than `/ProjectA/*` and `/LibraryC/*`:
 
 ```yaml
-ignore:
-  paths:
-    - `^(?!\/ProductA\/|\/LibraryC\/).*`
+calculation:
+  ignore:
+    paths:
+      - `^(?!\/ProductA\/|\/LibraryC\/).*`
 ```
 
 A commit having changes only in `/ProjectB/*` path would be ignored. A commit having changes in the following paths wouldn't be ignored:
@@ -346,17 +441,19 @@ there is a rogue commit in history yielding a bad version. You can use either
 style below:
 
 ```yaml
-ignore:
-  sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
+calculation:
+  ignore:
+    sha: [e7bc24c0f34728a25c9187b8d0b041d935763e3a, 764e16321318f2fdb9cdeaa56d1156a1cba307d7]
 ```
 
 or
 
 ```yaml
-ignore:
-  sha:
-    - e7bc24c0f34728a25c9187b8d0b041d935763e3a
-    - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
+calculation:
+  ignore:
+    sha:
+      - e7bc24c0f34728a25c9187b8d0b041d935763e3a
+      - 764e16321318f2fdb9cdeaa56d1156a1cba307d7
 ```
 
 #### tags
@@ -368,10 +465,11 @@ use OR semantics, and `^` and `$` can be used to anchor a match. To require
 case-sensitive matching, prefix a pattern with `(?-i)`.
 
 ```yaml
-ignore:
-  tags:
-    - ^experimental-
-    - ^v0\.
+calculation:
+  ignore:
+    tags:
+      - ^experimental-
+      - ^v0\.
 ```
 
 Ignoring a tag does not ignore the commit it points to. The commit remains part
@@ -405,23 +503,25 @@ branch.
 A complete example:
 
 ```yaml
-branches:
-  unstable:
-    regex: ...
-    is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
+calculation:
+  branches:
+    unstable:
+      regex: ...
+      is-source-branch-for: ['main', 'develop', 'feature', 'hotfix', 'support']
 ```
 
 Without this configuration value you would have to do:
 
 ```yaml
-branches:
-  unstable:
-    regex:
-  feature:
-    source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
-  release:
-    source-branches: ['unstable', 'develop']
-  etc...
+calculation:
+  branches:
+    unstable:
+      regex:
+    feature:
+      source-branches: ['unstable', 'develop', 'feature', 'hotfix', 'support']
+    release:
+      source-branches: ['unstable', 'develop']
+    etc...
 ```
 
 ### major-version-bump-message
@@ -605,7 +705,12 @@ Configures GitVersion to update the build number or not when running on a build 
 
 ## Branch configuration
 
-Then we have branch specific configuration, which looks something like this:
+The following **v4 migration example** illustrates the change from regular-expression
+keys to named branch configurations. It uses the legacy flat layout and is retained
+only for that historical migration context; it is not a valid v7 configuration. For
+new v7 configuration, place branch calculation settings under `calculation.branches`
+and branch output settings under `output.branches`, as shown in the [v7 configuration
+layout](#v7-configuration-layout).
 
 :::{.alert .alert-info}
 **Note**
@@ -613,8 +718,7 @@ Then we have branch specific configuration, which looks something like this:
 v4 changed from using regexes for keys, to named configs
 :::
 
-If you have branch specific configuration upgrading to v4 will force you to
-upgrade.
+If you have branch-specific configuration, upgrading to v4 required this change.
 
 ```yaml
 workflow: 'GitHubFlow/v1'

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -107,9 +107,35 @@ GitVersion [path]
                     GitVersion to not calculate your version as expected.
 ```
 
+## Configuration migration
+
+The POSIX parser exposes a `config migrate` subcommand for converting a v6
+configuration document to the v7 `calculation`/`output` layout:
+
+```shell
+gitversion config migrate
+gitversion config migrate --config GitVersion.yml --output GitVersion.v7.yml
+gitversion config migrate --config GitVersion.yml --in-place
+```
+
+It discovers a supported configuration filename when `--config` is omitted and
+writes YAML to stdout unless `--output` or `--in-place` is selected. `--output`
+will not replace an existing file without `--force`; it cannot be combined with
+`--in-place`. Replacing a file warns that comments are not preserved. The
+command does not require a Git repository and is unavailable when
+`GITVERSION_USE_V6_ARGUMENT_PARSER=true` selects the legacy parser.
+
 ## Override config
 
 `--override-config key=value` will override appropriate `key` from 'GitVersion.yml', 'GitVersion.yaml', '.GitVersion.yml' or '.GitVersion.yaml'.
+
+With the v7 default configuration layout, use a version-aware nested key. For
+example, `calculation.tag-prefix=custom`,
+`calculation.branches.main.increment=Patch`, and
+`output.branches.main.pre-release-weight=55000`. Flat v6 keys are rejected in
+v7 mode with their nested replacement. Set
+`GITVERSION_CONFIGURATION_VERSION=v6` only while validating a legacy file in
+v7.0.
 
 To specify multiple options add multiple `--override-config key=value` entries:
 `--override-config key1=value1 --override-config key2=value2`.

--- a/docs/input/docs/workflows/GitFlow/v1.yml
+++ b/docs/input/docs/workflows/GitFlow/v1.yml
@@ -1,170 +1,180 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/docs/input/docs/workflows/GitHubFlow/v1.yml
+++ b/docs/input/docs/workflows/GitHubFlow/v1.yml
@@ -1,119 +1,126 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/docs/input/docs/workflows/TrunkBased/preview1.yml
+++ b/docs/input/docs/workflows/TrunkBased/preview1.yml
@@ -1,104 +1,112 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -9,19 +9,100 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ArgumentParserTests : TestBase
 {
     private IEnvironment environment = null!;
     private IArgumentParser argumentParser = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void SetUp()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         var sp = ConfigureServices(services => services.AddModule(new GitVersionAppModule()));
         this.environment = sp.GetRequiredService<IEnvironment>();
         this.argumentParser = sp.GetRequiredService<IArgumentParser>();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void OverrideConfigSupportsNestedV7RootAndBranchPaths()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var arguments = this.argumentParser.ParseArguments(
+            "--override-config calculation.tag-prefix=custom- " +
+            "--override-config calculation.branches.main.increment=Major " +
+            "--override-config output.branches.main.pre-release-weight=42");
+
+        var normalized = ConfigurationDocumentMapper.Normalize(
+            arguments.OverrideConfiguration!, ConfigurationVersion.V7, "test override");
+        ConfigurationHelper configurationHelper = new(normalized);
+        var configuration = configurationHelper.Configuration;
+        configuration.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        configuration.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV6PathInV7WithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config tag-prefix=custom-"));
+
+        exception.Message.ShouldContain("calculation.tag-prefix");
+        exception.Message.ShouldContain("config migrate");
+    }
+
+    [Test]
+    public void OverrideConfigRejectsPropertyInWrongV7SectionWithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config calculation.update-build-number=false"));
+
+        exception.Message.ShouldContain("output.update-build-number");
+    }
+
+    [Test]
+    public void OverrideConfigSupportsV6BranchPath()
+    {
+        var arguments = this.argumentParser.ParseArguments("--override-config branches.main.increment=Major");
+
+        ConfigurationHelper configurationHelper = new(arguments.OverrideConfiguration);
+        configurationHelper.Configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV7PathInV6WithReplacement()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("--override-config output.update-build-number=false"));
+
+        exception.Message.ShouldContain("update-build-number");
+        exception.Message.ShouldContain("config migrate");
+    }
+
+    [Test]
+    public void OverrideConfigBatchValidationDoesNotApplyAnyValues()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        var parser = new OverrideConfigurationOptionParser();
+
+        Should.Throw<WarningException>(() => parser.SetValues(
+            ["calculation.tag-prefix=custom-", "tag-prefix=legacy"], "--override-config"));
+
+        parser.GetOverrideConfiguration().ShouldBeEmpty();
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -106,6 +106,27 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateParsesItsInputAndOutputOptions()
+    {
+        var arguments = this.argumentParser.ParseArguments(
+            "config migrate --config GitVersion.yml --output GitVersion.v7.yml --force");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.MigrationInputFile.ShouldBe("GitVersion.yml");
+        arguments.MigrationOutputFile.ShouldBe("GitVersion.v7.yml");
+        arguments.MigrationForce.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ConfigMigrateRejectsOutputAndInPlaceTogether()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("config migrate --output GitVersion.v7.yml --in-place"));
+
+        exception.Message.ShouldBe("Cannot use --output together with --in-place.");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -127,6 +127,15 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void TargetPathAllowsDirectoryNamedConfig()
+    {
+        var arguments = this.argumentParser.ParseArguments("--target-path config");
+
+        arguments.TargetPath.ShouldBe("config");
+        arguments.IsConfigurationMigration.ShouldBeFalse();
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
@@ -1,0 +1,44 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Tests;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationExecutorTests
+{
+    [Test]
+    public void InPlaceMigrationWarnsThatCommentsCannotBePreserved()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputFile = Path.Combine(directory.FullName, "legacy.yml");
+            File.WriteAllText(inputFile, "next-version: 2.0.0");
+            var logMessages = new List<string>();
+            var executor = new ConfigurationMigrationExecutor(
+                new FileSystem(),
+                new TestConsoleAdapter(new StringBuilder()),
+                new TestLogger<ConfigurationMigrationExecutor>(logMessages.Add),
+                Substitute.For<IConfigurationFileLocator>(),
+                new MigrationService());
+            var options = new GitVersionOptions { WorkingDirectory = directory.FullName };
+            options.ConfigurationMigrationInfo.IsMigration = true;
+            options.ConfigurationMigrationInfo.InputFile = inputFile;
+            options.ConfigurationMigrationInfo.InPlace = true;
+
+            executor.Execute(options).ShouldBe(0);
+
+            logMessages.ShouldContain(message => message.Contains("Comments cannot be preserved during migration.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private sealed class MigrationService : IConfigurationMigrationService
+    {
+        public string Migrate(string input) => "calculation: {}\noutput: {}\n";
+    }
+}

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -1,0 +1,58 @@
+using GitVersion.App.Tests.Helpers;
+using GitVersion.Configuration;
+using GitVersion.Helpers;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+public class ConfigurationVersionIntegrationTests
+{
+    [Test]
+    public void V6AndV7ConfigurationCalculateTheSameVersion()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        var configurationPath = FileSystemHelper.Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName);
+
+        FileSystemHelper.File.WriteAllText(configurationPath, "next-version: 2.0.0");
+        var v6Result = Execute(fixture.RepositoryPath, "v6");
+
+        FileSystemHelper.File.WriteAllText(configurationPath, """
+                                                             calculation:
+                                                               next-version: 2.0.0
+                                                             output: {}
+                                                             """);
+        var v7Result = Execute(fixture.RepositoryPath, "v7");
+
+        v6Result.ExitCode.ShouldBe(0);
+        v7Result.ExitCode.ShouldBe(0);
+        GetFullSemVer(v7Result.Output!).ShouldBe(GetFullSemVer(v6Result.Output!));
+    }
+
+    [TestCase("v6", false)]
+    [TestCase("v7", true)]
+    public void ShowConfigUsesSelectedConfigurationStructure(string version, bool nested)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var result = GitVersionHelper.ExecuteIn(
+            fixture.RepositoryPath,
+            " --show-config",
+            logToFile: false,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, version));
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotBeNull();
+        result.Output.Contains("calculation:", StringComparison.Ordinal).ShouldBe(nested);
+        result.Output.Contains("output:", StringComparison.Ordinal).ShouldBe(nested);
+    }
+
+    private static ExecutionResults Execute(string repositoryPath, string version) =>
+        GitVersionHelper.ExecuteIn(
+            repositoryPath,
+            arguments: null,
+            logToFile: false,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, version));
+
+    private static string? GetFullSemVer(string json) =>
+        JsonDocument.Parse(json).RootElement.GetProperty("FullSemVer").GetString();
+}

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -62,6 +62,30 @@ public class ConfigurationVersionIntegrationTests
     }
 
     [Test]
+    public async Task ConfigMigrateLeavesNoTemporaryFileAfterWritingOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(0);
+            var files = Directory.GetFiles(directory.FullName).Select(Path.GetFileName).ToArray();
+            files.Length.ShouldBe(2);
+            files.ShouldContain(ConfigurationFileLocator.DefaultFileName);
+            files.ShouldContain("GitVersion.v7.yml");
+            files.ShouldNotContain(file => file!.StartsWith(".", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
     {
         var directory = Directory.CreateTempSubdirectory();
@@ -77,6 +101,29 @@ public class ConfigurationVersionIntegrationTests
             result.Output.ShouldBeEmpty();
             var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
             migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotEmitLegacyFallbackWarning()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            var fixture = new ProgramFixture(directory.FullName);
+            fixture.WithEnv(new KeyValuePair<string, string>(ConfigurationVersionSelector.EnvironmentVariableName, "v6"));
+
+            var result = await fixture.Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output!.ShouldNotContain("temporary v6 compatibility mode");
+            result.Log!.ShouldNotContain("temporary v6 compatibility mode");
         }
         finally
         {

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -5,8 +5,85 @@ using GitVersion.Helpers;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationVersionIntegrationTests
 {
+    [Test]
+    public async Task ConfigMigrateWritesMigratedConfigurationToStandardOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("calculation:");
+            result.Output.ShouldContain("next-version: 2.0.0");
+            result.Output.ShouldContain("output: {}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotOverwriteOutputWithoutForce()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            var outputPath = Path.Combine(directory.FullName, "GitVersion.v7.yml");
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            await File.WriteAllTextAsync(outputPath, "existing configuration");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(1);
+            result.Output.ShouldBeEmpty();
+            var output = await File.ReadAllTextAsync(outputPath);
+            output.ShouldBe("existing configuration");
+
+            var forceResult = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml", "--force");
+
+            forceResult.ExitCode.ShouldBe(0);
+            var forcedOutput = await File.ReadAllTextAsync(outputPath);
+            forcedOutput.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            const string fileName = "legacy.yml";
+            var configurationPath = Path.Combine(directory.FullName, fileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--config", fileName, "--in-place");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldBeEmpty();
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [Test]
     public void V6AndV7ConfigurationCalculateTheSameVersion()
     {

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -55,7 +55,12 @@ public class HelpWriterTests : TestBase
         var ignored = new[]
         {
             nameof(Arguments.Authentication),
-            nameof(Arguments.UpdateAssemblyInfoFileName)
+            nameof(Arguments.UpdateAssemblyInfoFileName),
+            nameof(Arguments.IsConfigurationMigration),
+            nameof(Arguments.MigrationInputFile),
+            nameof(Arguments.MigrationOutputFile),
+            nameof(Arguments.MigrationInPlace),
+            nameof(Arguments.MigrationForce)
         };
         typeof(Arguments).GetFields()
             .Select(p => p.Name)

--- a/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
@@ -64,6 +64,14 @@ public class LegacyArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateIsRejectedAsASubcommand()
+    {
+        var exception = Should.Throw<WarningException>(() => this.argumentParser.ParseArguments("config migrate"));
+
+        exception.Message.ShouldContain("only available with the POSIX argument parser");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
@@ -9,19 +9,58 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class LegacyArgumentParserTests : TestBase
 {
     private IEnvironment environment = null!;
     private IArgumentParser argumentParser = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void SetUp()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         var sp = ConfigureServices(services => services.AddModule(new GitVersionAppModule(useLegacyParser: true)));
         this.environment = sp.GetRequiredService<IEnvironment>();
         this.argumentParser = sp.GetRequiredService<IArgumentParser>();
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void OverrideConfigSupportsNestedV7RootAndBranchPaths()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var arguments = this.argumentParser.ParseArguments(
+            "/overrideconfig calculation.tag-prefix=custom- " +
+            "/overrideconfig calculation.branches.main.increment=Major " +
+            "/overrideconfig output.branches.main.pre-release-weight=42");
+
+        var normalized = ConfigurationDocumentMapper.Normalize(
+            arguments.OverrideConfiguration!, ConfigurationVersion.V7, "test override");
+        ConfigurationHelper configurationHelper = new(normalized);
+        var configuration = configurationHelper.Configuration;
+        configuration.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        configuration.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void OverrideConfigRejectsV6PathInV7WithReplacement()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("/overrideconfig tag-prefix=custom-"));
+
+        exception.Message.ShouldContain("calculation.tag-prefix");
+        exception.Message.ShouldContain("config migrate");
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
+++ b/src/GitVersion.App.Tests/PullRequestInBuildAgentTest.cs
@@ -150,10 +150,12 @@ public class PullRequestInBuildAgentTest
     }
 
     private const string GitLabMergeRequestPullRequestConfig = """
-        workflow: GitFlow/v1
-        branches:
-          pull-request:
-            regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+        calculation:
+          workflow: GitFlow/v1
+          branches:
+            pull-request:
+              regex: ^merge-requests/(?<Number>\d+)/(head|merge)$
+        output: {}
         """;
 
     private static async Task VerifyGitLabMergeRequestVersionIsCalculatedProperly(string mergeRequestRef, Dictionary<string, string> env)

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -62,6 +62,11 @@ internal class ArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (parseResult.CommandResult.Command == options.Migrate)
+        {
+            return MapMigrationValues(parseResult, options);
+        }
+
         var arguments = new Arguments();
         AddAuthentication(arguments);
         MapParsedValues(arguments, parseResult, options);
@@ -133,6 +138,32 @@ internal class ArgumentParser(
 
         MapRemoteOptions(arguments, parseResult, options);
         ApplyDefaults(arguments, parseResult, options);
+    }
+
+    private static Arguments MapMigrationValues(ParseResult parseResult, CommandOptions options)
+    {
+        var outputFile = parseResult.GetValue(options.MigrationOutputFile);
+        var inPlace = parseResult.GetValue(options.InPlace);
+        var force = parseResult.GetValue(options.Force);
+        if (outputFile is not null && inPlace)
+        {
+            throw new WarningException("Cannot use --output together with --in-place.");
+        }
+
+        if (force && outputFile is null)
+        {
+            throw new WarningException("--force can only be used together with --output.");
+        }
+
+        return new Arguments
+        {
+            IsConfigurationMigration = true,
+            MigrationInputFile = parseResult.GetValue(options.MigrationInputFile),
+            MigrationOutputFile = outputFile,
+            MigrationInPlace = inPlace,
+            MigrationForce = force,
+            TargetPath = parseResult.GetValue(options.TargetPath) ?? SysEnv.CurrentDirectory
+        };
     }
 
     private static void MapOutputOptions(Arguments arguments, ParseResult parseResult, CommandOptions options)
@@ -451,6 +482,17 @@ internal class ArgumentParser(
         {
             Description = "By default dynamic repositories will be cloned to %tmp%. Use this option to override"
         };
+        var configCommand = new Command("config", "Manages GitVersion configuration.");
+        var migrate = new Command("migrate", "Migrates a v6 configuration document to the v7 structure.");
+        var migrationInputFile = new Option<string?>("--config") { Description = "Path to the configuration file to migrate." };
+        var migrationOutputFile = new Option<string?>("--output") { Description = "Path to write the migrated configuration document." };
+        var inPlace = new Option<bool>("--in-place") { Description = "Replace the input configuration file." };
+        var force = new Option<bool>("--force") { Description = "Allow --output to replace an existing file." };
+        migrate.Options.Add(migrationInputFile);
+        migrate.Options.Add(migrationOutputFile);
+        migrate.Options.Add(inPlace);
+        migrate.Options.Add(force);
+        configCommand.Subcommands.Add(migrate);
 
         var rootCommand = new RootCommand("Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.")
         {
@@ -481,6 +523,8 @@ internal class ArgumentParser(
             commit,
             dynamicRepoLocation
         };
+        rootCommand.Subcommands.Add(configCommand);
+        rootCommand.SetAction(_ => { });
 
         // Configure the built-in help system to wrap at 260 characters to avoid too small help messages
         var helpOption = rootCommand.Options.SingleOfType<HelpOption>();
@@ -497,7 +541,9 @@ internal class ArgumentParser(
             VerbosityOption: verbosity, UpdateAssemblyInfo: updateAssemblyInfo, UpdateProjectFiles: updateProjectFiles,
             EnsureAssemblyInfo: ensureAssemblyInfo, UpdateWixVersionFile: updateWixVersionFile,
             Url: url, Branch: branch, Username: username, Password: password,
-            Commit: commit, DynamicRepoLocation: dynamicRepoLocation
+            Commit: commit, DynamicRepoLocation: dynamicRepoLocation,
+            Migrate: migrate, MigrationInputFile: migrationInputFile, MigrationOutputFile: migrationOutputFile,
+            InPlace: inPlace, Force: force
         ));
     }
 
@@ -621,6 +667,11 @@ internal class ArgumentParser(
         Option<string?> Username,
         Option<string?> Password,
         Option<string?> Commit,
-        Option<string?> DynamicRepoLocation
+        Option<string?> DynamicRepoLocation,
+        Command Migrate,
+        Option<string?> MigrationInputFile,
+        Option<string?> MigrationOutputFile,
+        Option<bool> InPlace,
+        Option<bool> Force
     );
 }

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -591,24 +591,7 @@ internal class ArgumentParser(
         }
 
         var parser = new OverrideConfigurationOptionParser();
-
-        foreach (var keyValueOption in values)
-        {
-            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
-            if (keyAndValue.Length != 2)
-            {
-                throw new WarningException($"Could not parse --override-config option: {keyValueOption}. Ensure it is in format 'key=value'.");
-            }
-
-            var optionKey = keyAndValue[0].ToLowerInvariant();
-            if (!OverrideConfigurationOptionParser.SupportedProperties.Contains(optionKey))
-            {
-                throw new WarningException($"Could not parse --override-config option: {keyValueOption}. Unsupported key '{optionKey}'.");
-            }
-
-            parser.SetValue(optionKey, keyAndValue[1]);
-        }
-
+        parser.SetValues(values, "--override-config");
         arguments.OverrideConfiguration = parser.GetOverrideConfiguration();
     }
 

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -9,6 +9,11 @@ internal class Arguments
     public string? ConfigurationFile;
     public IReadOnlyDictionary<object, object?> OverrideConfiguration = new Dictionary<object, object?>();
     public bool ShowConfiguration;
+    public bool IsConfigurationMigration;
+    public string? MigrationInputFile;
+    public string? MigrationOutputFile;
+    public bool MigrationInPlace;
+    public bool MigrationForce;
 
     public string? TargetPath;
 
@@ -62,6 +67,15 @@ internal class Arguments
                 ConfigurationFile = this.ConfigurationFile,
                 OverrideConfiguration = this.OverrideConfiguration,
                 ShowConfiguration = this.ShowConfiguration
+            },
+
+            ConfigurationMigrationInfo =
+            {
+                IsMigration = this.IsConfigurationMigration,
+                InputFile = this.MigrationInputFile,
+                OutputFile = this.MigrationOutputFile,
+                InPlace = this.MigrationInPlace,
+                Force = this.MigrationForce
             },
 
             RepositoryInfo =

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -46,7 +46,26 @@ internal class ConfigurationMigrationExecutor(
             this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", inputFile);
         }
 
-        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        WriteAtomically(outputFile, migrated);
         return 0;
+    }
+
+    private void WriteAtomically(string outputFile, string migrated)
+    {
+        var directory = this.fileSystem.Path.GetDirectoryName(outputFile)!;
+        var temporaryFile = this.fileSystem.Path.Combine(directory, $".{this.fileSystem.Path.GetFileName(outputFile)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            this.fileSystem.File.WriteAllText(temporaryFile, migrated);
+            this.fileSystem.File.Move(temporaryFile, outputFile, overwrite: true);
+        }
+        finally
+        {
+            if (this.fileSystem.File.Exists(temporaryFile))
+            {
+                this.fileSystem.File.Delete(temporaryFile);
+            }
+        }
     }
 }

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -1,0 +1,52 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion;
+
+internal class ConfigurationMigrationExecutor(
+    IFileSystem fileSystem,
+    IConsole console,
+    ILogger<ConfigurationMigrationExecutor> logger,
+    IConfigurationFileLocator configurationFileLocator,
+    IConfigurationMigrationService migrationService) : IConfigurationMigrationExecutor
+{
+    private readonly IFileSystem fileSystem = fileSystem.NotNull();
+    private readonly IConsole console = console.NotNull();
+    private readonly ILogger<ConfigurationMigrationExecutor> logger = logger.NotNull();
+    private readonly IConfigurationFileLocator configurationFileLocator = configurationFileLocator.NotNull();
+    private readonly IConfigurationMigrationService migrationService = migrationService.NotNull();
+
+    public int Execute(GitVersionOptions options)
+    {
+        var migration = options.ConfigurationMigrationInfo;
+        var inputFile = migration.InputFile is null
+            ? this.configurationFileLocator.GetConfigurationFile(options.WorkingDirectory)
+            : Path.GetFullPath(migration.InputFile, options.WorkingDirectory);
+        if (inputFile is null || !this.fileSystem.File.Exists(inputFile))
+        {
+            throw new WarningException("Could not find a configuration file to migrate. Specify one with --config.");
+        }
+
+        var migrated = this.migrationService.Migrate(this.fileSystem.File.ReadAllText(inputFile));
+        if (!migration.InPlace && migration.OutputFile is null)
+        {
+            this.console.Write(migrated);
+            return 0;
+        }
+
+        var outputFile = migration.InPlace ? inputFile : Path.GetFullPath(migration.OutputFile!, options.WorkingDirectory);
+        if (!migration.InPlace && this.fileSystem.File.Exists(outputFile) && !migration.Force)
+        {
+            throw new WarningException($"The output file '{outputFile}' already exists. Use --force to replace it.");
+        }
+
+        if (migration.InPlace)
+        {
+            this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", inputFile);
+        }
+
+        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        return 0;
+    }
+}

--- a/src/GitVersion.App/GitVersionApp.cs
+++ b/src/GitVersion.App/GitVersionApp.cs
@@ -5,10 +5,12 @@ namespace GitVersion;
 internal class GitVersionApp(
     IHostApplicationLifetime applicationLifetime,
     IGitVersionExecutor gitVersionExecutor,
+    IConfigurationMigrationExecutor configurationMigrationExecutor,
     IOptions<GitVersionOptions> options)
 {
     private readonly IHostApplicationLifetime applicationLifetime = applicationLifetime.NotNull();
     private readonly IGitVersionExecutor gitVersionExecutor = gitVersionExecutor.NotNull();
+    private readonly IConfigurationMigrationExecutor configurationMigrationExecutor = configurationMigrationExecutor.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
     public Task RunAsync(CancellationToken _)
@@ -19,6 +21,10 @@ internal class GitVersionApp(
             if (gitVersionOptions.IsHelp || gitVersionOptions.IsVersion)
             {
                 SysEnv.ExitCode = 0;
+            }
+            else if (gitVersionOptions.ConfigurationMigrationInfo.IsMigration)
+            {
+                SysEnv.ExitCode = this.configurationMigrationExecutor.Execute(gitVersionOptions);
             }
             else
             {

--- a/src/GitVersion.App/GitVersionAppModule.cs
+++ b/src/GitVersion.App/GitVersionAppModule.cs
@@ -19,6 +19,7 @@ internal class GitVersionAppModule(string[]? args = null, bool useLegacyParser =
 
         services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
         services.AddSingleton<IGitVersionExecutor, GitVersionExecutor>();
+        services.AddSingleton<IConfigurationMigrationExecutor, ConfigurationMigrationExecutor>();
         services.AddSingleton<GitVersionApp>();
 
         services.AddSingleton(sp =>

--- a/src/GitVersion.App/IConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/IConfigurationMigrationExecutor.cs
@@ -1,0 +1,6 @@
+namespace GitVersion;
+
+internal interface IConfigurationMigrationExecutor
+{
+    int Execute(GitVersionOptions options);
+}

--- a/src/GitVersion.App/LegacyArgumentParser.cs
+++ b/src/GitVersion.App/LegacyArgumentParser.cs
@@ -511,25 +511,7 @@ internal class LegacyArgumentParser(
         }
 
         var parser = new OverrideConfigurationOptionParser();
-
-        // key=value
-        foreach (var keyValueOption in values)
-        {
-            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
-            if (keyAndValue.Length != 2)
-            {
-                throw new WarningException($"Could not parse /overrideconfig option: {keyValueOption}. Ensure it is in format 'key=value'.");
-            }
-
-            var optionKey = keyAndValue[0].ToLowerInvariant();
-            if (!OverrideConfigurationOptionParser.SupportedProperties.Contains(optionKey))
-            {
-                throw new WarningException($"Could not parse /overrideconfig option: {keyValueOption}. Unsupported key '{optionKey}'.");
-            }
-
-            parser.SetValue(optionKey, keyAndValue[1]);
-        }
-
+        parser.SetValues(values, "/overrideconfig");
         arguments.OverrideConfiguration = parser.GetOverrideConfiguration();
     }
 

--- a/src/GitVersion.App/LegacyArgumentParser.cs
+++ b/src/GitVersion.App/LegacyArgumentParser.cs
@@ -78,6 +78,12 @@ internal class LegacyArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (firstArgument.Equals("config", StringComparison.OrdinalIgnoreCase)
+            && commandLineArguments.Skip(1).FirstOrDefault()?.Equals("migrate", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            throw new WarningException("The 'config migrate' command is only available with the POSIX argument parser.");
+        }
+
         var arguments = new Arguments();
 
         AddAuthentication(arguments);

--- a/src/GitVersion.App/OverrideConfigurationOptionParser.cs
+++ b/src/GitVersion.App/OverrideConfigurationOptionParser.cs
@@ -12,6 +12,9 @@ internal class OverrideConfigurationOptionParser
 
     internal static ILookup<string?, PropertyInfo> SupportedProperties => _lazySupportedProperties.Value;
 
+    private static readonly Lazy<HashSet<string>> _lazySupportedBranchProperties =
+        new(GetSupportedBranchProperties, true);
+
     /// <summary>
     /// Dynamically creates <see cref="System.Linq.ILookup{TKey, TElement}"/> of
     /// <see cref="GitVersionConfiguration"/> properties supported as a part of command line '/overrideconfig' option.
@@ -50,7 +53,172 @@ internal class OverrideConfigurationOptionParser
                || unwrappedType == typeof(VersionStrategies[]);
     }
 
-    internal void SetValue(string key, string value) => this.overrideConfiguration[key] = QuotedStringHelpers.UnquoteText(value);
+    internal static bool TryValidate(string key, out string? error)
+    {
+        var version = ConfigurationVersionSelector.Resolve();
+        var segments = key.Split('.');
+        if (IsValidPath(version, segments))
+        {
+            error = null;
+            return true;
+        }
+
+        var replacement = GetReplacement(version, segments);
+        error = replacement is null
+            ? $"Unsupported key '{key}'."
+            : $"Key '{key}' is not valid in the selected configuration structure. Use '{replacement}' instead. " +
+              "Run 'gitversion config migrate' to convert a legacy configuration.";
+        return false;
+    }
+
+    internal void SetValues(IReadOnlyCollection<string> values, string optionName)
+    {
+        List<(string Key, string Value)> parsedOptions = [];
+
+        foreach (var keyValueOption in values)
+        {
+            var keyAndValue = QuotedStringHelpers.SplitUnquoted(keyValueOption, '=');
+            if (keyAndValue.Length != 2)
+            {
+                throw new WarningException($"Could not parse {optionName} option: {keyValueOption}. Ensure it is in format 'key=value'.");
+            }
+
+            var optionKey = keyAndValue[0].ToLowerInvariant();
+            if (!TryValidate(optionKey, out var error))
+            {
+                throw new WarningException($"Could not parse {optionName} option: {keyValueOption}. {error}");
+            }
+
+            parsedOptions.Add((optionKey, keyAndValue[1]));
+        }
+
+        foreach (var (key, value) in parsedOptions)
+        {
+            SetValue(key, value);
+        }
+    }
+
+    internal void SetValue(string key, string value)
+    {
+        var segments = key.Split('.');
+        IDictionary<object, object?> current = this.overrideConfiguration;
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            var segment = segments[index];
+            if (!current.TryGetValue(segment, out var nested))
+            {
+                nested = new Dictionary<object, object?>();
+                current[segment] = nested;
+            }
+
+            current = (IDictionary<object, object?>)nested!;
+        }
+
+        current[segments[^1]] = QuotedStringHelpers.UnquoteText(value);
+    }
 
     internal IReadOnlyDictionary<object, object?> GetOverrideConfiguration() => this.overrideConfiguration;
+
+    private static HashSet<string> GetSupportedBranchProperties() => typeof(BranchConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(property => IsSupportedPropertyType(property.PropertyType) && property.CanWrite)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    private static bool IsValidPath(ConfigurationVersion version, IReadOnlyList<string> segments)
+    {
+        if (version == ConfigurationVersion.V6)
+        {
+            return segments.Count switch
+            {
+                1 => SupportedProperties.Contains(segments[0]),
+                3 when segments[0] == ConfigurationDocumentMapper.BranchesPropertyName
+                    => _lazySupportedBranchProperties.Value.Contains(segments[2]),
+                _ => false
+            };
+        }
+
+        if (segments.Count == 2 && IsSection(segments[0]))
+        {
+            return SupportedProperties.Contains(segments[1])
+                   && IsCorrectSection(segments[0], segments[1], branchProperty: false);
+        }
+
+        return segments.Count == 4
+               && IsSection(segments[0])
+               && segments[1] == ConfigurationDocumentMapper.BranchesPropertyName
+               && _lazySupportedBranchProperties.Value.Contains(segments[3])
+               && IsCorrectSection(segments[0], segments[3], branchProperty: true);
+    }
+
+    private static string? GetReplacement(ConfigurationVersion version, IReadOnlyList<string> segments) =>
+        version == ConfigurationVersion.V7
+            ? GetV7Replacement(segments)
+            : GetV6Replacement(segments);
+
+    private static string? GetV7Replacement(IReadOnlyList<string> segments)
+    {
+        if (IsFlatRootPath(segments))
+        {
+            return $"{GetSection(segments[0], branchProperty: false)}.{segments[0]}";
+        }
+
+        if (IsFlatBranchPath(segments))
+        {
+            return $"{GetSection(segments[2], branchProperty: true)}.{string.Join('.', segments)}";
+        }
+
+        if (IsNestedRootPath(segments))
+        {
+            return $"{GetSection(segments[1], branchProperty: false)}.{segments[1]}";
+        }
+
+        return IsNestedBranchPath(segments)
+            ? $"{GetSection(segments[3], branchProperty: true)}.{string.Join('.', segments.Skip(1))}"
+            : null;
+    }
+
+    private static string? GetV6Replacement(IReadOnlyList<string> segments)
+    {
+        if (IsNestedRootPath(segments))
+        {
+            return segments[1];
+        }
+
+        return IsNestedBranchPath(segments) ? string.Join('.', segments.Skip(1)) : null;
+    }
+
+    private static bool IsFlatRootPath(IReadOnlyList<string> segments) =>
+        segments.Count == 1 && SupportedProperties.Contains(segments[0]);
+
+    private static bool IsFlatBranchPath(IReadOnlyList<string> segments) =>
+        segments.Count == 3
+        && segments[0] == ConfigurationDocumentMapper.BranchesPropertyName
+        && _lazySupportedBranchProperties.Value.Contains(segments[2]);
+
+    private static bool IsNestedRootPath(IReadOnlyList<string> segments) =>
+        segments.Count == 2
+        && IsSection(segments[0])
+        && SupportedProperties.Contains(segments[1]);
+
+    private static bool IsNestedBranchPath(IReadOnlyList<string> segments) =>
+        segments.Count == 4
+        && IsSection(segments[0])
+        && segments[1] == ConfigurationDocumentMapper.BranchesPropertyName
+        && _lazySupportedBranchProperties.Value.Contains(segments[3]);
+
+    private static bool IsSection(string value)
+        => value is ConfigurationDocumentMapper.CalculationSectionName or ConfigurationDocumentMapper.OutputSectionName;
+
+    private static bool IsCorrectSection(string section, string propertyName, bool branchProperty)
+        => section == GetSection(propertyName, branchProperty);
+
+    private static string GetSection(string propertyName, bool branchProperty)
+    {
+        var isOutput = branchProperty
+            ? ConfigurationDocumentMapper.IsOutputBranchProperty(propertyName)
+            : ConfigurationDocumentMapper.IsOutputProperty(propertyName);
+        return isOutput ? ConfigurationDocumentMapper.OutputSectionName : ConfigurationDocumentMapper.CalculationSectionName;
+    }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationDocumentMapperTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationDocumentMapperTests.cs
@@ -1,0 +1,155 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationDocumentMapperTests
+{
+    [Test]
+    public void AssignsEverySerializedPropertyToExactlyOneV7Section()
+    {
+        var serializedProperties = typeof(GitVersionConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.GetCustomAttribute<JsonPropertyNameAttribute>() is not null)
+            .ToArray();
+        var calculationProperties = GetInterfacePropertyNames(typeof(ICalculationConfiguration));
+        calculationProperties.Remove(nameof(ICalculationConfiguration.VersionStrategy));
+        calculationProperties.Add(nameof(GitVersionConfiguration.VersionStrategies));
+        var outputProperties = GetInterfacePropertyNames(typeof(IOutputConfiguration));
+
+        calculationProperties.Intersect(outputProperties)
+            .ShouldBe([nameof(ICalculationConfiguration.Branches)]);
+        calculationProperties.Union(outputProperties).Order()
+            .ShouldBe(serializedProperties.Select(property => property.Name).Order());
+
+        var expectedOutputPropertyNames = serializedProperties
+            .Where(property => outputProperties.Contains(property.Name)
+                && property.Name != nameof(IOutputConfiguration.Branches))
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Order();
+        serializedProperties
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Where(ConfigurationDocumentMapper.IsOutputProperty)
+            .Order()
+            .ShouldBe(expectedOutputPropertyNames);
+
+        var branchProperties = typeof(BranchConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.GetCustomAttribute<JsonPropertyNameAttribute>() is not null)
+            .ToArray();
+        var calculationBranchProperties = GetInterfacePropertyNames(typeof(ICalculationBranchConfiguration));
+        var outputBranchProperties = GetInterfacePropertyNames(typeof(IOutputBranchConfiguration));
+
+        calculationBranchProperties.Intersect(outputBranchProperties).ShouldBeEmpty();
+        calculationBranchProperties.Union(outputBranchProperties).Order()
+            .ShouldBe(branchProperties.Select(property => property.Name).Order());
+        branchProperties
+            .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+            .Where(ConfigurationDocumentMapper.IsOutputBranchProperty)
+            .Order()
+            .ShouldBe(branchProperties
+                .Where(property => outputBranchProperties.Contains(property.Name))
+                .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name)
+                .Order());
+    }
+
+    [Test]
+    public void DetectsEmptyFlatNestedAndMixedDocuments()
+    {
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?>())
+            .ShouldBe(ConfigurationDocumentKind.Empty);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?> { ["tag-prefix"] = "v" })
+            .ShouldBe(ConfigurationDocumentKind.V6);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?> { ["calculation"] = new Dictionary<object, object?>() })
+            .ShouldBe(ConfigurationDocumentKind.V7);
+        ConfigurationDocumentMapper.Detect(new Dictionary<object, object?>
+        {
+            ["calculation"] = new Dictionary<object, object?>(),
+            ["tag-prefix"] = "v"
+        })
+            .ShouldBe(ConfigurationDocumentKind.Mixed);
+    }
+
+    [Test]
+    public void FlattensAndMergesCalculationAndOutputBranches()
+    {
+        Dictionary<object, object?> document = new()
+        {
+            ["calculation"] = new Dictionary<object, object?>
+            {
+                ["tag-prefix"] = "v",
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["increment"] = "Patch" }
+                }
+            },
+            ["output"] = new Dictionary<object, object?>
+            {
+                ["update-build-number"] = false,
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["pre-release-weight"] = 42 },
+                    ["develop"] = new Dictionary<object, object?> { ["custom-version-format"] = "{SemVer}" }
+                }
+            }
+        };
+
+        var result = ConfigurationDocumentMapper.Flatten(document);
+
+        result["tag-prefix"].ShouldBe("v");
+        result["update-build-number"].ShouldBe(false);
+        var branches = result["branches"].ShouldBeOfType<Dictionary<object, object?>>();
+        var main = branches["main"].ShouldBeOfType<Dictionary<object, object?>>();
+        main["increment"].ShouldBe("Patch");
+        main["pre-release-weight"].ShouldBe(42);
+        branches.ContainsKey("develop").ShouldBeTrue();
+    }
+
+    [Test]
+    public void RejectsMixedAndSelectedVersionMismatches()
+    {
+        Dictionary<object, object?> flat = new() { ["tag-prefix"] = "v" };
+        Dictionary<object, object?> nested = new() { ["calculation"] = new Dictionary<object, object?>() };
+        Dictionary<object, object?> mixed = new()
+        {
+            ["calculation"] = new Dictionary<object, object?>(),
+            ["tag-prefix"] = "v"
+        };
+
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(flat, ConfigurationVersion.V7, "test"));
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(nested, ConfigurationVersion.V6, "test"));
+        Should.Throw<ConfigurationException>(() =>
+            ConfigurationDocumentMapper.Normalize(mixed, ConfigurationVersion.V7, "test"));
+    }
+
+    [Test]
+    public void RejectsPropertiesInTheWrongV7SectionWithReplacement()
+    {
+        Dictionary<object, object?> wrongRoot = new()
+        {
+            ["calculation"] = new Dictionary<object, object?> { ["update-build-number"] = false }
+        };
+        Dictionary<object, object?> wrongBranch = new()
+        {
+            ["output"] = new Dictionary<object, object?>
+            {
+                ["branches"] = new Dictionary<object, object?>
+                {
+                    ["main"] = new Dictionary<object, object?> { ["increment"] = "Major" }
+                }
+            }
+        };
+
+        Should.Throw<ConfigurationException>(() => ConfigurationDocumentMapper.Flatten(wrongRoot))
+            .Message.ShouldContain("output.update-build-number");
+        Should.Throw<ConfigurationException>(() => ConfigurationDocumentMapper.Flatten(wrongBranch))
+            .Message.ShouldContain("calculation.branches.<branch>.increment");
+    }
+
+    private static HashSet<string> GetInterfacePropertyNames(Type interfaceType) =>
+        interfaceType.GetInterfaces()
+            .Append(interfaceType)
+            .SelectMany(type => type.GetProperties())
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,3 +1,5 @@
+using SharpYaml;
+
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
@@ -45,6 +47,29 @@ public class ConfigurationMigrationServiceTests
     }
 
     [Test]
+    public void MigratesConfiguredValuesWithoutAddingDefaults()
+    {
+        const string input = """
+                             workflow: GitHubFlow/v1
+                             mode: ContinuousDeployment
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Minor
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldContain("mode: ContinuousDeployment");
+        result.ShouldContain("update-build-number: false");
+        result.ShouldContain("increment: Minor");
+        result.ShouldContain("pre-release-weight: 42");
+        result.ShouldNotContain("tag-prefix:");
+    }
+
+    [Test]
     public void RejectsMixedConfiguration()
     {
         const string input = """
@@ -53,5 +78,13 @@ public class ConfigurationMigrationServiceTests
                              """;
 
         Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+
+    [Test]
+    public void RejectsMalformedYaml()
+    {
+        const string input = "branches: [";
+
+        Should.Throw<YamlException>(() => this.migrationService.Migrate(input));
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,0 +1,57 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationServiceTests
+{
+    private readonly IConfigurationMigrationService migrationService = new ConfigurationMigrationService(new ConfigurationSerializer());
+
+    [Test]
+    public void MigratesFlatConfigurationToCalculationAndOutputSections()
+    {
+        const string input = """
+                             workflow: GitFlow/v1
+                             tag-prefix: custom-
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Major
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("calculation:");
+        result.ShouldContain("  workflow: GitFlow/v1");
+        result.ShouldContain("  tag-prefix: custom-");
+        result.ShouldContain("      increment: Major");
+        result.ShouldContain("output:");
+        result.ShouldContain("  update-build-number: false");
+        result.ShouldContain("      pre-release-weight: 42");
+    }
+
+    [Test]
+    public void AcceptsNestedConfigurationAndProducesDeterministicOutput()
+    {
+        const string input = """
+                             output:
+                               update-build-number: false
+                             calculation:
+                               tag-prefix: custom-
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [Test]
+    public void RejectsMixedConfiguration()
+    {
+        const string input = """
+                             calculation: {}
+                             tag-prefix: custom-
+                             """;
+
+        Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -417,14 +417,14 @@ public class ConfigurationProviderTests : TestBase
     }
 
     [Test]
-    public void NoWarnOnGitVersionYmlFile()
+    public void WarnsOnceWhenExplicitV6LoadsAConfigurationFile()
     {
         const string text = "";
         using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
 
-        var stringLogger = string.Empty;
+        var logMessages = new List<string>();
 
-        var loggerFactory = new TestLoggerFactory(message => stringLogger = message);
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
 
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services =>
@@ -435,9 +435,13 @@ public class ConfigurationProviderTests : TestBase
         this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
 
         this.configurationProvider.ProvideForDirectory(this.repoPath);
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
 
         var filePath = FileSystemHelper.Path.Combine(this.repoPath, ConfigurationFileLocator.DefaultFileName);
-        stringLogger.ShouldContain($"Using configuration file '{filePath}'");
+        logMessages.ShouldContain(message => message.Contains($"Configuration file '{filePath}' uses the temporary v6 compatibility mode.", StringComparison.Ordinal));
+        logMessages.Count(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal)).ShouldBe(1);
+        logMessages.ShouldContain(message => message.Contains("GitVersion 7.1", StringComparison.Ordinal));
+        logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -444,6 +444,45 @@ public class ConfigurationProviderTests : TestBase
         logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
     }
 
+    [TestCase(null)]
+    [TestCase("v7")]
+    public void DoesNotWarnWhenV6IsNotExplicitlySelected(string? configurationVersion)
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, configurationVersion);
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: "");
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void DoesNotWarnForExplicitV6BuiltInDefaults()
+    {
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
     [Test]
     public void ShouldUseSpecifiedSourceBranchesForDevelop()
     {

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -7,15 +7,19 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationProviderTests : TestBase
 {
     private string repoPath = null!;
     private ConfigurationProvider configurationProvider = null!;
     private IFileSystem fileSystem = null!;
+    private string? originalConfigurationVersion;
 
     [SetUp]
     public void Setup()
     {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
         this.repoPath = FileSystemHelper.Path.Combine(FileSystemHelper.Path.GetTempPath(), "MyGitRepo");
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services => services.AddSingleton(options));
@@ -23,6 +27,93 @@ public class ConfigurationProviderTests : TestBase
         this.fileSystem = sp.GetRequiredService<IFileSystem>();
 
         ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
+
+    [Test]
+    public void ProvidesNestedV7ConfigurationAndMergesOutputOnlyWorkflowBranch()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        const string text = """
+                            calculation:
+                              workflow: GitFlow/v1
+                              tag-prefix: custom-
+                            output:
+                              update-build-number: false
+                              branches:
+                                develop:
+                                  custom-version-format: '{SemVer}'
+                                  pre-release-weight: 42
+                            """;
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
+
+        var configuration = this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        configuration.Calculation.TagPrefixPattern.ShouldBe("custom-");
+        configuration.Output.UpdateBuildNumber.ShouldBeFalse();
+        configuration.Calculation.Branches.ShouldContainKey("develop");
+        configuration.Output.Branches["develop"].CustomVersionFormat.ShouldBe("{SemVer}");
+        configuration.Output.Branches["develop"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void ResolvesEquivalentV6AndV7Configuration()
+    {
+        const string v6 = """
+                          tag-prefix: custom-
+                          update-build-number: false
+                          branches:
+                            main:
+                              increment: Major
+                              pre-release-weight: 42
+                          """;
+        const string v7 = """
+                          calculation:
+                            tag-prefix: custom-
+                            branches:
+                              main:
+                                increment: Major
+                          output:
+                            update-build-number: false
+                            branches:
+                              main:
+                                pre-release-weight: 42
+                          """;
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+        IGitVersionConfiguration legacy;
+        using (this.fileSystem.SetupConfigFile(path: this.repoPath, text: v6))
+        {
+            legacy = this.configurationProvider.ProvideForDirectory(this.repoPath);
+        }
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        using (this.fileSystem.SetupConfigFile(path: this.repoPath, text: v7))
+        {
+            var nested = this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+            ConfigurationSerializer.SerializeLegacy(nested).ShouldBe(ConfigurationSerializer.SerializeLegacy(legacy));
+        }
+    }
+
+    [Test]
+    public void RejectsMixedV7Configuration()
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        const string text = """
+                            calculation:
+                              tag-prefix: custom-
+                            update-build-number: false
+                            """;
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
+
+        var exception = Should.Throw<ConfigurationException>(() =>
+            this.configurationProvider.ProvideForDirectory(this.repoPath));
+
+        exception.Message.ShouldContain("mixes the v6 flat configuration structure");
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationSerializerTests.cs
@@ -1,9 +1,51 @@
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationSerializerTests
 {
     private readonly ConfigurationSerializer serializer = new();
+
+    [Test]
+    public void SerializesV7CalculationAndOutputSectionsAndRoundTrips()
+    {
+        using var scope = new EnvironmentVariableScope("v7");
+        var configuration = new GitVersionConfiguration
+        {
+            TagPrefixPattern = "custom-",
+            UpdateBuildNumber = false,
+            Branches = new Dictionary<string, BranchConfiguration>
+            {
+                ["main"] = new() { Increment = IncrementStrategy.Major, PreReleaseWeight = 42 }
+            }
+        };
+
+        var yaml = this.serializer.Serialize(configuration);
+        var roundTrip = ConfigurationSerializer.ReadConfiguration(yaml);
+
+        yaml.ShouldContain("calculation:");
+        yaml.ShouldContain("output:");
+        yaml.ShouldContain("  tag-prefix: custom-");
+        yaml.ShouldContain("    main:");
+        roundTrip.ShouldNotBeNull();
+        roundTrip.TagPrefixPattern.ShouldBe("custom-");
+        roundTrip.UpdateBuildNumber.ShouldBeFalse();
+        roundTrip.Branches["main"].Increment.ShouldBe(IncrementStrategy.Major);
+        roundTrip.Branches["main"].PreReleaseWeight.ShouldBe(42);
+    }
+
+    [Test]
+    public void SerializesFlatConfigurationWhenV6IsSelected()
+    {
+        using var scope = new EnvironmentVariableScope("v6");
+        var configuration = new GitVersionConfiguration { TagPrefixPattern = "custom-" };
+
+        var yaml = this.serializer.Serialize(configuration);
+
+        yaml.ShouldContain("tag-prefix: custom-");
+        yaml.ShouldNotContain("calculation:");
+        yaml.ShouldNotContain("output:");
+    }
 
     [Test]
     public void Serialize_OrdersConfigurationPropertiesAndPreservesBranchNames()
@@ -39,4 +81,15 @@ public class ConfigurationSerializerTests
     }
 
     private static string GetPropertyName(string line) => line.TrimStart().Split(':', 2)[0];
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.original);
+    }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/IgnoreConfigurationTests.cs
@@ -6,9 +6,22 @@ using SharpYaml;
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class IgnoreConfigurationTests : TestBase
 {
     private readonly ConfigurationSerializer serializer = new();
+    private string? originalConfigurationVersion;
+
+    [SetUp]
+    public void Setup()
+    {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
     public void CanDeserialize()
@@ -20,7 +33,7 @@ public class IgnoreConfigurationTests : TestBase
                 sha: [b6c0c9fda88830ebcd563e500a5a7da5a1658e98]
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -40,7 +53,7 @@ public class IgnoreConfigurationTests : TestBase
                     - 6c19c7c219ecf8dbc468042baefa73a1b213e8b1
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -53,7 +66,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "ignore:\n  branches: ['^legacy/', '^release/old$']";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
@@ -64,7 +77,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "ignore:\n  tags: ['^preview-', '^v0\\.']";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Tags.ShouldBe(["^preview-", "^v0\\."]);
@@ -83,7 +96,7 @@ public class IgnoreConfigurationTests : TestBase
                     - ^preview-
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Branches.ShouldBe(["^legacy/", "^release/old$"]);
@@ -101,7 +114,7 @@ public class IgnoreConfigurationTests : TestBase
                     - ^v0\.
             """;
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.Tags.ShouldBe(["^preview-", "^v0\\."]);
@@ -112,7 +125,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "next-version: 1.0";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.Ignore.ShouldNotBeNull();
@@ -212,7 +225,7 @@ public class IgnoreConfigurationTests : TestBase
                 commits-before: bad format date
             """;
 
-        Should.Throw<YamlException>(() => this.serializer.ReadConfiguration(yaml));
+        Should.Throw<YamlException>(() => ConfigurationSerializer.ReadConfiguration(yaml));
     }
 
     [Test]
@@ -220,7 +233,7 @@ public class IgnoreConfigurationTests : TestBase
     {
         const string yaml = "strategies: ConfiguredNextVersion, TaggedCommit";
 
-        var configuration = this.serializer.ReadConfiguration(yaml);
+        var configuration = ConfigurationSerializer.ReadConfiguration(yaml);
 
         configuration.ShouldNotBeNull();
         configuration.VersionStrategy.ShouldBe(VersionStrategies.ConfiguredNextVersion | VersionStrategies.TaggedCommit);

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitFlow/v1.yml
@@ -1,170 +1,180 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  develop:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: false
-    is-source-branch-for: []
-    label: alpha
-    mode: ContinuousDelivery
-    pre-release-weight: 0
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: ^dev(elop)?(ment)?$
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: true
-    tracks-release-branches: true
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Minor
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - support
-      - hotfix
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - develop
-      - main
-      - release
-      - feature
-      - support
-      - hotfix
-    track-merge-message: true
-  hotfix:
-    increment: Inherit
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - support
-  support:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^support[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-target: false
-    tracks-release-branches: false
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: true
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - develop
-      - release
-      - feature
-      - pull-request
-      - hotfix
-      - support
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    develop:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: false
+      is-source-branch-for: []
+      label: alpha
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: ^dev(elop)?(ment)?$
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: true
+      tracks-release-branches: true
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Minor
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - support
+        - hotfix
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - develop
+        - main
+        - release
+        - feature
+        - support
+        - hotfix
+      track-merge-message: true
+    hotfix:
+      increment: Inherit
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - support
+    support:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^support[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-target: false
+      tracks-release-branches: false
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: true
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - develop
+        - release
+        - feature
+        - pull-request
+        - hotfix
+        - support
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    develop:
+      pre-release-weight: 0
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    support:
+      pre-release-weight: 55000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/GitHubFlow/v1.yml
@@ -1,119 +1,126 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  release:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: beta
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-branch-merged: false
-      when-current-commit-tagged: false
-    regex: "^releases?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-    track-merge-message: true
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - release
-      - feature
-    track-merge-message: true
-  unknown:
-    increment: Inherit
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ManualDeployment
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-      - release
-      - feature
-      - pull-request
-    track-merge-message: false
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - Fallback
-  - ConfiguredNextVersion
-  - MergeMessage
-  - TaggedCommit
-  - TrackReleaseBranches
-  - VersionInBranchName
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    release:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: beta
+      mode: ManualDeployment
+      prevent-increment:
+        of-merged-branch: true
+        when-branch-merged: false
+        when-current-commit-tagged: false
+      regex: "^releases?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+      track-merge-message: true
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - release
+        - feature
+      track-merge-message: true
+    unknown:
+      increment: Inherit
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ManualDeployment
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+        - release
+        - feature
+        - pull-request
+      track-merge-message: false
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - Fallback
+    - ConfiguredNextVersion
+    - MergeMessage
+    - TaggedCommit
+    - TrackReleaseBranches
+    - VersionInBranchName
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    release:
+      pre-release-weight: 30000
+    feature:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
+++ b/src/GitVersion.Configuration.Tests/Workflows/approved/TrunkBased/preview1.yml
@@ -1,104 +1,112 @@
-assembly-file-versioning-scheme: MajorMinorPatch
-assembly-versioning-scheme: MajorMinorPatch
-branches:
-  main:
-    increment: Patch
-    is-main-branch: true
-    is-release-branch: false
-    is-source-branch-for: []
-    label: ''
-    mode: ContinuousDeployment
-    pre-release-weight: 55000
-    prevent-increment:
-      of-merged-branch: true
-    regex: "^master$|^main$"
-    source-branches: []
-    track-merge-message: true
-    track-merge-target: false
-    tracks-release-branches: false
-  feature:
-    increment: Minor
-    is-main-branch: false
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^features?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-    track-merge-message: true
-  hotfix:
-    increment: Patch
-    is-main-branch: false
-    is-release-branch: true
-    is-source-branch-for: []
-    label: "{BranchName}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
-    source-branches:
-      - main
-  pull-request:
-    increment: Inherit
-    is-source-branch-for: []
-    label: "PullRequest{Number}"
-    mode: ContinuousDelivery
-    pre-release-weight: 30000
-    prevent-increment:
-      of-merged-branch: true
-      when-current-commit-tagged: false
-    regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
-    source-branches:
-      - main
-      - feature
-      - hotfix
-    track-merge-message: true
-  unknown:
-    increment: Patch
-    is-source-branch-for: []
-    pre-release-weight: 30000
-    prevent-increment:
-      when-current-commit-tagged: false
-    regex: "(?<BranchName>.+)"
-    source-branches:
-      - main
-commit-date-format: yyyy-MM-dd
-commit-message-incrementing: Enabled
-ignore:
-  branches: []
-  paths: []
-  sha: []
-  tags: []
-increment: Inherit
-is-main-branch: false
-is-release-branch: false
-is-source-branch-for: []
-label: "{BranchName}"
-major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
-merge-message-formats: {}
-minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
-mode: ContinuousDelivery
-no-bump-message: "[+=]semver:\\s?(none|skip)"
-patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
-prevent-increment:
-  of-merged-branch: false
-  when-branch-merged: false
-  when-current-commit-tagged: true
-regex: ''
-semantic-version-format: Strict
-source-branches: []
-strategies:
-  - ConfiguredNextVersion
-  - Mainline
-tag-pre-release-weight: 60000
-tag-prefix: "[vV]?"
-track-merge-message: true
-track-merge-target: false
-tracks-release-branches: false
-update-build-number: true
-version-bump-reset-message: "=semver:"
-version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+calculation:
+  branches:
+    main:
+      increment: Patch
+      is-main-branch: true
+      is-release-branch: false
+      is-source-branch-for: []
+      label: ''
+      mode: ContinuousDeployment
+      prevent-increment:
+        of-merged-branch: true
+      regex: "^master$|^main$"
+      source-branches: []
+      track-merge-message: true
+      track-merge-target: false
+      tracks-release-branches: false
+    feature:
+      increment: Minor
+      is-main-branch: false
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^features?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+      track-merge-message: true
+    hotfix:
+      increment: Patch
+      is-main-branch: false
+      is-release-branch: true
+      is-source-branch-for: []
+      label: "{BranchName}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "^hotfix(es)?[\\/-](?<BranchName>.+)"
+      source-branches:
+        - main
+    pull-request:
+      increment: Inherit
+      is-source-branch-for: []
+      label: "PullRequest{Number}"
+      mode: ContinuousDelivery
+      prevent-increment:
+        of-merged-branch: true
+        when-current-commit-tagged: false
+      regex: "^(pull-requests|pull|pr)[\\/-](?<Number>\\d*)"
+      source-branches:
+        - main
+        - feature
+        - hotfix
+      track-merge-message: true
+    unknown:
+      increment: Patch
+      is-source-branch-for: []
+      prevent-increment:
+        when-current-commit-tagged: false
+      regex: "(?<BranchName>.+)"
+      source-branches:
+        - main
+  commit-message-incrementing: Enabled
+  ignore:
+    branches: []
+    paths: []
+    sha: []
+    tags: []
+  increment: Inherit
+  is-main-branch: false
+  is-release-branch: false
+  is-source-branch-for: []
+  label: "{BranchName}"
+  major-version-bump-message: "[+=]semver:\\s?(breaking|major)"
+  merge-message-formats: {}
+  minor-version-bump-message: "[+=]semver:\\s?(feature|minor)"
+  mode: ContinuousDelivery
+  no-bump-message: "[+=]semver:\\s?(none|skip)"
+  patch-version-bump-message: "[+=]semver:\\s?(fix|patch)"
+  prevent-increment:
+    of-merged-branch: false
+    when-branch-merged: false
+    when-current-commit-tagged: true
+  regex: ''
+  semantic-version-format: Strict
+  source-branches: []
+  strategies:
+    - ConfiguredNextVersion
+    - Mainline
+  tag-prefix: "[vV]?"
+  track-merge-message: true
+  track-merge-target: false
+  tracks-release-branches: false
+  version-bump-reset-message: "=semver:"
+  version-in-branch-pattern: "(?<version>[vV]?\\d+(\\.\\d+)?(\\.\\d+)?).*"
+output:
+  assembly-file-versioning-scheme: MajorMinorPatch
+  assembly-versioning-scheme: MajorMinorPatch
+  branches:
+    main:
+      pre-release-weight: 55000
+    feature:
+      pre-release-weight: 30000
+    hotfix:
+      pre-release-weight: 30000
+    pull-request:
+      pre-release-weight: 30000
+    unknown:
+      pre-release-weight: 30000
+  commit-date-format: yyyy-MM-dd
+  tag-pre-release-weight: 60000
+  update-build-number: true

--- a/src/GitVersion.Configuration/BranchConfiguration.cs
+++ b/src/GitVersion.Configuration/BranchConfiguration.cs
@@ -25,6 +25,9 @@ internal record BranchConfiguration : IBranchConfiguration
     [JsonIgnore]
     IPreventIncrementConfiguration IBranchConfiguration.PreventIncrement => PreventIncrement;
 
+    [JsonIgnore]
+    IPreventIncrementConfiguration ICalculationBranchConfiguration.PreventIncrement => PreventIncrement;
+
     [JsonPropertyName("prevent-increment")]
     [JsonPropertyDescription("The prevent increment configuration section.")]
     public PreventIncrementConfiguration PreventIncrement { get; set; } = new();
@@ -56,12 +59,18 @@ internal record BranchConfiguration : IBranchConfiguration
     [JsonIgnore]
     IReadOnlyCollection<string> IBranchConfiguration.SourceBranches => SourceBranches;
 
+    [JsonIgnore]
+    IReadOnlyCollection<string> ICalculationBranchConfiguration.SourceBranches => SourceBranches;
+
     [JsonPropertyName("is-source-branch-for")]
     [JsonPropertyDescription("The branches that this branch is a source branch.")]
     public HashSet<string> IsSourceBranchFor { get; set; } = [];
 
     [JsonIgnore]
     IReadOnlyCollection<string> IBranchConfiguration.IsSourceBranchFor => IsSourceBranchFor;
+
+    [JsonIgnore]
+    IReadOnlyCollection<string> ICalculationBranchConfiguration.IsSourceBranchFor => IsSourceBranchFor;
 
     [JsonPropertyName("tracks-release-branches")]
     [JsonPropertyDescription("Indicates this branch configuration represents develop in GitFlow.")]

--- a/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
+++ b/src/GitVersion.Configuration/Builders/ConfigurationBuilderBase.cs
@@ -338,45 +338,47 @@ internal abstract class ConfigurationBuilderBase<TConfigurationBuilder> : IConfi
 
     public TConfigurationBuilder WithConfiguration(IGitVersionConfiguration value)
     {
-        WithAssemblyVersioningScheme(value.AssemblyVersioningScheme);
-        WithAssemblyFileVersioningScheme(value.AssemblyFileVersioningScheme);
-        WithAssemblyInformationalFormat(value.AssemblyInformationalFormat);
-        WithAssemblyVersioningFormat(value.AssemblyVersioningFormat);
-        WithAssemblyFileVersioningFormat(value.AssemblyFileVersioningFormat);
-        WithCustomVersionFormat(value.CustomVersionFormat);
-        WithTagPrefixPattern(value.TagPrefixPattern);
-        WithVersionInBranchPattern(value.VersionInBranchPattern);
-        WithNextVersion(value.NextVersion);
-        WithMajorVersionBumpMessage(value.MajorVersionBumpMessage);
-        WithMinorVersionBumpMessage(value.MinorVersionBumpMessage);
-        WithPatchVersionBumpMessage(value.PatchVersionBumpMessage);
-        WithNoBumpMessage(value.NoBumpMessage);
-        WithVersionBumpResetMessage(value.VersionBumpResetMessage);
-        WithTagPreReleaseWeight(value.TagPreReleaseWeight);
-        WithIgnoreConfiguration(value.Ignore);
-        WithCommitDateFormat(value.CommitDateFormat);
-        WithUpdateBuildNumber(value.UpdateBuildNumber);
-        WithSemanticVersionFormat(value.SemanticVersionFormat);
-        WithVersionStrategy(value.VersionStrategy);
-        WithMergeMessageFormats(value.MergeMessageFormats);
+        var calculation = value.Calculation;
+        var output = value.Output;
+        WithAssemblyVersioningScheme(output.AssemblyVersioningScheme);
+        WithAssemblyFileVersioningScheme(output.AssemblyFileVersioningScheme);
+        WithAssemblyInformationalFormat(output.AssemblyInformationalFormat);
+        WithAssemblyVersioningFormat(output.AssemblyVersioningFormat);
+        WithAssemblyFileVersioningFormat(output.AssemblyFileVersioningFormat);
+        WithCustomVersionFormat(output.CustomVersionFormat);
+        WithTagPrefixPattern(calculation.TagPrefixPattern);
+        WithVersionInBranchPattern(calculation.VersionInBranchPattern);
+        WithNextVersion(calculation.NextVersion);
+        WithMajorVersionBumpMessage(calculation.MajorVersionBumpMessage);
+        WithMinorVersionBumpMessage(calculation.MinorVersionBumpMessage);
+        WithPatchVersionBumpMessage(calculation.PatchVersionBumpMessage);
+        WithNoBumpMessage(calculation.NoBumpMessage);
+        WithVersionBumpResetMessage(calculation.VersionBumpResetMessage);
+        WithTagPreReleaseWeight(output.TagPreReleaseWeight);
+        WithIgnoreConfiguration(calculation.Ignore);
+        WithCommitDateFormat(output.CommitDateFormat);
+        WithUpdateBuildNumber(output.UpdateBuildNumber);
+        WithSemanticVersionFormat(calculation.SemanticVersionFormat);
+        WithVersionStrategy(calculation.VersionStrategy);
+        WithMergeMessageFormats(calculation.MergeMessageFormats);
         foreach (var (name, branchConfiguration) in value.Branches)
         {
             WithBranch(name).WithConfiguration(branchConfiguration);
         }
-        WithDeploymentMode(value.DeploymentMode);
-        WithLabel(value.Label);
-        WithIncrement(value.Increment);
-        WithPreventIncrementOfMergedBranch(value.PreventIncrement.OfMergedBranch);
-        WithPreventIncrementWhenBranchMerged(value.PreventIncrement.WhenBranchMerged);
-        WithPreventIncrementWhenCurrentCommitTagged(value.PreventIncrement.WhenCurrentCommitTagged);
-        WithTrackMergeTarget(value.TrackMergeTarget);
-        WithTrackMergeMessage(value.TrackMergeMessage);
-        WithCommitMessageIncrementing(value.CommitMessageIncrementing);
-        WithRegularExpression(value.RegularExpression);
-        WithTracksReleaseBranches(value.TracksReleaseBranches);
-        WithIsReleaseBranch(value.IsReleaseBranch);
-        WithIsMainBranch(value.IsMainBranch);
-        WithPreReleaseWeight(value.PreReleaseWeight);
+        WithDeploymentMode(calculation.DeploymentMode);
+        WithLabel(calculation.Label);
+        WithIncrement(calculation.Increment);
+        WithPreventIncrementOfMergedBranch(calculation.PreventIncrement.OfMergedBranch);
+        WithPreventIncrementWhenBranchMerged(calculation.PreventIncrement.WhenBranchMerged);
+        WithPreventIncrementWhenCurrentCommitTagged(calculation.PreventIncrement.WhenCurrentCommitTagged);
+        WithTrackMergeTarget(calculation.TrackMergeTarget);
+        WithTrackMergeMessage(calculation.TrackMergeMessage);
+        WithCommitMessageIncrementing(calculation.CommitMessageIncrementing);
+        WithRegularExpression(calculation.RegularExpression);
+        WithTracksReleaseBranches(calculation.TracksReleaseBranches);
+        WithIsReleaseBranch(calculation.IsReleaseBranch);
+        WithIsMainBranch(calculation.IsMainBranch);
+        WithPreReleaseWeight(output.PreReleaseWeight);
         return (TConfigurationBuilder)this;
     }
 

--- a/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
+++ b/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
@@ -153,6 +153,34 @@ internal static class ConfigurationDocumentMapper
         };
     }
 
+    public static Dictionary<object, object?> Nest(IReadOnlyDictionary<object, object?> document)
+    {
+        Dictionary<object, object?> calculation = [];
+        Dictionary<object, object?> output = [];
+
+        foreach (var (key, value) in document)
+        {
+            if (key is string propertyName && propertyName.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                SplitBranches(value, calculation, output);
+            }
+            else if (key is string outputPropertyName && OutputPropertyNames.Contains(outputPropertyName))
+            {
+                output[key] = CloneValue(value);
+            }
+            else
+            {
+                calculation[key] = CloneValue(value);
+            }
+        }
+
+        return new()
+        {
+            [CalculationSectionName] = calculation,
+            [OutputSectionName] = output
+        };
+    }
+
     public static bool IsOutputProperty(string propertyName) => OutputPropertyNames.Contains(propertyName);
 
     public static bool IsOutputBranchProperty(string propertyName) => OutputBranchPropertyNames.Contains(propertyName);
@@ -262,6 +290,56 @@ internal static class ConfigurationDocumentMapper
             foreach (var (propertyName, propertyValue) in branch)
             {
                 (OutputBranchPropertyNames.Contains(propertyName) ? outputBranch : calculationBranch)[propertyName] = propertyValue;
+            }
+
+            if (calculationBranch.Count != 0)
+            {
+                calculationBranches[branchName] = calculationBranch;
+            }
+
+            if (outputBranch.Count != 0)
+            {
+                outputBranches[branchName] = outputBranch;
+            }
+        }
+
+        if (calculationBranches.Count != 0)
+        {
+            calculation[BranchesPropertyName] = calculationBranches;
+        }
+
+        if (outputBranches.Count != 0)
+        {
+            output[BranchesPropertyName] = outputBranches;
+        }
+    }
+
+    private static void SplitBranches(
+        object? value,
+        IDictionary<object, object?> calculation,
+        IDictionary<object, object?> output)
+    {
+        if (value is not IReadOnlyDictionary<object, object?> branches)
+        {
+            calculation[BranchesPropertyName] = CloneValue(value);
+            return;
+        }
+
+        Dictionary<object, object?> calculationBranches = [];
+        Dictionary<object, object?> outputBranches = [];
+        foreach (var (branchName, branchValue) in branches)
+        {
+            if (branchValue is not IReadOnlyDictionary<object, object?> branch)
+            {
+                calculationBranches[branchName] = CloneValue(branchValue);
+                continue;
+            }
+
+            Dictionary<object, object?> calculationBranch = [];
+            Dictionary<object, object?> outputBranch = [];
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                (propertyName is string name && OutputBranchPropertyNames.Contains(name) ? outputBranch : calculationBranch)[propertyName] = CloneValue(propertyValue);
             }
 
             if (calculationBranch.Count != 0)

--- a/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
+++ b/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
@@ -1,0 +1,318 @@
+namespace GitVersion.Configuration;
+
+internal enum ConfigurationDocumentKind
+{
+    Empty,
+    V6,
+    V7,
+    Mixed
+}
+
+internal static class ConfigurationDocumentMapper
+{
+    public const string CalculationSectionName = "calculation";
+    public const string OutputSectionName = "output";
+    public const string BranchesPropertyName = "branches";
+
+    private static readonly HashSet<string> OutputPropertyNames =
+    [
+        "assembly-file-versioning-format",
+        "assembly-file-versioning-scheme",
+        "assembly-informational-format",
+        "assembly-versioning-format",
+        "assembly-versioning-scheme",
+        "commit-date-format",
+        "custom-version-format",
+        "pre-release-weight",
+        "tag-pre-release-weight",
+        "update-build-number"
+    ];
+
+    private static readonly HashSet<string> OutputBranchPropertyNames =
+    [
+        "custom-version-format",
+        "pre-release-weight"
+    ];
+
+    private static readonly HashSet<string> KnownPropertyNames = typeof(GitVersionConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    private static readonly HashSet<string> KnownBranchPropertyNames = typeof(BranchConfiguration)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Select(property => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .OfType<string>()
+        .ToHashSet(StringComparer.Ordinal);
+
+    public static ConfigurationDocumentKind Detect(IReadOnlyDictionary<object, object?> document)
+    {
+        if (document.Count == 0)
+        {
+            return ConfigurationDocumentKind.Empty;
+        }
+
+        var hasNested = document.ContainsKey(CalculationSectionName) || document.ContainsKey(OutputSectionName);
+        var hasFlat = document.Keys.OfType<string>().Any(key =>
+            !key.Equals(CalculationSectionName, StringComparison.Ordinal)
+            && !key.Equals(OutputSectionName, StringComparison.Ordinal));
+
+        return (hasNested, hasFlat) switch
+        {
+            (true, true) => ConfigurationDocumentKind.Mixed,
+            (true, false) => ConfigurationDocumentKind.V7,
+            _ => ConfigurationDocumentKind.V6
+        };
+    }
+
+    public static Dictionary<object, object?> Normalize(
+        IReadOnlyDictionary<object, object?> document,
+        ConfigurationVersion selectedVersion,
+        string source)
+    {
+        var kind = Detect(document);
+        if (kind == ConfigurationDocumentKind.Mixed)
+        {
+            throw new ConfigurationException(
+                $"The {source} mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure. Run 'gitversion config migrate' to convert a v6 configuration.");
+        }
+
+        if (kind == ConfigurationDocumentKind.V6 && selectedVersion == ConfigurationVersion.V7)
+        {
+            throw new ConfigurationException(
+                $"The {source} uses the legacy v6 configuration structure, but {ConfigurationVersionSelector.EnvironmentVariableName}=v7 is selected. " +
+                $"Run 'gitversion config migrate' or set {ConfigurationVersionSelector.EnvironmentVariableName}=v6 temporarily.");
+        }
+
+        if (kind == ConfigurationDocumentKind.V7 && selectedVersion == ConfigurationVersion.V6)
+        {
+            throw new ConfigurationException(
+                $"The {source} uses the v7 configuration structure, but {ConfigurationVersionSelector.EnvironmentVariableName}=v6 is selected. " +
+                $"Remove the override or set {ConfigurationVersionSelector.EnvironmentVariableName}=v7.");
+        }
+
+        return kind == ConfigurationDocumentKind.V7 ? Flatten(document) : CloneDictionary(document);
+    }
+
+    public static Dictionary<object, object?> NormalizeInternal(IReadOnlyDictionary<object, object?> document, string source)
+    {
+        var kind = Detect(document);
+        return kind switch
+        {
+            ConfigurationDocumentKind.Empty => [],
+            ConfigurationDocumentKind.V6 => CloneDictionary(document),
+            ConfigurationDocumentKind.V7 => Flatten(document),
+            _ => throw new ConfigurationException(
+                $"The {source} mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure.")
+        };
+    }
+
+    public static Dictionary<object, object?> Flatten(IReadOnlyDictionary<object, object?> document)
+    {
+        Dictionary<object, object?> result = [];
+        Dictionary<object, object?> branches = [];
+
+        FlattenSection(document, CalculationSectionName, result, branches);
+        FlattenSection(document, OutputSectionName, result, branches);
+
+        if (branches.Count != 0)
+        {
+            result[BranchesPropertyName] = branches;
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, object?> Nest(IReadOnlyDictionary<string, object?> document)
+    {
+        Dictionary<string, object?> calculation = [];
+        Dictionary<string, object?> output = [];
+
+        foreach (var (key, value) in document)
+        {
+            if (key.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                SplitBranches(value, calculation, output);
+            }
+            else if (OutputPropertyNames.Contains(key))
+            {
+                output[key] = value;
+            }
+            else
+            {
+                calculation[key] = value;
+            }
+        }
+
+        return new Dictionary<string, object?>
+        {
+            [CalculationSectionName] = calculation,
+            [OutputSectionName] = output
+        };
+    }
+
+    public static bool IsOutputProperty(string propertyName) => OutputPropertyNames.Contains(propertyName);
+
+    public static bool IsOutputBranchProperty(string propertyName) => OutputBranchPropertyNames.Contains(propertyName);
+
+    private static void FlattenSection(
+        IReadOnlyDictionary<object, object?> document,
+        string sectionName,
+        IDictionary<object, object?> result,
+        IDictionary<object, object?> branches)
+    {
+        if (!document.TryGetValue(sectionName, out var sectionValue) || sectionValue is null)
+        {
+            return;
+        }
+
+        if (sectionValue is not IReadOnlyDictionary<object, object?> section)
+        {
+            throw new ConfigurationException($"Configuration section '{sectionName}' must be a mapping.");
+        }
+
+        foreach (var (key, value) in section)
+        {
+            if (key is string propertyName && propertyName.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                MergeBranches(branches, value, sectionName);
+                continue;
+            }
+
+            if (key is string configuredPropertyName)
+            {
+                ValidatePropertyOwnership(sectionName, configuredPropertyName, branchProperty: false);
+            }
+
+            if (!result.TryAdd(key, CloneValue(value)))
+            {
+                throw new ConfigurationException(
+                    $"Configuration property '{key}' is defined in both '{CalculationSectionName}' and '{OutputSectionName}'.");
+            }
+        }
+    }
+
+    private static void MergeBranches(IDictionary<object, object?> target, object? value, string sectionName)
+    {
+        if (value is not IReadOnlyDictionary<object, object?> source)
+        {
+            throw new ConfigurationException($"Configuration property '{sectionName}.{BranchesPropertyName}' must be a mapping.");
+        }
+
+        foreach (var (branchName, branchValue) in source)
+        {
+            if (branchValue is not IReadOnlyDictionary<object, object?> branch)
+            {
+                throw new ConfigurationException(
+                    $"Configuration branch '{sectionName}.{BranchesPropertyName}.{branchName}' must be a mapping.");
+            }
+
+            foreach (var propertyName in branch.Keys.OfType<string>())
+            {
+                ValidatePropertyOwnership(sectionName, propertyName, branchProperty: true);
+            }
+
+            if (!target.TryGetValue(branchName, out var existing))
+            {
+                target[branchName] = CloneDictionary(branch);
+                continue;
+            }
+
+            if (existing is not IDictionary<object, object?> targetBranch)
+            {
+                throw new ConfigurationException($"Configuration branch '{branchName}' must be a mapping.");
+            }
+
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                if (!targetBranch.TryAdd(propertyName, CloneValue(propertyValue)))
+                {
+                    throw new ConfigurationException(
+                        $"Configuration branch property '{branchName}.{propertyName}' is defined in both " +
+                        $"'{CalculationSectionName}' and '{OutputSectionName}'.");
+                }
+            }
+        }
+    }
+
+    private static void SplitBranches(
+        object? value,
+        IDictionary<string, object?> calculation,
+        IDictionary<string, object?> output)
+    {
+        if (value is not IReadOnlyDictionary<string, object?> branches)
+        {
+            return;
+        }
+
+        Dictionary<string, object?> calculationBranches = [];
+        Dictionary<string, object?> outputBranches = [];
+
+        foreach (var (branchName, branchValue) in branches)
+        {
+            if (branchValue is not IReadOnlyDictionary<string, object?> branch)
+            {
+                continue;
+            }
+
+            Dictionary<string, object?> calculationBranch = [];
+            Dictionary<string, object?> outputBranch = [];
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                (OutputBranchPropertyNames.Contains(propertyName) ? outputBranch : calculationBranch)[propertyName] = propertyValue;
+            }
+
+            if (calculationBranch.Count != 0)
+            {
+                calculationBranches[branchName] = calculationBranch;
+            }
+
+            if (outputBranch.Count != 0)
+            {
+                outputBranches[branchName] = outputBranch;
+            }
+        }
+
+        if (calculationBranches.Count != 0)
+        {
+            calculation[BranchesPropertyName] = calculationBranches;
+        }
+
+        if (outputBranches.Count != 0)
+        {
+            output[BranchesPropertyName] = outputBranches;
+        }
+    }
+
+    private static Dictionary<object, object?> CloneDictionary(IReadOnlyDictionary<object, object?> dictionary)
+        => dictionary.ToDictionary(item => item.Key, item => CloneValue(item.Value));
+
+    private static void ValidatePropertyOwnership(string sectionName, string propertyName, bool branchProperty)
+    {
+        var knownProperties = branchProperty ? KnownBranchPropertyNames : KnownPropertyNames;
+        if (!knownProperties.Contains(propertyName))
+        {
+            return;
+        }
+
+        var belongsToOutput = branchProperty
+            ? OutputBranchPropertyNames.Contains(propertyName)
+            : OutputPropertyNames.Contains(propertyName);
+        var expectedSection = belongsToOutput ? OutputSectionName : CalculationSectionName;
+        if (!sectionName.Equals(expectedSection, StringComparison.Ordinal))
+        {
+            var branchPath = branchProperty ? $"{BranchesPropertyName}.<branch>." : string.Empty;
+            throw new ConfigurationException(
+                $"Configuration property '{sectionName}.{branchPath}{propertyName}' belongs under " +
+                $"'{expectedSection}.{branchPath}{propertyName}'.");
+        }
+    }
+
+    private static object? CloneValue(object? value) => value switch
+    {
+        IReadOnlyDictionary<object, object?> dictionary => CloneDictionary(dictionary),
+        _ => value
+    };
+}

--- a/src/GitVersion.Configuration/ConfigurationHelper.cs
+++ b/src/GitVersion.Configuration/ConfigurationHelper.cs
@@ -6,8 +6,8 @@ internal class ConfigurationHelper
 {
     private static ConfigurationSerializer Serializer => new();
     private string Yaml => this.yaml ??= this.dictionary == null
-        ? Serializer.Serialize(this.configuration!)
-        : Serializer.Serialize(this.dictionary);
+        ? ConfigurationSerializer.SerializeLegacy(this.configuration!)
+        : ConfigurationSerializer.SerializeLegacy(this.dictionary);
     private string? yaml;
 
     internal IReadOnlyDictionary<object, object?> Dictionary
@@ -19,14 +19,14 @@ internal class ConfigurationHelper
                 return this.dictionary;
             }
 
-            this.yaml ??= Serializer.Serialize(this.configuration!);
+            this.yaml ??= ConfigurationSerializer.SerializeLegacy(this.configuration!);
             this.dictionary = Serializer.Deserialize<Dictionary<object, object?>>(this.yaml);
             return this.dictionary;
         }
     }
     private IReadOnlyDictionary<object, object?>? dictionary;
 
-    public IGitVersionConfiguration Configuration => this.configuration ??= Serializer.Deserialize<GitVersionConfiguration>(Yaml);
+    public IGitVersionConfiguration Configuration => this.configuration ??= ConfigurationSerializer.DeserializeLegacyConfiguration(Yaml)!;
     private IGitVersionConfiguration? configuration;
 
     internal ConfigurationHelper(string yaml) => this.yaml = yaml.NotNull();

--- a/src/GitVersion.Configuration/ConfigurationMigrationService.cs
+++ b/src/GitVersion.Configuration/ConfigurationMigrationService.cs
@@ -1,0 +1,22 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Configuration;
+
+internal class ConfigurationMigrationService(IConfigurationSerializer configurationSerializer) : IConfigurationMigrationService
+{
+    private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
+
+    public string Migrate(string input)
+    {
+        var document = this.configurationSerializer.Deserialize<Dictionary<object, object?>>(input);
+        return ConfigurationDocumentMapper.Detect(document) switch
+        {
+            ConfigurationDocumentKind.Empty or ConfigurationDocumentKind.V6 =>
+                this.configurationSerializer.SerializeDocument(ConfigurationDocumentMapper.Nest(document)),
+            ConfigurationDocumentKind.V7 => this.configurationSerializer.SerializeDocument(document),
+            _ => throw new ConfigurationException(
+                "The configuration document mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure before migrating.")
+        };
+    }
+}

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -18,6 +18,7 @@ internal class ConfigurationProvider(
     private readonly ILogger<ConfigurationProvider> logger = logger.NotNull();
     private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
+    private bool legacyConfigurationWarningLogged;
 
     public IGitVersionConfiguration Provide(IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
@@ -46,6 +47,7 @@ internal class ConfigurationProvider(
         var configurationVersion = ConfigurationVersionSelector.Resolve();
         this.logger.LogInformation("Configuration version: {ConfigurationVersion}", ConfigurationVersionSelector.ResolveName());
         var configurationFromFile = ReadOverrideConfiguration(configFile);
+        WarnAboutExplicitLegacyConfiguration(configFile, configurationFromFile);
         var overrideConfigurationFromFile = configurationFromFile is null
             ? null
             : ConfigurationDocumentMapper.Normalize(configurationFromFile, configurationVersion, "configuration file");
@@ -100,6 +102,21 @@ internal class ConfigurationProvider(
         this.logger.LogInformation("Using configuration file '{ConfigFilePath}'", configFilePath);
         var content = this.fileSystem.File.ReadAllText(configFilePath);
         return this.configurationSerializer.Deserialize<Dictionary<object, object?>>(content);
+    }
+
+    private void WarnAboutExplicitLegacyConfiguration(string? configFilePath, Dictionary<object, object?>? configuration)
+    {
+        if (configuration is null || this.legacyConfigurationWarningLogged || !ConfigurationVersionSelector.IsExplicitV6())
+        {
+            return;
+        }
+
+        this.legacyConfigurationWarningLogged = true;
+        this.logger.LogWarning(
+            "Configuration file '{ConfigurationFile}' uses the temporary v6 compatibility mode. Legacy configuration loading is removed in GitVersion 7.1. " +
+            "Run 'gitversion config migrate' and validate with {ConfigurationVersion}=v7.",
+            configFilePath,
+            ConfigurationVersionSelector.EnvironmentVariableName);
     }
 
     private static string? GetWorkflow(IReadOnlyDictionary<object, object?>? overrideConfiguration, IReadOnlyDictionary<object, object?>? overrideConfigurationFromFile)

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -43,16 +43,27 @@ internal class ConfigurationProvider(
     private IGitVersionConfiguration ProvideConfiguration(string? configFile,
                                                           IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
-        var overrideConfigurationFromFile = ReadOverrideConfiguration(configFile);
+        var configurationVersion = ConfigurationVersionSelector.Resolve();
+        this.logger.LogInformation("Configuration version: {ConfigurationVersion}", ConfigurationVersionSelector.ResolveName());
+        var configurationFromFile = ReadOverrideConfiguration(configFile);
+        var overrideConfigurationFromFile = configurationFromFile is null
+            ? null
+            : ConfigurationDocumentMapper.Normalize(configurationFromFile, configurationVersion, "configuration file");
+        var normalizedOverrideConfiguration = overrideConfiguration is null
+            ? null
+            : ConfigurationDocumentMapper.NormalizeInternal(overrideConfiguration, "runtime override configuration");
 
-        var workflow = GetWorkflow(overrideConfiguration, overrideConfigurationFromFile);
+        var workflow = GetWorkflow(normalizedOverrideConfiguration, overrideConfigurationFromFile);
 
         IConfigurationBuilder configurationBuilder = (workflow is null)
             ? GitFlowConfigurationBuilder.New
             : ConfigurationBuilder.New;
 
-        var overrideConfigurationFromWorkflow = WorkflowManager.GetOverrideConfiguration(workflow);
-        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, overrideConfiguration }
+        var workflowConfiguration = WorkflowManager.GetOverrideConfiguration(workflow);
+        var overrideConfigurationFromWorkflow = workflowConfiguration is null
+            ? null
+            : ConfigurationDocumentMapper.NormalizeInternal(workflowConfiguration, "embedded workflow");
+        foreach (var item in new[] { overrideConfigurationFromWorkflow, overrideConfigurationFromFile, normalizedOverrideConfiguration }
                      .OfType<IReadOnlyDictionary<object, object?>>())
         {
             configurationBuilder.AddOverride(item);

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -29,14 +29,7 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
         if (typeof(T) == typeof(GitVersionConfiguration))
         {
-            try
-            {
-                return (T)(object)YamlSerializer.Deserialize<GitVersionConfiguration>(input, GeneratedContext)!;
-            }
-            catch (Exception exception) when (exception is not YamlException)
-            {
-                throw new YamlException(exception.Message, exception);
-            }
+            return (T)(object)DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document")!;
         }
 
         return YamlSerializer.Deserialize<T>(input, SerializerOptions)!;
@@ -44,12 +37,42 @@ internal class ConfigurationSerializer : IConfigurationSerializer
 
     public string Serialize(object graph)
     {
-        var yaml = YamlSerializer.Serialize(graph, SerializerOptions);
+        var yaml = SerializeLegacy(graph);
         var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        if (graph is IGitVersionConfiguration && ConfigurationVersionSelector.Resolve() == ConfigurationVersion.V7)
+        {
+            configuration = ConfigurationDocumentMapper.Nest(configuration);
+        }
+
         return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
     }
 
-    public IGitVersionConfiguration? ReadConfiguration(string input) => Deserialize<GitVersionConfiguration?>(input);
+    public static IGitVersionConfiguration? ReadConfiguration(string input)
+        => DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document");
+
+    internal static string SerializeLegacy(object graph) => YamlSerializer.Serialize(graph, SerializerOptions);
+
+    internal static GitVersionConfiguration? DeserializeLegacyConfiguration(string input)
+        => DeserializeConfiguration(input, ConfigurationVersion.V6, "internal effective configuration");
+
+    private static GitVersionConfiguration? DeserializeConfiguration(
+        string input,
+        ConfigurationVersion version,
+        string source)
+    {
+        try
+        {
+            var graph = YamlSerializer.Deserialize<Dictionary<string, object?>>(input, SerializerOptions);
+            var objectGraph = ConvertToObjectDictionary(graph);
+            var normalized = ConfigurationDocumentMapper.Normalize(objectGraph, version, source);
+            var normalizedYaml = YamlSerializer.Serialize(normalized, SerializerOptions);
+            return YamlSerializer.Deserialize<GitVersionConfiguration>(normalizedYaml, GeneratedContext);
+        }
+        catch (Exception exception) when (exception is not YamlException and not ConfigurationException)
+        {
+            throw new YamlException(exception.Message, exception);
+        }
+    }
 
     private static Dictionary<object, object?> ConvertToObjectDictionary(IReadOnlyDictionary<string, object?>? source)
     {

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -47,6 +47,13 @@ internal class ConfigurationSerializer : IConfigurationSerializer
         return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
     }
 
+    public string SerializeDocument(IReadOnlyDictionary<object, object?> document)
+    {
+        var yaml = SerializeLegacy(document);
+        var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
+    }
+
     public static IGitVersionConfiguration? ReadConfiguration(string input)
         => DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document");
 

--- a/src/GitVersion.Configuration/GitVersionConfiguration.cs
+++ b/src/GitVersion.Configuration/GitVersionConfiguration.cs
@@ -7,6 +7,12 @@ namespace GitVersion.Configuration;
 
 internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersionConfiguration
 {
+    [JsonIgnore]
+    public ICalculationConfiguration Calculation => new CalculationConfiguration(this);
+
+    [JsonIgnore]
+    public IOutputConfiguration Output => new OutputConfiguration(this);
+
     [JsonPropertyName("workflow")]
     [JsonPropertyDescription("The base template of the configuration to use. Possible values are: 'GitFlow/v1' or 'GitHubFlow/v1'")]
     public string? Workflow { get; set; }
@@ -148,4 +154,52 @@ internal sealed record GitVersionConfiguration : BranchConfiguration, IGitVersio
         Label = BranchNamePlaceholder,
         Increment = IncrementStrategy.Inherit
     };
+
+    private sealed class CalculationConfiguration(GitVersionConfiguration configuration) : ICalculationConfiguration
+    {
+        public string? Workflow => configuration.Workflow;
+        public string? TagPrefixPattern => configuration.TagPrefixPattern;
+        public string? VersionInBranchPattern => configuration.VersionInBranchPattern;
+        public string? NextVersion => configuration.NextVersion;
+        public string? MajorVersionBumpMessage => configuration.MajorVersionBumpMessage;
+        public string? MinorVersionBumpMessage => configuration.MinorVersionBumpMessage;
+        public string? PatchVersionBumpMessage => configuration.PatchVersionBumpMessage;
+        public string? NoBumpMessage => configuration.NoBumpMessage;
+        public string? VersionBumpResetMessage => configuration.VersionBumpResetMessage;
+        public IReadOnlyDictionary<string, string> MergeMessageFormats => configuration.MergeMessageFormats;
+        public SemanticVersionFormat SemanticVersionFormat => configuration.SemanticVersionFormat;
+        public VersionStrategies VersionStrategy => ((IGitVersionConfiguration)configuration).VersionStrategy;
+        public IReadOnlyDictionary<string, ICalculationBranchConfiguration> Branches
+            => configuration.Branches.ToDictionary(element => element.Key, ICalculationBranchConfiguration (element) => element.Value);
+        public IIgnoreConfiguration Ignore => configuration.Ignore;
+        public DeploymentMode? DeploymentMode => configuration.DeploymentMode;
+        public string? Label => configuration.Label;
+        public IncrementStrategy Increment => configuration.Increment;
+        public IPreventIncrementConfiguration PreventIncrement => configuration.PreventIncrement;
+        public bool? TrackMergeTarget => configuration.TrackMergeTarget;
+        public bool? TrackMergeMessage => configuration.TrackMergeMessage;
+        public CommitMessageIncrementMode? CommitMessageIncrementing => configuration.CommitMessageIncrementing;
+        public string? RegularExpression => configuration.RegularExpression;
+        public IReadOnlyCollection<string> SourceBranches => configuration.SourceBranches;
+        public IReadOnlyCollection<string> IsSourceBranchFor => configuration.IsSourceBranchFor;
+        public bool? TracksReleaseBranches => configuration.TracksReleaseBranches;
+        public bool? IsReleaseBranch => configuration.IsReleaseBranch;
+        public bool? IsMainBranch => configuration.IsMainBranch;
+    }
+
+    private sealed class OutputConfiguration(GitVersionConfiguration configuration) : IOutputConfiguration
+    {
+        public AssemblyVersioningScheme? AssemblyVersioningScheme => configuration.AssemblyVersioningScheme;
+        public AssemblyFileVersioningScheme? AssemblyFileVersioningScheme => configuration.AssemblyFileVersioningScheme;
+        public string? AssemblyInformationalFormat => configuration.AssemblyInformationalFormat;
+        public string? AssemblyVersioningFormat => configuration.AssemblyVersioningFormat;
+        public string? AssemblyFileVersioningFormat => configuration.AssemblyFileVersioningFormat;
+        public int? TagPreReleaseWeight => configuration.TagPreReleaseWeight;
+        public string? CommitDateFormat => configuration.CommitDateFormat;
+        public bool UpdateBuildNumber => configuration.UpdateBuildNumber;
+        public IReadOnlyDictionary<string, IOutputBranchConfiguration> Branches
+            => configuration.Branches.ToDictionary(element => element.Key, IOutputBranchConfiguration (element) => element.Value);
+        public string? CustomVersionFormat => configuration.CustomVersionFormat;
+        public int? PreReleaseWeight => configuration.PreReleaseWeight;
+    }
 }

--- a/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
+++ b/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
@@ -8,6 +8,7 @@ public class GitVersionConfigurationModule : IGitVersionModule
     {
         services.AddSingleton<IGitVersionCacheKeyFactory, GitVersionCacheKeyFactory>();
         services.AddSingleton<IConfigurationSerializer, ConfigurationSerializer>();
+        services.AddSingleton<IConfigurationMigrationService, ConfigurationMigrationService>();
         services.AddSingleton<IConfigurationProvider, ConfigurationProvider>();
         services.AddSingleton<IConfigurationFileLocator, ConfigurationFileLocator>();
     }

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -21,6 +21,17 @@ public class ConfigurationVersionSelectorTests : TestBase
         ConfigurationVersionSelector.Resolve().ShouldBe(isV6 ? ConfigurationVersion.V6 : ConfigurationVersion.V7);
     }
 
+    [TestCase(null, false)]
+    [TestCase("v6", true)]
+    [TestCase(" V6 ", true)]
+    [TestCase("v7", false)]
+    public void IdentifiesExplicitV6Selection(string? value, bool expected)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        ConfigurationVersionSelector.IsExplicitV6().ShouldBe(expected);
+    }
+
     [TestCase("6")]
     [TestCase("7")]
     [TestCase("true")]

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -1,0 +1,48 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class ConfigurationVersionSelectorTests : TestBase
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase("v6", true)]
+    [TestCase("V6", true)]
+    [TestCase(" v6 ", true)]
+    [TestCase("v7", false)]
+    [TestCase("V7", false)]
+    [TestCase(" v7 ", false)]
+    public void ResolvesKnownValues(string? value, bool isV6)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        ConfigurationVersionSelector.Resolve().ShouldBe(isV6 ? ConfigurationVersion.V6 : ConfigurationVersion.V7);
+    }
+
+    [TestCase("6")]
+    [TestCase("7")]
+    [TestCase("true")]
+    [TestCase("legacy")]
+    public void FailsFastOnUnknownValues(string value)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        var exception = Should.Throw<InvalidOperationException>(() => ConfigurationVersionSelector.Resolve());
+        exception.Message.ShouldContain(value);
+        exception.Message.ShouldContain("v6");
+        exception.Message.ShouldContain("v7");
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+
+        public EnvironmentVariableScope(string? value) =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, value);
+
+        public void Dispose() =>
+            System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.original);
+    }
+}

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -18,6 +18,7 @@ public class GitVersionExecutorTests : TestBase
     private IFileSystem fileSystem = null!;
     private GitVersionCacheProvider gitVersionCacheProvider = null!;
     private IServiceProvider sp = null!;
+    private string? originalConfigurationVersion;
 
     private const string versionCacheFileContent =
         """
@@ -52,6 +53,17 @@ public class GitVersionExecutorTests : TestBase
           "WeightedPreReleaseNumber": 19
         }
         """;
+
+    [SetUp]
+    public void SetupConfigurationVersion()
+    {
+        this.originalConfigurationVersion = System.Environment.GetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+    }
+
+    [TearDown]
+    public void RestoreConfigurationVersion() =>
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
     public void ResolvedConfiguration_IsCreatedOncePerExecution()

--- a/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitVersionExecutorTests.cs
@@ -66,6 +66,23 @@ public class GitVersionExecutorTests : TestBase
         System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, this.originalConfigurationVersion);
 
     [Test]
+    public void ConfigurationVersionChangeInvalidatesCache()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeACommit();
+        var options = new GitVersionOptions { WorkingDirectory = fixture.RepositoryPath };
+        _ = GetGitVersionCalculator(options);
+        var cacheKeyFactory = this.sp.GetRequiredService<IGitVersionCacheKeyFactory>();
+
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v6");
+        var v6Key = cacheKeyFactory.Create(null);
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, "v7");
+        var v7Key = cacheKeyFactory.Create(null);
+
+        v7Key.ShouldNotBe(v6Key);
+    }
+
+    [Test]
     public void ResolvedConfiguration_IsCreatedOncePerExecution()
     {
         var configuration = GitFlowConfigurationBuilder.New.Build();

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -1,0 +1,28 @@
+namespace GitVersion.Configuration;
+
+internal enum ConfigurationVersion
+{
+    V6,
+    V7
+}
+
+internal static class ConfigurationVersionSelector
+{
+    public const string EnvironmentVariableName = "GITVERSION_CONFIGURATION_VERSION";
+
+    public static ConfigurationVersion Resolve()
+    {
+        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
+
+        return value switch
+        {
+            null or "" => ConfigurationVersion.V7,
+            _ when value.Equals("v6", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V6,
+            _ when value.Equals("v7", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V7,
+            _ => throw new InvalidOperationException(
+                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'v6' and 'v7'.")
+        };
+    }
+
+    public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
+}

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -25,4 +25,7 @@ internal static class ConfigurationVersionSelector
     }
 
     public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
+
+    public static bool IsExplicitV6() =>
+        SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim().Equals("v6", StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IBranchConfiguration.cs
@@ -4,35 +4,35 @@ using GitVersion.VersionCalculation;
 namespace GitVersion.Configuration;
 
 /// <summary>Represents the version-related configuration for a specific branch or branch pattern.</summary>
-public interface IBranchConfiguration
+public interface IBranchConfiguration : ICalculationBranchConfiguration, IOutputBranchConfiguration
 {
     /// <summary>Gets the deployment mode used to compute versions on this branch.</summary>
-    DeploymentMode? DeploymentMode { get; }
+    new DeploymentMode? DeploymentMode { get; }
 
     /// <summary>Gets the pre-release label applied to versions produced on this branch.</summary>
-    string? Label { get; }
+    new string? Label { get; }
 
     /// <summary>Gets the format string used to compute the custom version output on this branch.</summary>
-    string? CustomVersionFormat => null;
+    new string? CustomVersionFormat => null;
 
     /// <summary>Gets the version field that is incremented when creating a new release from this branch.</summary>
-    IncrementStrategy Increment { get; }
+    new IncrementStrategy Increment { get; }
 
     /// <summary>Gets the configuration that controls under what conditions automatic version increments are suppressed.</summary>
-    IPreventIncrementConfiguration PreventIncrement { get; }
+    new IPreventIncrementConfiguration PreventIncrement { get; }
 
     /// <summary>Gets a value indicating whether to track the merge target branch for version calculation.</summary>
-    bool? TrackMergeTarget { get; }
+    new bool? TrackMergeTarget { get; }
 
     /// <summary>Gets a value indicating whether merge commit messages are considered when determining version increments.</summary>
-    bool? TrackMergeMessage { get; }
+    new bool? TrackMergeMessage { get; }
 
     /// <summary>Gets the mode that controls how commit messages drive version increments.</summary>
-    CommitMessageIncrementMode? CommitMessageIncrementing { get; }
+    new CommitMessageIncrementMode? CommitMessageIncrementing { get; }
 
     /// <summary>Gets the regular expression that matches branch names eligible for this configuration.</summary>
     [StringSyntax(StringSyntaxAttribute.Regex)]
-    string? RegularExpression { get; }
+    new string? RegularExpression { get; }
 
     /// <summary>Returns whether the given branch name matches the <see cref="RegularExpression"/> for this configuration.</summary>
     bool IsMatch(string branchName)
@@ -47,22 +47,22 @@ public interface IBranchConfiguration
     }
 
     /// <summary>Gets the names of branches that this branch may be branched from.</summary>
-    IReadOnlyCollection<string> SourceBranches { get; }
+    new IReadOnlyCollection<string> SourceBranches { get; }
 
     /// <summary>Gets the names of branches for which this branch may act as a source.</summary>
-    IReadOnlyCollection<string> IsSourceBranchFor { get; }
+    new IReadOnlyCollection<string> IsSourceBranchFor { get; }
 
     /// <summary>Gets a value indicating whether this branch tracks release branches.</summary>
-    bool? TracksReleaseBranches { get; }
+    new bool? TracksReleaseBranches { get; }
 
     /// <summary>Gets a value indicating whether this branch is a release branch.</summary>
-    bool? IsReleaseBranch { get; }
+    new bool? IsReleaseBranch { get; }
 
     /// <summary>Gets a value indicating whether this branch is treated as a main/trunk branch.</summary>
-    bool? IsMainBranch { get; }
+    new bool? IsMainBranch { get; }
 
     /// <summary>Gets the numeric weight applied to the pre-release tag number to produce a weighted pre-release number.</summary>
-    int? PreReleaseWeight { get; }
+    new int? PreReleaseWeight { get; }
 
     /// <summary>Returns a new configuration that inherits unset values from <paramref name="configuration"/>.</summary>
     IBranchConfiguration Inherit(IBranchConfiguration configuration);

--- a/src/GitVersion.Core/Configuration/ICalculationBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/ICalculationBranchConfiguration.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Configuration;
+
+/// <summary>Represents branch settings that affect semantic-version calculation.</summary>
+public interface ICalculationBranchConfiguration
+{
+    /// <summary>Gets the deployment mode used to compute versions on this branch.</summary>
+    DeploymentMode? DeploymentMode { get; }
+
+    /// <summary>Gets the pre-release label applied to versions produced on this branch.</summary>
+    string? Label { get; }
+
+    /// <summary>Gets the version field that is incremented when creating a new release from this branch.</summary>
+    IncrementStrategy Increment { get; }
+
+    /// <summary>Gets the configuration that controls under what conditions automatic version increments are suppressed.</summary>
+    IPreventIncrementConfiguration PreventIncrement { get; }
+
+    /// <summary>Gets a value indicating whether to track the merge target branch for version calculation.</summary>
+    bool? TrackMergeTarget { get; }
+
+    /// <summary>Gets a value indicating whether merge commit messages are considered when determining version increments.</summary>
+    bool? TrackMergeMessage { get; }
+
+    /// <summary>Gets the mode that controls how commit messages drive version increments.</summary>
+    CommitMessageIncrementMode? CommitMessageIncrementing { get; }
+
+    /// <summary>Gets the regular expression that matches branch names eligible for this configuration.</summary>
+    [StringSyntax(StringSyntaxAttribute.Regex)]
+    string? RegularExpression { get; }
+
+    /// <summary>Gets the names of branches that this branch may be branched from.</summary>
+    IReadOnlyCollection<string> SourceBranches { get; }
+
+    /// <summary>Gets the names of branches for which this branch may act as a source.</summary>
+    IReadOnlyCollection<string> IsSourceBranchFor { get; }
+
+    /// <summary>Gets a value indicating whether this branch tracks release branches.</summary>
+    bool? TracksReleaseBranches { get; }
+
+    /// <summary>Gets a value indicating whether this branch is a release branch.</summary>
+    bool? IsReleaseBranch { get; }
+
+    /// <summary>Gets a value indicating whether this branch is treated as a main/trunk branch.</summary>
+    bool? IsMainBranch { get; }
+}

--- a/src/GitVersion.Core/Configuration/ICalculationConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/ICalculationConfiguration.cs
@@ -1,0 +1,49 @@
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Configuration;
+
+/// <summary>Represents settings that participate in semantic-version calculation.</summary>
+public interface ICalculationConfiguration : ICalculationBranchConfiguration
+{
+    /// <inheritdoc cref="IGitVersionConfiguration.Workflow"/>
+    string? Workflow { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.TagPrefixPattern"/>
+    string? TagPrefixPattern { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionInBranchPattern"/>
+    string? VersionInBranchPattern { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.NextVersion"/>
+    string? NextVersion { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MajorVersionBumpMessage"/>
+    string? MajorVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MinorVersionBumpMessage"/>
+    string? MinorVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.PatchVersionBumpMessage"/>
+    string? PatchVersionBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.NoBumpMessage"/>
+    string? NoBumpMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionBumpResetMessage"/>
+    string? VersionBumpResetMessage { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.MergeMessageFormats"/>
+    IReadOnlyDictionary<string, string> MergeMessageFormats { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.SemanticVersionFormat"/>
+    SemanticVersionFormat SemanticVersionFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.VersionStrategy"/>
+    VersionStrategies VersionStrategy { get; }
+
+    /// <summary>Gets calculation settings for each configured branch.</summary>
+    IReadOnlyDictionary<string, ICalculationBranchConfiguration> Branches { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.Ignore"/>
+    IIgnoreConfiguration Ignore { get; }
+}

--- a/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.Configuration;
+
+internal interface IConfigurationMigrationService
+{
+    string Migrate(string input);
+}

--- a/src/GitVersion.Core/Configuration/IConfigurationSerializer.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationSerializer.cs
@@ -4,4 +4,5 @@ internal interface IConfigurationSerializer
 {
     T Deserialize<T>(string input);
     string Serialize(object graph);
+    string SerializeDocument(IReadOnlyDictionary<object, object?> document);
 }

--- a/src/GitVersion.Core/Configuration/IGitVersionConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IGitVersionConfiguration.cs
@@ -5,6 +5,12 @@ namespace GitVersion.Configuration;
 /// <summary>Represents the top-level GitVersion configuration, extending branch-level configuration with global settings.</summary>
 public interface IGitVersionConfiguration : IBranchConfiguration
 {
+    /// <summary>Gets the settings that participate in semantic-version calculation.</summary>
+    ICalculationConfiguration Calculation { get; }
+
+    /// <summary>Gets the settings that affect rendered version output.</summary>
+    IOutputConfiguration Output { get; }
+
     /// <summary>Gets the name of the workflow preset (e.g. <c>GitFlow/v1</c> or <c>GitHubFlow/v1</c>) used as a base configuration.</summary>
     string? Workflow { get; }
 

--- a/src/GitVersion.Core/Configuration/IOutputBranchConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IOutputBranchConfiguration.cs
@@ -1,0 +1,11 @@
+namespace GitVersion.Configuration;
+
+/// <summary>Represents branch settings that affect rendered version output.</summary>
+public interface IOutputBranchConfiguration
+{
+    /// <summary>Gets the format string used to compute the custom version output on this branch.</summary>
+    string? CustomVersionFormat { get; }
+
+    /// <summary>Gets the numeric weight applied to the pre-release tag number to produce a weighted pre-release number.</summary>
+    int? PreReleaseWeight { get; }
+}

--- a/src/GitVersion.Core/Configuration/IOutputConfiguration.cs
+++ b/src/GitVersion.Core/Configuration/IOutputConfiguration.cs
@@ -1,0 +1,32 @@
+namespace GitVersion.Configuration;
+
+/// <summary>Represents settings that affect assembly, build-server, and formatted version output.</summary>
+public interface IOutputConfiguration : IOutputBranchConfiguration
+{
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyVersioningScheme"/>
+    AssemblyVersioningScheme? AssemblyVersioningScheme { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyFileVersioningScheme"/>
+    AssemblyFileVersioningScheme? AssemblyFileVersioningScheme { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyInformationalFormat"/>
+    string? AssemblyInformationalFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyVersioningFormat"/>
+    string? AssemblyVersioningFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.AssemblyFileVersioningFormat"/>
+    string? AssemblyFileVersioningFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.TagPreReleaseWeight"/>
+    int? TagPreReleaseWeight { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.CommitDateFormat"/>
+    string? CommitDateFormat { get; }
+
+    /// <inheritdoc cref="IGitVersionConfiguration.UpdateBuildNumber"/>
+    bool UpdateBuildNumber { get; }
+
+    /// <summary>Gets output settings for each configured branch.</summary>
+    IReadOnlyDictionary<string, IOutputBranchConfiguration> Branches { get; }
+}

--- a/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
+++ b/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
@@ -1,0 +1,20 @@
+namespace GitVersion;
+
+/// <summary>Settings that control a configuration migration operation.</summary>
+public class ConfigurationMigrationInfo
+{
+    /// <summary>Gets or sets a value indicating whether the configuration migration command should be executed.</summary>
+    public bool IsMigration { get; set; }
+
+    /// <summary>Gets or sets the configuration file to migrate.</summary>
+    public string? InputFile { get; set; }
+
+    /// <summary>Gets or sets the file to which the migrated configuration should be written.</summary>
+    public string? OutputFile { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the source configuration file should be replaced.</summary>
+    public bool InPlace { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether an existing output file may be replaced.</summary>
+    public bool Force { get; set; }
+}

--- a/src/GitVersion.Core/Options/GitVersionOptions.cs
+++ b/src/GitVersion.Core/Options/GitVersionOptions.cs
@@ -17,6 +17,9 @@ public class GitVersionOptions
     /// <summary>Gets the settings that control how the GitVersion configuration file is located and applied.</summary>
     public ConfigurationInfo ConfigurationInfo { get; } = new();
 
+    /// <summary>Gets the settings that control configuration migration.</summary>
+    public ConfigurationMigrationInfo ConfigurationMigrationInfo { get; } = new();
+
     /// <summary>Gets the repository-targeting settings (URL, branch, commit, clone path).</summary>
     public RepositoryInfo RepositoryInfo { get; } = new();
 

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+GitVersion.ConfigurationMigrationInfo
+GitVersion.ConfigurationMigrationInfo.ConfigurationMigrationInfo() -> void
+GitVersion.ConfigurationMigrationInfo.Force.get -> bool
+GitVersion.ConfigurationMigrationInfo.Force.set -> void
+GitVersion.ConfigurationMigrationInfo.InPlace.get -> bool
+GitVersion.ConfigurationMigrationInfo.InPlace.set -> void
+GitVersion.ConfigurationMigrationInfo.InputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.InputFile.set -> void
+GitVersion.ConfigurationMigrationInfo.IsMigration.get -> bool
+GitVersion.ConfigurationMigrationInfo.IsMigration.set -> void
+GitVersion.ConfigurationMigrationInfo.OutputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.OutputFile.set -> void
+GitVersion.GitVersionOptions.ConfigurationMigrationInfo.get -> GitVersion.ConfigurationMigrationInfo!
 GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -2,10 +2,54 @@
 GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration
+GitVersion.Configuration.ICalculationBranchConfiguration.CommitMessageIncrementing.get -> GitVersion.VersionCalculation.CommitMessageIncrementMode?
+GitVersion.Configuration.ICalculationBranchConfiguration.DeploymentMode.get -> GitVersion.VersionCalculation.DeploymentMode?
+GitVersion.Configuration.ICalculationBranchConfiguration.Increment.get -> GitVersion.IncrementStrategy
+GitVersion.Configuration.ICalculationBranchConfiguration.IsMainBranch.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.IsReleaseBranch.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.IsSourceBranchFor.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+GitVersion.Configuration.ICalculationBranchConfiguration.Label.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration.PreventIncrement.get -> GitVersion.Configuration.IPreventIncrementConfiguration!
+GitVersion.Configuration.ICalculationBranchConfiguration.RegularExpression.get -> string?
+GitVersion.Configuration.ICalculationBranchConfiguration.SourceBranches.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+GitVersion.Configuration.ICalculationBranchConfiguration.TrackMergeMessage.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.TrackMergeTarget.get -> bool?
+GitVersion.Configuration.ICalculationBranchConfiguration.TracksReleaseBranches.get -> bool?
+GitVersion.Configuration.ICalculationConfiguration
+GitVersion.Configuration.ICalculationConfiguration.Branches.get -> System.Collections.Generic.IReadOnlyDictionary<string!, GitVersion.Configuration.ICalculationBranchConfiguration!>!
+GitVersion.Configuration.ICalculationConfiguration.Ignore.get -> GitVersion.Configuration.IIgnoreConfiguration!
+GitVersion.Configuration.ICalculationConfiguration.MajorVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.MergeMessageFormats.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+GitVersion.Configuration.ICalculationConfiguration.MinorVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.NextVersion.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.NoBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.PatchVersionBumpMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.SemanticVersionFormat.get -> GitVersion.SemanticVersionFormat
+GitVersion.Configuration.ICalculationConfiguration.TagPrefixPattern.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionBumpResetMessage.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionInBranchPattern.get -> string?
+GitVersion.Configuration.ICalculationConfiguration.VersionStrategy.get -> GitVersion.VersionCalculation.VersionStrategies
+GitVersion.Configuration.ICalculationConfiguration.Workflow.get -> string?
+GitVersion.Configuration.IGitVersionConfiguration.Calculation.get -> GitVersion.Configuration.ICalculationConfiguration!
+GitVersion.Configuration.IGitVersionConfiguration.Output.get -> GitVersion.Configuration.IOutputConfiguration!
 GitVersion.Configuration.IGitVersionConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IIgnoreConfiguration.Branches.get -> System.Collections.Generic.IReadOnlySet<string!>!
 GitVersion.Configuration.IIgnoreConfiguration.Tags.get -> System.Collections.Generic.IReadOnlySet<string!>!
 GitVersion.Git.ReferenceName.WithoutRemote.get -> string!
+GitVersion.Configuration.IOutputBranchConfiguration
+GitVersion.Configuration.IOutputBranchConfiguration.CustomVersionFormat.get -> string?
+GitVersion.Configuration.IOutputBranchConfiguration.PreReleaseWeight.get -> int?
+GitVersion.Configuration.IOutputConfiguration
+GitVersion.Configuration.IOutputConfiguration.AssemblyFileVersioningFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyFileVersioningScheme.get -> GitVersion.Configuration.AssemblyFileVersioningScheme?
+GitVersion.Configuration.IOutputConfiguration.AssemblyInformationalFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyVersioningFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.AssemblyVersioningScheme.get -> GitVersion.Configuration.AssemblyVersioningScheme?
+GitVersion.Configuration.IOutputConfiguration.Branches.get -> System.Collections.Generic.IReadOnlyDictionary<string!, GitVersion.Configuration.IOutputBranchConfiguration!>!
+GitVersion.Configuration.IOutputConfiguration.CommitDateFormat.get -> string?
+GitVersion.Configuration.IOutputConfiguration.TagPreReleaseWeight.get -> int?
+GitVersion.Configuration.IOutputConfiguration.UpdateBuildNumber.get -> bool
 GitVersion.VersionCalculation.CommitMessageIncrement
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement() -> void
 GitVersion.VersionCalculation.CommitMessageIncrement.CommitMessageIncrement(GitVersion.VersionField Increment, bool VersionBumpNeedsToBeReset) -> void

--- a/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
+++ b/src/GitVersion.Core/VersionCalculation/Caching/GitVersionCacheKeyFactory.cs
@@ -32,8 +32,9 @@ internal class GitVersionCacheKeyFactory(
         var repositorySnapshotHash = GetRepositorySnapshotHash();
         var repositoryTargetHash = GetRepositoryTargetHash();
         var overrideConfigHash = GetOverrideConfigHash(overrideConfiguration);
+        var configurationVersionHash = GetHash(ConfigurationVersionSelector.ResolveName());
 
-        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, repositoryTargetHash, overrideConfigHash);
+        var compositeHash = GetHash(gitSystemHash, configFileHash, repositorySnapshotHash, repositoryTargetHash, overrideConfigHash, configurationVersionHash);
         return new(compositeHash);
     }
 

--- a/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
+++ b/src/GitVersion.MsBuild.Tests/Tasks/WriteVersionInfoTest.cs
@@ -36,7 +36,11 @@ public class WriteVersionInfoTest : TestTaskBase
     public void WriteVersionInfoTaskShouldNotUpdateBuildNumberInAzurePipeline(string buildNumber)
     {
         var task = new WriteVersionInfoToBuildLog();
-        const string content = "update-build-number: false";
+        const string content = """
+                               calculation: {}
+                               output:
+                                 update-build-number: false
+                               """;
 
         using var result = ExecuteMsBuildTaskInAzurePipeline(task, buildNumber, content);
 


### PR DESCRIPTION
## Summary

- Documents the implemented v7 `calculation` and `output` configuration layout and ownership mapping.
- Documents configuration migration, nested overrides, and the active configuration-format fallback.
- Regenerates the configuration reference from its authored source.

## Validation

- `dotnet build ./src/GitVersion.slnx --no-restore`
- Targeted `GitVersion.App.Tests`: 277 passed
- `mdsnippets --write-header false`
- `BuildPrepare` and `GenerateSchemas` (no schema changes required)
- `git diff --check`
