### PR TITLE
feat: track prerelease tags on unversioned release branches

### DIFF
--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -749,7 +749,28 @@ branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
 
 ### tracks-release-branches
 
-Indicates this branch config represents develop in GitFlow.
+Controls whether this branch tracks release branches when calculating its version.
+This is typically enabled for `develop` in GitFlow.
+
+With the `TrackReleaseBranches` strategy enabled, a release branch's version is
+taken from its name. If the name contains no version, GitVersion uses the highest
+semantic prerelease tag matching that release branch's [configured label](#label). Matching
+is case-insensitive. Tags must be on the release branch's first-parent history,
+outside the first-parent history of configured `main` branches. A release tag
+remains eligible when its commit is merged into `main` through a merge commit.
+Like versioned release names, tags are evaluated against the current release
+refs, including when versioning an older commit. Tags on newer sibling release
+commits are eligible; advancing the tracking branch alone does not change tag eligibility.
+This does not reconstruct historical branch or tag state. [Tag prefix](#tag-prefix),
+[semantic version format](#semantic-version-format), and [ignore](#ignore) settings apply.
+The release branch must share an ancestor with the commit being versioned.
+
+For example, with release label `rc`, `releases/R2301` tagged `1.0.0-RC.1` lets
+`develop` advance to `1.1.0-beta.1` after its next commit when `develop`'s label is
+`beta`. Versioned release names retain precedence over tags within this strategy.
+Git does not record which branch created a tag; first-parent history and the
+release label determine eligibility, including when the tracking branch
+(typically `develop`) was branched from the tagged release commit.
 
 ### commit-date-format
 

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -316,7 +316,28 @@ branch. For example `develop` → `release/1.0.0` → merge into `main` and tag
 
 ### tracks-release-branches
 
-Indicates this branch config represents develop in GitFlow.
+Controls whether this branch tracks release branches when calculating its version.
+This is typically enabled for `develop` in GitFlow.
+
+With the `TrackReleaseBranches` strategy enabled, a release branch's version is
+taken from its name. If the name contains no version, GitVersion uses the highest
+semantic prerelease tag matching that release branch's [configured label](#label). Matching
+is case-insensitive. Tags must be on the release branch's first-parent history,
+outside the first-parent history of configured `main` branches. A release tag
+remains eligible when its commit is merged into `main` through a merge commit.
+Like versioned release names, tags are evaluated against the current release
+refs, including when versioning an older commit. Tags on newer sibling release
+commits are eligible; advancing the tracking branch alone does not change tag eligibility.
+This does not reconstruct historical branch or tag state. [Tag prefix](#tag-prefix),
+[semantic version format](#semantic-version-format), and [ignore](#ignore) settings apply.
+The release branch must share an ancestor with the commit being versioned.
+
+For example, with release label `rc`, `releases/R2301` tagged `1.0.0-RC.1` lets
+`develop` advance to `1.1.0-beta.1` after its next commit when `develop`'s label is
+`beta`. Versioned release names retain precedence over tags within this strategy.
+Git does not record which branch created a tag; first-parent history and the
+release label determine eligibility, including when the tracking branch
+(typically `develop`) was branched from the tagged release commit.
 
 ### commit-date-format
 

--- a/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow.cs
@@ -953,7 +953,8 @@ public class CompareTheDifferentWhenUsingMainlineVersionStrategyWithGitFlow
         fixture.MergeNoFF("hotfix/foo");
 
         // ✅ succeeds as expected
-        fixture.AssertFullSemver("0.1.0-PullRequest2.5", configuration);
+        // Release tracking now recognizes the hotfix tag and counts from its branch point.
+        fixture.AssertFullSemver(useMainline ? "0.1.0-PullRequest2.5" : "0.1.0-PullRequest2.4", configuration);
 
         fixture.Checkout("main");
         fixture.BranchTo("pull/3/merge");

--- a/src/GitVersion.Core.Tests/IntegrationTests/TrackReleaseBranchesScenarios.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/TrackReleaseBranchesScenarios.cs
@@ -1,0 +1,337 @@
+using GitVersion.Configuration;
+using GitVersion.VersionCalculation;
+using LibGit2Sharp;
+
+namespace GitVersion.Tests.IntegrationTests;
+
+[TestFixture]
+public class TrackReleaseBranchesScenarios : TestBase
+{
+    [TestCase("releases/R2301")]
+    [TestCase("release/1.0.0")]
+    public void DevelopBranchedFromTaggedReleaseAdvancesMinor(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeACommit();
+        fixture.BranchTo(releaseBranch);
+        fixture.MakeATaggedCommit("1.0.0-RC.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithBranch("develop", branch => branch.WithLabel("beta"))
+            .WithBranch("release", branch => branch.WithLabel("rc"))
+            .WithBranch("hotfix", branch => branch.WithLabel("rc"))
+            .Build();
+
+        fixture.AssertFullSemver("1.1.0-beta.1", configuration);
+    }
+
+    [TestCase("release/some_release")]
+    [TestCase("release/1.3.0")]
+    public void DevelopWithSiblingTaggedReleaseAdvancesMinor(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo(releaseBranch);
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("1.4.0-alpha.1");
+    }
+
+    [TestCase("release/some_release")]
+    [TestCase("release/1.3.0")]
+    public void CurrentDevelopTipTracksNewerReleaseTag(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo(releaseBranch);
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+
+        fixture.AssertFullSemver("1.4.0-alpha.0");
+    }
+
+    [TestCase("release/some_release")]
+    [TestCase("release/1.3.0")]
+    public void TaggedReleaseMergedIntoMainRetainsDevelopVersion(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo(releaseBranch);
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        var developCommit = fixture.MakeACommit();
+        fixture.AssertFullSemver("1.4.0-alpha.1");
+
+        fixture.Checkout(MainBranch);
+        fixture.MergeNoFF(releaseBranch);
+        fixture.Checkout("develop");
+        fixture.AssertFullSemver("1.4.0-alpha.1", commitId: developCommit);
+
+        fixture.Checkout(MainBranch);
+        fixture.MakeACommit();
+        fixture.Checkout("develop");
+        fixture.AssertFullSemver("1.4.0-alpha.1", commitId: developCommit);
+
+        fixture.Checkout(MainBranch);
+        fixture.ApplyTag("1.3.0");
+        fixture.Checkout("develop");
+        fixture.AssertFullSemver("1.4.0-alpha.1", commitId: developCommit);
+    }
+
+    [Test]
+    public void VersionedReleaseNameTakesPrecedenceOverHigherTag()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/1.3.0");
+        fixture.MakeATaggedCommit("9.0.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        // Other strategies still see the higher tag, but release tracking must not bump it to 9.1.0.
+        fixture.AssertFullSemver("9.0.0-alpha.2");
+    }
+
+    [Test]
+    public void HighestReleaseVersionWinsRegardlessOfTagDateOrBranchOrder()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/a");
+        fixture.MakeATaggedCommit("2.0.0-beta.2+build.7");
+        fixture.MakeATaggedCommit("1.5.0-beta.3");
+        fixture.Checkout("develop");
+        fixture.BranchTo("release/z");
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("2.1.0-alpha.1");
+    }
+
+    [TestCase(null)]
+    [TestCase("not-a-version")]
+    [TestCase("9.0.0")]
+    [TestCase("9.0.0-alpha.1")]
+    public void ReleaseWithoutEligiblePrereleaseTagDoesNotAdvanceMinor(string? tag)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        fixture.MakeACommit();
+        if (tag is not null)
+        {
+            fixture.ApplyTag(tag);
+        }
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        // Isolate release tracking from TaggedCommit, which independently consumes stable/alpha tags.
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithNextVersion("1.3.0")
+            .WithVersionStrategies(VersionStrategies.ConfiguredNextVersion, VersionStrategies.TrackReleaseBranches)
+            .Build();
+        fixture.GetVersion(configuration).MajorMinorPatch.ShouldBe("1.3.0");
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void TagOnAnotherBranchIsNotOwnedByRelease(bool mergeIntoRelease)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("feature/other");
+        fixture.MakeATaggedCommit("9.0.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.BranchTo("release/some_release");
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        if (mergeIntoRelease)
+        {
+            fixture.MergeNoFF("feature/other");
+        }
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        // TaggedCommit can use the higher tag as an alternative, without the release-tracking increment.
+        fixture.AssertFullSemver("9.0.0-alpha.2");
+    }
+
+    [Test]
+    public void PrereleaseTagInheritedFromMainDoesNotIdentifyActiveRelease()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("9.0.0-beta.1");
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        fixture.MakeACommit();
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("9.0.0-alpha.2");
+    }
+
+    [TestCase("tag")]
+    [TestCase("commit")]
+    [TestCase("branch")]
+    public void IgnoredReleaseTagCommitOrBranchDoesNotAdvanceMinor(string ignored)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        var taggedCommit = fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+
+        var ignore = ignored switch
+        {
+            "tag" => new IgnoreConfiguration { Tags = ["^1\\.3\\.0-beta\\.1$"] },
+            "commit" => new IgnoreConfiguration { Shas = [taggedCommit] },
+            _ => new IgnoreConfiguration { Branches = ["^release/"] }
+        };
+        var configuration = GitFlowConfigurationBuilder.New.WithIgnoreConfiguration(ignore).Build();
+
+        fixture.AssertFullSemver("1.3.0-alpha.2", configuration);
+    }
+
+    [Test]
+    public void TagPrefixAndIgnoreRulesPreserveEligibleTagOnSameCommit()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("v1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        fixture.MakeATaggedCommit("v1.3.0-beta.1");
+        fixture.ApplyTag("v9.0.0-beta.1");
+        fixture.ApplyTag("other-8.0.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithTagPrefixPattern("^v")
+            .WithIgnoreConfiguration(new IgnoreConfiguration { Tags = ["^v9\\."] })
+            .Build();
+
+        fixture.AssertFullSemver("1.4.0-alpha.1", configuration);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void DisabledReleaseTrackingDoesNotUseTagFallback(bool disableStrategy)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.MakeACommit();
+        var builder = GitFlowConfigurationBuilder.New;
+        if (disableStrategy)
+        {
+            builder.WithVersionStrategies(VersionStrategies.Fallback, VersionStrategies.TaggedCommit);
+        }
+        else
+        {
+            builder.WithBranch("develop", branch => branch.WithTracksReleaseBranches(false));
+        }
+
+        fixture.AssertFullSemver("1.3.0-alpha.2", builder.Build());
+    }
+
+    [TestCase("release/some_release")]
+    [TestCase("release/1.3.0")]
+    public void DevelopCommitRetainsReleaseVersionAfterBranchAdvances(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        var historicalCommit = fixture.MakeACommit();
+        fixture.BranchTo(releaseBranch);
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        fixture.AssertFullSemver("1.4.0-alpha.0", commitId: historicalCommit);
+        fixture.MakeACommit();
+
+        fixture.AssertFullSemver("1.4.0-alpha.0", commitId: historicalCommit);
+        fixture.AssertFullSemver("1.4.0-alpha.1");
+    }
+
+    [TestCase("release/unrelated")]
+    [TestCase("release/9.0.0")]
+    public void ReleaseWithUnrelatedHistoryDoesNotAdvanceMinor(string releaseBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        var mainCommit = fixture.Repository.Head.Tip;
+        var unrelatedCommit = fixture.Repository.ObjectDatabase.CreateCommit(
+            mainCommit.Author, mainCommit.Committer, "Unrelated release root", mainCommit.Tree, [], false);
+        fixture.Repository.CreateBranch(releaseBranch, unrelatedCommit);
+        fixture.Repository.Tags.Add("9.0.0-beta.1", unrelatedCommit);
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        var configuration = GitFlowConfigurationBuilder.New
+            .WithNextVersion("1.3.0")
+            .WithVersionStrategies(VersionStrategies.ConfiguredNextVersion, VersionStrategies.TrackReleaseBranches)
+            .Build();
+
+        fixture.GetVersion(configuration).MajorMinorPatch.ShouldBe("1.3.0");
+    }
+
+    [Test]
+    public void HistoricalDevelopUsesMergeBaseAtSelectedCommit()
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("1.2.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo("release/some_release");
+        fixture.MakeATaggedCommit("1.3.0-beta.1");
+        fixture.Checkout("develop");
+        var historicalCommit = fixture.MakeACommit();
+        fixture.MergeNoFF("release/some_release");
+
+        fixture.AssertFullSemver("1.4.0-alpha.1", commitId: historicalCommit);
+    }
+
+    [TestCase("hotfix/foo")]
+    [TestCase("hotfix/0.0.2")]
+    public void PullRequestTrackingTaggedHotfixUsesSameSourceAsVersionedName(string hotfixBranch)
+    {
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.MakeATaggedCommit("0.0.1");
+        fixture.BranchTo("develop");
+        fixture.MakeACommit();
+        fixture.BranchTo(hotfixBranch);
+        fixture.MakeATaggedCommit("0.0.2-beta.1");
+        fixture.MakeACommit();
+        fixture.MakeACommit();
+        fixture.Checkout("develop");
+        fixture.BranchTo("pull/2/merge");
+        fixture.MergeNoFF(hotfixBranch);
+
+        fixture.AssertFullSemver("0.1.0-PullRequest2.4");
+    }
+}

--- a/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
+++ b/src/GitVersion.Core/VersionCalculation/VersionSearchStrategies/TrackReleaseBranchesVersionStrategy.cs
@@ -9,6 +9,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
     Lazy<GitVersionContext> contextLazy,
     IRepositoryStore repositoryStore,
     IBranchRepository branchRepository,
+    ITaggedSemanticVersionRepository taggedSemanticVersionRepository,
     IIncrementStrategyFinder incrementStrategyFinder,
     IEnvironment environment)
     : IVersionStrategy
@@ -16,6 +17,7 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
     private readonly Lazy<GitVersionContext> contextLazy = contextLazy.NotNull();
     private readonly IRepositoryStore repositoryStore = repositoryStore.NotNull();
     private readonly IBranchRepository branchRepository = branchRepository.NotNull();
+    private readonly ITaggedSemanticVersionRepository taggedSemanticVersionRepository = taggedSemanticVersionRepository.NotNull();
     private readonly IIncrementStrategyFinder incrementStrategyFinder = incrementStrategyFinder.NotNull();
     private readonly IEnvironment environment = environment.NotNull();
     private readonly VersionInBranchNameVersionStrategy releaseVersionStrategy = new(contextLazy, environment);
@@ -36,9 +38,10 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
             yield break;
         }
 
+        var mainCommits = new Lazy<HashSet<ICommit>>(GetMainCommits);
         foreach (var releaseBranch in this.branchRepository.GetReleaseBranches(Context.Configuration))
         {
-            if (TryGetBaseVersion(releaseBranch, configuration, out var baseVersion))
+            if (TryGetBaseVersion(releaseBranch, configuration, mainCommits, out var baseVersion))
             {
                 yield return baseVersion;
             }
@@ -46,17 +49,24 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
     }
 
     private bool TryGetBaseVersion(
-        IBranch releaseBranch, EffectiveBranchConfiguration configuration, [NotNullWhen(true)] out BaseVersion? result)
+        IBranch releaseBranch, EffectiveBranchConfiguration configuration, Lazy<HashSet<ICommit>> mainCommits,
+        [NotNullWhen(true)] out BaseVersion? result)
     {
         result = null;
 
         var releaseBranchConfiguration = Context.Configuration.GetEffectiveBranchConfiguration(releaseBranch);
-        if (!this.releaseVersionStrategy.TryGetBaseVersion(releaseBranchConfiguration, out var baseVersion))
+        if (!this.releaseVersionStrategy.TryGetBaseVersion(releaseBranchConfiguration, out var baseVersion)
+            && !TryGetTaggedBaseVersion(releaseBranchConfiguration, mainCommits, out baseVersion))
         {
             return result is not null;
         }
         // Find the commit where the child branch was created.
         var baseVersionSource = this.repositoryStore.FindMergeBase(releaseBranch, Context.CurrentBranch);
+        if (baseVersionSource is null)
+        {
+            return false;
+        }
+
         var label = configuration.Value.GetBranchSpecificLabel(Context.CurrentBranch.Name, null, this.environment);
         var increment = this.incrementStrategyFinder.DetermineIncrementedField(
             currentCommit: Context.CurrentCommit,
@@ -79,4 +89,58 @@ internal sealed class TrackReleaseBranchesVersionStrategy(
 
         return true;
     }
+
+    private bool TryGetTaggedBaseVersion(
+        EffectiveBranchConfiguration configuration, Lazy<HashSet<ICommit>> mainCommits,
+        [NotNullWhen(true)] out BaseVersion? result)
+    {
+        result = null;
+        var releaseBranch = configuration.Branch;
+        var baseVersionSource = releaseBranch.Tip is null
+            ? null : this.repositoryStore.FindMergeBase(releaseBranch.Tip, Context.CurrentCommit);
+        if (baseVersionSource is null)
+        {
+            return false;
+        }
+
+        var label = configuration.Value.GetBranchSpecificLabel(releaseBranch.Name, null, this.environment);
+        var tags = this.taggedSemanticVersionRepository.GetTaggedSemanticVersionsOfBranch(
+            releaseBranch, configuration.Value.TagPrefixPattern, configuration.Value.SemanticVersionFormat,
+            Context.Configuration.Ignore);
+
+        // Exclude tags inherited from main's first-parent history, but preserve release
+        // tags subsequently brought into main by a merge. Ignore merged side branches
+        // when determining the release's own history as well.
+        var mainCommitSet = mainCommits.Value;
+        var releaseCommits = releaseBranch.Commits.QueryBy(new CommitFilter
+        {
+            IncludeReachableFrom = releaseBranch,
+            FirstParentOnly = true
+        }).Where(commit => !mainCommitSet.Contains(commit)).ToHashSet();
+
+        // Like versioned release names, tags describe the current release refs even
+        // when calculating an older commit. Advancing develop must not change eligibility.
+        var tag = tags.Where(group => releaseCommits.Contains(group.Key))
+            .SelectMany(group => group)
+            .Where(candidate => candidate.Value.IsPreRelease && candidate.Value.IsMatchForBranchSpecificLabel(label))
+            .MaxBy(candidate => candidate.Value);
+        if (tag is null)
+        {
+            return false;
+        }
+
+        // Treat the release's target as a stable version so the normal develop increment
+        // advances the minor instead of only changing the prerelease label or number.
+        var version = tag.Value;
+        result = new BaseVersion($"Version in release branch tag '{tag.Tag.Name.Friendly}'",
+            new SemanticVersion(version.Major, version.Minor, version.Patch));
+        return true;
+    }
+
+    private HashSet<ICommit> GetMainCommits() => [.. this.branchRepository.GetMainBranches(Context.Configuration)
+        .SelectMany(branch => branch.Commits.QueryBy(new CommitFilter
+        {
+            IncludeReachableFrom = branch,
+            FirstParentOnly = true
+        }))];
 }


### PR DESCRIPTION
## Description

Allow `TrackReleaseBranches` to identify an unversioned release branch from its highest eligible semantic prerelease tag. For example, `releases/R2301` tagged `1.0.0-RC.1` lets develop advance to `1.1.0-beta.1` after its next commit.

Versioned release names retain precedence. Tag selection respects release labels, tag prefixes, parsing and ignore settings, using release first-parent history outside main first-parent history. Eligibility uses current release refs consistently for tip and historical calculations. The existing branch-aware merge base supplies commit counts.

## Related Issue

Resolves #3149

## Motivation and Context

Develop currently tracks release versions encoded in branch names but misses equivalent prerelease tags on unversioned release branches. This extends that capability, including sibling release branches. Tests also cover retaining the same develop version after develop advances and after the release is merged into main.

GitFlow hotfixes are release branches too: the existing non-Mainline hotfix scenario now counts from the recognized release branch point, matching the versioned-hotfix control.

## How Has This Been Tested?

- macOS arm64, .NET SDK 10.0.400.
- 33 focused cases pass with each of the managed and libgit2 backends.
- Full core suite: 36,290 passed, zero failures or skips on each backend.
- Regression confirmed to fail before the same-SHA fix for the unversioned release, while the versioned-name control passed.
- Formatting verification and `git diff --check` pass; configuration documentation regenerated with `mdsnippets`.
- Tests ran before rebasing onto current main; the only intervening upstream change updates Scriban in the separate `new-cli` tree.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing core tests passed.
