### PR TITLE
docs: document master configuration migration from v5

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -156,6 +156,32 @@ The `GITVERSION_REMOTE_USERNAME` and `GITVERSION_REMOTE_PASSWORD` environment va
 
 ### Configuration changes:
 
+* Configurations upgrading from v5 that use `branches.master` to override the built-in main branch configuration must use `branches.main` in v6. Later v5 releases already used `main` internally but accepted `master` for compatibility; v6 no longer applies that compatibility mapping.
+
+  v5 configuration:
+
+  ```yaml
+  branches:
+    master:
+      increment: Minor
+    feature:
+      source-branches: [master]
+  ```
+
+  Equivalent v6 configuration (flat layout):
+
+  ```yaml
+  branches:
+    main:
+      increment: Minor
+    feature:
+      source-branches: [main]
+  ```
+
+  These are **configuration keys**, not Git branch names. The built-in `main` configuration's default `regex` matches both `main` and `master`, so you do not need to rename your Git branch. In v6, `master` is treated as a separate custom configuration entry; a partial override can fail with `Branch configuration 'master' is missing required configuration 'regex'`.
+
+  Update `source-branches` and any other references to the renamed configuration key, including `is-source-branch-for` where applicable. Preserve other entries in those lists. Do not blindly rename intentionally custom configurations or literal Git branch names and regular expressions. For the v7 nested layout and further guidance, see [configuration migration](https://gitversion.net/docs/reference/configuration#migrating-master-overrides-from-v5).
+
 * The configuration properties `continuous-delivery-fallback-tag`, `tag-number-pattern`, and `tag` were renamed to `continuous-delivery-fallback-label`, `label-number-pattern`, and `label` respectively. `tag-pre-release-weight` and `tag-prefix` remained as they were as they are referring to a Git tag.
 
 * When using a commit message that matches **both** `*-version-bump-message` and `no-bump-message`, there is no increment for that commit. In other words, `no-bump-message` now takes precedence over `*-version-bump-message`.

--- a/docs/input/docs/reference/configuration.md
+++ b/docs/input/docs/reference/configuration.md
@@ -73,6 +73,10 @@ a user configuration that way.
 
 ### Migrating an existing configuration
 
+When upgrading from v5, first [migrate any `master` overrides](#migrating-master-overrides-from-v5)
+to the v6 configuration keys. The layout migration command below does not
+rename branch configuration keys or references to them.
+
 Use the migration command with the default POSIX-style argument parser to
 convert a v6 document without opening a repository. It works on all supported
 operating systems; the legacy v6 argument parser does not support it:
@@ -94,6 +98,62 @@ already nested v7 document produces the same YAML again.
 Migration also relocates `calculation.workflow` from the earlier v7 draft layout
 to the root. Runtime loading accepts only root-level `workflow`; duplicate
 root/nested selectors and `output.workflow` are rejected.
+
+### Migrating master overrides from v5
+
+If your v5 configuration uses `branches.master` to override the built-in main
+branch settings, change that key to `branches.main` for v6. Later v5 releases
+already used `main` internally but accepted `master` for compatibility. v6
+removed that compatibility mapping; see the
+[v6.0.0 breaking changes](https://github.com/GitTools/GitVersion/blob/main/BREAKING_CHANGES.md#v600).
+
+For example, this v5 configuration overrides the main branch increment and
+restricts the feature configuration's source branches:
+
+```yaml
+branches:
+  master:
+    increment: Minor
+  feature:
+    source-branches: [master]
+```
+
+The equivalent v6 configuration uses the flat layout:
+
+```yaml
+branches:
+  main:
+    increment: Minor
+  feature:
+    source-branches: [main]
+```
+
+For v7, use the nested layout (or convert the corrected v6 file with
+`gitversion config migrate`):
+
+```yaml
+calculation:
+  branches:
+    main:
+      increment: Minor
+    feature:
+      source-branches: [main]
+```
+
+`main` here is a **configuration key**, not a requirement to rename your Git
+branch. The built-in `main` configuration's default `regex` matches both Git
+branches `main` and `master`. The overrides above therefore also apply when
+your repository's branch is still named `master`.
+
+In v6 and v7, a `master` configuration entry is a separate custom entry, so a
+partial override can fail with
+`Branch configuration 'master' is missing required configuration 'regex'`.
+Update references to the renamed key in `source-branches` and, where
+applicable, `is-source-branch-for`, preserving the other entries in each list.
+These properties refer to configuration keys. Do not blindly rename
+intentionally custom configurations or literal Git branch names and regular
+expressions. Custom configurations still need their own required settings,
+including `regex` and `source-branches`.
 
 ### Overriding v7 configuration
 
@@ -644,7 +704,10 @@ For information on using format strings in these properties, see
 
 ### branches
 
-The header for all the individual branch configuration.
+The header for all the individual branch configurations. Entries are named
+configuration keys; their `regex` selects the Git branches they apply to.
+The built-in `main` key matches both `main` and `master` by default. For v5
+files that use `branches.master`, see [migration guidance](#migrating-master-overrides-from-v5).
 
 ### increment
 

--- a/docs/input/docs/reference/mdsource/configuration.source.md
+++ b/docs/input/docs/reference/mdsource/configuration.source.md
@@ -73,6 +73,10 @@ a user configuration that way.
 
 ### Migrating an existing configuration
 
+When upgrading from v5, first [migrate any `master` overrides](#migrating-master-overrides-from-v5)
+to the v6 configuration keys. The layout migration command below does not
+rename branch configuration keys or references to them.
+
 Use the migration command with the default POSIX-style argument parser to
 convert a v6 document without opening a repository. It works on all supported
 operating systems; the legacy v6 argument parser does not support it:
@@ -94,6 +98,62 @@ already nested v7 document produces the same YAML again.
 Migration also relocates `calculation.workflow` from the earlier v7 draft layout
 to the root. Runtime loading accepts only root-level `workflow`; duplicate
 root/nested selectors and `output.workflow` are rejected.
+
+### Migrating master overrides from v5
+
+If your v5 configuration uses `branches.master` to override the built-in main
+branch settings, change that key to `branches.main` for v6. Later v5 releases
+already used `main` internally but accepted `master` for compatibility. v6
+removed that compatibility mapping; see the
+[v6.0.0 breaking changes](https://github.com/GitTools/GitVersion/blob/main/BREAKING_CHANGES.md#v600).
+
+For example, this v5 configuration overrides the main branch increment and
+restricts the feature configuration's source branches:
+
+```yaml
+branches:
+  master:
+    increment: Minor
+  feature:
+    source-branches: [master]
+```
+
+The equivalent v6 configuration uses the flat layout:
+
+```yaml
+branches:
+  main:
+    increment: Minor
+  feature:
+    source-branches: [main]
+```
+
+For v7, use the nested layout (or convert the corrected v6 file with
+`gitversion config migrate`):
+
+```yaml
+calculation:
+  branches:
+    main:
+      increment: Minor
+    feature:
+      source-branches: [main]
+```
+
+`main` here is a **configuration key**, not a requirement to rename your Git
+branch. The built-in `main` configuration's default `regex` matches both Git
+branches `main` and `master`. The overrides above therefore also apply when
+your repository's branch is still named `master`.
+
+In v6 and v7, a `master` configuration entry is a separate custom entry, so a
+partial override can fail with
+`Branch configuration 'master' is missing required configuration 'regex'`.
+Update references to the renamed key in `source-branches` and, where
+applicable, `is-source-branch-for`, preserving the other entries in each list.
+These properties refer to configuration keys. Do not blindly rename
+intentionally custom configurations or literal Git branch names and regular
+expressions. Custom configurations still need their own required settings,
+including `regex` and `source-branches`.
 
 ### Overriding v7 configuration
 
@@ -211,7 +271,10 @@ For information on using format strings in these properties, see
 
 ### branches
 
-The header for all the individual branch configuration.
+The header for all the individual branch configurations. Entries are named
+configuration keys; their `regex` selects the Git branches they apply to.
+The built-in `main` key matches both `main` and `master` by default. For v5
+files that use `branches.master`, see [migration guidance](#migrating-master-overrides-from-v5).
 
 ### increment
 


### PR DESCRIPTION
Configurations upgrading from v5 can fail with a missing `regex` error when `branches.master` was intended to override the built-in main branch settings. v5 mapped that key to `main` for compatibility; v6 removed the mapping.

Document the migration under the historical v6.0.0 Configuration changes and in the configuration reference, with v5, v6 flat, and v7 nested examples. Explain that the actual Git branch can remain `master`, update references such as `source-branches` where applicable, and distinguish intentional custom configurations. Regenerate the reference from its source.

Fixes #5074.

Validation:
- Built the CLI with .NET SDK 10.0.401: no warnings or errors.
- Passed 14 runtime/migration assertions on a repository whose branch remains `master`, using released v5.12.0/v6.0.0 and current code with both managed/libgit2 backends and v6/v7 configuration modes.
- Verified the history of the compatibility mapping and its removal.
- Documentation generation is repeatable; new anchors and matching examples were checked; `git diff --check` passes.
- Remark reports only 16 pre-existing `final-definition` warnings in the configuration source/generated files. No full website build or .NET unit-test suite was run.

GitHub release notes are unchanged.
