### PR TITLE
Default to v7 feature selections and standardize compatibility selectors

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -35,14 +35,14 @@ GitVersion is migrating away from LibGit2Sharp and its native libgit2 binaries t
 
 | Release | Default backend | Switch |
 | ------- | --------------- | ------ |
-| v7.0    | `libgit2`       | `GITVERSION_GIT_BACKEND=managed` to opt in to the new backend |
-| v7.1    | `managed`       | `GITVERSION_GIT_BACKEND=libgit2` to fall back |
-| later   | `managed`       | libgit2 backend removed |
+| v7.0    | `managed`       | `GITVERSION_GIT_BACKEND=libgit2` is a temporary fallback |
+| v7.1    | `managed`       | libgit2 is removed; `libgit2` reports an actionable error, explicit `managed` remains accepted |
+| v8      | `managed`       | the selector is removed |
 
 Behavioral notes when using the `managed` backend:
 
 * Mutating and network operations (repository normalization on CI build agents, dynamic repositories via `--url`, checkout, fetch) are performed by invoking the `git` executable, which must be available on the `PATH`. Plain version calculation on an already-prepared checkout does not require it.
-* v7.0 behavior is unchanged unless you opt in. Please test the `managed` backend and report issues — the libgit2 backend will be removed once the new backend has proven itself over several releases.
+* The default changes to `managed` in v7.0. LibGit2Sharp/native binaries remain available through the explicit fallback until their scheduled v7.1 removal.
 
 ### Invalid label formatting is not ignored
 Previously bad label formatting config would be silently accepted. For example `{Branhc}` (when BranchName is misspelled) or even `{BranchName` (missing a closing brace). This is not ignored now and exceptions will be thrown if formatting problems exist in the label config. This brings it into line with how assembly string formatting is treated.
@@ -53,7 +53,13 @@ The command-line interface has been migrated from Windows-style (`/switch` and s
 
 **Old-style arguments are no longer accepted by default.** Update any scripts, CI pipelines, or tooling accordingly.
 
-As a temporary migration aid, set the environment variable `GITVERSION_USE_V6_ARGUMENT_PARSER=true` to restore the legacy `/switch` and `-switch` argument handling. This escape hatch will be removed in a future release.
+As a temporary v7.0 migration aid, set `GITVERSION_ARGUMENT_PARSER_VERSION=v6` to restore legacy `/switch` and `-switch` handling. The default is `v7`. Unset `GITVERSION_USE_V6_ARGUMENT_PARSER`: any presence of that retired variable, including `false`, now fails with replacement guidance. The legacy parser is scheduled for removal in v7.1; the selector remains until v8.
+
+The parser, configuration and Git backend selectors are independent. They trim
+values, ignore case, treat blanks as unset and reject unknown values with the
+accepted values. Effective selections are logged at information level; console
+logs use stderr, including when build-server output is selected. Build-server
+integration commands continue to use their existing output channel.
 
 ### Configuration structure and migration
 
@@ -74,6 +80,10 @@ Convert files with `gitversion config migrate`. The command
 writes YAML to stdout by default, supports `--config`, `--output`,
 `--in-place`, and `--force`, and warns that comments cannot be preserved when
 replacing a file.
+
+Flat v6 runtime support is scheduled for removal in v7.1. Explicit `v7` remains
+accepted throughout v7.x, and the configuration selector is removed in v8.
+`gitversion config migrate` remains available after runtime removal.
 
 #### Full argument mapping
 

--- a/build/common/Utilities/DockerContextExtensions.cs
+++ b/build/common/Utilities/DockerContextExtensions.cs
@@ -261,7 +261,7 @@ public static class DockerContextExtensions
             }
 
             // Forward the selected Git backend into the container so the same image/package is
