### PR TITLE
Add POSIX configuration migration and legacy-format warnings

### DIFF
--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -143,6 +143,44 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateParsesItsInputAndOutputOptions()
+    {
+        var arguments = this.argumentParser.ParseArguments(
+            "config migrate --config GitVersion.yml --output GitVersion.v7.yml --force");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.MigrationInputFile.ShouldBe("GitVersion.yml");
+        arguments.MigrationOutputFile.ShouldBe("GitVersion.v7.yml");
+        arguments.MigrationForce.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ConfigMigrateUsesPositionalTargetPath()
+    {
+        var arguments = this.argumentParser.ParseArguments("path config migrate --in-place");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.TargetPath.ShouldBe("path");
+    }
+
+    [Test]
+    public void ConfigMigrateRejectsOutputAndInPlaceTogether()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("config migrate --output GitVersion.v7.yml --in-place"));
+
+        exception.Message.ShouldBe("Cannot use --output together with --in-place.");
+    }
+
+    [Test]
+    public void ConfigRequiresASubcommand()
+    {
+        var exception = Should.Throw<WarningException>(() => this.argumentParser.ParseArguments("config"));
+
+        exception.Message.ShouldBe("The 'config' command requires a subcommand. Use 'gitversion config migrate'.");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -181,6 +181,15 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void TargetPathAllowsDirectoryNamedConfig()
+    {
+        var arguments = this.argumentParser.ParseArguments("--target-path config");
+
+        arguments.TargetPath.ShouldBe("config");
+        arguments.IsConfigurationMigration.ShouldBeFalse();
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -211,6 +211,15 @@ public class ArgumentParserTests : TestBase
     }
 
     [Test]
+    public void TargetPathAllowsDirectoryNamedConfig()
+    {
+        var arguments = this.argumentParser.ParseArguments("--target-path config");
+
+        arguments.TargetPath.ShouldBe("config");
+        arguments.IsConfigurationMigration.ShouldBeFalse();
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App.Tests/ArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/ArgumentParserTests.cs
@@ -169,6 +169,47 @@ public class ArgumentParserTests : TestBase
         parser.GetOverrideConfiguration().ShouldBeEmpty();
     }
 
+    [TestCase("config migrate --config GitVersion.yml")]
+    [TestCase("config migrate -c GitVersion.yml")]
+    [TestCase("--config GitVersion.yml config migrate")]
+    [TestCase("-c GitVersion.yml config migrate")]
+    public void ConfigMigrateParsesItsInputAndOutputOptions(string inputArguments)
+    {
+        var arguments = this.argumentParser.ParseArguments(
+            $"{inputArguments} --output GitVersion.v7.yml --force");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.MigrationInputFile.ShouldBe("GitVersion.yml");
+        arguments.MigrationOutputFile.ShouldBe("GitVersion.v7.yml");
+        arguments.MigrationForce.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ConfigMigrateUsesPositionalTargetPath()
+    {
+        var arguments = this.argumentParser.ParseArguments("path config migrate --in-place");
+
+        arguments.IsConfigurationMigration.ShouldBeTrue();
+        arguments.TargetPath.ShouldBe("path");
+    }
+
+    [Test]
+    public void ConfigMigrateRejectsOutputAndInPlaceTogether()
+    {
+        var exception = Should.Throw<WarningException>(() =>
+            this.argumentParser.ParseArguments("config migrate --output GitVersion.v7.yml --in-place"));
+
+        exception.Message.ShouldBe("Cannot use --output together with --in-place.");
+    }
+
+    [Test]
+    public void ConfigRequiresASubcommand()
+    {
+        var exception = Should.Throw<WarningException>(() => this.argumentParser.ParseArguments("config"));
+
+        exception.Message.ShouldBe("The 'config' command requires a subcommand. Use 'gitversion config migrate'.");
+    }
+
     [Test]
     public void EmptyMeansUseCurrentDirectory()
     {

--- a/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
@@ -1,0 +1,39 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Tests;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationExecutorTests
+{
+    [Test]
+    public void InPlaceMigrationWarnsThatCommentsCannotBePreserved()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputFile = Path.Combine(directory.FullName, "legacy.yml");
+            File.WriteAllText(inputFile, "next-version: 2.0.0");
+            var logMessages = new List<string>();
+            var executor = new ConfigurationMigrationExecutor(
+                new FileSystem(),
+                new TestConsoleAdapter(new StringBuilder()),
+                new TestLogger<ConfigurationMigrationExecutor>(logMessages.Add),
+                Substitute.For<IConfigurationFileLocator>(),
+                new ConfigurationMigrationService(new ConfigurationSerializer()));
+            var options = new GitVersionOptions { WorkingDirectory = directory.FullName };
+            options.ConfigurationMigrationInfo.IsMigration = true;
+            options.ConfigurationMigrationInfo.InputFile = inputFile;
+            options.ConfigurationMigrationInfo.InPlace = true;
+
+            executor.Execute(options).ShouldBe(0);
+
+            logMessages.ShouldContain(message => message.Contains("Comments cannot be preserved during migration.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+}

--- a/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationMigrationExecutorTests.cs
@@ -36,4 +36,39 @@ public class ConfigurationMigrationExecutorTests
             directory.Delete(recursive: true);
         }
     }
+
+    [TestCase("workflow: GitHubFlow/v1\nnext-version: 2.0.0")]
+    [TestCase("calculation:\n  workflow: GitHubFlow/v1\n  next-version: 2.0.0")]
+    public void InPlaceMigrationWritesWorkflowAtRootAndIsIdempotent(string input)
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputFile = Path.Combine(directory.FullName, "GitVersion.yml");
+            File.WriteAllText(inputFile, input);
+            var executor = new ConfigurationMigrationExecutor(
+                new FileSystem(),
+                new TestConsoleAdapter(new StringBuilder()),
+                new TestLogger<ConfigurationMigrationExecutor>(),
+                Substitute.For<IConfigurationFileLocator>(),
+                new ConfigurationMigrationService(new ConfigurationSerializer()));
+            var options = new GitVersionOptions { WorkingDirectory = directory.FullName };
+            options.ConfigurationMigrationInfo.IsMigration = true;
+            options.ConfigurationMigrationInfo.InputFile = inputFile;
+            options.ConfigurationMigrationInfo.InPlace = true;
+
+            executor.Execute(options).ShouldBe(0);
+
+            var migrated = File.ReadAllText(inputFile);
+            migrated.ShouldContain("workflow: GitHubFlow/v1");
+            migrated.ShouldNotContain("  workflow:");
+            migrated.ShouldContain("  next-version: 2.0.0");
+            executor.Execute(options).ShouldBe(0);
+            File.ReadAllText(inputFile).ShouldBe(migrated);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
 }

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -67,6 +67,30 @@ public class ConfigurationVersionIntegrationTests
     }
 
     [Test]
+    public async Task ConfigMigrateLeavesNoTemporaryFileAfterWritingOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(0);
+            var files = Directory.GetFiles(directory.FullName).Select(Path.GetFileName).ToArray();
+            files.Length.ShouldBe(2);
+            files.ShouldContain(ConfigurationFileLocator.DefaultFileName);
+            files.ShouldContain("GitVersion.v7.yml");
+            files.ShouldNotContain(file => file!.StartsWith(".", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
     {
         var directory = Directory.CreateTempSubdirectory();
@@ -108,6 +132,29 @@ public class ConfigurationVersionIntegrationTests
             var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
             migratedConfiguration.ShouldContain("calculation:");
             migratedConfiguration.ShouldContain("next-version: 2.0.0");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotEmitLegacyFallbackWarning()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            var fixture = new ProgramFixture(directory.FullName);
+            fixture.WithEnv(new KeyValuePair<string, string>(ConfigurationVersionSelector.EnvironmentVariableName, "v6"));
+
+            var result = await fixture.Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output!.ShouldNotContain("temporary v6 compatibility mode");
+            result.Log!.ShouldNotContain("temporary v6 compatibility mode");
         }
         finally
         {

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -5,8 +5,116 @@ using GitVersion.Helpers;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationVersionIntegrationTests
 {
+    [Test]
+    public async Task ConfigMigrateWritesMigratedConfigurationToStandardOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("calculation:");
+            result.Output.ShouldContain("next-version: 2.0.0");
+            result.Output.ShouldContain("output: {}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotOverwriteOutputWithoutForce()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            var outputPath = Path.Combine(directory.FullName, "GitVersion.v7.yml");
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            await File.WriteAllTextAsync(outputPath, "existing configuration");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(1);
+            result.Output.ShouldBeEmpty();
+            var output = await File.ReadAllTextAsync(outputPath);
+            output.ShouldBe("existing configuration");
+
+            var forceResult = GitVersionHelper.ExecuteIn(
+                directory.FullName,
+                " config migrate --output GitVersion.v7.yml --force",
+                logToFile: false);
+
+            forceResult.ExitCode.ShouldBe(0);
+            forceResult.Output.ShouldNotBeNull();
+            forceResult.Output.ShouldContain("Comments cannot be preserved during migration.");
+            var forcedOutput = await File.ReadAllTextAsync(outputPath);
+            forcedOutput.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            const string fileName = "legacy.yml";
+            var configurationPath = Path.Combine(directory.FullName, fileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = GitVersionHelper.ExecuteIn(
+                directory.FullName,
+                $" config migrate --config {fileName} --in-place",
+                logToFile: false);
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("Comments cannot be preserved during migration.");
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceUsesPositionalTargetPath()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture().Run(directory.FullName, "config", "migrate", "--in-place");
+
+            result.ExitCode.ShouldBe(0);
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+            migratedConfiguration.ShouldContain("next-version: 2.0.0");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [Test]
     public void V6AndV7ConfigurationCalculateTheSameVersion()
     {

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -55,8 +55,9 @@ public class ConfigurationVersionIntegrationTests
                 logToFile: false);
 
             forceResult.ExitCode.ShouldBe(0);
-            forceResult.Output.ShouldNotBeNull();
-            forceResult.Output.ShouldContain("Comments cannot be preserved during migration.");
+            forceResult.StandardError.ShouldNotBeNull();
+            forceResult.StandardError.Split("Comments cannot be preserved during migration.").Length.ShouldBe(2);
+            forceResult.StandardOutput.ShouldBeEmpty();
             var forcedOutput = await File.ReadAllTextAsync(outputPath);
             forcedOutput.ShouldContain("calculation:");
         }
@@ -112,6 +113,29 @@ public class ConfigurationVersionIntegrationTests
     }
 
     [Test]
+    public async Task ConfigMigrateRejectsInvalidInputWithoutReplacingFile()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            const string input = "output:\n  increment: Major";
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, input);
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--in-place");
+
+            result.ExitCode.ShouldBe(1);
+            result.Output.ShouldBeEmpty();
+            (await File.ReadAllTextAsync(configurationPath)).ShouldBe(input);
+            Directory.GetFiles(directory.FullName).ShouldBe([configurationPath]);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
     {
         var directory = Directory.CreateTempSubdirectory();
@@ -127,8 +151,9 @@ public class ConfigurationVersionIntegrationTests
                 logToFile: false);
 
             result.ExitCode.ShouldBe(0);
-            result.Output.ShouldNotBeNull();
-            result.Output.ShouldContain("Comments cannot be preserved during migration.");
+            result.StandardError.ShouldNotBeNull();
+            result.StandardError.Split("Comments cannot be preserved during migration.").Length.ShouldBe(2);
+            result.StandardOutput.ShouldBeEmpty();
             var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
             migratedConfiguration.ShouldContain("calculation:");
         }
@@ -230,6 +255,62 @@ public class ConfigurationVersionIntegrationTests
             result.Log.ShouldNotBeNull();
             result.Log.ShouldContain("temporary v6 compatibility mode");
         }
+    }
+
+    [TestCase("v6", "")]
+    [TestCase("v7", "")]
+    [TestCase("v6", "workflow: GitHubFlow/v1")]
+    [TestCase("v7", "workflow: GitHubFlow/v1")]
+    public void CalculatesVersionWithSharedRootConfiguration(string version, string configuration)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        File.WriteAllText(Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName), configuration);
+
+        var result = Execute(fixture.RepositoryPath, version);
+
+        result.ExitCode.ShouldBe(0);
+        GetFullSemVer(result.StandardOutput!).ShouldNotBeNullOrEmpty();
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void RootWorkflowAppliesDefaultsToBothSectionsAndPreservesOverrides(bool hasOverrides)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        var configuration = "workflow: GitHubFlow/v1";
+        if (hasOverrides)
+        {
+            configuration += """
+
+                             calculation:
+                               tag-prefix: custom-
+                               branches:
+                                 main:
+                                   increment: Major
+                             output:
+                               assembly-versioning-scheme: None
+                               branches:
+                                 main:
+                                   pre-release-weight: 42
+                             """;
+        }
+        File.WriteAllText(Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName), configuration);
+
+        var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, " --show-config", logToFile: false,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, "v7"));
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotBeNull();
+        result.Output.ShouldContain("workflow: GitHubFlow/v1");
+        result.Output.ShouldNotContain("  workflow:");
+        var document = new ConfigurationSerializer().Deserialize<Dictionary<object, object?>>(result.Output);
+        var effective = new ConfigurationHelper(ConfigurationDocumentMapper.Flatten(document)).Configuration;
+        effective.AssemblyFileVersioningScheme.ShouldBe(AssemblyFileVersioningScheme.MajorMinorPatch);
+        effective.TagPrefixPattern.ShouldBe(hasOverrides ? "custom-" : "[vV]?");
+        effective.AssemblyVersioningScheme.ShouldBe(hasOverrides ? AssemblyVersioningScheme.None : AssemblyVersioningScheme.MajorMinorPatch);
+        effective.Branches["main"].Increment.ShouldBe(hasOverrides ? IncrementStrategy.Major : IncrementStrategy.Patch);
+        effective.Branches["main"].PreReleaseWeight.ShouldBe(hasOverrides ? 42 : 55000);
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -155,7 +155,47 @@ public class ConfigurationVersionIntegrationTests
 
         v6Result.ExitCode.ShouldBe(0);
         v7Result.ExitCode.ShouldBe(0);
