### PR TITLE
fix(devcontainer): pin feature versions for Dependabot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,23 +7,23 @@
         "context": "."
     },
     "features": {
-        "ghcr.io/devcontainers/features/common-utils": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.9": {
             "installZsh": "true",
             "username": "vscode",
             "userUid": "1000",
             "userGid": "1000",
             "upgradePackages": "true"
         },
-        "ghcr.io/devcontainers/features/powershell": {
+        "ghcr.io/devcontainers/features/powershell:2.0.2": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/github-cli": {
+        "ghcr.io/devcontainers/features/github-cli:1.1.0": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/docker-in-docker": {
+        "ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {
             "version": "latest"
         },
-        "ghcr.io/eitsupi/devcontainer-features/jq-likes": {
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes:2.1.1": {
             "jqVersion": "latest",
             "yqVersion": "latest",
             "xqVersion": "none"


### PR DESCRIPTION
## Summary

- pin every Dev Container feature reference to its current lock-file version
- provide explicit requirements for Dependabot devcontainer updates
- preserve the currently resolved feature versions and digests

This addresses the Dependabot updater TypeError seen in [run 33173447120](https://github.com/GitTools/GitVersion/actions/runs/33173447120/job/98855987994), where unversioned feature references produced nil requirement strings.

## Validation

- verified every feature pin matches devcontainer-lock.json
- devcontainer outdated completed successfully and reported all five pinned references
- git diff --check