### PR TITLE
Use managed Git backend for package builds

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -4,6 +4,7 @@ on:
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
+  GITVERSION_GIT_BACKEND: managed
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- run the reusable package build with the managed Git backend on Windows, Linux, and macOS
- dogfood the managed implementation without changing local build behavior ahead of the v7.0 product-default switch
- leave the explicit dual-backend unit, artifact, and Docker matrices unchanged

## Validation

- `actionlint .github/workflows/_build.yml`
- `git diff --check`

Relates to #5137.