### PR TITLE
chore(dependabot): group NUnit3TestAdapter updates by name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,7 @@ updates:
         group-by: dependency-name
         patterns:
           - "NUnit.*"
+          - "NUnit3TestAdapter"
       LibGit2Sharp:
         group-by: dependency-name
         patterns:


### PR DESCRIPTION
## Summary

- explicitly include NUnit3TestAdapter in the NUnit Dependabot group
- combine matching updates across the new-cli and src package roots into one PR
- prevent future duplicate per-directory updates like #5167 and #5168

## Validation

- parsed .github/dependabot.yml successfully
- verified dependency-name grouping and both package roots
- git diff --check