### PR TITLE
feat: support commit SHA placeholders in branch labels

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -657,6 +657,30 @@ of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?
 
 Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
 
+Use `{Sha}` for the full hash of the commit being versioned, or `{ShortSha}` for
+its abbreviated hash, using the same seven-character abbreviation as the
+`ShortSha` output variable. These placeholders work without named regex captures
+and can be combined with them, for example `label: '{BranchName}.ci.{ShortSha}'`.
+
+```yaml
+workflow: GitHubFlow/v1
+calculation:
+  branches:
+    feature:
+      label: 'ci.{ShortSha}'
+```
+
+For a commit whose abbreviated hash is `a1b2c3d`, this configures the label
+`ci.a1b2c3d`. The pre-release number still follows the selected deployment mode.
+In the temporary [v6 compatibility mode](#v7-configuration-layout), put the same
+`label` setting under `branches.feature` instead of `calculation.branches.feature`.
+
+Placeholder names are case-sensitive. If the branch regex contains a named
+capture `Sha` or `ShortSha`, that capture takes precedence over the corresponding
+commit value, including when the capture is empty. Commit values always refer
+to the commit being versioned, even while GitVersion examines earlier commits
+or merged branches to calculate its version.
+
 You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
 
 **Note:** To clear a default use an empty string: `label: ''`

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -224,6 +224,30 @@ of `alpha.foo` with `label: 'alpha.{BranchName}'` and `regex: '^features?[\/-](?
 
 Another example: branch `features/sc-12345/some-description` would become a pre-release label of `sc-12345` with `label: '{StoryNo}'` and `regex: '^features?[\/-](?<StoryNo>sc-\d+)[-/].+'`.
 
+Use `{Sha}` for the full hash of the commit being versioned, or `{ShortSha}` for
+its abbreviated hash, using the same seven-character abbreviation as the
+`ShortSha` output variable. These placeholders work without named regex captures
+and can be combined with them, for example `label: '{BranchName}.ci.{ShortSha}'`.
+
+```yaml
+workflow: GitHubFlow/v1
+calculation:
+  branches:
+    feature:
+      label: 'ci.{ShortSha}'
+```
+
+For a commit whose abbreviated hash is `a1b2c3d`, this configures the label
+`ci.a1b2c3d`. The pre-release number still follows the selected deployment mode.
+In the temporary [v6 compatibility mode](#v7-configuration-layout), put the same
+`label` setting under `branches.feature` instead of `calculation.branches.feature`.
+
+Placeholder names are case-sensitive. If the branch regex contains a named
+capture `Sha` or `ShortSha`, that capture takes precedence over the corresponding
+commit value, including when the capture is empty. Commit values always refer
+to the commit being versioned, even while GitVersion examines earlier commits
+or merged branches to calculate its version.
+
 You can also use environment variable placeholders with the `{env:VARIABLE_NAME}` syntax. Environment variable placeholders can also be combined with regex placeholders, for example `{BranchName}-{env:VARIABLE_NAME}`, and support fallback values using the `{env:VARIABLE_NAME ?? "fallback"}` syntax. These can be combined with cascading fallbacks using environment variables and placeholders like this: `{env:VARIABLE_NAME ?? BranchName ?? "fallback"}`.
 
 **Note:** To clear a default use an empty string: `label: ''`

--- a/schemas/7.0/GitVersion.configuration.json
+++ b/schemas/7.0/GitVersion.configuration.json
@@ -47,7 +47,7 @@
                 "$ref": "#/$defs/hashSetOfString"
               },
               "label": {
-                "description": "The label to use for this branch. Use the value {BranchName} or similar as a placeholder to insert a named capture group from RegularExpression (fx. the branch name).",
+                "description": "The label to use for this branch. Use {BranchName} or another named capture group from a regular expression, {Sha} for the current commit's full hash, or {ShortSha} for its abbreviated hash. Named regular expression capture groups take precedence over commit placeholders.",
                 "type": [
                   "null",
                   "string"
@@ -165,7 +165,7 @@
           "$ref": "#/$defs/hashSetOfString"
         },
         "label": {
-          "description": "The label to use for this branch. Use the value {BranchName} or similar as a placeholder to insert a named capture group from RegularExpression (fx. the branch name).",
+          "description": "The label to use for this branch. Use {BranchName} or another named capture group from a regular expression, {Sha} for the current commit's full hash, or {ShortSha} for its abbreviated hash. Named regular expression capture groups take precedence over commit placeholders.",
           "type": [
             "null",
             "string"

--- a/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
+++ b/src/GitVersion.App.Tests/ConfigurationVersionIntegrationTests.cs
@@ -8,6 +8,43 @@ namespace GitVersion.App.Tests;
 [NonParallelizable]
 public class ConfigurationVersionIntegrationTests
 {
+    [TestCase("ShortSha")]
+    [TestCase("Sha")]
+    public async Task V6V7AndMigratedConfigurationCalculateCurrentCommitLabel(string placeholder)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/topic");
+        fixture.MakeACommit();
+        var sha = fixture.Repository.Head.Tip.Sha;
+        var label = $"ci.{{{placeholder}}}";
+        var configurationPath = Path.Combine(fixture.RepositoryPath, ConfigurationFileLocator.DefaultFileName);
+        await File.WriteAllTextAsync(configurationPath, $"next-version: 2.0.0\nbranches:\n  feature:\n    label: '{label}'");
+
+        var v6 = Execute(fixture.RepositoryPath, "v6");
+        var migration = await new ProgramFixture(fixture.RepositoryPath).Run("config", "migrate");
+
+        migration.ExitCode.ShouldBe(0);
+        migration.Output.ShouldNotBeNull();
+        var migratedConfiguration = new ConfigurationSerializer().Deserialize<GitVersionConfiguration>(migration.Output);
+        migratedConfiguration.Branches["feature"].Label.ShouldBe(label);
+        await File.WriteAllTextAsync(configurationPath, migration.Output);
+        var migrated = Execute(fixture.RepositoryPath, "v7");
+
+        await File.WriteAllTextAsync(configurationPath, $"calculation:\n  next-version: 2.0.0\n  branches:\n    feature:\n      label: '{label}'\noutput: {{}}");
+        var v7 = Execute(fixture.RepositoryPath, "v7");
+
+        foreach (var result in new[] { v6, v7, migrated })
+        {
+            result.ExitCode.ShouldBe(0);
+            using var json = JsonDocument.Parse(result.StandardOutput!);
+            json.RootElement.GetProperty("PreReleaseLabelName").GetString().ShouldBe("ci." + (placeholder == "Sha" ? sha : sha[..7]));
+            json.RootElement.GetProperty("Sha").GetString().ShouldBe(sha);
+            json.RootElement.GetProperty("ShortSha").GetString().ShouldBe(sha[..7]);
+            GetFullSemVer(result.StandardOutput!).ShouldBe(GetFullSemVer(v6.StandardOutput!));
+        }
+    }
+
     [Test]
     public async Task ConfigMigrateWritesMigratedConfigurationToStandardOutput()
     {

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationExtensionsTests.cs
@@ -7,6 +7,109 @@ namespace GitVersion.Configuration.Tests;
 public class ConfigurationExtensionsTests : TestBase
 {
     private const string BranchName = "pull-request";
+    private const string CommitSha = "1234567890abcdef1234567890abcdef12345678";
+
+    [TestCase("{Sha}", CommitSha)]
+    [TestCase("ci.{ShortSha}", "ci.1234567")]
+    [TestCase("{ShortSha}.{Sha}.{ShortSha}", "1234567." + CommitSha + ".1234567")]
+    [TestCase("{StoryNo}.{BranchName}.{ShortSha}", "sc-42.add-login.1234567")]
+    [TestCase("{env:BUILD_LABEL ?? ShortSha}.{Sha}", "1234567." + CommitSha)]
+    [TestCase("{Missing ?? ShortSha}", "1234567")]
+    [TestCase(null, null)]
+    [TestCase("", "")]
+    [TestCase("literal", "literal")]
+    public void CommitLabelPlaceholdersComposeWithCapturesAndFallbacks(string? label, string? expected)
+    {
+        var configuration = LabelConfiguration(label, @"^feature/(?<StoryNo>sc-\d+)/(?<BranchName>.+)");
+
+        var actual = configuration.GetBranchSpecificLabel("feature/sc-42/add-login", null, new TestEnvironment(), CreateCommit());
+
+        actual.ShouldBe(expected);
+    }
+
+    [TestCase(null, "feature/topic", null)]
+    [TestCase("", "feature/topic", null)]
+    [TestCase("^release/", "feature/topic", null)]
+    [TestCase("^feature/", null, null)]
+    [TestCase("^feature/", "", null)]
+    [TestCase("^feature/", "feature/topic", "release/override")]
+    public void CommitLabelPlaceholdersDoNotRequireMatchingBranchRegex(string? regex, string? branch, string? branchOverride)
+    {
+        var actual = LabelConfiguration("ci.{ShortSha}", regex)
+            .GetBranchSpecificLabel(branch, branchOverride, new TestEnvironment(), CreateCommit());
+
+        actual.ShouldBe("ci.1234567");
+    }
+
+    [TestCase("Sha", "captured", "ci.captured")]
+    [TestCase("ShortSha", "captured", "ci.captured")]
+    [TestCase("Sha", "", "ci.")]
+    [TestCase("ShortSha", "", "ci.")]
+    public void NamedCapturesTakePrecedenceOverCommitPlaceholders(string name, string captured, string expected)
+    {
+        var configuration = LabelConfiguration($"ci.{{{name}}}", $"^feature/(?<{name}>.+)?$");
+
+        var actual = configuration.GetBranchSpecificLabel($"feature/{captured}", null, new TestEnvironment(), CreateCommit());
+
+        actual.ShouldBe(expected);
+    }
+
+    [Test]
+    public void BranchOverrideChangesCaptureButKeepsCurrentCommitHash()
+    {
+        var configuration = LabelConfiguration("{BranchName}.{ShortSha}", "^feature/(?<BranchName>.+)");
+
+        var actual = configuration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/original"),
+            "feature/override", new TestEnvironment(), CreateCommit());
+
+        actual.ShouldBe("override.1234567");
+    }
+
+    [Test]
+    public void EnvironmentValuesComposeWithCommitPlaceholdersAndAreSanitized()
+    {
+        var environment = new TestEnvironment();
+        environment.SetEnvironmentVariable("BUILD_LABEL", "team/topic");
+
+        var actual = LabelConfiguration("{env:BUILD_LABEL}.{ShortSha}", null)
+            .GetBranchSpecificLabel("feature/topic", null, environment, CreateCommit());
+
+        actual.ShouldBe("team-topic.1234567");
+    }
+
+    [TestCase("{Unknown}.{ShortSha}")]
+    [TestCase("{env:MISSING_VAR}.{ShortSha}")]
+    [TestCase("{sha}.{ShortSha}")]
+    [TestCase("{shortsha}.{Sha}")]
+    public void CommitPlaceholdersDoNotSuppressUnknownPlaceholderErrors(string label)
+        => Should.Throw<ArgumentException>(() => LabelConfiguration(label, null)
+            .GetBranchSpecificLabel("feature/topic", null, new TestEnvironment(), CreateCommit()));
+
+    [Test]
+    public void CommitPlaceholdersPreserveMalformedFallbackErrors()
+        => Should.Throw<FormatException>(() => LabelConfiguration("{env:MISSING_VAR ??? \"fallback\"}.{ShortSha}", null)
+            .GetBranchSpecificLabel("feature/topic", null, new TestEnvironment(), CreateCommit()));
+
+    [TestCase(null)]
+    [TestCase("ci.{ShortSha}")]
+    public void LabelResolutionRequiresExplicitCurrentCommit(string? label)
+        => Should.Throw<ArgumentNullException>(() => LabelConfiguration(label, null)
+            .GetBranchSpecificLabel("feature/topic", null, new TestEnvironment(), null!));
+
+    private static EffectiveConfiguration LabelConfiguration(string? label, string? regex) =>
+        new(GitFlowConfigurationBuilder.New.WithLabel(null).Build(),
+            new BranchConfiguration { Label = label, RegularExpression = regex });
+
+    private static ICommit CreateCommit()
+    {
+        var id = Substitute.For<IObjectId>();
+        id.Sha.Returns(CommitSha);
+        id.ToString(7).Returns("1234567");
+        var commit = Substitute.For<ICommit>();
+        commit.Sha.Returns(CommitSha);
+        commit.Id.Returns(id);
+        return commit;
+    }
 
     [Test]
     public void EnsureGetEffectiveConfigurationWithoutBranchUsesEmptyBranchConfiguration()
@@ -66,7 +169,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(branchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(branchName), null, new TestEnvironment());
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(branchName), null, new TestEnvironment(), CreateCommit());
         actual.ShouldBe(expectedLabel);
     }
 
@@ -84,7 +187,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment, CreateCommit());
         actual.ShouldBe("pr-feature-branch");
     }
 
@@ -102,7 +205,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment);
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment, CreateCommit());
         actual.ShouldBe("pr-unknown");
     }
 
@@ -120,7 +223,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test-branch"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-branch"), null, environment);
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-branch"), null, environment, CreateCommit());
         actual.ShouldBe("test-branch-feature-branch");
     }
 
@@ -135,7 +238,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test"), null, new TestEnvironment());
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test"), null, new TestEnvironment(), CreateCommit());
         actual.ShouldBe("test");
     }
 
@@ -154,7 +257,7 @@ public class ConfigurationExtensionsTests : TestBase
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
         Should.Throw<ArgumentException>(() =>
-            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment));
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, environment, CreateCommit()));
     }
 
     [Test]
@@ -169,7 +272,7 @@ public class ConfigurationExtensionsTests : TestBase
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName(BranchName));
         Should.Throw<ArgumentException>(() =>
-            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, new TestEnvironment()));
+            effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName(BranchName), null, new TestEnvironment(), CreateCommit()));
     }
 
     [TestCase("case-00/my-branch", "case-00-my-branch")]
@@ -188,7 +291,7 @@ public class ConfigurationExtensionsTests : TestBase
             .Build();
 
         var effectiveConfiguration = configuration.GetEffectiveConfiguration(ReferenceName.FromBranchName("feature/test-feature"));
-        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-feature"), null, environment);
+        var actual = effectiveConfiguration.GetBranchSpecificLabel(ReferenceName.FromBranchName("feature/test-feature"), null, environment, CreateCommit());
         actual.ShouldBe(expectedLabel);
     }
 }

--- a/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
+++ b/src/GitVersion.Configuration.Tests/Configuration/ConfigurationMigrationServiceTests.cs
@@ -7,6 +7,20 @@ public class ConfigurationMigrationServiceTests
 {
     private readonly IConfigurationMigrationService migrationService = new ConfigurationMigrationService(new ConfigurationSerializer());
 
+    [TestCase("ci.{ShortSha}")]
+    [TestCase("{BranchName}.{Sha}")]
+    public void MigrationPreservesCommitLabelTemplateUnderCalculationBranches(string label)
+    {
+        var migrated = this.migrationService.Migrate($"branches:\n  feature:\n    label: '{label}'");
+        var document = new ConfigurationSerializer().Deserialize<Dictionary<object, object?>>(migrated);
+        var configuration = new ConfigurationSerializer().Deserialize<GitVersionConfiguration>(migrated);
+
+        configuration.Branches["feature"].Label.ShouldBe(label);
+        document.ContainsKey("calculation").ShouldBeTrue();
+        document.ContainsKey("branches").ShouldBeFalse();
+        this.migrationService.Migrate(migrated).ShouldBe(migrated);
+    }
+
     [Test]
     public void MigratesFlatConfigurationToCalculationAndOutputSections()
     {

--- a/src/GitVersion.Configuration/BranchConfiguration.cs
+++ b/src/GitVersion.Configuration/BranchConfiguration.cs
@@ -11,7 +11,7 @@ internal record BranchConfiguration : IBranchConfiguration
     public DeploymentMode? DeploymentMode { get; set; }
 
     [JsonPropertyName("label")]
-    [JsonPropertyDescription("The label to use for this branch. Use the value {BranchName} or similar as a placeholder to insert a named capture group from RegularExpression (fx. the branch name).")]
+    [JsonPropertyDescription("The label to use for this branch. Use {BranchName} or another named capture group from a regular expression, {Sha} for the current commit's full hash, or {ShortSha} for its abbreviated hash. Named regular expression capture groups take precedence over commit placeholders.")]
     public string? Label { get; set; }
 
     [JsonPropertyName("custom-version-format")]

--- a/src/GitVersion.Core.Tests/IntegrationTests/ShaLabelScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/ShaLabelScenarios.cs
@@ -1,0 +1,116 @@
+using GitVersion.Configuration;
+using GitVersion.Git;
+using GitVersion.Testing.Extensions;
+using GitVersion.VersionCalculation;
+
+namespace GitVersion.Tests.IntegrationTests;
+
+[TestFixture]
+[NonParallelizable]
+public class ShaLabelScenarios : TestBase
+{
+    [TestCase("managed", "ShortSha")]
+    [TestCase("libgit2", "ShortSha")]
+    [TestCase("managed", "Sha")]
+    [TestCase("libgit2", "Sha")]
+    public void FeatureLabelUsesCurrentCommitAndChangesOnNextCommit(string backend, string placeholder)
+    {
+        using var backendScope = new BackendScope(backend);
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        var sourceSha = fixture.Repository.Head.Tip.Sha;
+        fixture.BranchTo("feature/topic");
+        fixture.MakeACommit();
+        var firstSha = fixture.Repository.Head.Tip.Sha;
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("feature", b => b.WithLabel($"ci.{{{placeholder}}}"))
+            .Build();
+
+        var first = fixture.GetVersion(configuration);
+
+        first.Sha.ShouldBe(firstSha);
+        first.ShortSha.ShouldBe(firstSha[..7]);
+        first.VersionSourceSha.ShouldBe(sourceSha);
+        first.PreReleaseLabelName.ShouldBe("ci." + (placeholder == "Sha" ? firstSha : firstSha[..7]));
+        first.FullSemVer.ShouldBe($"1.0.1-{first.PreReleaseLabelName}.1+1");
+
+        fixture.MakeACommit();
+        var secondSha = fixture.Repository.Head.Tip.Sha;
+        var second = fixture.GetVersion(configuration);
+
+        second.Sha.ShouldBe(secondSha);
+        second.ShortSha.ShouldBe(secondSha[..7]);
+        second.PreReleaseLabelName.ShouldBe("ci." + (placeholder == "Sha" ? secondSha : secondSha[..7]));
+        second.PreReleaseLabelName.ShouldNotBe(first.PreReleaseLabelName);
+        second.FullSemVer.ShouldBe($"1.0.1-{second.PreReleaseLabelName}.1+2");
+
+        // Explicit historical calculation must use the selected commit even when HEAD has advanced.
+        var historical = fixture.GetVersion(configuration, commitId: firstSha);
+        historical.FullSemVer.ShouldBe(first.FullSemVer);
+        historical.Sha.ShouldBe(firstSha);
+    }
+
+    [TestCase("managed")]
+    [TestCase("libgit2")]
+    public void MainlineMergedHistoryUsesCalculationCommitForLabel(string backend)
+    {
+        using var backendScope = new BackendScope(backend);
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        var sourceSha = fixture.Repository.Head.Tip.Sha;
+        fixture.BranchTo("feature/outer");
+        fixture.MakeACommit("outer");
+        fixture.BranchTo("feature/inner");
+        fixture.MakeACommit("inner");
+        fixture.MergeTo("feature/outer");
+        fixture.MergeTo("main");
+        var currentSha = fixture.Repository.Head.Tip.Sha;
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithVersionStrategy(VersionStrategies.Mainline)
+            .WithLabel("ci.{ShortSha}")
+            .WithBranch("main", b => b.WithLabel("ci.{ShortSha}").WithDeploymentMode(DeploymentMode.ManualDeployment))
+            .WithBranch("feature", b => b.WithLabel("ci.{ShortSha}").WithDeploymentMode(DeploymentMode.ManualDeployment))
+            .Build();
+
+        var actual = fixture.GetVersion(configuration);
+
+        actual.Sha.ShouldBe(currentSha);
+        actual.PreReleaseLabelName.ShouldBe("ci." + currentSha[..7]);
+        actual.PreReleaseLabelName.ShouldNotBe("ci." + sourceSha[..7]);
+        // A fixed literal label must produce identical version selection and prerelease counting.
+        var literalConfiguration = GitFlowConfigurationBuilder.New
+            .WithVersionStrategy(VersionStrategies.Mainline)
+            .WithLabel("ci." + currentSha[..7])
+            .WithBranch("main", b => b.WithLabel("ci." + currentSha[..7]).WithDeploymentMode(DeploymentMode.ManualDeployment))
+            .WithBranch("feature", b => b.WithLabel("ci." + currentSha[..7]).WithDeploymentMode(DeploymentMode.ManualDeployment))
+            .Build();
+        actual.FullSemVer.ShouldBe(fixture.GetVersion(literalConfiguration).FullSemVer);
+    }
+
+    [TestCase("managed")]
+    [TestCase("libgit2")]
+    public void TaggedCurrentCommitPreservesStableVersionWithShaLabel(string backend)
+    {
+        using var backendScope = new BackendScope(backend);
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.Repository.MakeATaggedCommit("1.0.0");
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("main", b => b.WithLabel("ci.{ShortSha}"))
+            .Build();
+
+        var actual = fixture.GetVersion(configuration);
+
+        actual.FullSemVer.ShouldBe("1.0.0");
+        actual.PreReleaseLabel.ShouldBeEmpty();
+        actual.Sha.ShouldBe(fixture.Repository.Head.Tip.Sha);
+    }
+
+    private sealed class BackendScope : IDisposable
+    {
+        private readonly string? original = System.Environment.GetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName);
+
+        public BackendScope(string backend) => System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, backend);
+
+        public void Dispose() => System.Environment.SetEnvironmentVariable(GitBackendSelector.EnvironmentVariableName, this.original);
+    }
+}

--- a/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/GitVersion.Core/Extensions/ConfigurationExtensions.cs
@@ -135,13 +135,14 @@ internal static class ConfigurationExtensions
 
     extension(EffectiveConfiguration configuration)
     {
-        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride, IEnvironment environment)
-            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride, environment);
+        public string? GetBranchSpecificLabel(ReferenceName branchName, string? branchNameOverride, IEnvironment environment, ICommit currentCommit)
+            => GetBranchSpecificLabel(configuration, branchName.WithoutOrigin, branchNameOverride, environment, currentCommit);
 
-        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride, IEnvironment environment)
+        public string? GetBranchSpecificLabel(string? branchName, string? branchNameOverride, IEnvironment environment, ICommit currentCommit)
         {
             configuration.NotNull();
             environment.NotNull();
+            currentCommit.NotNull();
 
             var label = configuration.Label;
 
@@ -152,6 +153,9 @@ internal static class ConfigurationExtensions
 
             var effectiveBranchName = branchNameOverride ?? branchName;
             var labelPlaceholders = BuildLabelPlaceholders(configuration.RegularExpression, effectiveBranchName);
+            // Preserve existing named captures, including those named Sha or ShortSha.
+            labelPlaceholders.TryAdd("Sha", currentCommit.Sha);
+            labelPlaceholders.TryAdd("ShortSha", currentCommit.Id.ToString(7));
 
             return label.FormatWith(labelPlaceholders, environment)
                 .RegexReplace(RegexPatterns.SanitizeLabelRegexPattern, "-");

--- a/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/EnrichIncrement.cs
@@ -32,7 +32,7 @@ internal sealed class EnrichIncrement : IContextPreEnricher
             context.Label = null;
         }
 
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
 
         if (effectiveConfiguration.IsMainBranch)
         {

--- a/src/GitVersion.Core/VersionCalculation/Mainline/EnrichSemanticVersion.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/EnrichSemanticVersion.cs
@@ -9,9 +9,9 @@ internal sealed class EnrichSemanticVersion : IContextPreEnricher
     {
         var branchSpecificLabel = context.TargetLabel;
         branchSpecificLabel ??= iteration.GetEffectiveConfiguration(context.Configuration)
-            .GetBranchSpecificLabel(commit.BranchName, null, context.Environemnt);
+            .GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
         branchSpecificLabel ??= commit.GetEffectiveConfiguration(context.Configuration)
-            .GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+            .GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
 
         var semanticVersions = commit.SemanticVersions.Where(
             element => element.IsMatchForBranchSpecificLabel(branchSpecificLabel)

--- a/src/GitVersion.Core/VersionCalculation/Mainline/MainlineContext.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/MainlineContext.cs
@@ -4,13 +4,16 @@ using GitVersion.Git;
 
 namespace GitVersion.VersionCalculation.Mainline;
 
-internal record MainlineContext(IIncrementStrategyFinder IncrementStrategyFinder, IGitVersionConfiguration Configuration, IEnvironment Environment)
+internal record MainlineContext(IIncrementStrategyFinder IncrementStrategyFinder, IGitVersionConfiguration Configuration, IEnvironment Environment, ICommit CurrentCommit)
 {
     public IIncrementStrategyFinder IncrementStrategyFinder { get; } = IncrementStrategyFinder.NotNull();
 
     public IGitVersionConfiguration Configuration { get; } = Configuration.NotNull();
 
-    public IEnvironment Environemnt { get; } = Environment.NotNull();
+    public IEnvironment Environment { get; } = Environment.NotNull();
+
+    // Keep the calculation commit unchanged while traversing ancestors and merged branches.
+    public ICommit CurrentCommit { get; } = CurrentCommit.NotNull();
 
     public string? TargetLabel { get; init; }
 

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunk.cs
@@ -24,7 +24,7 @@ internal sealed class CommitOnNonTrunk : IIncrementer
         }
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
 
         if (commit.Successor is not null)
         {

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkBranchedBase.cs
@@ -21,7 +21,7 @@ internal abstract class CommitOnNonTrunkBranchedBase : IIncrementer
         context.Increment = context.Increment.Consolidate(incrementForcedByBranch);
 
         var iterationEffectiveConfiguration = iteration.GetEffectiveConfiguration(context.Configuration);
-        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment) ?? context.Label;
+        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment, context.CurrentCommit) ?? context.Label;
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithPreReleaseTagBase.cs
@@ -24,7 +24,7 @@ internal abstract class CommitOnNonTrunkWithPreReleaseTagBase : IIncrementer
 
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
         context.ForceIncrement = false;
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/CommitOnNonTrunkWithStableTagBase.cs
@@ -24,6 +24,6 @@ internal abstract class CommitOnNonTrunkWithStableTagBase : IIncrementer
 
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/NonTrunk/MergeCommitOnNonTrunkBase.cs
@@ -26,7 +26,8 @@ internal abstract class MergeCommitOnNonTrunkBase : IIncrementer
                    targetLabel: context.TargetLabel,
                    incrementStrategyFinder: context.IncrementStrategyFinder,
                    configuration: context.Configuration,
-                   environment: context.Environment
+                   environment: context.Environment,
+                   currentCommit: context.CurrentCommit
                );
 
             context.Label ??= baseVersion.Operator?.Label;

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunk.cs
@@ -23,7 +23,7 @@ internal sealed class CommitOnTrunk : IIncrementer
         }
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label ??= effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkBranchedBase.cs
@@ -28,7 +28,7 @@ internal abstract class CommitOnTrunkBranchedBase : IIncrementer
         context.Increment = incrementForcedByBranch;
 
         var iterationEffectiveConfiguration = iteration.GetEffectiveConfiguration(context.Configuration);
-        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment) ?? context.Label;
+        context.Label = iterationEffectiveConfiguration.GetBranchSpecificLabel(iteration.BranchName, null, context.Environment, context.CurrentCommit) ?? context.Label;
         context.ForceIncrement = true;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/CommitOnTrunkWithStableTagBase.cs
@@ -22,6 +22,6 @@ internal abstract class CommitOnTrunkWithStableTagBase : IIncrementer
         };
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
     }
 }

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/LastCommitOnTrunkWithPreReleaseTag.cs
@@ -26,7 +26,7 @@ internal sealed class LastCommitOnTrunkWithPreReleaseTag : CommitOnTrunkWithPreR
         context.Increment = commit.GetIncrementForcedByBranch(context.Configuration);
 
         var effectiveConfiguration = commit.GetEffectiveConfiguration(context.Configuration);
-        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment);
+        context.Label = effectiveConfiguration.GetBranchSpecificLabel(commit.BranchName, null, context.Environment, context.CurrentCommit);
         context.ForceIncrement = false;
 
         yield return new BaseVersionOperator

--- a/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
+++ b/src/GitVersion.Core/VersionCalculation/Mainline/Trunk/MergeCommitOnTrunkBase.cs
@@ -24,7 +24,8 @@ internal abstract class MergeCommitOnTrunkBase : IIncrementer
                    targetLabel: context.TargetLabel,
                    incrementStrategyFinder: context.IncrementStrategyFinder,
                    configuration: context.Configuration,
-                   environment: context.Environment
+                   environment: context.Environment,
+                   currentCommit: context.CurrentCommit
                );
 
             context.Label ??= baseVersion.Operator?.Label;

--- a/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionCalculators/NextVersionCalculator.cs
@@ -109,7 +109,7 @@ internal class NextVersionCalculator(
     {
         result = null;
 
-        var label = effectiveConfiguration.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var label = effectiveConfiguration.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
         var currentCommitTaggedVersion = taggedSemanticVersionsOfCurrentCommit
             .Where(element => element.Value.IsMatchForBranchSpecificLabel(label)).Max();
 

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/ConfiguredNextVersionVersionStrategy.cs
@@ -33,7 +33,7 @@ internal sealed class ConfiguredNextVersionVersionStrategy(Lazy<GitVersionContex
         var semanticVersion = SemanticVersion.Parse(
             nextVersion, Context.Configuration.TagPrefixPattern, Context.Configuration.SemanticVersionFormat
         );
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
 
         if (!semanticVersion.IsMatchForBranchSpecificLabel(label))
         {

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbackVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/FallbackVersionStrategy.cs
@@ -34,7 +34,7 @@ internal sealed class FallbackVersionStrategy(
             yield break;
         }
 
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
 
         var baseVersionSource = this.taggedSemanticVersionService.GetTaggedSemanticVersions(
             branch: Context.CurrentBranch,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MainlineVersionStrategy.cs
@@ -108,7 +108,7 @@ internal sealed class MainlineVersionStrategy(
             notOlderThan: Context.CurrentCommit.When,
             taggedSemanticVersion: taggedSemanticVersion
         );
-        var targetLabel = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var targetLabel = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
         IterateOverCommitsRecursive(
             commitsInReverseOrder: commitsInReverseOrder,
             iteration: iteration,
@@ -117,7 +117,7 @@ internal sealed class MainlineVersionStrategy(
             taggedSemanticVersions: taggedSemanticVersions
         );
 
-        yield return DetermineBaseVersion(iteration, targetLabel, this.incrementStrategyFinder, Context.Configuration, this.environment);
+        yield return DetermineBaseVersion(iteration, targetLabel, this.incrementStrategyFinder, Context.Configuration, this.environment, Context.CurrentCommit);
     }
 
     private MainlineIteration CreateIteration(
@@ -240,7 +240,7 @@ internal sealed class MainlineVersionStrategy(
         var label = targetLabel ?? new EffectiveConfiguration(
             configuration: Context.Configuration,
             branchConfiguration: state.Configuration
-        ).GetBranchSpecificLabel(state.BranchName, null, this.environment);
+        ).GetBranchSpecificLabel(state.BranchName, null, this.environment, Context.CurrentCommit);
 
         foreach (var semanticVersion in semanticVersions)
         {
@@ -400,15 +400,15 @@ internal sealed class MainlineVersionStrategy(
     }
 
     private static BaseVersion DetermineBaseVersion(MainlineIteration iteration, string? targetLabel,
-            IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
-        => DetermineBaseVersionRecursive(iteration, targetLabel, incrementStrategyFinder, configuration, environment);
+            IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment, ICommit currentCommit)
+        => DetermineBaseVersionRecursive(iteration, targetLabel, incrementStrategyFinder, configuration, environment, currentCommit);
 
     internal static BaseVersion DetermineBaseVersionRecursive(MainlineIteration iteration, string? targetLabel,
-        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
+        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment, ICommit currentCommit)
     {
         iteration.NotNull();
 
-        var incrementSteps = GetIncrements(iteration, targetLabel, incrementStrategyFinder, configuration, environment).ToArray();
+        var incrementSteps = GetIncrements(iteration, targetLabel, incrementStrategyFinder, configuration, environment, currentCommit).ToArray();
 
         BaseVersion? result = null;
         foreach (var baseVersionIncrement in incrementSteps)
@@ -431,9 +431,9 @@ internal sealed class MainlineVersionStrategy(
     }
 
     private static IEnumerable<IBaseVersionIncrement> GetIncrements(MainlineIteration iteration, string? targetLabel,
-        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment)
+        IIncrementStrategyFinder incrementStrategyFinder, IGitVersionConfiguration configuration, IEnvironment environment, ICommit currentCommit)
     {
-        MainlineContext context = new(incrementStrategyFinder, configuration, environment)
+        MainlineContext context = new(incrementStrategyFinder, configuration, environment, currentCommit)
         {
             TargetLabel = targetLabel
         };

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/MergeMessageVersionStrategy.cs
@@ -50,7 +50,7 @@ internal sealed class MergeMessageVersionStrategy(ILogger<MergeMessageVersionStr
                 baseVersionSource = this.repositoryStore.FindMergeBase(commit.Parents[0], commit.Parents[1]);
             }
 
-            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
             var increment = configuration.Value.PreventIncrementOfMergedBranch
                 ? VersionField.None : this.incrementStrategyFinder.DetermineIncrementedField(
                     currentCommit: Context.CurrentCommit,

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TaggedCommitVersionStrategy.cs
@@ -44,7 +44,7 @@ internal sealed class TaggedCommitVersionStrategy(
             taggedSemanticVersion: configuration.Value.GetTaggedSemanticVersion()
         ).SelectMany(elements => elements).Distinct().ToArray();
 
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
 
         var semanticVersionTreshold = SemanticVersion.Empty;
         List<SemanticVersionWithTag> alternativeSemanticVersionsWithTag = [];

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -67,7 +67,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
             return false;
         }
 
-        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
+        var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment, Context.CurrentCommit);
         var increment = this.incrementStrategyFinder.DetermineIncrementedField(
             currentCommit: Context.CurrentCommit,
             baseVersionSource: baseVersionSource,
@@ -103,7 +103,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
             return false;
         }
 
-        var label = configuration.Value.GetBranchSpecificLabel(releaseBranch.Name, null, this.environment);
+        var label = configuration.Value.GetBranchSpecificLabel(releaseBranch.Name, null, this.environment, Context.CurrentCommit);
         var tags = this.taggedSemanticVersionRepository.GetTaggedSemanticVersionsOfBranch(
             releaseBranch, configuration.Value.TagPrefixPattern, configuration.Value.SemanticVersionFormat,
             Context.Configuration.Ignore);

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/VersionInBranchNameVersionStrategy.cs
@@ -52,7 +52,7 @@ internal sealed class VersionInBranchNameVersionStrategy(Lazy<GitVersionContext>
                 branchNameOverride = result.Name;
             }
 
-            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, branchNameOverride, this.environment);
+            var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, branchNameOverride, this.environment, Context.CurrentCommit);
 
             baseVersion = new BaseVersion("Version in branch name", result.Value)
             {


### PR DESCRIPTION
## Description

Branch labels such as `label: 'ci.{ShortSha}'` currently fail with an unknown-placeholder error. Add `{Sha}` and `{ShortSha}` using the commit being versioned, so these templates participate in version calculation under `calculation.branches.<branch>.label`.

Pass the calculation commit through version-search strategies and recursive mainline traversal. Reuse the existing seven-character short-SHA operation. Named regex captures retain precedence, including empty captures, and existing formatting, fallbacks, sanitization, and missing-placeholder errors remain unchanged.

Update the configuration reference and generated v7 schema. The same templates work through explicit v6 compatibility mode and configuration migration.

## Related Issue

Resolves #3035

## Motivation and Context

Allow commit hashes in calculated prerelease labels while preserving existing regex-based configurations. The new built-ins are limited to `Sha` and `ShortSha`; prerelease numbering continues to follow the selected deployment mode.

## How Has This Been Tested?

Local validation on macOS with .NET 10:

- Full core suite: 36,269 passed.
- Full configuration suite: 198 passed.
- CLI configuration integration suite: 25 passed.
- History regressions cover both managed and LibGit2Sharp backends, successive commits, explicit historical commits, nested merges, and tagged-current behavior.
- Temporarily removing the SHA inputs caused six new placeholder cases to fail; restoring them returned the configuration suite to green.
- Full solution build: zero warnings/errors. Formatting and diff checks passed.
- Repeated schema/reference generation produced identical files.

## Checklist

- [x] Code follows the project style.
- [x] Documentation and generated schema updated.
- [x] Regression tests added.
- [x] Relevant test suites passed.