-        GetFullSemVer(v7Result.Output!).ShouldBe(GetFullSemVer(v6Result.Output!));
+        GetFullSemVer(v7Result.StandardOutput!).ShouldBe(GetFullSemVer(v6Result.StandardOutput!));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ExplicitV6WarningUsesStandardErrorOnceWithoutContaminatingJson(bool logToFile)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        var configurationPath = Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName);
+        File.WriteAllText(configurationPath, "next-version: 2.0.0");
+
+        var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, " --no-cache", logToFile,
+            new KeyValuePair<string, string?>(ConfigurationVersionSelector.EnvironmentVariableName, "v6"));
+
+        result.ExitCode.ShouldBe(0);
+        GetFullSemVer(result.StandardOutput!).ShouldBe("2.0.0-1");
+        result.StandardError.ShouldNotBeNull();
+        result.StandardError.Split("temporary v6 compatibility mode").Length.ShouldBe(2);
+        result.StandardError.ShouldContain(configurationPath);
+        result.StandardError.ShouldContain("GitVersion 7.1");
+        result.StandardError.ShouldContain("gitversion config migrate");
+        result.StandardError.ShouldContain("GITVERSION_CONFIGURATION_VERSION=v7");
+        if (logToFile)
+        {
+            result.Log.ShouldNotBeNull();
+            result.Log.ShouldContain("temporary v6 compatibility mode");
+        }
+    }
+
+    [Test]
+    public void ExplicitV6WithoutUserConfigurationDoesNotWarnOnStandardError()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+
+        var result = Execute(fixture.RepositoryPath, "v6");
+
+        result.ExitCode.ShouldBe(0);
+        result.StandardError.ShouldBeEmpty();
+        GetFullSemVer(result.StandardOutput!).ShouldNotBeNullOrEmpty();
     }
 
     [TestCase("v6", false)]

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -5,8 +5,137 @@ using GitVersion.Helpers;
 namespace GitVersion.App.Tests;
 
 [TestFixture]