-            // exercised against both libgit2 and managed (set per-step in CI). Absent = libgit2 default.
+            // exercised against both libgit2 and managed (set per-step in CI). Absent = managed default.
             var gitBackend = context.EnvironmentVariable("GITVERSION_GIT_BACKEND");
             if (!string.IsNullOrWhiteSpace(gitBackend))
             {

--- a/docs/design/managed-git-migration.md
+++ b/docs/design/managed-git-migration.md
@@ -200,7 +200,7 @@ Build `GitVersion.Git.Managed` bottom-up with per-layer unit tests against git-C
 (loose/packed/mixed objects, packed-refs, worktrees, shallow, multi-pack-index, index v4).
 The final B step takes the `GitVersion.Core` reference, lands the direct `IGitRepository`/
 `IMutatingGitRepository` implementations, absorbs `GitVersion.Git.CommandLine` (see §4), and wires
-backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2`). Validation:
+backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (initially `libgit2`, changed to `managed` for v7.0 under #5135). Validation:
 - **CI matrix**: full integration suites (`GitVersion.Core.Tests`, `GitVersion.App.Tests`) run on both backends,
   three OSes — the suites assert exact SemVer strings over complex histories and are the strongest parity oracle
 - **DualBackendParityTests**: open the same fixture with both backends; deep-equality on ref enumeration,
@@ -209,10 +209,13 @@ backend selection via `GITVERSION_GIT_BACKEND=managed|libgit2` (default `libgit2
 - **Real-world corpus script**: `gitversion /nocache /output json` diffed across backends on this repo,
   GitReleaseManager, dotnet/runtime, a shallow CI-style clone, and a worktree checkout
 
-### Phase C — default flip in v7.1 · ~1 week + multi-release soak
-**v7.0 ships with default `libgit2`** (managed opt-in); **v7.1 flips the default to `managed`** with
-`GITVERSION_GIT_BACKEND=libgit2` as the fallback while users validate the new backend. The dual-backend
-CI matrix stays green throughout the window.
+### Phase C — managed default in v7.0
+**v7.0 ships with default `managed`** under #5135, with
+`GITVERSION_GIT_BACKEND=libgit2` as the temporary fallback. The independent
+parser/configuration selectors default to `v7`. All selectors trim values,
+ignore case, treat blanks as unset and reject unknown values. Effective
+selections are logged without mixing logs into machine-readable stdout.
+The dual-backend CI matrix stays green throughout the v7.0 window.
 
 ### Phase D — fixture migration (parallel with B) · ~2–3 weeks
 `GitVersion.Testing` moves to pure git-CLI writes via the existing `ExecuteGitCmd` pattern:
@@ -220,13 +223,18 @@ deterministic `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env (several tests advance commit
 `git commit --allow-empty`, `-c commit.gpgsign=false -c gc.auto=0`. Migrate the six direct-usage test files.
 If suite time regresses from process spawns, batch history creation with `git fast-import`.
 
-### Phase E — remove LibGit2Sharp · ~1–2 weeks
+### Phase E — remove LibGit2Sharp in v7.1 (#5040)
 Delete `src/GitVersion.LibGit2Sharp` and `new-cli/GitVersion.Core.Libgit2Sharp`; drop the package from
 `Directory.Packages.props`; re-point new-cli source-linking at `GitVersion.Git.Managed`
 (read-only subset). Add a packaging assertion test: **zero `runtimes/**/native/*` entries** in the
 `GitVersion.MsBuild` and `GitVersion.Tool` nupkgs. Document the new runtime requirement: `git` on PATH is needed
 **only** for dynamic-repo/CI-normalization scenarios — pure version calculation on a prepared checkout needs no
 git binary at all (a strict improvement for MSBuild-task users).
+
+Parser and flat configuration runtime removal in v7.1 is tracked separately
+by #5188. Keep `gitversion config migrate` and actionable retired selector
+value diagnostics throughout v7.x. #5136 removes all three selectors in v8;
+explicit `v7` and `managed` remain accepted until then.
 
 ### Phase F (optional) — performance accelerators · ~2–3 weeks
 Commit-graph reader (generation numbers for topo sort and merge-base), benchmark-driven pack cache tuning.

--- a/docs/input/docs/migration/v6-to-v7.md
+++ b/docs/input/docs/migration/v6-to-v7.md
@@ -51,7 +51,7 @@ GitVersion now uses POSIX-style command-line arguments powered by System.Command
 :::{.alert .alert-warning}
 **Breaking change:** Legacy Windows-style (`/switch`) and legacy single-dash long-form (`-switch`) arguments are no longer accepted by default.
 
-As a temporary migration aid, set `GITVERSION_USE_V6_ARGUMENT_PARSER=true` to restore legacy argument handling. This compatibility mode is temporary and will be removed in a future release.
+As a temporary v7.0 migration aid, set `GITVERSION_ARGUMENT_PARSER_VERSION=v6` to restore legacy argument handling. The legacy parser is removed in v7.1. Unset the retired `GITVERSION_USE_V6_ARGUMENT_PARSER` variable: its presence is an error, even when set to `false`; it is not an alias for the new selector.
 :::
 
 ### What you need to change
@@ -149,14 +149,14 @@ migrate` to retain schema validation.
 
 ## Git backend
 
-GitVersion v7 introduces a fully managed Git backend as an alternative to the native LibGit2Sharp (libgit2) implementation. The backend is selected with the `GITVERSION_GIT_BACKEND` environment variable. When the variable is not set (or empty), the release's default backend is used — you never need to set it. Setting it to any value other than `libgit2` or `managed` (case-insensitive) is an error: GitVersion fails fast instead of silently running the default backend with a typo unnoticed.
+GitVersion v7.0 uses the managed Git backend by default. The `GITVERSION_GIT_BACKEND` environment variable accepts `managed` or the temporary `libgit2` fallback.
 
 :::{.alert .alert-info}
-In v7.0 the `libgit2` backend remains the **default** — behaviour is unchanged unless you opt in. Set `GITVERSION_GIT_BACKEND=managed` to try the managed backend and help validate it. In v7.1 the default flips to `managed`, with `GITVERSION_GIT_BACKEND=libgit2` available as a fallback. Both backends ship side by side for several releases before libgit2 is removed.
+In v7.0, use `GITVERSION_GIT_BACKEND=libgit2` only if you need the temporary native backend fallback. LibGit2Sharp and its native binaries are scheduled for removal in v7.1. Explicit `managed` remains accepted throughout v7.x; the selector is removed in v8.
 :::
 
-- `libgit2` — the native, libgit2-based backend (default in v7.0).
-- `managed` — a managed implementation for all read/history operations, combined with the `git` command-line executable for network and write operations (clone, fetch, checkout, and CI repository normalization).
+- `libgit2` — the temporary native backend fallback in v7.0.
+- `managed` — the v7.0 default: a managed implementation for all read/history operations, combined with the `git` command-line executable for network and write operations (clone, fetch, checkout, and CI repository normalization).
 
 :::{.alert .alert-warning}
 When using the `managed` backend, the `git` executable must be available on the `PATH` **only** for the network/normalization scenarios above (dynamic repositories, build-agent normalization). Plain version calculation on an already-prepared checkout does not require `git` on the `PATH`.
@@ -169,7 +169,27 @@ The environment variables relevant to migrating from v6 to v7:
 | Variable                            | Purpose                                                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `GITVERSION_CONFIGURATION_VERSION`   | Selects the configuration layout: `v7` (default) or temporary flat `v6` fallback.                                   |
-| `GITVERSION_GIT_BACKEND`             | Selects the Git backend: `libgit2` (default in v7.0) or `managed`. See [Git backend](#git-backend).                 |
-| `GITVERSION_USE_V6_ARGUMENT_PARSER` | Set to `true` to temporarily restore the legacy v6 (`/switch`) argument parser. Removed in a future release.        |
+| `GITVERSION_GIT_BACKEND`             | Selects the Git backend: `managed` (default) or temporary `libgit2` fallback. See [Git backend](#git-backend). |
+| `GITVERSION_ARGUMENT_PARSER_VERSION` | Selects the argument parser: `v7` (default, POSIX syntax) or temporary `v6` fallback (`/switch` and `-switch`). |
 | `GITVERSION_REMOTE_USERNAME`        | Alternative to `--username` for dynamic-repository credentials.                                                     |
 | `GITVERSION_REMOTE_PASSWORD`        | Alternative to `--password` for dynamic-repository credentials.                                                     |
+
+The three selectors are independent: selecting the v6 parser does not select
+flat configuration or libgit2. Values are trimmed and case-insensitive;
+unset, empty, and whitespace-only values use the defaults. Unknown values
+fail before execution and list the accepted values. Replace
+`GITVERSION_USE_V6_ARGUMENT_PARSER=true` with
+`GITVERSION_ARGUMENT_PARSER_VERSION=v6` and unset the old variable.
+
+Effective selections are logged at information level. Use `--log-file <path>`
+to capture them or `--log-file console` to see them on stderr. Console logs
+also use stderr when build-server output is selected, including combinations
+with JSON or other machine-readable output. Build-server integration commands
+retain their normal output channel. For migration, place logging options before the command:
+`gitversion --log-file console config migrate --config GitVersion.yml`.
+
+In v7.1, legacy parser and flat configuration runtime support are scheduled
+for removal alongside libgit2. Retired `v6`/`libgit2` selections will report
+actionable errors; explicit `v7`/`managed` selections remain accepted during
+v7.x. All three selectors are removed in v8. `gitversion config migrate`
+remains available to convert flat files after runtime support is removed.

--- a/docs/input/docs/reference/environment-variables.md
+++ b/docs/input/docs/reference/environment-variables.md
@@ -8,7 +8,7 @@ Distinguish variables **read by GitVersion** from version variables **exported t
 
 `Git_Branch` can identify the branch or tag when the build context is ambiguous. Provider-specific detection is described in the [CI guides](/docs/reference/build-servers). Ensure the selected reference and its history are available in the checkout.
 
-The [v6 to v7 migration guide](/docs/migration/v6-to-v7#environment-variables) documents Git backend selection and temporary compatibility controls, including `GITVERSION_USE_V6_ARGUMENT_PARSER`. Compatibility switches are migration aids, not recommended defaults for a new setup.
+The [v6 to v7 migration guide](/docs/migration/v6-to-v7#environment-variables) documents the independent selectors `GITVERSION_ARGUMENT_PARSER_VERSION`, `GITVERSION_CONFIGURATION_VERSION`, and `GITVERSION_GIT_BACKEND`. Their v7.0 defaults are `v7`, `v7`, and `managed`; temporary fallbacks are `v6`, `v6`, and `libgit2`. Values are trimmed and case-insensitive; blank values use the defaults and unknown values fail with accepted-value guidance. The retired `GITVERSION_USE_V6_ARGUMENT_PARSER` variable must be unset. Legacy implementations are removed in v7.1 and selectors in v8.
 
 ## Output variables
 

--- a/docs/input/docs/usage/cli/arguments.md
+++ b/docs/input/docs/usage/cli/arguments.md
@@ -8,7 +8,10 @@ Description: The supported arguments of the GitVersion Command Line Interface
 **Note:** GitVersion uses POSIX-style `--long-name` arguments from version 7 and up. Long-form
 arguments are recommended for readability in scripts and documentation. Short aliases
 (e.g. `-l`, `-o`, `-b`) are also supported. The legacy `/switch` and `-switch`
-syntax is still available when `GITVERSION_USE_V6_ARGUMENT_PARSER=true` is set.
+syntax is available during v7.0 when `GITVERSION_ARGUMENT_PARSER_VERSION=v6` is set.
+The default is `v7`. Unset the retired `GITVERSION_USE_V6_ARGUMENT_PARSER`
+variable; it now produces a replacement diagnostic. The legacy parser is
+removed in v7.1 and the selector in v8.
 
 See [Migration v6 to v7](/docs/migration/v6-to-v7) for upgrade guidance and the full argument mapping.
 :::
@@ -47,7 +50,7 @@ GitVersion [path]
                     Supports C# format strings - see [Format Strings](/docs/reference/custom-formatting) for details.
                     E.g. --output json --format {SemVer} - will output `1.2.3+beta.4`
                          --output json --format {Major}.{Minor} - will output `1.2`
-    --log-file, -l  Path to logfile; specify 'console' to emit to stdout.
+    --log-file, -l  Path to logfile; specify 'console' to emit to stderr.
     --config, -c    Path to config file (defaults to GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml)
     --show-config   Outputs the effective GitVersion config (defaults + custom
                     from GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml) in yaml format
@@ -122,7 +125,8 @@ writes YAML to stdout unless `--output` or `--in-place` is selected. `--output`
 will not replace an existing file without `--force`; it cannot be combined with
 `--in-place`. Replacing a file warns that comments are not preserved. The
 command does not require a Git repository and is unavailable when
-`GITVERSION_USE_V6_ARGUMENT_PARSER=true` selects the legacy parser.
+`GITVERSION_ARGUMENT_PARSER_VERSION=v6` selects the legacy parser. Migration
+remains available after v6 runtime support is removed in v7.1.
 
 ## Override config
 

--- a/new-cli/GitVersion.Common/GitVersion.Common.csproj
+++ b/new-cli/GitVersion.Common/GitVersion.Common.csproj
@@ -13,6 +13,7 @@
         <Compile Include="..\..\src\GitVersion.Core\Core\Abstractions\IEnvironment.cs" Link="Infrastructure\%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Core\Exceptions\WarningException.cs" Link="Exceptions\%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Core\RegexPatterns.cs" Link="%(Filename)%(Extension)" />
+        <Compile Include="..\..\src\GitVersion.Core\FeatureSelector.cs" Link="%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Extensions\DictionaryExtensions.cs" Link="%(Filename)%(Extension)" />
         <Compile Include="..\..\src\GitVersion.Core\Extensions\StringExtensions.cs" Link="Extensions\StringExtensions.cs" />
         <Compile Include="..\..\src\GitVersion.Core\Extensions\CommonExtensions.cs" Link="Extensions\CommonExtensions.cs" />

--- a/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
+++ b/src/GitVersion.App.Tests/ExecCmdLineArgumentTest.cs
@@ -46,7 +46,7 @@ public class ExecCmdLineArgumentTest
         var headCommit = fixture.MakeACommit();
 
         var environment = new KeyValuePair<string, string?>(
-            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+            "GITVERSION_ARGUMENT_PARSER_VERSION", useLegacyParser ? "v6" : null);
         var showVariableArgument = useLegacyParser ? "-showvariable" : "--show-variable";
         var commitArgument = useLegacyParser ? "-c" : "--commit";
         var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
@@ -76,7 +76,7 @@ public class ExecCmdLineArgumentTest
         fixture.MakeACommit();
 
         var environment = new KeyValuePair<string, string?>(
-            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+            "GITVERSION_ARGUMENT_PARSER_VERSION", useLegacyParser ? "v6" : null);
         var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
         var targetPathArgument = useLegacyParser ? $" \"{fixture.RepositoryPath}\"" : string.Empty;
         var outputArguments = useLegacyParser
@@ -107,7 +107,7 @@ public class ExecCmdLineArgumentTest
         fixture.MakeACommit();
 
         var environment = new KeyValuePair<string, string?>(
-            "GITVERSION_USE_V6_ARGUMENT_PARSER", useLegacyParser ? "true" : null);
+            "GITVERSION_ARGUMENT_PARSER_VERSION", useLegacyParser ? "v6" : null);
         var workingDirectory = useLegacyParser ? null : fixture.RepositoryPath;
         var targetPathArgument = useLegacyParser ? $" \"{fixture.RepositoryPath}\"" : string.Empty;
         var verbosityArgument = useLegacyParser ? "/verbosity Verbose" : "--verbosity verbose";

--- a/src/GitVersion.App.Tests/ExecFeatureSelectorTests.cs
+++ b/src/GitVersion.App.Tests/ExecFeatureSelectorTests.cs
@@ -1,0 +1,161 @@
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class ExecFeatureSelectorTests
+{
+    [Test]
+    [Combinatorial]
+    public void SelectorCombinationsCalculateAndLogWithoutPollutingOutput(
+        [Values("v6", "v7")] string parser,
+        [Values("v6", "v7")] string configuration,
+        [Values("libgit2", "managed")] string backend,
+        [Values("json", "variable", "config")] string output,
+        [Values(false, true)] bool buildServer)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("release-1.2.3");
+        File.WriteAllText(Path.Combine(fixture.RepositoryPath, "GitVersion.yml"),
+            configuration == "v6" ? "tag-prefix: release-" : "calculation:\n  tag-prefix: release-");
+        var legacy = parser == "v6";
+        var logPath = Path.Combine(fixture.RepositoryPath, "selectors.log");
+        var outputArgument = OutputArguments(output, legacy, buildServer);
+        var arguments = $"\"{fixture.RepositoryPath}\" {(legacy ? "/l" : "--log-file")} \"{logPath}\" {outputArgument}";
+
+        var result = GitVersionHelper.ExecuteIn(null, arguments, false, Selectors(parser, configuration, backend));
+
+        result.ExitCode.ShouldBe(0, result.Output);
+        var stdout = result.StandardOutput!;
+        stdout.ShouldNotContain("INFO [");
+        if (buildServer && output != "config")
+        {
+            var integrationOutput = $"Set Build Number for 'LocalBuild'.{SysEnv.NewLine}{SysEnv.NewLine}Set Output Variables for 'LocalBuild'.{SysEnv.NewLine}";
+            stdout.ShouldStartWith(integrationOutput);
+            stdout = stdout[integrationOutput.Length..];
+        }
+        if (output == "json")
+        {
+            using var json = JsonDocument.Parse(stdout);
+            json.RootElement.GetProperty("FullSemVer").GetString().ShouldBe("1.2.3");
+        }
+        else if (output == "variable")
+        {
+            stdout.Trim().ShouldBe("1.2.3");
+        }
+        else
+        {
+            stdout.ShouldContain("tag-prefix: release-");
+            stdout.Contains("calculation:", StringComparison.Ordinal).ShouldBe(configuration == "v7");
+        }
+
+        stdout.ShouldNotContain("Argument parser version:");
+        stdout.ShouldNotContain("Configuration version:");
+        stdout.ShouldNotContain("Git backend:");
+        if (buildServer && (!legacy || output != "config"))
+        {
+            result.StandardError.ShouldNotBeNull();
+            result.StandardError.ShouldContain($"Argument parser version: {parser}");
+        }
+        var log = File.ReadAllText(logPath);
+        log.ShouldContain($"Argument parser version: {parser}");
+        log.ShouldContain($"Configuration version: {configuration}");
+        log.ShouldContain($"Git backend: {backend}");
+        log.Split("Git backend:").Length.ShouldBe(2);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" \t ")]
+    public void DefaultsSelectV7AndManagedWithConsoleLogsOnStderr(string? value)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.3");
+        File.WriteAllText(Path.Combine(fixture.RepositoryPath, "GitVersion.yml"), "calculation:\n  tag-prefix: '[vV]?'");
+
+        var result = GitVersionHelper.ExecuteIn(fixture.RepositoryPath, " --show-variable FullSemVer --log-file console", false,
+            Selectors(value, value, value));
+
+        result.ExitCode.ShouldBe(0, result.Output);
+        result.StandardOutput!.Trim().ShouldBe("1.2.3");
+        result.StandardError.ShouldNotBeNull();
+        result.StandardError.ShouldContain("Argument parser version: v7");
+        result.StandardError.ShouldContain("Configuration version: v7");
+        result.StandardError.ShouldContain("Git backend: managed");
+    }
+
+    [TestCase("GITVERSION_ARGUMENT_PARSER_VERSION", "true", "'v6' and 'v7'")]
+    [TestCase("GITVERSION_CONFIGURATION_VERSION", "v8", "'v6' and 'v7'")]
+    [TestCase("GITVERSION_GIT_BACKEND", "manged", "'libgit2' and 'managed'")]
+    [TestCase("GITVERSION_USE_V6_ARGUMENT_PARSER", "true", "GITVERSION_ARGUMENT_PARSER_VERSION=v6")]
+    [TestCase("GITVERSION_USE_V6_ARGUMENT_PARSER", "false", "GITVERSION_ARGUMENT_PARSER_VERSION=v6")]
+    [TestCase("GITVERSION_USE_V6_ARGUMENT_PARSER", "", "GITVERSION_ARGUMENT_PARSER_VERSION=v6")]
+    public void InvalidSelectorsFailBeforeHelpWithActionableStderr(string variable, string value, string guidance)
+    {
+        var environment = Selectors("v7", "v7", "managed").ToDictionary(pair => pair.Key, pair => pair.Value);
+        environment[variable] = value;
+
+        var result = GitVersionHelper.ExecuteIn(null, "--help", false, [.. environment]);
+
+        result.ExitCode.ShouldBe(1);
+        result.StandardOutput.ShouldBeEmpty();
+        result.StandardError.ShouldNotBeNull();
+        result.StandardError.ShouldContain(variable);
+        result.StandardError.ShouldContain(guidance);
+        result.StandardError.ShouldNotContain("Unhandled exception");
+    }
+
+    [Test]
+    [Combinatorial]
+    public void MigrationRetainsYamlStdoutWithEitherConfigurationAndBackend(
+        [Values("v6", "v7")] string configuration,
+        [Values("libgit2", "managed")] string backend)
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var input = Path.Combine(directory.FullName, "GitVersion.yml");
+            File.WriteAllText(input, "next-version: 2.0.0");
+            var result = GitVersionHelper.ExecuteIn(null,
+                $"--log-file console config migrate --config \"{input}\"", false, Selectors("v7", configuration, backend));
+
+            result.ExitCode.ShouldBe(0, result.Output);
+            result.StandardOutput.ShouldNotBeNull();
+            result.StandardError.ShouldNotBeNull();
+            result.StandardOutput.ShouldContain("calculation:");
+            result.StandardOutput.ShouldContain("  next-version: 2.0.0");
+            result.StandardOutput.ShouldNotContain("INFO");
+            result.StandardError.ShouldContain($"Configuration version: {configuration}");
+            result.StandardError.ShouldContain($"Git backend: {backend}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private static string OutputArguments(string output, bool legacy, bool buildServer)
+    {
+        var arguments = (legacy, output) switch
+        {
+            (true, "variable") => "/output json /showvariable FullSemVer",
+            (false, "variable") => "--output json --show-variable FullSemVer",
+            (true, "config") => "/showconfig",
+            (false, "config") => "--show-config",
+            (true, _) => "/output json",
+            _ => "--output json"
+        };
+        if (buildServer)
+        {
+            arguments += legacy ? " /output buildserver" : " --output buildserver";
+        }
+        return arguments;
+    }
+
+    private static KeyValuePair<string, string?>[] Selectors(string? parser, string? configuration, string? backend) =>
+    [
+        new("GITVERSION_ARGUMENT_PARSER_VERSION", parser),
+        new("GITVERSION_CONFIGURATION_VERSION", configuration),
+        new("GITVERSION_GIT_BACKEND", backend),
+        new("GITVERSION_USE_V6_ARGUMENT_PARSER", null)
+    ];
+}

--- a/src/GitVersion.App.Tests/FeatureSelectorTests.cs
+++ b/src/GitVersion.App.Tests/FeatureSelectorTests.cs
@@ -1,0 +1,110 @@
+using GitVersion.Configuration;
+using GitVersion.Git;
+using GitVersion.Tests;
+
+namespace GitVersion.App.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class FeatureSelectorTests
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase(" \t ", false)]
+    [TestCase("v6", true)]
+    [TestCase(" V6 ", true)]
+    [TestCase("v7", false)]
+    [TestCase(" V7 ", false)]
+    public void ParserResolvesKnownValues(string? value, bool legacy)
+    {
+        using var scope = new SelectorScope(parser: value);
+
+        ArgumentParserVersionSelector.Resolve().ShouldBe(legacy ? ArgumentParserVersion.V6 : ArgumentParserVersion.V7);
+    }
+
+    [TestCase("true")]
+    [TestCase("6")]
+    [TestCase("v8")]
+    public void ParserRejectsUnknownValues(string value)
+    {
+        using var scope = new SelectorScope(parser: value);
+
+        var exception = Should.Throw<WarningException>(() => ArgumentParserVersionSelector.Resolve());
+        exception.Message.ShouldContain(ArgumentParserVersionSelector.EnvironmentVariableName);
+        exception.Message.ShouldContain(value);
+        exception.Message.ShouldContain("'v6' and 'v7'");
+    }
+
+    [TestCase("true")]
+    [TestCase("false")]
+    [TestCase(" ")]
+    public void RetiredBooleanIsRejectedEvenWithNewSelector(string value)
+    {
+        using var scope = new SelectorScope(parser: "v7", retired: value);
+
+        var exception = Should.Throw<WarningException>(() => ArgumentParserVersionSelector.Resolve());
+        exception.Message.ShouldContain(ArgumentParserVersionSelector.RetiredEnvironmentVariableName);
+        exception.Message.ShouldContain("GITVERSION_ARGUMENT_PARSER_VERSION=v6");
+    }
+
+    [Test]
+    [Combinatorial]
+    public void CompositionRegistersSelectedImplementations(
+        [Values("v6", "v7")] string parser,
+        [Values("v6", "v7")] string configuration,
+        [Values("libgit2", "managed")] string backend)
+    {
+        using var scope = new SelectorScope(parser, configuration, backend);
+        using var fixture = new EmptyRepositoryFixture();
+        var builder = CliHost.CreateCliHostBuilder([fixture.RepositoryPath]);
+        using var host = builder.Build();
+
+        host.Services.GetRequiredService<IArgumentParser>().GetType()
+            .ShouldBe(parser == "v6" ? typeof(LegacyArgumentParser) : typeof(ArgumentParser));
+        host.Services.GetRequiredService<IGitRepository>().GetType().Assembly
+            .ShouldBe(backend == "libgit2" ? typeof(GitVersionLibGit2SharpModule).Assembly : typeof(GitVersionManagedGitModule).Assembly);
+    }
+
+    [Test]
+    public void SelectionLogUsesCapturedValues()
+    {
+        FeatureSelections selections;
+        using (new SelectorScope("v6", "v6", "libgit2"))
+        {
+            selections = FeatureSelections.Resolve();
+        }
+
+        using var scope = new SelectorScope("v7", "v7", "managed");
+        var messages = new List<string>();
+        selections.Log(new TestLogger<FeatureSelections>(messages.Add));
+
+        messages.ShouldBe(new[] { "Argument parser version: v6; Configuration version: v6; Git backend: libgit2" });
+    }
+
+    private sealed class SelectorScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> originals = new();
+
+        public SelectorScope(string? parser = null, string? configuration = null, string? backend = null, string? retired = null)
+        {
+            Set(ArgumentParserVersionSelector.EnvironmentVariableName, parser);
+            Set(ConfigurationVersionSelector.EnvironmentVariableName, configuration);
+            Set(GitBackendSelector.EnvironmentVariableName, backend);
+            Set(ArgumentParserVersionSelector.RetiredEnvironmentVariableName, retired);
+        }
+
+        private void Set(string name, string? value)
+        {
+            this.originals[name] = SysEnv.GetEnvironmentVariable(name);
+            SysEnv.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in this.originals)
+            {
+                SysEnv.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
+}

--- a/src/GitVersion.App/ArgumentParser.cs
+++ b/src/GitVersion.App/ArgumentParser.cs
@@ -167,6 +167,7 @@ internal class ArgumentParser(
             MigrationOutputFile = outputFile,
             MigrationInPlace = inPlace,
             MigrationForce = force,
+            LogFilePath = parseResult.GetValue(options.LogFile),
             TargetPath = parseResult.GetValue(options.TargetPath)
                          ?? parseResult.GetValue(options.Path)
                          ?? SysEnv.CurrentDirectory
@@ -371,7 +372,7 @@ internal class ArgumentParser(
         };
         var logFile = new Option<string?>("--log-file", "-l")
         {
-            Description = "Path to logfile; specify 'console' to emit to stdout"
+            Description = "Path to logfile; specify 'console' to emit to stderr"
         };
         var output = new Option<OutputType[]>("--output", "-o")
         {

--- a/src/GitVersion.App/ArgumentParserVersion.cs
+++ b/src/GitVersion.App/ArgumentParserVersion.cs
@@ -1,0 +1,26 @@
+namespace GitVersion;
+
+internal enum ArgumentParserVersion
+{
+    V6,
+    V7
+}
+
+internal static class ArgumentParserVersionSelector
+{
+    public const string EnvironmentVariableName = "GITVERSION_ARGUMENT_PARSER_VERSION";
+    public const string RetiredEnvironmentVariableName = "GITVERSION_USE_V6_ARGUMENT_PARSER";
+
+    public static ArgumentParserVersion Resolve()
+    {
+        if (SysEnv.GetEnvironmentVariable(RetiredEnvironmentVariableName) is not null)
+        {
+            throw new WarningException(
+                $"{RetiredEnvironmentVariableName} has been removed. Unset it and use {EnvironmentVariableName}=v6 for the temporary legacy parser, or {EnvironmentVariableName}=v7 (the default).");
+        }
+
+        return FeatureSelector.Resolve(EnvironmentVariableName, "v7", "v6", "v7") == "v6"
+            ? ArgumentParserVersion.V6
+            : ArgumentParserVersion.V7;
+    }
+}

--- a/src/GitVersion.App/CliHost.cs
+++ b/src/GitVersion.App/CliHost.cs
@@ -29,17 +29,17 @@ internal static class CliHost
 
     private static void RegisterGitVersionModules(IServiceCollection services, string[] args)
     {
+        var selections = FeatureSelections.Resolve();
+        services.AddSingleton(selections);
         services.AddModule(new GitVersionCoreModule());
         services.AddModule(new GitVersionBuildAgentsModule());
         services.AddModule(new GitVersionConfigurationModule());
         services.AddModule(new GitVersionOutputModule());
 
-        services.AddModule(GitBackendSelector.Resolve() == GitBackend.Managed
+        services.AddModule(selections.GitBackend == GitBackend.Managed
             ? new GitVersionManagedGitModule()
             : new GitVersionLibGit2SharpModule());
 
-        var envValue = SysEnv.GetEnvironmentVariable("GITVERSION_USE_V6_ARGUMENT_PARSER");
-        var useLegacyParser = string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
-        services.AddModule(new GitVersionAppModule(args, useLegacyParser));
+        services.AddModule(new GitVersionAppModule(args, selections.ArgumentParser == ArgumentParserVersion.V6));
     }
 }

--- a/src/GitVersion.App/FeatureSelections.cs
+++ b/src/GitVersion.App/FeatureSelections.cs
@@ -1,0 +1,17 @@
+using GitVersion.Configuration;
+using GitVersion.Git;
+
+namespace GitVersion;
+
+internal sealed record FeatureSelections(ArgumentParserVersion ArgumentParser, ConfigurationVersion Configuration, GitBackend GitBackend)
+{
+    public static FeatureSelections Resolve() => new(
+        ArgumentParserVersionSelector.Resolve(), ConfigurationVersionSelector.Resolve(), GitBackendSelector.Resolve());
+
+    public void Log(ILogger logger) =>
+        logger.LogInformation(
+            "Argument parser version: {ArgumentParserVersion}; Configuration version: {ConfigurationVersion}; Git backend: {GitBackend}",
+            ArgumentParser == ArgumentParserVersion.V6 ? "v6" : "v7",
+            Configuration == ConfigurationVersion.V6 ? "v6" : "v7",
+            GitBackend == GitBackend.Managed ? "managed" : "libgit2");
+}

--- a/src/GitVersion.App/GitVersionApp.cs
+++ b/src/GitVersion.App/GitVersionApp.cs
@@ -6,6 +6,8 @@ internal class GitVersionApp(
     IHostApplicationLifetime applicationLifetime,
     IGitVersionExecutor gitVersionExecutor,
     IConfigurationMigrationExecutor configurationMigrationExecutor,
+    FeatureSelections selections,
+    ILogger<GitVersionApp> logger,
     IOptions<GitVersionOptions> options)
 {
     private readonly IHostApplicationLifetime applicationLifetime = applicationLifetime.NotNull();
@@ -18,6 +20,7 @@ internal class GitVersionApp(
         try
         {
             var gitVersionOptions = this.options.Value;
+            selections.Log(logger);
             if (gitVersionOptions.IsHelp || gitVersionOptions.IsVersion)
             {
                 SysEnv.ExitCode = 0;

--- a/src/GitVersion.App/GitVersionExecutor.cs
+++ b/src/GitVersion.App/GitVersionExecutor.cs
@@ -131,8 +131,6 @@ internal class GitVersionExecutor(
         {
             this.logger.LogInformation("Working directory: {WorkingDirectory}", workingDirectory);
         }
-
-        this.logger.LogInformation("Git backend: {GitBackend}", GitBackendSelector.ResolveName());
     }
 
     private bool VerifyAndDisplayConfiguration(GitVersionOptions gitVersionOptions)

--- a/src/GitVersion.App/Program.cs
+++ b/src/GitVersion.App/Program.cs
@@ -1,15 +1,17 @@
 using GitVersion;
 
-var builder = CliHost.CreateCliHostBuilder(args);
-
-var host = builder.Build();
-var app = host.Services.GetRequiredService<GitVersionApp>();
-
-var cts = new CancellationTokenSource();
-Console.CancelKeyPress += (_, _) =>
+try
 {
-    cts.Cancel();
-    cts.Dispose();
-};
+    var builder = CliHost.CreateCliHostBuilder(args);
 
-await app.RunAsync(cts.Token).ConfigureAwait(false);
+    using var host = builder.Build();
+    var app = host.Services.GetRequiredService<GitVersionApp>();
+
+    await app.RunAsync(CancellationToken.None).ConfigureAwait(false);
+}
+catch (WarningException exception)
+{
+    await Console.Error.WriteLineAsync("An error occurred:").ConfigureAwait(false);
+    await Console.Error.WriteLineAsync(exception.Message).ConfigureAwait(false);
+    SysEnv.ExitCode = 1;
+}

--- a/src/GitVersion.App/legacy_help.md
+++ b/src/GitVersion.App/legacy_help.md
@@ -25,7 +25,7 @@ GitVersion [path]
                     Supports C# format strings - see [Format Strings](/docs/reference/custom-formatting) for details.
                     E.g. /output json /format {SemVer} - will output `1.2.3+beta.4`
                          /output json /format {Major}.{Minor} - will output `1.2`
-    /l              Path to logfile; specify 'console' to emit to stdout.
+    /l              Path to logfile; specify 'console' to emit to stderr.
     /config         Path to config file (defaults to GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml)
     /showconfig     Outputs the effective GitVersion config (defaults + custom
                     from GitVersion.yml, GitVersion.yaml, .GitVersion.yml or .GitVersion.yaml) in yaml format

--- a/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/ConfigurationVersionSelectorTests.cs
@@ -8,6 +8,7 @@ public class ConfigurationVersionSelectorTests : TestBase
 {
     [TestCase(null, false)]
     [TestCase("", false)]
+    [TestCase(" \t ", false)]
     [TestCase("v6", true)]
     [TestCase("V6", true)]
     [TestCase(" v6 ", true)]

--- a/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
+++ b/src/GitVersion.Core.Tests/Core/GitBackendSelectorTests.cs
@@ -6,10 +6,12 @@ namespace GitVersion.Tests;
 [NonParallelizable]
 public class GitBackendSelectorTests : TestBase
 {
-    [TestCase(null, false)]
-    [TestCase("", false)]
+    [TestCase(null, true)]
+    [TestCase("", true)]
+    [TestCase(" \t ", true)]
     [TestCase("libgit2", false)]
     [TestCase("LIBGIT2", false)]
+    [TestCase(" LIBGIT2 ", false)]
     [TestCase("managed", true)]
     [TestCase("Managed", true)]
     [TestCase(" managed ", true)]
@@ -25,12 +27,12 @@ public class GitBackendSelectorTests : TestBase
     [TestCase("true")]
     public void FailsFastOnUnknownValues(string value)
     {
-        // A silently ignored typo would make a user believe they validated the
-        // managed backend while actually running libgit2.
         using var scope = new EnvironmentVariableScope(value);
 
-        Should.Throw<InvalidOperationException>(() => GitBackendSelector.Resolve())
-            .Message.ShouldContain(value);
+        var exception = Should.Throw<WarningException>(() => GitBackendSelector.Resolve());
+        exception.Message.ShouldContain(value);
+        exception.Message.ShouldContain(GitBackendSelector.EnvironmentVariableName);
+        exception.Message.ShouldContain("'libgit2' and 'managed'");
     }
 
     private sealed class EnvironmentVariableScope : IDisposable

--- a/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
+++ b/src/GitVersion.Core/Configuration/ConfigurationVersion.cs
@@ -10,19 +10,10 @@ internal static class ConfigurationVersionSelector
 {
     public const string EnvironmentVariableName = "GITVERSION_CONFIGURATION_VERSION";
 
-    public static ConfigurationVersion Resolve()
-    {
-        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
-
-        return value switch
-        {
-            null or "" => ConfigurationVersion.V7,
-            _ when value.Equals("v6", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V6,
-            _ when value.Equals("v7", StringComparison.OrdinalIgnoreCase) => ConfigurationVersion.V7,
-            _ => throw new WarningException(
-                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'v6' and 'v7'.")
-        };
-    }
+    public static ConfigurationVersion Resolve() =>
+        FeatureSelector.Resolve(EnvironmentVariableName, "v7", "v6", "v7") == "v6"
+            ? ConfigurationVersion.V6
+            : ConfigurationVersion.V7;
 
     public static string ResolveName() => Resolve() == ConfigurationVersion.V6 ? "v6" : "v7";
 

--- a/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ServiceCollectionExtensions.cs
@@ -57,7 +57,8 @@ public static class ServiceCollectionExtensions
 
         if (ShouldLogToConsole())
         {
-            loggerConfig.WriteTo.Console(outputTemplate: outputTemplate, formatProvider: formatProvider);
+            loggerConfig.WriteTo.Console(outputTemplate: outputTemplate, formatProvider: formatProvider,
+                standardErrorFromLevel: LogEventLevel.Verbose);
         }
         else
         {

--- a/src/GitVersion.Core/FeatureSelector.cs
+++ b/src/GitVersion.Core/FeatureSelector.cs
@@ -1,0 +1,17 @@
+namespace GitVersion;
+
+internal static class FeatureSelector
+{
+    public static string Resolve(string environmentVariableName, string defaultValue, string firstValue, string secondValue)
+    {
+        var value = SysEnv.GetEnvironmentVariable(environmentVariableName)?.Trim();
+        return value switch
+        {
+            null or "" => defaultValue,
+            _ when value.Equals(firstValue, StringComparison.OrdinalIgnoreCase) => firstValue,
+            _ when value.Equals(secondValue, StringComparison.OrdinalIgnoreCase) => secondValue,
+            _ => throw new WarningException(
+                $"Unrecognized {environmentVariableName} value '{value}'. Valid values are '{firstValue}' and '{secondValue}'.")
+        };
+    }
+}

--- a/src/GitVersion.Core/Git/GitBackend.cs
+++ b/src/GitVersion.Core/Git/GitBackend.cs
@@ -2,52 +2,43 @@ namespace GitVersion.Git;
 
 /// <summary>
 /// The Git backend implementations selectable via the <c>GITVERSION_GIT_BACKEND</c>
-/// environment variable during the dual-backend window (v7.0–v7.x).
+/// environment variable during the dual-backend window (v7.0).
 /// </summary>
 internal enum GitBackend
 {
-    /// <summary>The libgit2-based backend (the v7.0 default).</summary>
+    /// <summary>The temporary libgit2-based fallback, removed in v7.1.</summary>
     LibGit2,
 
-    /// <summary>The managed reader + git CLI mutator backend.</summary>
+    /// <summary>The managed reader + git CLI mutator backend (the v7.0 default).</summary>
     Managed
 }
 
 /// <summary>
 /// The single place where <c>GITVERSION_GIT_BACKEND</c> is interpreted: every composition
 /// root selects the backend through this class so production and tests cannot drift, and
-/// the v7.1 default flip is a one-line change. This is configuration, not Git logic — it
+/// the v7.0 default is consistent. This is configuration, not Git logic — it
 /// names no backend internals, so it lives at the composition seam that every root already
 /// shares rather than inside one of the backend assemblies.
 /// </summary>
 internal static class GitBackendSelector
 {
     public const string EnvironmentVariableName = "GITVERSION_GIT_BACKEND";
+    private const string ManagedName = "managed";
 
     /// <summary>
     /// The canonical configuration name of the resolved backend, as users set it
     /// in <c>GITVERSION_GIT_BACKEND</c>: <c>libgit2</c> or <c>managed</c>.
     /// </summary>
-    public static string ResolveName() => Resolve() == GitBackend.Managed ? "managed" : "libgit2";
+    public static string ResolveName() => Resolve() == GitBackend.Managed ? ManagedName : "libgit2";
 
     /// <summary>
-    /// Resolves the backend from the environment: <c>libgit2</c> (the default when unset)
-    /// or <c>managed</c>. Unknown values fail fast — a silently ignored typo would make a
-    /// user believe they validated the managed backend while running libgit2.
+    /// Resolves the backend from the environment: <c>managed</c> (the default when unset)
+    /// or the temporary <c>libgit2</c> fallback. Unknown values fail fast.
     /// </summary>
     /// <returns>The selected backend.</returns>
-    /// <exception cref="InvalidOperationException">The variable is set to an unrecognized value.</exception>
-    public static GitBackend Resolve()
-    {
-        var value = SysEnv.GetEnvironmentVariable(EnvironmentVariableName)?.Trim();
-
-        return value switch
-        {
-            null or "" => GitBackend.LibGit2,
-            _ when value.Equals("libgit2", StringComparison.OrdinalIgnoreCase) => GitBackend.LibGit2,
-            _ when value.Equals("managed", StringComparison.OrdinalIgnoreCase) => GitBackend.Managed,
-            _ => throw new InvalidOperationException(
-                $"Unrecognized {EnvironmentVariableName} value '{value}'. Valid values are 'libgit2' and 'managed'.")
-        };
-    }
+    /// <exception cref="WarningException">The variable is set to an unrecognized value.</exception>
+    public static GitBackend Resolve() =>
+        FeatureSelector.Resolve(EnvironmentVariableName, ManagedName, "libgit2", ManagedName) == ManagedName
+            ? GitBackend.Managed
+            : GitBackend.LibGit2;
 }


### PR DESCRIPTION
## Summary

GitVersion v7.0 now defaults to the POSIX v7 parser, nested v7 configuration and managed Git. Replace `GITVERSION_USE_V6_ARGUMENT_PARSER` with `GITVERSION_ARGUMENT_PARSER_VERSION=v6|v7`; the retired variable reports an actionable error. All three independent selectors trim values, ignore case, treat blanks as defaults and reject unknown values consistently.

The CLI captures its effective selections before registration and logs them at information level through the configured logger. Console diagnostics use stderr, including when build-server output is combined with JSON or other output; build-server integration messages retain their existing channel. Migration honors a root-level `--log-file` option. Temporary v6 parser/configuration and libgit2 fallbacks remain available.

Closes #5135. The completed configuration foundation #5131 is closed; v7.1 parser/configuration removal is tracked separately in #5188, backend removal in #5040, and v8 selector removal in #5136. Milestones, roadmap #5137 and native dependency links were aligned before implementation. No legacy implementation is removed here.

## Commit organization

1. Shared selector validation, managed Git default, source-link compatibility and core tests.
2. CLI parser selection, startup diagnostics, effective-selection logging and executable/composition tests.
3. Migration and lifecycle documentation.

## Validation

- All 489 app tests pass locally, including selector and combined-output regressions.
- All 117 focused core selector/configuration tests pass locally.
- All eight parser/configuration/backend combinations verify concrete registrations and JSON, variable and configuration output, both with and without build-server output; migration is tested against both configuration versions and backends.
- Empty, unset, padded, case-insensitive, invalid and retired selectors are covered, including stderr diagnostics and captured effective values.
- Source/build formatting checks pass; the new-cli solution builds with zero warnings or errors.
- Before opening this PR, all four fork workflows passed on `54adbb24e613d8b6cbbbe5a27399e33c6068a165`: [CI](https://github.com/arturcic/GitVersion/actions/runs/34204948992), [Code Format](https://github.com/arturcic/GitVersion/actions/runs/34204948692), [Build (new-cli)](https://github.com/arturcic/GitVersion/actions/runs/34204948644), and [Markdown Update](https://github.com/arturcic/GitVersion/actions/runs/34204948699). CI includes managed/libgit2 tests on Linux, Windows and macOS, packaging and executable/container artifact checks.
