### PR TITLE
Follow up on GitHub tag build documentation and ref classification

### DIFF
--- a/docs/input/docs/reference/build-servers/github-actions.md
+++ b/docs/input/docs/reference/build-servers/github-actions.md
@@ -17,3 +17,18 @@ without it, GitHub Actions might perform a shallow clone, which will cause GitVe
 :::
 
 More information can be found at [gittools/actions](https://github.com/GitTools/actions/blob/main/docs/examples/github/gitversion/index.md).
+
+## Branch and tag builds
+
+GitVersion uses the following [GitHub Actions default environment variables](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables) to identify the ref being built:
+
+| Variable | How GitVersion uses it |
+| --- | --- |
+| `GITHUB_REF_TYPE` | Distinguishes tag builds (`tag`) from branch builds (`branch`). |
+| `GITHUB_REF` | Supplies the full ref, such as `refs/heads/main`, `refs/pull/42/merge`, or `refs/tags/1.2.3`. |
+
+For a tag build, GitVersion treats `GITHUB_REF` as the selected tag rather than a branch name. This also applies when manually running a workflow with `workflow_dispatch` and selecting a tag.
+
+A historical tag can point to a commit that is no longer the tip of any branch. If normalization cannot attach HEAD to a local branch, it checks the selected local tag. When that tag resolves to the checked-out commit, GitVersion keeps HEAD detached and avoids an unnecessary remote lookup for pull-request refs. Existing branch selection takes precedence when a local branch identifies HEAD.
+
+The selected tag must exist locally and resolve to HEAD for this behavior to apply. Checking out a different ref from the one reported by `GITHUB_REF` does not make an unrelated local tag identify the build. Keep `fetch-depth: 0` as described above so GitVersion has the full history available for version calculation.

--- a/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
+++ b/src/GitVersion.BuildAgents/Agents/GitHubActions.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using GitVersion.Extensions;
+using GitVersion.Git;
 using GitVersion.OutputVariables;
 
 namespace GitVersion.Agents;
@@ -64,7 +65,7 @@ internal class GitHubActions(IEnvironment environment, ILogger<GitHubActions> lo
         var reference = this.environment.GetEnvironmentVariable("GITHUB_REF");
         return string.Equals(refType, "tag", StringComparison.OrdinalIgnoreCase)
             && reference != null
-            && reference.StartsWith("refs/tags/", StringComparison.Ordinal)
+            && new ReferenceName(reference).IsTag
                 ? reference
                 : null;
     }


### PR DESCRIPTION
## Description

Follow-up to #5198, addressing the review feedback that remained after it merged:

- Reuse `ReferenceName.IsTag` to classify the GitHub Actions tag reference instead of duplicating the tag-prefix check. `ReferenceName` is the shared reference-name value object; the backend-specific `Tag` represents a repository object.
- Document how `GITHUB_REF_TYPE` and `GITHUB_REF` identify branch and tag builds, including manually dispatched historical tag builds and the local tag/HEAD matching requirement.

## Why `ReferenceName` rather than `Tag`?

The suggestion was to reuse an existing value object for parsing and validation. At this point the build agent only has the `GITHUB_REF` string and needs to determine whether it names a tag. `ReferenceName` already owns that classification through `IsTag`, without requiring repository access.

`GitVersion.Git.Tag` is an internal implementation in the LibGit2Sharp backend. Its constructor requires a `LibGit2Sharp.Tag`, a diff object, and a repository cache; it represents an existing repository tag and resolves its target commit. It is not a parser for an environment-variable string. Using it here would couple the build-agent adapter to one Git backend and require repository objects for a reference-name check.

Using `ReferenceName.IsTag` therefore follows the intent of the suggestion while keeping the adapter independent of the Git backend. It preserves the existing ordinal tag-prefix classification; it does not claim to validate tag existence or perform full Git ref-name validation. `GitPreparer` remains responsible for finding the selected local tag and checking that its commit matches HEAD.

## Related Issue

Follow-up to #5198, which resolved #4212.

Review feedback: [reference-name classification](https://github.com/GitTools/GitVersion/pull/5198#discussion_r3979016559) and [request for a follow-up](https://github.com/GitTools/GitVersion/pull/5198#issuecomment-5618905789).

## How Has This Been Tested?

- All 98 build-agent tests passed, including the existing tag/branch/PR environment cases.
- Formatting verification for the changed C# file passed.
- `git diff --check` passed.

The ref-classification change preserves the existing ordinal, case-sensitive tag-prefix behavior.