+[NonParallelizable]
 public class ConfigurationVersionIntegrationTests
 {
+    [Test]
+    public async Task ConfigMigrateWritesMigratedConfigurationToStandardOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("calculation:");
+            result.Output.ShouldContain("next-version: 2.0.0");
+            result.Output.ShouldContain("output: {}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotOverwriteOutputWithoutForce()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            var outputPath = Path.Combine(directory.FullName, "GitVersion.v7.yml");
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            await File.WriteAllTextAsync(outputPath, "existing configuration");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(1);
+            result.Output.ShouldBeEmpty();
+            var output = await File.ReadAllTextAsync(outputPath);
+            output.ShouldBe("existing configuration");
+
+            var forceResult = GitVersionHelper.ExecuteIn(
+                directory.FullName,
+                " config migrate --output GitVersion.v7.yml --force",
+                logToFile: false);
+
+            forceResult.ExitCode.ShouldBe(0);
+            forceResult.Output.ShouldNotBeNull();
+            forceResult.Output.ShouldContain("Comments cannot be preserved during migration.");
+            var forcedOutput = await File.ReadAllTextAsync(outputPath);
+            forcedOutput.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task ConfigMigrateDiscoversRootConfigurationUnlessWorkingDirectoryHasOne(bool hasLocalConfiguration)
+    {
+        using var repository = new EmptyRepositoryFixture();
+        var rootConfiguration = Path.Combine(repository.RepositoryPath, ConfigurationFileLocator.DefaultFileName);
+        await File.WriteAllTextAsync(rootConfiguration, "next-version: 2.0.0");
+        var subdirectory = Directory.CreateDirectory(Path.Combine(repository.RepositoryPath, "subdirectory"));
+        if (hasLocalConfiguration)
+        {
+            await File.WriteAllTextAsync(Path.Combine(subdirectory.FullName, ConfigurationFileLocator.DefaultFileName), "next-version: 3.0.0");
+        }
+
+        var result = await new ProgramFixture(subdirectory.FullName).Run("config", "migrate");
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotBeNull();
+        result.Output.ShouldContain(hasLocalConfiguration ? "next-version: 3.0.0" : "next-version: 2.0.0");
+        (await File.ReadAllTextAsync(rootConfiguration)).ShouldBe("next-version: 2.0.0");
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            const string fileName = "legacy.yml";
+            var configurationPath = Path.Combine(directory.FullName, fileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = GitVersionHelper.ExecuteIn(
+                directory.FullName,
+                $" config migrate --config {fileName} --in-place",
+                logToFile: false);
+
+            result.ExitCode.ShouldBe(0);
+            result.Output.ShouldNotBeNull();
+            result.Output.ShouldContain("Comments cannot be preserved during migration.");
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateInPlaceUsesPositionalTargetPath()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture().Run(directory.FullName, "config", "migrate", "--in-place");
+
+            result.ExitCode.ShouldBe(0);
+            var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
+            migratedConfiguration.ShouldContain("calculation:");
+            migratedConfiguration.ShouldContain("next-version: 2.0.0");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [Test]
     public void V6AndV7ConfigurationCalculateTheSameVersion()
     {

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -88,6 +88,30 @@ public class ConfigurationVersionIntegrationTests
     }
 
     [Test]
+    public async Task ConfigMigrateLeavesNoTemporaryFileAfterWritingOutput()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+
+            var result = await new ProgramFixture(directory.FullName).Run("config", "migrate", "--output", "GitVersion.v7.yml");
+
+            result.ExitCode.ShouldBe(0);
+            var files = Directory.GetFiles(directory.FullName).Select(Path.GetFileName).ToArray();
+            files.Length.ShouldBe(2);
+            files.ShouldContain(ConfigurationFileLocator.DefaultFileName);
+            files.ShouldContain("GitVersion.v7.yml");
+            files.ShouldNotContain(file => file!.StartsWith(".", StringComparison.Ordinal));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ConfigMigrateInPlaceMigratesExplicitConfigurationOutsideGitRepository()
     {
         var directory = Directory.CreateTempSubdirectory();
@@ -129,6 +153,29 @@ public class ConfigurationVersionIntegrationTests
             var migratedConfiguration = await File.ReadAllTextAsync(configurationPath);
             migratedConfiguration.ShouldContain("calculation:");
             migratedConfiguration.ShouldContain("next-version: 2.0.0");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ConfigMigrateDoesNotEmitLegacyFallbackWarning()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var configurationPath = Path.Combine(directory.FullName, ConfigurationFileLocator.DefaultFileName);
+            await File.WriteAllTextAsync(configurationPath, "next-version: 2.0.0");
+            var fixture = new ProgramFixture(directory.FullName);
+            fixture.WithEnv(new KeyValuePair<string, string>(ConfigurationVersionSelector.EnvironmentVariableName, "v6"));
+
+            var result = await fixture.Run("config", "migrate");
+
+            result.ExitCode.ShouldBe(0);
+            result.Output!.ShouldNotContain("temporary v6 compatibility mode");
+            result.Log!.ShouldNotContain("temporary v6 compatibility mode");
         }
         finally
         {

--- a/src/GitVersion.App.Tests/HelpWriterTests.cs
+++ b/src/GitVersion.App.Tests/HelpWriterTests.cs
@@ -55,7 +55,12 @@ public class HelpWriterTests : TestBase
         var ignored = new[]
         {
             nameof(Arguments.Authentication),
-            nameof(Arguments.UpdateAssemblyInfoFileName)
+            nameof(Arguments.UpdateAssemblyInfoFileName),
+            nameof(Arguments.IsConfigurationMigration),
+            nameof(Arguments.MigrationInputFile),
+            nameof(Arguments.MigrationOutputFile),
+            nameof(Arguments.MigrationInPlace),
+            nameof(Arguments.MigrationForce)
         };
         typeof(Arguments).GetFields()
             .Select(p => p.Name)

--- a/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
+++ b/src/GitVersion.App.Tests/Helpers/ExecutionResults.cs
@@ -9,6 +9,8 @@ public class ExecutionResults(int exitCode, string? output, string? logContents 
     public int ExitCode { get; } = exitCode;
     public string? Output { get; } = output;
     public string? Log { get; init; } = logContents;
+    public string? StandardOutput { get; init; }
+    public string? StandardError { get; init; }
 
     public GitVersionVariables? OutputVariables
     {

--- a/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
+++ b/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
@@ -24,6 +24,8 @@ public static class GitVersionHelper
     {
         var executable = ExecutableHelper.DotNetExecutable;
         var output = new StringBuilder();
+        var standardOutput = new StringBuilder();
+        var standardError = new StringBuilder();
 
         var environmentalVariables = new Dictionary<string, string?>
         {
@@ -53,8 +55,22 @@ public static class GitVersionHelper
             var workingDirectory = arguments.WorkingDirectory ?? FileSystemHelper.Path.GetCurrentDirectory();
 
             exitCode = ProcessHelper.Run(
-                s => output.AppendLine(s),
-                s => output.AppendLine(s),
+                s =>
+                {
+                    standardOutput.AppendLine(s);
+                    lock (output)
+                    {
+                        output.AppendLine(s);
+                    }
+                },
+                s =>
+                {
+                    standardError.AppendLine(s);
+                    lock (output)
+                    {
+                        output.AppendLine(s);
+                    }
+                },
                 null,
                 executable,
                 args,
@@ -79,7 +95,11 @@ public static class GitVersionHelper
 
         if (arguments.LogFile.IsNullOrWhiteSpace() || !FileSystemHelper.File.Exists(arguments.LogFile))
         {
-            return new(exitCode, output.ToString());
+            return new(exitCode, output.ToString())
+            {
+                StandardOutput = standardOutput.ToString(),
+                StandardError = standardError.ToString()
+            };
         }
 
         var logContents = FileSystemHelper.File.ReadAllText(arguments.LogFile);
@@ -90,6 +110,10 @@ public static class GitVersionHelper
         Console.WriteLine();
         Console.WriteLine("-------------------------------------------------------");
 
-        return new(exitCode, output.ToString(), logContents);
+        return new(exitCode, output.ToString(), logContents)
+        {
+            StandardOutput = standardOutput.ToString(),
+            StandardError = standardError.ToString()
+        };
     }
 }

--- a/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
+++ b/src/GitVersion.App.Tests/Helpers/GitVersionHelper.cs
@@ -57,17 +57,17 @@ public static class GitVersionHelper
             exitCode = ProcessHelper.Run(
                 s =>
                 {
-                    standardOutput.AppendLine(s);
                     lock (output)
                     {
+                        standardOutput.AppendLine(s);
                         output.AppendLine(s);
                     }
                 },
                 s =>
                 {
-                    standardError.AppendLine(s);
                     lock (output)
                     {
+                        standardError.AppendLine(s);
                         output.AppendLine(s);
                     }
                 },

--- a/src/GitVersion.App.Tests/JsonOutputOnBuildServerTest.cs
+++ b/src/GitVersion.App.Tests/JsonOutputOnBuildServerTest.cs
@@ -19,8 +19,9 @@ public class JsonOutputOnBuildServerTest
         var result = GitVersionHelper.ExecuteIn(fixture.LocalRepositoryFixture.RepositoryPath, arguments: " --output json", environments: env);
 
         result.ExitCode.ShouldBe(0);
-        result.Output.ShouldStartWith("{");
-        result.Output.TrimEnd().ShouldEndWith("}");
+        result.StandardOutput.ShouldNotBeNull();
+        using var json = JsonDocument.Parse(result.StandardOutput);
+        json.RootElement.GetProperty("FullSemVer").GetString().ShouldBe("0.0.1-5");
     }
 
     [Test]

--- a/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
+++ b/src/GitVersion.App.Tests/LegacyArgumentParserTests.cs
@@ -64,6 +64,14 @@ public class LegacyArgumentParserTests : TestBase
     }
 
     [Test]
+    public void ConfigMigrateIsRejectedAsASubcommand()
+    {
+        var exception = Should.Throw<WarningException>(() => this.argumentParser.ParseArguments("config migrate"));
+
+        exception.Message.ShouldContain("only available with the POSIX argument parser");
+    }
+
+    [Test]
     public void EmptyMeansUseCurrentDirectory()
     {
         var arguments = this.argumentParser.ParseArguments("");

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -62,6 +62,16 @@ internal class ArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (parseResult.CommandResult.Command == options.ConfigCommand)
+        {
+            throw new WarningException("The 'config' command requires a subcommand. Use 'gitversion config migrate'.");
+        }
+
+        if (parseResult.CommandResult.Command == options.Migrate)
+        {
+            return MapMigrationValues(parseResult, options);
+        }
+
         var arguments = new Arguments();
         AddAuthentication(arguments);
         MapParsedValues(arguments, parseResult, options);
@@ -78,6 +88,12 @@ internal class ArgumentParser(
 
     private static void ValidateParsedResult(ParseResult parseResult, CommandOptions options)
     {
+        if (parseResult.CommandResult.Command == options.ConfigCommand
+            && parseResult.Errors.Any(error => error.Message.Contains("Required command was not provided", StringComparison.Ordinal)))
+        {
+            throw new WarningException("The 'config' command requires a subcommand. Use 'gitversion config migrate'.");
+        }
+
         if (parseResult.Errors.Count > 0)
         {
             var message = parseResult.Errors[0].Message;
@@ -133,6 +149,34 @@ internal class ArgumentParser(
 
         MapRemoteOptions(arguments, parseResult, options);
         ApplyDefaults(arguments, parseResult, options);
+    }
+
+    private static Arguments MapMigrationValues(ParseResult parseResult, CommandOptions options)
+    {
+        var outputFile = parseResult.GetValue(options.MigrationOutputFile);
+        var inPlace = parseResult.GetValue(options.InPlace);
+        var force = parseResult.GetValue(options.Force);
+        if (outputFile is not null && inPlace)
+        {
+            throw new WarningException("Cannot use --output together with --in-place.");
+        }
+
+        if (force && outputFile is null)
+        {
+            throw new WarningException("--force can only be used together with --output.");
+        }
+
+        return new Arguments
+        {
+            IsConfigurationMigration = true,
+            MigrationInputFile = parseResult.GetValue(options.MigrationInputFile),
+            MigrationOutputFile = outputFile,
+            MigrationInPlace = inPlace,
+            MigrationForce = force,
+            TargetPath = parseResult.GetValue(options.TargetPath)
+                         ?? parseResult.GetValue(options.Path)
+                         ?? SysEnv.CurrentDirectory
+        };
     }
 
     private static void MapOutputOptions(Arguments arguments, ParseResult parseResult, CommandOptions options)
@@ -451,6 +495,17 @@ internal class ArgumentParser(
         {
             Description = "By default dynamic repositories will be cloned to %tmp%. Use this option to override"
         };
+        var configCommand = new Command("config", "Manages GitVersion configuration.");
+        var migrate = new Command("migrate", "Migrates a v6 configuration document to the v7 structure.");
+        var migrationInputFile = new Option<string?>("--config") { Description = "Path to the configuration file to migrate." };
+        var migrationOutputFile = new Option<string?>("--output") { Description = "Path to write the migrated configuration document." };
+        var inPlace = new Option<bool>("--in-place") { Description = "Replace the input configuration file." };
+        var force = new Option<bool>("--force") { Description = "Allow --output to replace an existing file." };
+        migrate.Options.Add(migrationInputFile);
+        migrate.Options.Add(migrationOutputFile);
+        migrate.Options.Add(inPlace);
+        migrate.Options.Add(force);
+        configCommand.Subcommands.Add(migrate);
 
         var rootCommand = new RootCommand("Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.")
         {
@@ -481,6 +536,11 @@ internal class ArgumentParser(
             commit,
             dynamicRepoLocation
         };
+        rootCommand.Subcommands.Add(configCommand);
+
+        // System.CommandLine requires an action on the root command so normal version calculation
+        // remains a valid invocation while subcommands provide their own parsing paths.
+        rootCommand.SetAction(_ => { });
 
         // Configure the built-in help system to wrap at 260 characters to avoid too small help messages
         var helpOption = rootCommand.Options.SingleOfType<HelpOption>();
@@ -497,7 +557,10 @@ internal class ArgumentParser(
             VerbosityOption: verbosity, UpdateAssemblyInfo: updateAssemblyInfo, UpdateProjectFiles: updateProjectFiles,
             EnsureAssemblyInfo: ensureAssemblyInfo, UpdateWixVersionFile: updateWixVersionFile,
             Url: url, Branch: branch, Username: username, Password: password,
-            Commit: commit, DynamicRepoLocation: dynamicRepoLocation
+            Commit: commit, DynamicRepoLocation: dynamicRepoLocation,
+            ConfigCommand: configCommand, Migrate: migrate,
+            MigrationInputFile: migrationInputFile, MigrationOutputFile: migrationOutputFile,
+            InPlace: inPlace, Force: force
         ));
     }
 
@@ -621,6 +684,12 @@ internal class ArgumentParser(
         Option<string?> Username,
         Option<string?> Password,
         Option<string?> Commit,
-        Option<string?> DynamicRepoLocation
+        Option<string?> DynamicRepoLocation,
+        Command ConfigCommand,
+        Command Migrate,
+        Option<string?> MigrationInputFile,
+        Option<string?> MigrationOutputFile,
+        Option<bool> InPlace,
+        Option<bool> Force
     );
 }

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -62,6 +62,16 @@ internal class ArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (parseResult.CommandResult.Command == options.ConfigCommand)
+        {
+            throw new WarningException("The 'config' command requires a subcommand. Use 'gitversion config migrate'.");
+        }
+
+        if (parseResult.CommandResult.Command == options.Migrate)
+        {
+            return MapMigrationValues(parseResult, options);
+        }
+
         var arguments = new Arguments();
         AddAuthentication(arguments);
         MapParsedValues(arguments, parseResult, options);
@@ -133,6 +143,34 @@ internal class ArgumentParser(
 
         MapRemoteOptions(arguments, parseResult, options);
         ApplyDefaults(arguments, parseResult, options);
+    }
+
+    private static Arguments MapMigrationValues(ParseResult parseResult, CommandOptions options)
+    {
+        var outputFile = parseResult.GetValue(options.MigrationOutputFile);
+        var inPlace = parseResult.GetValue(options.InPlace);
+        var force = parseResult.GetValue(options.Force);
+        if (outputFile is not null && inPlace)
+        {
+            throw new WarningException("Cannot use --output together with --in-place.");
+        }
+
+        if (force && outputFile is null)
+        {
+            throw new WarningException("--force can only be used together with --output.");
+        }
+
+        return new Arguments
+        {
+            IsConfigurationMigration = true,
+            MigrationInputFile = parseResult.GetValue(options.MigrationInputFile) ?? parseResult.GetValue(options.Config),
+            MigrationOutputFile = outputFile,
+            MigrationInPlace = inPlace,
+            MigrationForce = force,
+            TargetPath = parseResult.GetValue(options.TargetPath)
+                         ?? parseResult.GetValue(options.Path)
+                         ?? SysEnv.CurrentDirectory
+        };
     }
 
     private static void MapOutputOptions(Arguments arguments, ParseResult parseResult, CommandOptions options)
@@ -451,6 +489,18 @@ internal class ArgumentParser(
         {
             Description = "By default dynamic repositories will be cloned to %tmp%. Use this option to override"
         };
+        var configCommand = new Command("config", "Manages GitVersion configuration.");
+        configCommand.SetAction(_ => { });
+        var migrate = new Command("migrate", "Migrates a v6 configuration document to the v7 structure.");
+        var migrationInputFile = new Option<string?>("--config", "-c") { Description = "Path to the configuration file to migrate." };
+        var migrationOutputFile = new Option<string?>("--output") { Description = "Path to write the migrated configuration document." };
+        var inPlace = new Option<bool>("--in-place") { Description = "Replace the input configuration file." };
+        var force = new Option<bool>("--force") { Description = "Allow --output to replace an existing file." };
+        migrate.Options.Add(migrationInputFile);
+        migrate.Options.Add(migrationOutputFile);
+        migrate.Options.Add(inPlace);
+        migrate.Options.Add(force);
+        configCommand.Subcommands.Add(migrate);
 
         var rootCommand = new RootCommand("Use convention to derive a SemVer product version from a GitFlow or GitHub based repository.")
         {
@@ -481,6 +531,11 @@ internal class ArgumentParser(
             commit,
             dynamicRepoLocation
         };
+        rootCommand.Subcommands.Add(configCommand);
+
+        // System.CommandLine requires an action on the root command so normal version calculation
+        // remains a valid invocation while subcommands provide their own parsing paths.
+        rootCommand.SetAction(_ => { });
 
         // Configure the built-in help system to wrap at 260 characters to avoid too small help messages
         var helpOption = rootCommand.Options.SingleOfType<HelpOption>();
@@ -497,7 +552,10 @@ internal class ArgumentParser(
             VerbosityOption: verbosity, UpdateAssemblyInfo: updateAssemblyInfo, UpdateProjectFiles: updateProjectFiles,
             EnsureAssemblyInfo: ensureAssemblyInfo, UpdateWixVersionFile: updateWixVersionFile,
             Url: url, Branch: branch, Username: username, Password: password,
-            Commit: commit, DynamicRepoLocation: dynamicRepoLocation
+            Commit: commit, DynamicRepoLocation: dynamicRepoLocation,
+            ConfigCommand: configCommand, Migrate: migrate,
+            MigrationInputFile: migrationInputFile, MigrationOutputFile: migrationOutputFile,
+            InPlace: inPlace, Force: force
         ));
     }
 
@@ -621,6 +679,12 @@ internal class ArgumentParser(
         Option<string?> Username,
         Option<string?> Password,
         Option<string?> Commit,
-        Option<string?> DynamicRepoLocation
+        Option<string?> DynamicRepoLocation,
+        Command ConfigCommand,
+        Command Migrate,
+        Option<string?> MigrationInputFile,
+        Option<string?> MigrationOutputFile,
+        Option<bool> InPlace,
+        Option<bool> Force
     );
 }

--- a/src/GitVersion.App/Arguments.cs
+++ b/src/GitVersion.App/Arguments.cs
@@ -9,6 +9,11 @@ internal class Arguments
     public string? ConfigurationFile;
     public IReadOnlyDictionary<object, object?> OverrideConfiguration = new Dictionary<object, object?>();
     public bool ShowConfiguration;
+    public bool IsConfigurationMigration;
+    public string? MigrationInputFile;
+    public string? MigrationOutputFile;
+    public bool MigrationInPlace;
+    public bool MigrationForce;
 
     public string? TargetPath;
 
@@ -62,6 +67,15 @@ internal class Arguments
                 ConfigurationFile = this.ConfigurationFile,
                 OverrideConfiguration = this.OverrideConfiguration,
                 ShowConfiguration = this.ShowConfiguration
+            },
+
+            ConfigurationMigrationInfo =
+            {
+                IsMigration = this.IsConfigurationMigration,
+                InputFile = this.MigrationInputFile,
+                OutputFile = this.MigrationOutputFile,
+                InPlace = this.MigrationInPlace,
+                Force = this.MigrationForce
             },
 
             RepositoryInfo =

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -48,7 +48,26 @@ internal class ConfigurationMigrationExecutor(
             this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", outputFile);
         }
 
-        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        WriteAtomically(outputFile, migrated);
         return 0;
+    }
+
+    private void WriteAtomically(string outputFile, string migrated)
+    {
+        var directory = this.fileSystem.Path.GetDirectoryName(outputFile)!;
+        var temporaryFile = this.fileSystem.Path.Combine(directory, $".{this.fileSystem.Path.GetFileName(outputFile)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            this.fileSystem.File.WriteAllText(temporaryFile, migrated);
+            this.fileSystem.File.Move(temporaryFile, outputFile, overwrite: true);
+        }
+        finally
+        {
+            if (this.fileSystem.File.Exists(temporaryFile))
+            {
+                this.fileSystem.File.Delete(temporaryFile);
+            }
+        }
     }
 }

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -1,0 +1,54 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion;
+
+internal class ConfigurationMigrationExecutor(
+    IFileSystem fileSystem,
+    IConsole console,
+    ILogger<ConfigurationMigrationExecutor> logger,
+    IConfigurationFileLocator configurationFileLocator,
+    IConfigurationMigrationService migrationService) : IConfigurationMigrationExecutor
+{
+    private readonly IFileSystem fileSystem = fileSystem.NotNull();
+    private readonly IConsole console = console.NotNull();
+    private readonly ILogger<ConfigurationMigrationExecutor> logger = logger.NotNull();
+    private readonly IConfigurationFileLocator configurationFileLocator = configurationFileLocator.NotNull();
+    private readonly IConfigurationMigrationService migrationService = migrationService.NotNull();
+
+    public int Execute(GitVersionOptions options)
+    {
+        var migration = options.ConfigurationMigrationInfo;
+        var inputFile = migration.InputFile is null
+            ? this.configurationFileLocator.GetConfigurationFile(options.WorkingDirectory)
+            : Path.GetFullPath(migration.InputFile, options.WorkingDirectory);
+        if (inputFile is null || !this.fileSystem.File.Exists(inputFile))
+        {
+            throw new WarningException("Could not find a configuration file to migrate. Specify one with --config.");
+        }
+
+        var migrated = this.migrationService.Migrate(this.fileSystem.File.ReadAllText(inputFile));
+        if (!migration.InPlace && migration.OutputFile is null)
+        {
+            this.console.Write(migrated);
+            return 0;
+        }
+
+        var outputFile = migration.InPlace ? inputFile : Path.GetFullPath(migration.OutputFile!, options.WorkingDirectory);
+        var overwritesExistingFile = this.fileSystem.File.Exists(outputFile);
+        if (!migration.InPlace && overwritesExistingFile && !migration.Force)
+        {
+            throw new WarningException($"The output file '{outputFile}' already exists. Use --force to replace it.");
+        }
+
+        if (overwritesExistingFile)
+        {
+            Console.Error.WriteLine($"Replacing '{outputFile}'. Comments cannot be preserved during migration.");
+            this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", outputFile);
+        }
+
+        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        return 0;
+    }
+}

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -1,0 +1,55 @@
+using System.IO.Abstractions;
+using GitVersion.Configuration;
+using GitVersion.Extensions;
+
+namespace GitVersion;
+
+internal class ConfigurationMigrationExecutor(
+    IFileSystem fileSystem,
+    IConsole console,
+    ILogger<ConfigurationMigrationExecutor> logger,
+    IConfigurationFileLocator configurationFileLocator,
+    IConfigurationMigrationService migrationService) : IConfigurationMigrationExecutor
+{
+    private readonly IFileSystem fileSystem = fileSystem.NotNull();
+    private readonly IConsole console = console.NotNull();
+    private readonly ILogger<ConfigurationMigrationExecutor> logger = logger.NotNull();
+    private readonly IConfigurationFileLocator configurationFileLocator = configurationFileLocator.NotNull();
+    private readonly IConfigurationMigrationService migrationService = migrationService.NotNull();
+
+    public int Execute(GitVersionOptions options)
+    {
+        var migration = options.ConfigurationMigrationInfo;
+        var inputFile = migration.InputFile is null
+            ? this.configurationFileLocator.GetConfigurationFile(options.WorkingDirectory)
+              ?? this.configurationFileLocator.GetConfigurationFile(this.fileSystem.FindGitDir(options.WorkingDirectory)?.WorkingTreeDirectory)
+            : Path.GetFullPath(migration.InputFile, options.WorkingDirectory);
+        if (inputFile is null || !this.fileSystem.File.Exists(inputFile))
+        {
+            throw new WarningException("Could not find a configuration file to migrate. Specify one with --config.");
+        }
+
+        var migrated = this.migrationService.Migrate(this.fileSystem.File.ReadAllText(inputFile));
+        if (!migration.InPlace && migration.OutputFile is null)
+        {
+            this.console.Write(migrated);
+            return 0;
+        }
+
+        var outputFile = migration.InPlace ? inputFile : Path.GetFullPath(migration.OutputFile!, options.WorkingDirectory);
+        var overwritesExistingFile = this.fileSystem.File.Exists(outputFile);
+        if (!migration.InPlace && overwritesExistingFile && !migration.Force)
+        {
+            throw new WarningException($"The output file '{outputFile}' already exists. Use --force to replace it.");
+        }
+
+        if (overwritesExistingFile)
+        {
+            Console.Error.WriteLine($"Replacing '{outputFile}'. Comments cannot be preserved during migration.");
+            this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", outputFile);
+        }
+
+        this.fileSystem.File.WriteAllText(outputFile, migrated);
+        return 0;
+    }
+}

--- a/src/GitVersion.App/ConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/ConfigurationMigrationExecutor.cs
@@ -45,7 +45,6 @@ internal class ConfigurationMigrationExecutor(
 
         if (overwritesExistingFile)
         {
-            Console.Error.WriteLine($"Replacing '{outputFile}'. Comments cannot be preserved during migration.");
             this.logger.LogWarning("Replacing '{ConfigurationFile}'. Comments cannot be preserved during migration.", outputFile);
         }
 

--- a/src/GitVersion.App/GitVersionApp.cs
+++ b/src/GitVersion.App/GitVersionApp.cs
@@ -5,10 +5,12 @@ namespace GitVersion;
 internal class GitVersionApp(
     IHostApplicationLifetime applicationLifetime,
     IGitVersionExecutor gitVersionExecutor,
+    IConfigurationMigrationExecutor configurationMigrationExecutor,
     IOptions<GitVersionOptions> options)
 {
     private readonly IHostApplicationLifetime applicationLifetime = applicationLifetime.NotNull();
     private readonly IGitVersionExecutor gitVersionExecutor = gitVersionExecutor.NotNull();
+    private readonly IConfigurationMigrationExecutor configurationMigrationExecutor = configurationMigrationExecutor.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
 
     public Task RunAsync(CancellationToken _)
@@ -19,6 +21,10 @@ internal class GitVersionApp(
             if (gitVersionOptions.IsHelp || gitVersionOptions.IsVersion)
             {
                 SysEnv.ExitCode = 0;
+            }
+            else if (gitVersionOptions.ConfigurationMigrationInfo.IsMigration)
+            {
+                SysEnv.ExitCode = this.configurationMigrationExecutor.Execute(gitVersionOptions);
             }
             else
             {

--- a/src/GitVersion.App/GitVersionAppModule.cs
+++ b/src/GitVersion.App/GitVersionAppModule.cs
@@ -19,6 +19,7 @@ internal class GitVersionAppModule(string[]? args = null, bool useLegacyParser =
 
         services.AddSingleton<IGlobbingResolver, GlobbingResolver>();
         services.AddSingleton<IGitVersionExecutor, GitVersionExecutor>();
+        services.AddSingleton<IConfigurationMigrationExecutor, ConfigurationMigrationExecutor>();
         services.AddSingleton<GitVersionApp>();
 
         services.AddSingleton(sp =>

--- a/src/GitVersion.App/IConfigurationMigrationExecutor.cs
+++ b/src/GitVersion.App/IConfigurationMigrationExecutor.cs
@@ -1,0 +1,6 @@
+namespace GitVersion;
+
+internal interface IConfigurationMigrationExecutor
+{
+    int Execute(GitVersionOptions options);
+}

--- a/src/GitVersion.App/LegacyArgumentParser.cs
+++ b/src/GitVersion.App/LegacyArgumentParser.cs
@@ -78,6 +78,12 @@ internal class LegacyArgumentParser(
             return new Arguments { IsVersion = true };
         }
 
+        if (firstArgument.Equals("config", StringComparison.OrdinalIgnoreCase)
+            && commandLineArguments.Skip(1).FirstOrDefault()?.Equals("migrate", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            throw new WarningException("The 'config migrate' command is only available with the POSIX argument parser.");
+        }
+
         var arguments = new Arguments();
 
         AddAuthentication(arguments);

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,3 +1,5 @@
+using SharpYaml;
+
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
@@ -45,6 +47,29 @@ public class ConfigurationMigrationServiceTests
     }
 
     [Test]
+    public void MigratesConfiguredValuesWithoutAddingDefaults()
+    {
+        const string input = """
+                             workflow: GitHubFlow/v1
+                             mode: ContinuousDeployment
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Minor
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldContain("mode: ContinuousDeployment");
+        result.ShouldContain("update-build-number: false");
+        result.ShouldContain("increment: Minor");
+        result.ShouldContain("pre-release-weight: 42");
+        result.ShouldNotContain("tag-prefix:");
+    }
+
+    [Test]
     public void RejectsMixedConfiguration()
     {
         const string input = """
@@ -53,5 +78,13 @@ public class ConfigurationMigrationServiceTests
                              """;
 
         Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+
+    [Test]
+    public void RejectsMalformedYaml()
+    {
+        const string input = "branches: [";
+
+        Should.Throw<YamlException>(() => this.migrationService.Migrate(input));
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,0 +1,57 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationServiceTests
+{
+    private readonly IConfigurationMigrationService migrationService = new ConfigurationMigrationService(new ConfigurationSerializer());
+
+    [Test]
+    public void MigratesFlatConfigurationToCalculationAndOutputSections()
+    {
+        const string input = """
+                             workflow: GitFlow/v1
+                             tag-prefix: custom-
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Major
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("calculation:");
+        result.ShouldContain("  workflow: GitFlow/v1");
+        result.ShouldContain("  tag-prefix: custom-");
+        result.ShouldContain("      increment: Major");
+        result.ShouldContain("output:");
+        result.ShouldContain("  update-build-number: false");
+        result.ShouldContain("      pre-release-weight: 42");
+    }
+
+    [Test]
+    public void AcceptsNestedConfigurationAndProducesDeterministicOutput()
+    {
+        const string input = """
+                             output:
+                               update-build-number: false
+                             calculation:
+                               tag-prefix: custom-
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [Test]
+    public void RejectsMixedConfiguration()
+    {
+        const string input = """
+                             calculation: {}
+                             tag-prefix: custom-
+                             """;
+
+        Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,3 +1,5 @@
+using SharpYaml;
+
 namespace GitVersion.Configuration.Tests;
 
 [TestFixture]
@@ -102,6 +104,29 @@ public class ConfigurationMigrationServiceTests
     }
 
     [Test]
+    public void MigratesConfiguredValuesWithoutAddingDefaults()
+    {
+        const string input = """
+                             workflow: GitHubFlow/v1
+                             mode: ContinuousDeployment
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Minor
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldContain("mode: ContinuousDeployment");
+        result.ShouldContain("update-build-number: false");
+        result.ShouldContain("increment: Minor");
+        result.ShouldContain("pre-release-weight: 42");
+        result.ShouldNotContain("tag-prefix:");
+    }
+
+    [Test]
     public void RejectsMixedConfiguration()
     {
         const string input = """
@@ -110,5 +135,33 @@ public class ConfigurationMigrationServiceTests
                              """;
 
         Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+
+    [Test]
+    public void RejectsMalformedYaml()
+    {
+        const string input = "branches: [";
+
+        Should.Throw<YamlException>(() => this.migrationService.Migrate(input));
+    }
+
+    [TestCase("update-build-number: not-a-boolean")]
+    [TestCase("output:\n  update-build-number: not-a-boolean")]
+    [TestCase("branches:\n  main:\n    increment: Invalid")]
+    [TestCase("calculation:\n  branches:\n    main:\n      increment: Invalid")]
+    [TestCase("unknown-setting: true")]
+    [TestCase("calculation:\n  unknown-setting: true")]
+    public void RejectsInvalidSettings(string input) =>
+        Should.Throw<YamlException>(() => this.migrationService.Migrate(input));
+
+    [TestCase("output:\n  increment: Major", "calculation.increment")]
+    [TestCase("calculation:\n  branches:\n    main:\n      pre-release-weight: 42", "output.branches.<branch>.pre-release-weight")]
+    [TestCase("output: []", "must be a mapping")]
+    [TestCase("calculation:\n  branches: []", "must be a mapping")]
+    public void RejectsInvalidNestedStructure(string input, string diagnostic)
+    {
+        var exception = Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+
+        exception.Message.ShouldContain(diagnostic);
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -1,0 +1,114 @@
+namespace GitVersion.Configuration.Tests;
+
+[TestFixture]
+public class ConfigurationMigrationServiceTests
+{
+    private readonly IConfigurationMigrationService migrationService = new ConfigurationMigrationService(new ConfigurationSerializer());
+
+    [Test]
+    public void MigratesFlatConfigurationToCalculationAndOutputSections()
+    {
+        const string input = """
+                             workflow: GitFlow/v1
+                             tag-prefix: custom-
+                             update-build-number: false
+                             branches:
+                               main:
+                                 increment: Major
+                                 pre-release-weight: 42
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("calculation:");
+        result.ShouldContain("workflow: GitFlow/v1");
+        result.ShouldNotContain("  workflow:");
+        result.ShouldContain("  tag-prefix: custom-");
+        result.ShouldContain("      increment: Major");
+        result.ShouldContain("output:");
+        result.ShouldContain("  update-build-number: false");
+        result.ShouldContain("      pre-release-weight: 42");
+    }
+
+    [Test]
+    public void AcceptsNestedConfigurationAndProducesDeterministicOutput()
+    {
+        const string input = """
+                             output:
+                               update-build-number: false
+                             workflow: GitHubFlow/v1
+                             calculation:
+                               tag-prefix: custom-
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldNotContain("  workflow:");
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [TestCase("GitFlow/v1")]
+    [TestCase("GitHubFlow/v1")]
+    public void MigratesWorkflowOnlyConfigurationAtRoot(string workflow)
+    {
+        var result = this.migrationService.Migrate($"workflow: {workflow}");
+
+        result.ShouldContain($"workflow: {workflow}");
+        result.ShouldNotContain("  workflow:");
+        result.ShouldNotContain("tag-prefix:");
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [Test]
+    public void MigratesDraftCalculationWorkflowToRootWithoutChangingOverrides()
+    {
+        const string input = """
+                             calculation:
+                               workflow: GitHubFlow/v1
+                               tag-prefix: custom-
+                             output:
+                               update-build-number: false
+                             """;
+
+        var result = this.migrationService.Migrate(input);
+
+        result.ShouldContain("workflow: GitHubFlow/v1");
+        result.ShouldNotContain("  workflow:");
+        result.ShouldContain("  tag-prefix: custom-");
+        result.ShouldContain("  update-build-number: false");
+        this.migrationService.Migrate(result).ShouldBe(result);
+    }
+
+    [TestCase("GitHubFlow/v1")]
+    [TestCase("GitFlow/v1")]
+    public void RejectsDuplicateRootAndCalculationWorkflowsEvenWhenEqual(string nestedWorkflow)
+    {
+        var input = $"workflow: GitHubFlow/v1\ncalculation:\n  workflow: {nestedWorkflow}";
+
+        var exception = Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+
+        exception.Message.ShouldContain("both the document root and 'calculation.workflow'");
+    }
+
+    [TestCase("output:\n  workflow: GitHubFlow/v1")]
+    [TestCase("workflow: GitHubFlow/v1\noutput:\n  workflow: GitHubFlow/v1")]
+    public void RejectsOutputWorkflow(string input)
+    {
+        var exception = Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+
+        exception.Message.ShouldContain("'output.workflow'");
+        exception.Message.ShouldContain("document root");
+    }
+
+    [Test]
+    public void RejectsMixedConfiguration()
+    {
+        const string input = """
+                             calculation: {}
+                             tag-prefix: custom-
+                             """;
+
+        Should.Throw<ConfigurationException>(() => this.migrationService.Migrate(input));
+    }
+}

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -440,14 +440,14 @@ public class ConfigurationProviderTests : TestBase
     }
 
     [Test]
-    public void NoWarnOnGitVersionYmlFile()
+    public void WarnsOnceWhenExplicitV6LoadsAConfigurationFile()
     {
         const string text = "";
         using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
 
-        var stringLogger = string.Empty;
+        var logMessages = new List<string>();
 
-        var loggerFactory = new TestLoggerFactory(message => stringLogger = message);
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
 
         var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
         var sp = ConfigureServices(services =>
@@ -458,9 +458,37 @@ public class ConfigurationProviderTests : TestBase
         this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
 
         this.configurationProvider.ProvideForDirectory(this.repoPath);
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
 
         var filePath = FileSystemHelper.Path.Combine(this.repoPath, ConfigurationFileLocator.DefaultFileName);
-        stringLogger.ShouldContain($"Using configuration file '{filePath}'");
+        logMessages.ShouldContain(message => message.Contains($"Configuration file '{filePath}' uses the temporary v6 compatibility mode.", StringComparison.Ordinal));
+        logMessages.Count(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal)).ShouldBe(1);
+        logMessages.ShouldContain(message => message.Contains("GitVersion 7.1", StringComparison.Ordinal));
+        logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void DoesNotWarnWhenExplicitV6ConfigurationFailsNormalization()
+    {
+        const string text = """
+                            calculation:
+                              next-version: 2.0.0
+                            output: {}
+                            """;
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: text);
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        Should.Throw<ConfigurationException>(() => this.configurationProvider.ProvideForDirectory(this.repoPath));
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
     }
 
     [Test]

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationProviderTests.cs
@@ -467,6 +467,45 @@ public class ConfigurationProviderTests : TestBase
         logMessages.ShouldContain(message => message.Contains("gitversion config migrate", StringComparison.Ordinal));
     }
 
+    [TestCase(null)]
+    [TestCase("v7")]
+    public void DoesNotWarnWhenV6IsNotExplicitlySelected(string? configurationVersion)
+    {
+        System.Environment.SetEnvironmentVariable(ConfigurationVersionSelector.EnvironmentVariableName, configurationVersion);
+        using var _ = this.fileSystem.SetupConfigFile(path: this.repoPath, text: "");
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void DoesNotWarnForExplicitV6BuiltInDefaults()
+    {
+        var logMessages = new List<string>();
+        var loggerFactory = new TestLoggerFactory(logMessages.Add);
+        var options = Options.Create(new GitVersionOptions { WorkingDirectory = this.repoPath });
+        var sp = ConfigureServices(services =>
+        {
+            services.AddSingleton(options);
+            loggerFactory.RegisterWith(services);
+        });
+        this.configurationProvider = (ConfigurationProvider)sp.GetRequiredService<IConfigurationProvider>();
+
+        this.configurationProvider.ProvideForDirectory(this.repoPath);
+
+        logMessages.ShouldNotContain(message => message.Contains("temporary v6 compatibility mode", StringComparison.Ordinal));
+    }
+
     [Test]
     public void DoesNotWarnWhenExplicitV6ConfigurationFailsNormalization()
     {

--- a/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
+++ b/src/GitVersion.Configuration/ConfigurationDocumentMapper.cs
@@ -153,6 +153,34 @@ internal static class ConfigurationDocumentMapper
         };
     }
 
+    public static Dictionary<object, object?> Nest(IReadOnlyDictionary<object, object?> document)
+    {
+        Dictionary<object, object?> calculation = [];
+        Dictionary<object, object?> output = [];
+
+        foreach (var (key, value) in document)
+        {
+            if (key is string propertyName && propertyName.Equals(BranchesPropertyName, StringComparison.Ordinal))
+            {
+                SplitBranches(value, calculation, output);
+            }
+            else if (key is string outputPropertyName && OutputPropertyNames.Contains(outputPropertyName))
+            {
+                output[key] = CloneValue(value);
+            }
+            else
+            {
+                calculation[key] = CloneValue(value);
+            }
+        }
+
+        return new()
+        {
+            [CalculationSectionName] = calculation,
+            [OutputSectionName] = output
+        };
+    }
+
     public static bool IsOutputProperty(string propertyName) => OutputPropertyNames.Contains(propertyName);
 
     public static bool IsOutputBranchProperty(string propertyName) => OutputBranchPropertyNames.Contains(propertyName);
@@ -262,6 +290,56 @@ internal static class ConfigurationDocumentMapper
             foreach (var (propertyName, propertyValue) in branch)
             {
                 (OutputBranchPropertyNames.Contains(propertyName) ? outputBranch : calculationBranch)[propertyName] = propertyValue;
+            }
+
+            if (calculationBranch.Count != 0)
+            {
+                calculationBranches[branchName] = calculationBranch;
+            }
+
+            if (outputBranch.Count != 0)
+            {
+                outputBranches[branchName] = outputBranch;
+            }
+        }
+
+        if (calculationBranches.Count != 0)
+        {
+            calculation[BranchesPropertyName] = calculationBranches;
+        }
+
+        if (outputBranches.Count != 0)
+        {
+            output[BranchesPropertyName] = outputBranches;
+        }
+    }
+
+    private static void SplitBranches(
+        object? value,
+        IDictionary<object, object?> calculation,
+        IDictionary<object, object?> output)
+    {
+        if (value is not IReadOnlyDictionary<object, object?> branches)
+        {
+            calculation[BranchesPropertyName] = CloneValue(value);
+            return;
+        }
+
+        Dictionary<object, object?> calculationBranches = [];
+        Dictionary<object, object?> outputBranches = [];
+        foreach (var (branchName, branchValue) in branches)
+        {
+            if (branchValue is not IReadOnlyDictionary<object, object?> branch)
+            {
+                calculationBranches[branchName] = CloneValue(branchValue);
+                continue;
+            }
+
+            Dictionary<object, object?> calculationBranch = [];
+            Dictionary<object, object?> outputBranch = [];
+            foreach (var (propertyName, propertyValue) in branch)
+            {
+                (propertyName is string name && OutputBranchPropertyNames.Contains(name) ? outputBranch : calculationBranch)[propertyName] = CloneValue(propertyValue);
             }
 
             if (calculationBranch.Count != 0)

--- a/src/GitVersion.Configuration/ConfigurationMigrationService.cs
+++ b/src/GitVersion.Configuration/ConfigurationMigrationService.cs
@@ -1,0 +1,22 @@
+using GitVersion.Extensions;
+
+namespace GitVersion.Configuration;
+
+internal class ConfigurationMigrationService(IConfigurationSerializer configurationSerializer) : IConfigurationMigrationService
+{
+    private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
+
+    public string Migrate(string input)
+    {
+        var document = this.configurationSerializer.Deserialize<Dictionary<object, object?>>(input);
+        return ConfigurationDocumentMapper.Detect(document) switch
+        {
+            ConfigurationDocumentKind.Empty or ConfigurationDocumentKind.V6 =>
+                ConfigurationSerializer.SerializeDocument(ConfigurationDocumentMapper.Nest(document)),
+            ConfigurationDocumentKind.V7 => ConfigurationSerializer.SerializeDocument(document),
+            _ => throw new ConfigurationException(
+                "The configuration document mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure before migrating.")
+        };
+    }
+}

--- a/src/GitVersion.Configuration/ConfigurationMigrationService.cs
+++ b/src/GitVersion.Configuration/ConfigurationMigrationService.cs
@@ -1,0 +1,58 @@
+using GitVersion.Extensions;
+using SharpYaml;
+
+namespace GitVersion.Configuration;
+
+internal class ConfigurationMigrationService(IConfigurationSerializer configurationSerializer) : IConfigurationMigrationService
+{
+    private static readonly YamlSerializerOptions ValidationOptions = new()
+    {
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        Converters = [VersionStrategiesConverter.Instance]
+    };
+
+    private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
+
+    public string Migrate(string input)
+    {
+        var document = this.configurationSerializer.Deserialize<Dictionary<object, object?>>(input);
+        MoveDraftWorkflowToRoot(document);
+        var normalized = ConfigurationDocumentMapper.NormalizeInternal(document, "configuration document");
+        // Validate the effective types without serializing defaults back into the user's document.
+        _ = YamlSerializer.Deserialize<GitVersionConfiguration>(ConfigurationSerializer.SerializeLegacy(normalized), ValidationOptions);
+
+        return ConfigurationDocumentMapper.Detect(document) switch
+        {
+            ConfigurationDocumentKind.Empty or ConfigurationDocumentKind.Shared or ConfigurationDocumentKind.V6 =>
+                ConfigurationSerializer.SerializeDocument(ConfigurationDocumentMapper.Nest(document)),
+            ConfigurationDocumentKind.V7 => ConfigurationSerializer.SerializeDocument(document),
+            _ => throw new ConfigurationException(
+                "The configuration document mixes the v6 flat configuration structure with the v7 'calculation'/'output' structure. " +
+                "Use only one structure before migrating.")
+        };
+    }
+
+    private static void MoveDraftWorkflowToRoot(Dictionary<object, object?> document)
+    {
+        if (document.TryGetValue(ConfigurationDocumentMapper.OutputSectionName, out var outputValue)
+            && outputValue is IReadOnlyDictionary<object, object?> output && output.ContainsKey(ConfigurationDocumentMapper.WorkflowPropertyName))
+        {
+            throw new ConfigurationException("Configuration property 'output.workflow' is not supported. Move 'workflow' to the document root before migrating.");
+        }
+
+        if (!document.TryGetValue(ConfigurationDocumentMapper.CalculationSectionName, out var calculationValue)
+            || calculationValue is not IDictionary<object, object?> calculation
+            || !calculation.TryGetValue(ConfigurationDocumentMapper.WorkflowPropertyName, out var workflow))
+        {
+            return;
+        }
+
+        if (document.ContainsKey(ConfigurationDocumentMapper.WorkflowPropertyName))
+        {
+            throw new ConfigurationException("Configuration property 'workflow' is defined at both the document root and 'calculation.workflow'. Keep only one before migrating.");
+        }
+
+        calculation.Remove(ConfigurationDocumentMapper.WorkflowPropertyName);
+        document[ConfigurationDocumentMapper.WorkflowPropertyName] = workflow;
+    }
+}

--- a/src/GitVersion.Configuration/ConfigurationProvider.cs
+++ b/src/GitVersion.Configuration/ConfigurationProvider.cs
@@ -18,6 +18,7 @@ internal class ConfigurationProvider(
     private readonly ILogger<ConfigurationProvider> logger = logger.NotNull();
     private readonly IConfigurationSerializer configurationSerializer = configurationSerializer.NotNull();
     private readonly IOptions<GitVersionOptions> options = options.NotNull();
+    private bool legacyConfigurationWarningLogged;
 
     public IGitVersionConfiguration Provide(IReadOnlyDictionary<object, object?>? overrideConfiguration = null)
     {
@@ -49,6 +50,7 @@ internal class ConfigurationProvider(
         var overrideConfigurationFromFile = configurationFromFile is null
             ? null
             : ConfigurationDocumentMapper.Normalize(configurationFromFile, configurationVersion, "configuration file");
+        WarnAboutExplicitLegacyConfiguration(configFile, configurationFromFile);
         var normalizedOverrideConfiguration = overrideConfiguration is null
             ? null
             : ConfigurationDocumentMapper.NormalizeInternal(overrideConfiguration, "runtime override configuration");
@@ -100,6 +102,21 @@ internal class ConfigurationProvider(
         this.logger.LogInformation("Using configuration file '{ConfigFilePath}'", configFilePath);
         var content = this.fileSystem.File.ReadAllText(configFilePath);
         return this.configurationSerializer.Deserialize<Dictionary<object, object?>>(content);
+    }
+
+    private void WarnAboutExplicitLegacyConfiguration(string? configFilePath, Dictionary<object, object?>? configuration)
+    {
+        if (configuration is null || this.legacyConfigurationWarningLogged || !ConfigurationVersionSelector.IsExplicitV6())
+        {
+            return;
+        }
+
+        this.legacyConfigurationWarningLogged = true;
+        this.logger.LogWarning(
+            "Configuration file '{ConfigurationFile}' uses the temporary v6 compatibility mode. Legacy configuration loading is removed in GitVersion 7.1. " +
+            "Run 'gitversion config migrate' and validate with {ConfigurationVersion}=v7.",
+            configFilePath,
+            ConfigurationVersionSelector.EnvironmentVariableName);
     }
 
     private static string? GetWorkflow(IReadOnlyDictionary<object, object?>? overrideConfiguration, IReadOnlyDictionary<object, object?>? overrideConfigurationFromFile)

--- a/src/GitVersion.Configuration/ConfigurationSerializer.cs
+++ b/src/GitVersion.Configuration/ConfigurationSerializer.cs
@@ -47,6 +47,13 @@ internal class ConfigurationSerializer : IConfigurationSerializer
         return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
     }
 
+    internal static string SerializeDocument(IReadOnlyDictionary<object, object?> document)
+    {
+        var yaml = SerializeLegacy(document);
+        var configuration = YamlSerializer.Deserialize<Dictionary<string, object?>>(yaml, SerializerOptions) ?? [];
+        return YamlSerializer.Serialize(OrderProperties(configuration), SerializerOptions);
+    }
+
     public static IGitVersionConfiguration? ReadConfiguration(string input)
         => DeserializeConfiguration(input, ConfigurationVersionSelector.Resolve(), "configuration document");
 

--- a/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
+++ b/src/GitVersion.Configuration/GitVersionConfigurationModule.cs
@@ -8,6 +8,7 @@ public class GitVersionConfigurationModule : IGitVersionModule
     {
         services.AddSingleton<IGitVersionCacheKeyFactory, GitVersionCacheKeyFactory>();
         services.AddSingleton<IConfigurationSerializer, ConfigurationSerializer>();
+        services.AddSingleton<IConfigurationMigrationService, ConfigurationMigrationService>();
         services.AddSingleton<IConfigurationProvider, ConfigurationProvider>();
         services.AddSingleton<IConfigurationFileLocator, ConfigurationFileLocator>();
     }

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -21,6 +21,17 @@ public class ConfigurationVersionSelectorTests : TestBase
         ConfigurationVersionSelector.Resolve().ShouldBe(isV6 ? ConfigurationVersion.V6 : ConfigurationVersion.V7);
     }
 
+    [TestCase(null, false)]
+    [TestCase("v6", true)]
+    [TestCase(" V6 ", true)]
+    [TestCase("v7", false)]
+    public void IdentifiesExplicitV6Selection(string? value, bool expected)
+    {
+        using var scope = new EnvironmentVariableScope(value);
+
+        ConfigurationVersionSelector.IsExplicitV6().ShouldBe(expected);
+    }
+
     [TestCase("6")]
     [TestCase("7")]
     [TestCase("true")]

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -25,4 +25,7 @@ internal static class ConfigurationVersionSelector
     }
 
     public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
+
+    public static bool IsExplicitV6() =>
+        SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim().Equals("v6", StringComparison.OrdinalIgnoreCase) ?? false;
 }

--- a/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
+++ b/src/GitVersion.Core/Configuration/IConfigurationMigrationService.cs
@@ -1,0 +1,6 @@
+namespace GitVersion.Configuration;
+
+internal interface IConfigurationMigrationService
+{
+    string Migrate(string input);
+}

--- a/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using GitVersion.Logging;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
 
 namespace GitVersion.Extensions;
 
@@ -57,6 +58,15 @@ public static class ServiceCollectionExtensions
         if (ShouldLogToConsole())
         {
             loggerConfig.WriteTo.Console(outputTemplate: outputTemplate, formatProvider: formatProvider);
+        }
+        else
+        {
+            // Keep warnings visible without mixing them into machine-readable stdout.
+            // Errors already have an explicit stderr path in the CLI executors.
+            loggerConfig.WriteTo.Logger(warnings => warnings
+                .Filter.ByIncludingOnly(logEvent => logEvent.Level == LogEventLevel.Warning)
+                .WriteTo.Console(outputTemplate: outputTemplate, formatProvider: formatProvider,
+                    standardErrorFromLevel: LogEventLevel.Warning));
         }
 
         if (ShouldLogToFile())

--- a/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
+++ b/src/GitVersion.Core/Options/ConfigurationMigrationInfo.cs
@@ -1,0 +1,20 @@
+namespace GitVersion;
+
+/// <summary>Settings that control a configuration migration operation.</summary>
+public class ConfigurationMigrationInfo
+{
+    /// <summary>Gets or sets a value indicating whether the configuration migration command should be executed.</summary>
+    public bool IsMigration { get; set; }
+
+    /// <summary>Gets or sets the configuration file to migrate.</summary>
+    public string? InputFile { get; set; }
+
+    /// <summary>Gets or sets the file to which the migrated configuration should be written.</summary>
+    public string? OutputFile { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the source configuration file should be replaced.</summary>
+    public bool InPlace { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether an existing output file may be replaced.</summary>
+    public bool Force { get; set; }
+}

--- a/src/GitVersion.Core/Options/GitVersionOptions.cs
+++ b/src/GitVersion.Core/Options/GitVersionOptions.cs
@@ -17,6 +17,9 @@ public class GitVersionOptions
     /// <summary>Gets the settings that control how the GitVersion configuration file is located and applied.</summary>
     public ConfigurationInfo ConfigurationInfo { get; } = new();
 
+    /// <summary>Gets the settings that control configuration migration.</summary>
+    public ConfigurationMigrationInfo ConfigurationMigrationInfo { get; } = new();
+
     /// <summary>Gets the repository-targeting settings (URL, branch, commit, clone path).</summary>
     public RepositoryInfo RepositoryInfo { get; } = new();
 

--- a/src/GitVersion.Core/PublicAPI.Unshipped.txt
+++ b/src/GitVersion.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+GitVersion.ConfigurationMigrationInfo
+GitVersion.ConfigurationMigrationInfo.ConfigurationMigrationInfo() -> void
+GitVersion.ConfigurationMigrationInfo.Force.get -> bool
+GitVersion.ConfigurationMigrationInfo.Force.set -> void
+GitVersion.ConfigurationMigrationInfo.InPlace.get -> bool
+GitVersion.ConfigurationMigrationInfo.InPlace.set -> void
+GitVersion.ConfigurationMigrationInfo.InputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.InputFile.set -> void
+GitVersion.ConfigurationMigrationInfo.IsMigration.get -> bool
+GitVersion.ConfigurationMigrationInfo.IsMigration.set -> void
+GitVersion.ConfigurationMigrationInfo.OutputFile.get -> string?
+GitVersion.ConfigurationMigrationInfo.OutputFile.set -> void
+GitVersion.GitVersionOptions.ConfigurationMigrationInfo.get -> GitVersion.ConfigurationMigrationInfo!
 GitVersion.Configuration.EffectiveConfiguration.CustomVersionFormat.get -> string?
 GitVersion.Configuration.EffectiveConfiguration.VersionBumpResetMessage.get -> string?
 GitVersion.Configuration.IBranchConfiguration.CustomVersionFormat.get -> string?


### PR DESCRIPTION
## Summary

- Adds the POSIX-only `gitversion config migrate` command with atomic output, overwrite safeguards, and explicit-v6 warnings.
- Preserves root-level `workflow` while migrating flat settings into `calculation` and `output`.
- Migration can relocate the earlier draft's `calculation.workflow`; duplicate selectors and `output.workflow` are rejected. Runtime loading remains strict.
- Preserves migration idempotence and effective configuration.

## Validation

- Full-stack configuration tests — 168 passed; app tests — 406 passed.
- Includes workflow-only input, draft-selector migration, duplicate rejection, and in-place idempotence.
- Full solution build and scoped dotnet format.

Closes #5133
