### PR TITLE
docs: document trunk-based workflow with executable examples

### DIFF
--- a/build/docs/Utilities/Mermaid.cs
+++ b/build/docs/Utilities/Mermaid.cs
@@ -61,7 +61,7 @@ public static class Mermaid
                 context.DotNetTest(DocumentationTestsProject.FullPath, new DotNetTestSettings
                 {
                     PathType = DotNetTestPathType.Project,
-                    Filter = "FullyQualifiedName~DocumentationSamplesForGitFlow|FullyQualifiedName~DocumentationSamplesForGitHubFlow",
+                    Filter = "FullyQualifiedName~DocumentationSamplesForGitFlow|FullyQualifiedName~DocumentationSamplesForGitHubFlow|FullyQualifiedName~DocumentationSamplesForTrunkBased",
                     WorkingDirectory = context.MakeAbsolute(Paths.Root),
                     EnvironmentVariables = new Dictionary<string, string>
                     {

--- a/docs/diagrams/DocumentationSamplesForTrunkBased_CommitMessageIncrements.mmd
+++ b/docs/diagrams/DocumentationSamplesForTrunkBased_CommitMessageIncrements.mmd
@@ -1,0 +1,23 @@
+sequenceDiagram
+    activate main
+    main->>main: commit
+    main->>main: tag 1.2.0
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.0
+    end
+    main->>main: Commit 'Fix a bug +semver: patch'
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.1
+    end
+    main->>main: Commit 'Add an API +semver: minor'
+    rect rgb(211, 211, 211)
+        Note over main: 1.3.0
+    end
+    main->>main: Commit 'Break an API +semver: major'
+    rect rgb(211, 211, 211)
+        Note over main: 2.0.0
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 2.0.1
+    end

--- a/docs/diagrams/DocumentationSamplesForTrunkBased_DirectCommitsAndReleaseTags.mmd
+++ b/docs/diagrams/DocumentationSamplesForTrunkBased_DirectCommitsAndReleaseTags.mmd
@@ -1,0 +1,23 @@
+sequenceDiagram
+    activate main
+    main->>main: commit
+    main->>main: tag 1.2.0
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.0
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.1
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.2
+    end
+    main->>main: tag v1.2.2
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.2
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.3
+    end

--- a/docs/diagrams/DocumentationSamplesForTrunkBased_feature_BranchMerge.mmd
+++ b/docs/diagrams/DocumentationSamplesForTrunkBased_feature_BranchMerge.mmd
@@ -1,0 +1,31 @@
+sequenceDiagram
+    activate main
+    main->>main: commit
+    main->>main: tag 1.2.0
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.0
+    end
+    create participant feature_foo as feature/foo
+    main->>feature_foo: branch from main
+    deactivate main
+    activate feature_foo
+    feature_foo->>feature_foo: commit
+    rect rgb(211, 211, 211)
+        Note over feature_foo: 1.3.0-foo.1
+    end
+    feature_foo->>feature_foo: commit
+    rect rgb(211, 211, 211)
+        Note over feature_foo: 1.3.0-foo.2
+    end
+    activate main
+    feature_foo->>main: merge
+    deactivate feature_foo
+    destroy feature_foo
+    main--xfeature_foo: delete branch
+    rect rgb(211, 211, 211)
+        Note over main: 1.3.0
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 1.3.1
+    end

--- a/docs/diagrams/DocumentationSamplesForTrunkBased_hotfix_BranchMerge.mmd
+++ b/docs/diagrams/DocumentationSamplesForTrunkBased_hotfix_BranchMerge.mmd
@@ -1,0 +1,31 @@
+sequenceDiagram
+    activate main
+    main->>main: commit
+    main->>main: tag 1.2.0
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.0
+    end
+    create participant hotfix_fix as hotfix/fix
+    main->>hotfix_fix: branch from main
+    deactivate main
+    activate hotfix_fix
+    hotfix_fix->>hotfix_fix: commit
+    rect rgb(211, 211, 211)
+        Note over hotfix_fix: 1.2.1-fix.1
+    end
+    hotfix_fix->>hotfix_fix: commit
+    rect rgb(211, 211, 211)
+        Note over hotfix_fix: 1.2.1-fix.2
+    end
+    activate main
+    hotfix_fix->>main: merge
+    deactivate hotfix_fix
+    destroy hotfix_fix
+    main--xhotfix_fix: delete branch
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.1
+    end
+    main->>main: commit
+    rect rgb(211, 211, 211)
+        Note over main: 1.2.2
+    end

--- a/docs/input/docs/learn/branching-strategies/index.cshtml
+++ b/docs/input/docs/learn/branching-strategies/index.cshtml
@@ -8,7 +8,7 @@ RedirectFrom:
 - docs/examples
 ---
 
-<p>Start by <a href="/docs/usage/choose-workflow">choosing a workflow</a>. The examples below illustrate GitFlow and GitHubFlow histories; read each example with its configuration. For experimental trunk-based defaults, see <a href="/docs/reference/configuration#global-configuration">TrunkBased/preview1</a>.</p>
+<p>Start by <a href="/docs/usage/choose-workflow">choosing a workflow</a>. The examples below illustrate GitFlow, GitHubFlow, and <a href="/docs/learn/branching-strategies/trunkbased">TrunkBased/preview1</a> histories; read each example with its configuration. The <a href="/docs/learn/branching-strategies/trunkbased/examples">trunk-based examples</a> use the experimental preset without overrides.</p>
 
 <img src="/docs/img/CommitGraph.png" alt="Commit graph">
 

--- a/docs/input/docs/learn/branching-strategies/trunkbased/examples.md
+++ b/docs/input/docs/learn/branching-strategies/trunkbased/examples.md
@@ -1,0 +1,77 @@
+---
+Order: 50
+Title: Trunk-based examples
+---
+
+All examples use the unmodified [TrunkBased preview preset](/docs/learn/branching-strategies/trunkbased):
+
+```yaml
+workflow: TrunkBased/preview1
+```
+
+Each scenario starts independently on `main` with a commit tagged `1.2.0`.
+The diagrams display asserted **FullSemVer** values.
+
+## Direct commits and release tags
+
+Two ordinary commits on main produce `1.2.1` and `1.2.2`. Tagging the latter
+`v1.2.2` preserves that version; the following commit produces `1.2.3`.
+GitVersion calculates these values; it does not create the release tags for you.
+Tag the commit you release, using the version you published.
+
+<pre class="mermaid" aria-label="Trunk-based direct commits and release tags diagram">
+^"../../../../../diagrams/DocumentationSamplesForTrunkBased_DirectCommitsAndReleaseTags.mmd"
+</pre>
+
+## Feature merge
+
+Create `feature/foo` from the tagged main commit, make two commits, and merge
+it into main with `git merge --no-ff feature/foo`. The feature defaults to a
+Minor increment: the branch builds are `1.3.0-foo.1` and `1.3.0-foo.2`.
+The merge produces `1.3.0` on main, and the next ordinary main commit produces
+`1.3.1`. Delete the feature branch after merging.
+
+<pre class="mermaid" aria-label="Trunk-based feature merge diagram">
+^"../../../../../diagrams/DocumentationSamplesForTrunkBased_feature_BranchMerge.mmd"
+</pre>
+
+## Hotfix merge
+
+Create `hotfix/fix` from the tagged main commit, make two commits, and merge
+it with `git merge --no-ff hotfix/fix`. The hotfix defaults to a Patch increment:
+branch builds are `1.2.1-fix.1` and `1.2.1-fix.2`. The merge produces
+`1.2.1` on main, and the next ordinary main commit produces `1.2.2`.
+Delete the hotfix branch after merging.
+
+<pre class="mermaid" aria-label="Trunk-based hotfix merge diagram">
+^"../../../../../diagrams/DocumentationSamplesForTrunkBased_hotfix_BranchMerge.mmd"
+</pre>
+
+## Commit-message increments
+
+On main, the following sequence illustrates the enabled commit-message rules:
+
+| Commit message | FullSemVer |
+| --- | --- |
+| `Fix a bug +semver: patch` | `1.2.1` |
+| `Add an API +semver: minor` | `1.3.0` |
+| `Break an API +semver: major` | `2.0.0` |
+| Ordinary commit | `2.0.1` |
+
+The default patterns also accept `fix`, `feature`, and `breaking` as aliases
+for `patch`, `minor`, and `major`. See
+[version increments](/docs/reference/version-increments) for the configurable
+message patterns.
+
+<pre class="mermaid" aria-label="Trunk-based commit-message increments diagram">
+^"../../../../../diagrams/DocumentationSamplesForTrunkBased_CommitMessageIncrements.mmd"
+</pre>
+
+## Executable source
+
+These diagrams come from
+[`DocumentationSamplesForTrunkBased.cs`](https://github.com/GitTools/GitVersion/blob/main/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForTrunkBased.cs),
+which constructs `TrunkBasedConfigurationBuilder.New.Build()` in each scenario
+and asserts every displayed version. To update them, run the
+`GenerateMermaidSources` Cake task and then `ValidateMermaidDiagrams`.
+See [contributing examples](/docs/learn/branching-strategies/contribute-examples).

--- a/docs/input/docs/learn/branching-strategies/trunkbased/index.md
+++ b/docs/input/docs/learn/branching-strategies/trunkbased/index.md
@@ -1,0 +1,74 @@
+---
+Order: 40
+Title: Trunk-based (preview)
+Description: Configure and evaluate the experimental TrunkBased workflow
+---
+
+Use `TrunkBased/preview1` when your team integrates into one main branch,
+works directly on that branch or uses short-lived feature and hotfix branches,
+and wants versions calculated from that mainline history. Release tags record
+published versions; a separate develop or release branch is not required.
+
+This preset is **experimental**. Evaluate it against representative histories
+before adopting it. Its defaults and behavior may change; it does not have the
+same compatibility guarantees as `GitFlow/v1` and `GitHubFlow/v1`.
+
+## Start with the preset
+
+Create `GitVersion.yml` at the repository root:
+
+```yaml
+workflow: TrunkBased/preview1
+```
+
+Inspect the resolved defaults and the version at your current commit:
+
+```shell
+dotnet-gitversion --show-config
+dotnet-gitversion --show-variable FullSemVer
+```
+
+The preset selects the `ConfiguredNextVersion` and `Mainline` calculation
+strategies. [Mainline](/docs/reference/modes/mainline) interprets commits and
+merges to calculate version increments; it is a strategy, not a deployment mode.
+You do not need to override `strategies` or set `next-version` to use this preset.
+
+For overrides, follow the [v7 configuration layout](/docs/reference/configuration#v7-configuration-layout):
+`workflow` stays at the root, version-calculation settings go under
+`calculation`, and output settings go under `output`.
+
+## Branch defaults
+
+These are the defaults of `TrunkBased/preview1`, without overrides:
+
+| Branch type | Recognized names | Increment | Deployment mode | Pre-release label |
+| --- | --- | --- | --- | --- |
+| main | `main`, `master` | Patch | ContinuousDeployment | Empty |
+| feature | `feature/foo`, `features/foo` | Minor | ContinuousDelivery | Branch name, such as `foo` |
+| hotfix | `hotfix/fix`, `hotfixes/fix` | Patch | ContinuousDelivery | Branch name, such as `fix` |
+| pull-request | `pull/42`, `pull-requests/42`, `pr/42` (including merge refs) | Inherit | ContinuousDelivery | `PullRequest42` |
+| unknown | Other names | Patch | ContinuousDelivery | Branch name |
+
+The feature, hotfix, and pull-request patterns also accept `-` as the separator.
+Feature, hotfix, and unknown branches list `main` as their source branch type;
+pull requests list `main`, `feature`, and `hotfix`. Hotfix branches are marked
+`is-release-branch: true`. The preset has no dedicated `develop`, `release`, or
+`support` branch configuration: those names use the unknown-branch fallback.
+
+On `main`, ContinuousDeployment produces versions without a pre-release suffix.
+An untagged commit can therefore have a stable-looking version; that alone does
+not mean it has been published. Feature and hotfix builds carry branch labels.
+Commit-message incrementing is enabled, and the default tag prefix accepts
+both `1.2.0` and `v1.2.0`.
+
+See the [complete built-in configuration](/docs/reference/configuration#global-configuration)
+for the exact regular expressions, merge handling, and output weights. Do not
+substitute the outputs of customized GitFlow Mainline examples for this preset.
+
+## Try representative histories
+
+The [worked examples](examples) show direct commits on main, feature and hotfix
+merges, release tags, and commit-message increments using this exact preset.
+Compare those histories with your repository, including your actual merge
+policy, before switching workflows. Squash and fast-forward merges produce
+different histories from the explicit merge commits in these examples.

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -16,6 +16,17 @@ every workflow uses the same deployment mode.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## Configuration tool
+
+The interactive configuration tool (`gitversion init`) was removed in
+GitVersion v6.0.0. The [removal commit](https://github.com/GitTools/GitVersion/commit/09014f1af2367d79d53919c759a82ea998d9db6c)
+removed the init wizard and its command handling. Create `GitVersion.yml`
+manually, [choose a workflow](/docs/usage/choose-workflow), and inspect the
+resolved settings with `gitversion --show-config`. Follow
+[Configure GitVersion](/docs/usage/configure) for current configuration guidance,
+or the [trunk-based guide](/docs/learn/branching-strategies/trunkbased) to try
+`TrunkBased/preview1`.
+
 ## v7 configuration layout
 
 GitVersion v7 separates version **calculation** from version **output**. Put
@@ -102,7 +113,7 @@ The following supported workflow configurations are available in GitVersion and 
 
 * GitFlow (GitFlow/v1)
 * GitHubFlow (GitHubFlow/v1)
-* TrunkBased (TrunkBased/preview1, experimental preview)
+* [TrunkBased](/docs/learn/branching-strategies/trunkbased) (`TrunkBased/preview1`, experimental preview; [worked examples](/docs/learn/branching-strategies/trunkbased/examples))
 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -16,6 +16,17 @@ every workflow uses the same deployment mode.
 To see the effective configuration (defaults and overrides), you can run
 `gitversion --show-config`.
 
+## Configuration tool
+
+The interactive configuration tool (`gitversion init`) was removed in
+GitVersion v6.0.0. The [removal commit](https://github.com/GitTools/GitVersion/commit/09014f1af2367d79d53919c759a82ea998d9db6c)
+removed the init wizard and its command handling. Create `GitVersion.yml`
+manually, [choose a workflow](/docs/usage/choose-workflow), and inspect the
+resolved settings with `gitversion --show-config`. Follow
+[Configure GitVersion](/docs/usage/configure) for current configuration guidance,
+or the [trunk-based guide](/docs/learn/branching-strategies/trunkbased) to try
+`TrunkBased/preview1`.
+
 ## v7 configuration layout
 
 GitVersion v7 separates version **calculation** from version **output**. Put
@@ -102,7 +113,7 @@ The following supported workflow configurations are available in GitVersion and 
 
 * GitFlow (GitFlow/v1)
 * GitHubFlow (GitHubFlow/v1)
-* TrunkBased (TrunkBased/preview1, experimental preview)
+* [TrunkBased](/docs/learn/branching-strategies/trunkbased) (`TrunkBased/preview1`, experimental preview; [worked examples](/docs/learn/branching-strategies/trunkbased/examples))
 
 Example of using a `GitHubFlow` workflow with a different `tag-prefix`:
 

--- a/docs/input/docs/usage/choose-workflow.md
+++ b/docs/input/docs/usage/choose-workflow.md
@@ -30,5 +30,6 @@ Read [workflows, modes, and strategies](/docs/learn/workflows-modes-strategies) 
 
 - [GitHub Flow](/docs/learn/branching-strategies/githubflow) and [examples](/docs/learn/branching-strategies/githubflow/examples).
 - [Git Flow](/docs/learn/branching-strategies/gitflow) and [examples](/docs/learn/branching-strategies/gitflow/examples).
+- [Trunk-based (preview)](/docs/learn/branching-strategies/trunkbased) and [examples](/docs/learn/branching-strategies/trunkbased/examples).
 - [Built-in configurations](/docs/reference/configuration#global-configuration).
 - [Create and inspect configuration](/docs/usage/configure).

--- a/docs/input/docs/usage/configure.md
+++ b/docs/input/docs/usage/configure.md
@@ -4,13 +4,16 @@ Order: 2
 ---
 Start with a workflow and override only the settings your repository needs.
 
+The old interactive `init` configuration tool was [removed in v6](/docs/reference/configuration#configuration-tool). Create and edit the YAML file directly.
+
 ## Create a configuration file
 
 Put `GitVersion.yml` at the repository root. GitVersion also recognizes `GitVersion.yaml`, `.GitVersion.yml`, and `.GitVersion.yaml`.
 
 ```yaml
 workflow: GitHubFlow/v1
-tag-prefix: '[vV]?'
+calculation:
+  tag-prefix: '[vV]?'
 ```
 
 This selects the GitHubFlow defaults and permits a leading v or V in version tags. For a different starting point, [choose a workflow](/docs/usage/choose-workflow).

--- a/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForTrunkBased.cs
+++ b/src/GitVersion.Core.Tests/IntegrationTests/DocumentationSamplesForTrunkBased.cs
@@ -1,0 +1,86 @@
+using GitVersion.Configuration;
+
+namespace GitVersion.Tests.IntegrationTests;
+
+[TestFixture]
+public class DocumentationSamplesForTrunkBased
+{
+    [Test]
+    public void DirectCommitsAndReleaseTags()
+    {
+        var configuration = TrunkBasedConfigurationBuilder.New.Build();
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.SequenceDiagram.Activate("main");
+        fixture.MakeACommit();
+        fixture.ApplyTag("1.2.0");
+        fixture.AssertFullSemver("1.2.0", configuration);
+
+        fixture.MakeACommit();
+        fixture.AssertFullSemver("1.2.1", configuration);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver("1.2.2", configuration);
+        fixture.ApplyTag("v1.2.2");
+        fixture.AssertFullSemver("1.2.2", configuration);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver("1.2.3", configuration);
+
+        DocumentationDiagramWriter.Write(fixture.SequenceDiagram,
+            $"{nameof(DocumentationSamplesForTrunkBased)}_{nameof(DirectCommitsAndReleaseTags)}", true);
+    }
+
+    [TestCase("feature/foo", "1.3.0-foo.1", "1.3.0-foo.2", "1.3.0", "1.3.1")]
+    [TestCase("hotfix/fix", "1.2.1-fix.1", "1.2.1-fix.2", "1.2.1", "1.2.2")]
+    public void BranchMerge(string branchName, string firstCommitVersion, string secondCommitVersion,
+        string mergedVersion, string nextVersion)
+    {
+        var configuration = TrunkBasedConfigurationBuilder.New.Build();
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.SequenceDiagram.Activate("main");
+        fixture.MakeACommit();
+        fixture.ApplyTag("1.2.0");
+        fixture.AssertFullSemver("1.2.0", configuration);
+
+        fixture.BranchTo(branchName);
+        fixture.SequenceDiagram.Deactivate("main");
+        fixture.SequenceDiagram.Activate(branchName);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver(firstCommitVersion, configuration);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver(secondCommitVersion, configuration);
+
+        fixture.Checkout("main");
+        fixture.SequenceDiagram.Activate("main");
+        fixture.MergeNoFF(branchName);
+        fixture.SequenceDiagram.Deactivate(branchName);
+        fixture.Remove(branchName);
+        fixture.AssertFullSemver(mergedVersion, configuration);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver(nextVersion, configuration);
+
+        DocumentationDiagramWriter.Write(fixture.SequenceDiagram,
+            $"{nameof(DocumentationSamplesForTrunkBased)}_{branchName.Split('/')[0]}_{nameof(BranchMerge)}", true);
+    }
+
+    [Test]
+    public void CommitMessageIncrements()
+    {
+        var configuration = TrunkBasedConfigurationBuilder.New.Build();
+        using var fixture = new EmptyRepositoryFixture();
+        fixture.SequenceDiagram.Activate("main");
+        fixture.MakeACommit();
+        fixture.ApplyTag("1.2.0");
+        fixture.AssertFullSemver("1.2.0", configuration);
+
+        fixture.MakeACommit("Fix a bug +semver: patch");
+        fixture.AssertFullSemver("1.2.1", configuration);
+        fixture.MakeACommit("Add an API +semver: minor");
+        fixture.AssertFullSemver("1.3.0", configuration);
+        fixture.MakeACommit("Break an API +semver: major");
+        fixture.AssertFullSemver("2.0.0", configuration);
+        fixture.MakeACommit();
+        fixture.AssertFullSemver("2.0.1", configuration);
+
+        DocumentationDiagramWriter.Write(fixture.SequenceDiagram,
+            $"{nameof(DocumentationSamplesForTrunkBased)}_{nameof(CommitMessageIncrements)}", true);
+    }
+}


### PR DESCRIPTION
## Description

Add a practical guide for the experimental `TrunkBased/preview1` preset, including minimal configuration, branch defaults, deployment modes, and worked examples. The examples use the unmodified `TrunkBasedConfigurationBuilder` and generate four Mermaid diagrams covering direct main commits, release tags, feature/hotfix merges, and commit-message increments.

Link the guide from workflow selection and branching-strategy and configuration references. Restore the `#configuration-tool` anchor with the history-verified explanation that the init wizard was removed in v6, and direct readers to current YAML configuration guidance. No production version-calculation behavior changes; rebuilding the wizard remains separate in #3900.

## Related Issue

Resolves #3915

## Motivation and Context

The preset already exists, but has no dedicated guide or verified examples. Its defaults differ from the customized GitFlow Mainline examples, so the new examples assert the actual preset outputs.

## How Has This Been Tested?

- All 48 executable documentation cases passed, including the four new trunk-based cases; both documentation-reference tests passed.
- The documentation build verified 17 generated diagram sources and validated all 18 Mermaid diagrams.
- Full `BuildDocs` completed for the 7.0, 6.8, and 5.12 editions, including rendered-link validation. Ran in a temporary clone containing identical changes because build-root discovery does not support linked worktrees.
- Browser inspection confirmed the guide, sidebar navigation, and all four diagrams render.
- Formatting verification and `git diff --check` passed; a second snippet regeneration made no changes.
- New guide and edited usage pages passed Markdown lint. The configuration source retains the same eight pre-existing link-definition warnings as the base revision. Shared dark-theme diagram contrast is unchanged.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing documentation tests passed (the full production test suite was not run).
